### PR TITLE
Enhance NuGet Trusted Publishing workflow and documentation

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -1,5 +1,19 @@
 name: Release MCP Server
 
+# This workflow uses NuGet Trusted Publishing via OIDC (OpenID Connect)
+# The NuGet/login action exchanges GitHub OIDC tokens for short-lived NuGet API keys
+# See: docs/NUGET_TRUSTED_PUBLISHING.md for setup instructions
+#
+# Required GitHub Secret:
+# - NUGET_USER: Your NuGet.org username (profile name, NOT email)
+#
+# Required NuGet.org Configuration:
+# - Package: Sbroenne.ExcelMcp.McpServer
+# - Trusted Publisher: GitHub Actions
+# - Owner: sbroenne
+# - Repository: mcp-server-excel
+# - Workflow: release-mcp-server.yml
+
 on:
   push:
     tags:
@@ -13,6 +27,7 @@ jobs:
       issues: write
       pull-requests: write
       packages: write
+      id-token: write  # Required for NuGet Trusted Publishing via OIDC
     
     steps:
     - uses: actions/checkout@v4
@@ -72,15 +87,21 @@ jobs:
     - name: Pack NuGet Package
       run: dotnet pack src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj --configuration Release --no-build --output ./nupkg
       
-    - name: Publish to NuGet.org
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}  # Your nuget.org username (profile name), NOT email
+    
+    - name: Publish to NuGet.org (Trusted Publishing)
       run: |
         $version = $env:PACKAGE_VERSION
         $packagePath = "nupkg/Sbroenne.ExcelMcp.McpServer.$version.nupkg"
         
-        Write-Output "Publishing $packagePath to NuGet.org..."
+        Write-Output "Publishing $packagePath to NuGet.org using Trusted Publishing (OIDC)..."
         
         dotnet nuget push $packagePath `
-          --api-key ${{ secrets.NUGET_API_KEY }} `
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} `
           --source https://api.nuget.org/v3/index.json `
           --skip-duplicate
         

--- a/docs/NUGET_TRUSTED_PUBLISHING_CHECKLIST.md
+++ b/docs/NUGET_TRUSTED_PUBLISHING_CHECKLIST.md
@@ -1,0 +1,118 @@
+# NuGet Trusted Publishing Setup Checklist
+
+Quick reference for configuring NuGet Trusted Publishing for the ExcelMcp MCP Server.
+
+## Prerequisites ✅
+
+- [ ] Package exists on NuGet.org (must publish v1.0.0+ manually first)
+- [ ] You have owner/admin access to the package on NuGet.org
+- [ ] You have admin access to the GitHub repository
+- [ ] You know your NuGet.org username (profile name, NOT email)
+
+## GitHub Repository Configuration ✅
+
+### Step 1: Add NUGET_USER Secret
+
+- [ ] Go to <https://github.com/sbroenne/mcp-server-excel/settings/secrets/actions>
+- [ ] Click "New repository secret"
+- [ ] Name: `NUGET_USER`
+- [ ] Value: Your NuGet.org username (profile name, NOT email address)
+- [ ] Click "Add secret"
+
+### Step 2: Verify Workflow Configuration
+
+The workflow is **already configured** in `.github/workflows/release-mcp-server.yml`:
+
+- [x] `id-token: write` permission added
+- [x] `NuGet/login@v1` action for OIDC authentication
+- [x] Short-lived API key from login action output
+- [x] Correct source URL (`https://api.nuget.org/v3/index.json`)
+- [x] Documentation comments added
+
+## NuGet.org Configuration (Required)
+
+Follow these steps on NuGet.org:
+
+### Step 1: Navigate to Package Management
+
+- [ ] Go to <https://www.nuget.org>
+- [ ] Sign in with your Microsoft account
+- [ ] Go to <https://www.nuget.org/packages/Sbroenne.ExcelMcp.McpServer/manage>
+
+### Step 2: Add Trusted Publisher
+
+- [ ] Click on the "Trusted Publishers" tab
+- [ ] Click "Add Trusted Publisher" button
+- [ ] Select "GitHub Actions" as Publisher Type
+
+### Step 3: Configure GitHub Actions Publisher
+
+Enter these exact values:
+
+| Field | Value | Status |
+|-------|-------|--------|
+| **Publisher Type** | GitHub Actions | ⬜ |
+| **Owner** | `sbroenne` | ⬜ |
+| **Repository** | `mcp-server-excel` | ⬜ |
+| **Workflow** | `release-mcp-server.yml` | ⬜ |
+| **Environment** | *(leave empty)* | ⬜ |
+
+- [ ] Click "Add" to save configuration
+- [ ] Verify the trusted publisher appears in the list
+
+## Testing
+
+### Step 1: Create Test Release
+
+- [ ] Create a new tag (e.g., `mcp-v1.0.5`)
+- [ ] Push the tag to trigger the workflow
+- [ ] Monitor GitHub Actions workflow run
+
+### Step 2: Verify Publish Success
+
+- [ ] Workflow completes successfully
+- [ ] No authentication errors in logs
+- [ ] Package appears on NuGet.org
+- [ ] Version number matches the release tag
+
+## Troubleshooting
+
+If authentication fails:
+
+- [ ] Verify trusted publisher configuration matches exactly
+- [ ] Check workflow has `id-token: write` permission
+- [ ] Ensure no `--api-key` parameter in publish command
+- [ ] Confirm package exists on NuGet.org before setup
+- [ ] Review detailed logs in GitHub Actions
+
+## Security Cleanup
+
+After Trusted Publishing is working:
+
+- [ ] Old `NUGET_API_KEY` secret can remain deleted (no longer used with Trusted Publishing)
+- [ ] ✅ `NUGET_USER` secret configured (required for NuGet/login action)
+- [ ] ✅ Revoke old long-lived API keys on NuGet.org (if any)
+- [ ] ✅ Document the setup in team documentation
+
+## Benefits Achieved
+
+Once configured, you have:
+
+- ✅ Short-lived API keys (generated per workflow run, expire immediately)
+- ✅ No long-lived API keys to manage or rotate
+- ✅ Automatic authentication via OIDC
+- ✅ Enhanced security with token-based authentication
+- ✅ Full audit trail of all publishes
+- ✅ Minimal maintenance required (only `NUGET_USER` secret)
+
+## Reference
+
+- **Full Documentation**: `docs/NUGET_TRUSTED_PUBLISHING.md`
+- **Workflow File**: `.github/workflows/release-mcp-server.yml`
+- **Package URL**: <https://www.nuget.org/packages/Sbroenne.ExcelMcp.McpServer>
+- **Microsoft Docs**: <https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package#trust-based-publishing>
+
+---
+
+**Last Updated**: October 20, 2025  
+**Status**: Workflow configured ✅ | NuGet.org configuration needed ⬜

--- a/src/ExcelMcp.Core/Commands/ParameterCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ParameterCommands.cs
@@ -40,9 +40,22 @@ public class ParameterCommands : IParameterCommands
                         
                         // Try to get value
                         object? value = null;
+                        string valueType = "null";
                         try
                         {
-                            value = nameObj.RefersToRange?.Value2;
+                            var rawValue = nameObj.RefersToRange?.Value2;
+                            
+                            // Convert 2D array to List<List<object?>> for JSON serialization
+                            if (rawValue is object[,] array2D)
+                            {
+                                value = ConvertArrayToList(array2D);
+                                valueType = "Array";
+                            }
+                            else
+                            {
+                                value = rawValue;
+                                valueType = rawValue?.GetType().Name ?? "null";
+                            }
                         }
                         catch { }
                         
@@ -51,7 +64,7 @@ public class ParameterCommands : IParameterCommands
                             Name = name,
                             RefersTo = refersTo,
                             Value = value,
-                            ValueType = value?.GetType().Name ?? "null"
+                            ValueType = valueType
                         });
                     }
                     catch { }
@@ -288,5 +301,31 @@ public class ParameterCommands : IParameterCommands
         catch { }
         
         return null;
+    }
+
+    /// <summary>
+    /// Converts a 2D array from Excel to a serializable List of Lists
+    /// </summary>
+    /// <param name="array2D">The 2D array from Excel (1-based indexing)</param>
+    /// <returns>List of Lists representation</returns>
+    private static List<List<object?>> ConvertArrayToList(object[,] array2D)
+    {
+        var result = new List<List<object?>>();
+        
+        // Excel arrays are 1-based, get the bounds
+        int rows = array2D.GetLength(0);
+        int cols = array2D.GetLength(1);
+        
+        for (int row = 1; row <= rows; row++)
+        {
+            var rowList = new List<object?>();
+            for (int col = 1; col <= cols; col++)
+            {
+                rowList.Add(array2D[row, col]);
+            }
+            result.Add(rowList);
+        }
+        
+        return result;
     }
 }


### PR DESCRIPTION
Improve the NuGet Trusted Publishing workflow by integrating OIDC for authentication and updating the documentation to reflect the necessary setup steps and configurations. Add a checklist for configuring Trusted Publishing and enhance error handling in the code.