### PR TITLE
Fix: Exclude vendor directory from Jekyll processing

### DIFF
--- a/gh-pages/_config.yml
+++ b/gh-pages/_config.yml
@@ -35,3 +35,5 @@ exclude:
   - LICENSE
   - Gemfile
   - Gemfile.lock
+  - vendor
+  - .bundle


### PR DESCRIPTION
## Summary

Fix Jekyll build error by excluding `vendor/` directory from processing.

## Problem

Jekyll workflow was failing with error:
```
Liquid Exception: Liquid syntax error (line 44): Unknown tag 'schema' in vendor/bundle/ruby/3.3.0/gems/html-pipeline-2.14.3/lib/html/pipeline/toc_filter.rb
```

Jekyll was trying to process template files in the `vendor/bundle` directory (where gems are installed), which contain Liquid-like syntax that shouldn't be processed.

## Solution

Add `vendor/` to the `exclude:` list in `_config.yml` to prevent Jekyll from processing gem files.

## Changes

```yaml
exclude:
  - README.md
  - LICENSE
  - Gemfile
  - Gemfile.lock
  - vendor/  # ← Added this
```

## Testing

Will test in CI/CD (local testing on Windows ARM requires complex native compilation setup for nokogiri).

## References

- [Jekyll Configuration - Exclude](https://jekyllrb.com/docs/configuration/options/#global-configuration)
- Failed workflow run: https://github.com/sbroenne/mcp-server-excel/actions/runs/12109565439