### PR TITLE
fix: reset package.json version to 1.0.0 baseline - versions controlled by git tags

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "excelmcp",
   "displayName": "ExcelMcp - MCP Server for Excel",
   "description": "Excel automation MCP server - Power Query, DAX, VBA, Tables, Ranges & more via AI assistants",
-  "version": "1.1.2",
+  "version": "1.0.0",
   "publisher": "sbroenne",
   "icon": "icon.png",
   "repository": {


### PR DESCRIPTION
## Fix Package Version Baseline

### Problem
The package.json version was left at "1.1.2" from the previous release workflow, but it should maintain a stable baseline version in git. The actual version should be determined entirely by git tags during the release process.

### Solution
- Reset package.json version to "1.0.0" as the baseline
- Release workflow will extract version from git tag (e.g., `vscode-v1.1.3` → `1.1.3`)
- Workflow updates package.json locally during build (using `--no-git-tag-version`)
- No version changes are committed back to git

### Benefits
- ✅ **Clean git history** - No version bump commits
- ✅ **Tag-driven releases** - Version determined by git tag only  
- ✅ **Consistent baseline** - package.json always at stable version in repo
- ✅ **Workflow simplicity** - Single source of truth (git tags)

### Workflow Flow
1. Create git tag: `vscode-v1.1.3`
2. Push tag triggers workflow
3. Workflow extracts "1.1.3" from tag name
4. Workflow updates package.json locally to "1.1.3" 
5. Build and package extension with correct version
6. Create GitHub release with VSIX
7. **No commits back to git** (as intended)

This enables clean release of version 1.1.3 once merged.