### PR TITLE
CI: Add GitHub Actions workflow for Pages deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,56 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'gh-pages/**'
+      - '.github/workflows/deploy-gh-pages.yml'
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: gh-pages
+
+      - name: Build with Jekyll
+        working-directory: gh-pages
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'gh-pages/_site'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to deploy GitHub Pages from `gh-pages/` directory.

## Problem

GitHub Pages only supports `/` or `/docs` as source directories via repository settings. We want:
- `docs/` for project documentation
- `gh-pages/` for the landing page website

## Solution

Use GitHub Actions to build and deploy from `gh-pages/` directory instead of relying on repository settings.

## Changes

- ✅ Created `.github/workflows/deploy-gh-pages.yml`
- ✅ Changed repository Pages settings to use GitHub Actions (via API)
- ✅ Workflow triggers on changes to `gh-pages/**` or manual dispatch
- ✅ Builds Jekyll site in CI/CD with full control
- ✅ Auto-deploys to GitHub Pages environment

## Workflow Features

- **Ruby 3.3** with bundler cache for fast builds
- **Production environment** (`JEKYLL_ENV=production`)
- **Automated deployment** on push to main
- **Manual trigger** via workflow_dispatch
- **Concurrency control** (only one deployment at a time)

## Benefits

- ✅ Clean separation: `docs/` = project docs, `gh-pages/` = website
- ✅ Full Jekyll build control in CI/CD
- ✅ No conflicts with repository settings limitations
- ✅ Plugins (jekyll-sitemap, jekyll-seo-tag) work automatically

## Testing

- ✅ All pre-commit checks passed
- ✅ Workflow will run on next push to main

## Post-Merge

The workflow will automatically deploy the GitHub Pages site on the next push to main that includes changes to `gh-pages/`.