### PR TITLE
Refactor CreateFromDataModel to return JSON responses consistently

### DIFF
--- a/src/ExcelMcp.McpServer/Tools/PivotTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/PivotTableTool.cs
@@ -217,11 +217,7 @@ public static class PivotTableTool
             async (batch) => await commands.CreateFromDataModelAsync(batch, tableName!, destSheet!, destCell!, pivotTableName!)
         );
 
-        if (!result.Success && !string.IsNullOrEmpty(result.ErrorMessage))
-        {
-            throw new ModelContextProtocol.McpException($"create-from-datamodel failed: {result.ErrorMessage}");
-        }
-
+        // Always return JSON (success or failure) - MCP clients handle the success flag
         return JsonSerializer.Serialize(result, JsonOptions);
     }
 


### PR DESCRIPTION
Ensure that CreateFromDataModel always returns JSON responses, improving handling for clients regardless of success or failure.