### PR TITLE
Fix YAML syntax in VS Code extension release workflow

### DIFF
--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -85,8 +85,8 @@ jobs:
         npm version "$version" --no-git-tag-version
 
         # Update CHANGELOG.md - replace the first version number and date
-        $date = Get-Date -Format "yyyy-MM-dd"
-        $changelogPath = "CHANGELOG.md"
+        $date = Get-Date -Format 'yyyy-MM-dd'
+        $changelogPath = 'CHANGELOG.md'
         $changelogContent = Get-Content $changelogPath -Raw
         $changelogContent = $changelogContent -replace '(?m)^## \[\d+\.\d+\.\d+\] - \d{4}-\d{2}-\d{2}', "## [$version] - $date"
         Set-Content $changelogPath $changelogContent


### PR DESCRIPTION
## Problem

The workflow file has YAML syntax errors due to mixing single/double quotes in PowerShell strings within the YAML multiline block.

GitHub Actions is rejecting the workflow file.

## Solution

Changed PowerShell string literals from double quotes to single quotes where they don't contain variables that need expansion:
- \Get-Date -Format 'yyyy-MM-dd'\ (was double quotes)
- \\ = 'CHANGELOG.md'\ (was double quotes)

This prevents YAML parser conflicts while maintaining PowerShell functionality.

## Testing
- [x] Pre-commit checks passed
- [x] Workflow file syntax should now be valid

After merge, will test with \scode-v1.2.0\ tag release.