### PR TITLE
Fix Google Search Console verification meta tag format

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 ---
-google-site-verification: 7BSNb2Q6rNfwdJCSGEUs9_2o3NOK09tBy4svR9A1bUg
 layout: default
 ---
 
+<meta name="google-site-verification" content="7BSNb2Q6rNfwdJCSGEUs9_2o3NOK09tBy4svR9A1bUg" />
 <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 <link rel="icon" type="image/png" href="{{ '/assets/images/icon.png' | relative_url }}">
 


### PR DESCRIPTION
## Summary
Fix Google Search Console verification meta tag format

## Change
Changed from Jekyll front-matter to proper HTML meta tag format as required by Google Search Console

## Before
```yaml
---
google-site-verification: 7BSNb2Q6rNfwdJCSGEUs9_2o3NOK09tBy4svR9A1bUg
---
```

## After
```html
<meta name="google-site-verification" content="7BSNb2Q6rNfwdJCSGEUs9_2o3NOK09tBy4svR9A1bUg" />
```

This is the correct format that Google Search Console expects for site verification.