### PR TITLE
fix: correct server.json path in MCP Registry publish step

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -133,11 +133,11 @@ jobs:
         Write-Output "Server name: io.github.sbroenne/mcp-server-excel"
         Write-Output "Version: $version"
         
-        # Navigate to MCP Server directory (where server.json is located)
-        Set-Location src/ExcelMcp.McpServer
+        # Navigate to MCP Server .mcp directory (where server.json is located)
+        Set-Location src/ExcelMcp.McpServer/.mcp
         
         # Publish to registry
-        ../../mcp-publisher.exe publish
+        ../../../mcp-publisher.exe publish
         
         Write-Output "🚀 Published to MCP Registry"
         Write-Output "🔗 Server available at: https://registry.modelcontextprotocol.io/servers/io.github.sbroenne/mcp-server-excel"


### PR DESCRIPTION
## Problem
GitHub Actions run 18907751552 was failing with the error:
```
Error: server.json not found. Run 'mcp-publisher init' to create one
```

## Root Cause
The MCP Registry publish step in the release workflow was looking for `server.json` in the wrong directory:
- **Expected location**: `src/ExcelMcp.McpServer/server.json` 
- **Actual location**: `src/ExcelMcp.McpServer/.mcp/server.json`

## Solution
Updated the workflow to navigate to the correct `.mcp` subdirectory:
- Changed `Set-Location src/ExcelMcp.McpServer` → `Set-Location src/ExcelMcp.McpServer/.mcp`
- Updated publisher path `../../mcp-publisher.exe` → `../../../mcp-publisher.exe`

## Verification
- [x] Verified `server.json` exists in `src/ExcelMcp.McpServer/.mcp/`
- [x] Verified relative path `../../../` correctly points to root from `.mcp` directory
- [x] Checked other workflow references - they already use correct `.mcp` path

## Testing
This fix will be validated when the next MCP server release is triggered.

Fixes: GitHub Actions run 18907751552