### PR TITLE
Fix: Power Query Update merges instead of replaces M code

### DIFF
--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Lifecycle.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Lifecycle.cs
@@ -845,10 +845,20 @@ public partial class PowerQueryCommands
                         return result;
                     }
 
-                    // Update M code formula
-                    query.Formula = mCode;
+                    // Update M code formula - CRITICAL: Must completely replace, not append
+                    // Delete and recreate to ensure clean replacement (avoid merging bug)
+                    string originalName = query.Name;
+
+                    // Delete the old query
+                    query.Delete();
+                    ComUtilities.Release(ref query);
+                    query = null;
+
+                    // Create new query with updated M code
+                    query = queries.Add(originalName, mCode);
 
                     // Auto-refresh to keep data in sync with new M code
+
                     // For UpdateAsync, we need to recreate QueryTables to handle column structure changes
 
                     // Step 1: Recreate QueryTables with new schema (handles column structure changes)


### PR DESCRIPTION
## Fixes #140

### Problem
Power Query `UpdateAsync` was **merging/concatenating** new M code with existing M code instead of replacing it, causing severely corrupted query definitions with:
- Duplicate `let` and `in` keywords
- Triple-merged comments
- Invalid M syntax that failed to load

### Root Cause
The bug was in `PowerQueryCommands.Lifecycle.cs` line 849:
```csharp
query.Formula = mCode;  // ❌ Was merging instead of replacing
```

Excel COM API's `query.Formula` property appends/merges instead of replacing.

### Solution
Changed `UpdateAsync` to **delete and recreate** the query for clean replacement:
```csharp
// Delete old query completely
string originalName = query.Name;
query.Delete();
ComUtilities.Release(ref query);
query = null;

// Create new query with updated M code
query = queries.Add(originalName, mCode);  // ✅ Clean replacement
```

### Why Tests Didn't Catch It
The existing `Update_ExistingQuery_ReturnsSuccess` test only validated operation completion:
```csharp
Assert.True(result.Success);  // ❌ Doesn't verify actual content
```

**Missing validation:**
- No round-trip verification (update → view → verify content)
- No check that old content was removed
- No check that new content was actually present
- No sequential update tests (which exposed compounding corruption)

### New Regression Tests
Added 2 comprehensive tests to prevent recurrence:

1. **`Update_ExistingQuery_ReplacesNotMergesMCode`** - Single update validation:
   - Creates query with "ORIGINAL_MARKER"
   - Updates with "NEW_MARKER"
   - ✅ Verifies NEW_MARKER present
   - ✅ Verifies ORIGINAL_MARKER gone
   - ✅ Checks for duplicate `let`/`in` keywords

2. **`Update_MultipleSequentialUpdates_EachReplacesCompletely`** - No compounding:
   - Updates V1 → V2 → V3
   - ✅ Verifies only V3 remains
   - ✅ Verifies V1 and V2 completely gone

### Test Results
All tests pass ✅:
- `Update_ExistingQuery_ReturnsSuccess` (original - 14s)
- `Update_ExistingQuery_ReplacesNotMergesMCode` (new - 17s)
- `Update_MultipleSequentialUpdates_EachReplacesCompletely` (new - 16s)

### Documentation Updates
Updated `.github/instructions/testing-strategy.instructions.md`:
- Added "Content Replacement Validation (CRITICAL)" section
- Documents why checking only Success flag is insufficient
- Provides pattern for testing replacement operations
- References this bug as lesson learned

### Files Changed
- `src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Lifecycle.cs` - Fixed UpdateAsync
- `tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.cs` - Added 2 regression tests
- `.github/instructions/testing-strategy.instructions.md` - Added validation guidance

### Impact
✅ Fixes critical bug affecting version-controlled Power Query workflows
✅ Prevents silent data corruption
✅ Improves test coverage and quality standards
✅ Safe for production use