### PR TITLE
fix: Add shell:bash to Package Extension step in VS Code workflow

### DIFF
--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -75,6 +75,7 @@ jobs:
         echo "Created $VSIX_FILE"
         ls -lh "$VSIX_FILE"
         echo "VSIX_PATH=vscode-extension/$VSIX_FILE" >> $GITHUB_ENV
+      shell: bash
 
     - name: Publish to VS Code Marketplace
       uses: HaaLeo/publish-vscode-extension@v2


### PR DESCRIPTION
## Problem

Workflow run #18902699767 failed at Package Extension step with:
``nParserError: Missing '(' after 'if' in if statement.
``n
Windows runners use PowerShell by default, but the packaging script uses bash syntax (test -f, mv commands).

## Solution

Added explicit shell:bash to Package Extension step to ensure proper script execution on windows-latest runner.

## Changes

- Added shell:bash to Package Extension step in .github/workflows/release-vscode-extension.yml

## Testing

After merging, re-tag with vscode-v1.1.2 to trigger successful release build.