### PR TITLE
fix: Change VS Code extension release workflow to windows-latest runner

### DIFF
--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release-vscode-extension:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Problem

GitHub Actions workflow run #18902225239 failed with:
``nnpm error notsup Unsupported platform for excelmcp@1.1.2: wanted {os:win32} (current: {os:linux})
``n
The workflow was running on ubuntu-latest, but the VS Code extension package.json specifies os:win32, which restricts it to Windows only.

## Solution

Changed the workflow runner from ubuntu-latest to windows-latest to match the platform requirement. This is correct since the extension requires Excel COM interop, which is Windows-only.

## Changes

- Updated .github/workflows/release-vscode-extension.yml to use runs-on: windows-latest

## Testing

After merging, re-tag with vscode-v1.1.2 to trigger a successful release build.