### PR TITLE
Fix markdown rendering in GitHub Pages content section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ layout: default
   </div>
 </div>
 
-<div class="container content-section">
+<div class="container content-section" markdown="1">
 
 ## What is This Project?
 


### PR DESCRIPTION
## Summary
Fix markdown rendering in GitHub Pages - bold/italic text now renders correctly

## Problem
Markdown content inside HTML `<div>` tags wasn't being processed by Jekyll, causing raw markdown syntax to display (e.g., `**text**` instead of **text**)

## Solution
Added `markdown="1"` attribute to the content-section div to enable markdown processing inside HTML tags

## Changes
- `docs/index.md`: Added `markdown="1"` to `<div class="container content-section">` tag

## Result
- Bold text renders correctly: **ExcelMcp**
- Lists render correctly
- All markdown formatting now works properly