### PR TITLE
Fix SEO: Remove duplicate H1 heading from hero section

### DIFF
--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -9,7 +9,6 @@ canonical_url: "https://sbroenne.github.io/mcp-server-excel/"
 <div class="hero">
   <div class="container">
     <img src="{{ '/assets/images/icon.png' | relative_url }}" alt="Excel MCP Server - AI-powered Excel automation showing a table with green gradient background" class="hero-icon">
-    <h1>Excel MCP Server</h1>
     <p class="subtitle">Control Microsoft Excel with Natural Language through AI assistants like GitHub Copilot and Claude</p>
   </div>
 </div>


### PR DESCRIPTION
## SEO Fix: Remove Duplicate H1 Heading

### Problem
The hero section had a duplicate "Excel MCP Server" H1 heading, creating visual redundancy and an SEO issue (multiple H1s on the same page).

### Solution
- Removed the redundant H1 from the hero section
- The title is already present in the page header/navigation from the layout template
- Now the page has exactly **one H1** heading (SEO best practice)

### Result
- ✅ Cleaner visual design
- ✅ Proper SEO structure with single H1
- ✅ Hero focuses on icon and subtitle