### PR TITLE
fix: Exclude vscode-v* tags from MCP Server release workflow

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -28,6 +28,7 @@ on:
   push:
     tags:
       - 'v*'  # Unified version tag (e.g., v1.2.3)
+      - '!vscode-v*'  # Exclude VS Code extension tags
 
 jobs:
   release-mcp-and-cli:


### PR DESCRIPTION
## Problem

The MCP Server release workflow was incorrectly triggering on VS Code extension tags (`vscode-v*`) because the tag filter `v*` matches **all** tags starting with 'v', including:
- `v1.2.3` ✅ (intended - MCP Server/CLI releases)
- `vscode-v1.2.13` ❌ (unintended - VS Code extension releases)

This caused build failures when pushing VS Code extension tags:
```
error : 'scode-v1.2.13' is not a valid version string. (Parameter 'value')
```

The workflow attempted to strip the 'v' prefix from `vscode-v1.2.13`, resulting in the invalid version string `scode-v1.2.13`.

## Solution

Add an exclusion pattern to the MCP Server release workflow:

```yaml
on:
  push:
    tags:
      - 'v*'          # Match MCP Server/CLI tags (v1.2.3)
      - '!vscode-v*'  # Exclude VS Code extension tags
```

## Tag Pattern Summary

| Tag Pattern | Triggers | Purpose |
|------------|----------|---------|
| `v1.2.3` | `release-mcp-server.yml` | MCP Server & CLI unified release |
| `vscode-v1.2.13` | `release-vscode-extension.yml` | VS Code extension release |

## Testing

- ✅ Pre-commit checks passed (COM leaks, coverage, naming, success flags, smoke test)
- Workflow will correctly ignore `vscode-v*` tags going forward
- VS Code extension workflow continues to work as expected

## Files Changed

- `.github/workflows/release-mcp-server.yml` - Added exclusion pattern for vscode tags