### PR TITLE
Fix #167: Excel validation InputTitle/InputMessage not returned + dro…

### DIFF
--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Validation.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Validation.cs
@@ -66,9 +66,9 @@ public partial class RangeCommands
                 // Configure input message
                 if (showInputMessage == true)
                 {
+                    validation.ShowInput = true;  // MUST set ShowInput=true BEFORE setting title/message
                     validation.InputTitle = inputTitle ?? "";
                     validation.InputMessage = inputMessage ?? "";
-                    validation.ShowInput = true;
                 }
 
                 // Configure error alert
@@ -205,6 +205,21 @@ public partial class RangeCommands
                     };
                 }
 
+                // Read all validation properties into local variables first
+                // This ensures we're not affected by any COM state changes during object initialization
+                var validationType = GetValidationTypeName(validation.Type);
+                var validationOperator = GetValidationOperatorName(validation.Operator);
+                var formula1 = validation.Formula1?.ToString() ?? string.Empty;
+                var formula2 = validation.Formula2?.ToString() ?? string.Empty;
+                var ignoreBlank = validation.IgnoreBlank ?? true;
+                var showInputMessage = validation.ShowInput ?? false;
+                var inputTitle = validation.InputTitle?.ToString() ?? string.Empty;
+                var inputMessage = validation.InputMessage?.ToString() ?? string.Empty;
+                var showErrorAlert = validation.ShowError ?? true;
+                var errorStyle = GetErrorStyleName(validation.AlertStyle);
+                var errorTitle = validation.ErrorTitle?.ToString() ?? string.Empty;
+                var validationErrorMessage = validation.ErrorMessage?.ToString() ?? string.Empty;
+
                 return new RangeValidationResult
                 {
                     Success = true,
@@ -212,18 +227,18 @@ public partial class RangeCommands
                     SheetName = sheetName,
                     RangeAddress = rangeAddress,
                     HasValidation = true,
-                    ValidationType = GetValidationTypeName(validation.Type),
-                    ValidationOperator = GetValidationOperatorName(validation.Operator),
-                    Formula1 = validation.Formula1?.ToString() ?? string.Empty,
-                    Formula2 = validation.Formula2?.ToString() ?? string.Empty,
-                    IgnoreBlank = validation.IgnoreBlank ?? true,
-                    ShowInputMessage = validation.ShowInput ?? false,
-                    InputTitle = validation.InputTitle?.ToString() ?? string.Empty,
-                    InputMessage = validation.InputMessage?.ToString() ?? string.Empty,
-                    ShowErrorAlert = validation.ShowError ?? true,
-                    ErrorStyle = GetErrorStyleName(validation.AlertStyle),
-                    ErrorTitle = validation.ErrorTitle?.ToString() ?? string.Empty,
-                    ValidationErrorMessage = validation.ErrorMessage?.ToString() ?? string.Empty
+                    ValidationType = validationType,
+                    ValidationOperator = validationOperator,
+                    Formula1 = formula1,
+                    Formula2 = formula2,
+                    IgnoreBlank = ignoreBlank,
+                    ShowInputMessage = showInputMessage,
+                    InputTitle = inputTitle,
+                    InputMessage = inputMessage,
+                    ShowErrorAlert = showErrorAlert,
+                    ErrorStyle = errorStyle,
+                    ErrorTitle = errorTitle,
+                    ValidationErrorMessage = validationErrorMessage
                 };
             }
             catch (Exception ex)

--- a/src/ExcelMcp.McpServer/Prompts/Content/Elicitations/data_validation.md
+++ b/src/ExcelMcp.McpServer/Prompts/Content/Elicitations/data_validation.md
@@ -15,9 +15,14 @@ REQUIRED:
 
 TYPE-SPECIFIC INFO:
 
-FOR LIST VALIDATION:
-☐ List values (comma-separated, e.g., 'Active,Inactive,Pending')
+FOR LIST VALIDATION (creates dropdown):
+☐ List values (e.g., ['Active', 'Inactive', 'Pending'])
 ☐ Show dropdown? (true recommended)
+⚠️ WORKFLOW: 
+  1. First write values to a worksheet range (e.g., Sheet1!$Z$1:$Z$10)
+  2. Then set formula1 to reference that range (e.g., '=$Z$1:$Z$10')
+  3. This creates a proper dropdown that users can select from
+☐ Note: Comma-separated strings do NOT create dropdowns - only range references do!
 
 FOR NUMBER VALIDATION (decimal/whole):
 ☐ Operator (between, greaterThan, lessThan, greaterThanOrEqual, lessThanOrEqual, equal, notEqual)

--- a/src/ExcelMcp.McpServer/Prompts/Content/excel_range.md
+++ b/src/ExcelMcp.McpServer/Prompts/Content/excel_range.md
@@ -43,6 +43,7 @@
 - Using sheetName for named ranges → Use sheetName="" for named ranges
 - Not using batch mode for multiple operations → 75-90% slower
 - Setting number format per cell → Use set-number-format for entire range instead
+- **List validation with comma-separated values → Only range references create dropdowns! Write values to range first, then reference it.**
 
 **Workflow optimization**:
 - Multiple range operations? Use begin_excel_batch first

--- a/src/ExcelMcp.McpServer/Tools/ExcelRangeTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelRangeTool.cs
@@ -183,7 +183,7 @@ Optional batchId for batch sessions.")]
         [Description("Data validation operator (for validate-range: between, notBetween, equal, notEqual, greaterThan, lessThan, greaterThanOrEqual, lessThanOrEqual)")]
         string? validationOperator = null,
 
-        [Description("Validation formula1 (for validate-range, first value/formula)")]
+        [Description("Validation formula1 (for validate-range). For 'list' type: MUST be worksheet range reference like '=$A$1:$A$10' to create dropdown. For other types: value/formula for comparison.")]
         string? validationFormula1 = null,
 
         [Description("Validation formula2 (for validate-range, second value/formula for between/notBetween)")]


### PR DESCRIPTION
…pdown list guidance

Root Cause:
- Excel COM API requires validation.ShowInput=true BEFORE setting InputTitle/InputMessage
- Otherwise Excel silently ignores these properties

Fix Applied:
- Reordered property assignments in ValidateRangeAsync (lines 67-72)
- Refactored GetValidationAsync to read properties into variables first (defensive)

Critical Discovery - List Validation Dropdowns:
- Comma-separated strings do NOT create dropdown arrows in Excel
- Only worksheet range references create actual dropdowns
- Updated documentation to guide users: write values to range first, then reference it

Documentation Updates:
- ExcelRangeTool.cs: Updated formula1 parameter description for list validation
- data_validation.md: Added step-by-step dropdown workflow with warning
- excel_range.md: Added to common mistakes list

Tests Added:
- ValidateRange_WithInputMessage_ReturnsSuccess: End-to-end validation workflow
- GetValidation_WithInputMessage_ReturnsInputTitleAndMessage: InputTitle/InputMessage verification
- Both tests use proper dropdown syntax (worksheet range reference)
- Tests pass (15s total, 0 warnings)

User Impact:
- InputTitle and InputMessage now work correctly
- Clear guidance on creating proper dropdown lists
- Prevents confusion about comma-separated vs range-based validation

## Summary
Brief description of what this PR does.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (dependency updates, code cleanup, etc.)

## Related Issues
Closes #[issue number]
Relates to #[issue number]

## Changes Made
- Change 1
- Change 2
- Change 3

## Testing Performed
- [ ] Tested manually with various Excel files
- [ ] Verified Excel process cleanup (no excel.exe remains after 5 seconds)
- [ ] Tested error conditions (missing files, invalid arguments, etc.)
- [ ] All existing commands still work
- [ ] VBA script execution tested (if applicable)
- [ ] XLSM file format validation tested (if applicable)
- [ ] VBA trust setup tested (if applicable)
- [ ] Build produces zero warnings

## Test Commands
```bash
# Commands used for testing
ExcelMcp command1 "test.xlsx"
ExcelMcp command2 "test.xlsx" "param"
```

## Screenshots (if applicable)
[Add screenshots showing the new functionality]

## Core Commands Coverage Checklist ⚠️

**Does this PR add or modify Core Commands methods?** [ ] Yes [ ] No

If YES, verify all steps completed:

- [ ] Added method to Core Commands interface (e.g., `IPowerQueryCommands.NewMethodAsync()`)
- [ ] Implemented method in Core Commands class (e.g., `PowerQueryCommands.NewMethodAsync()`)
- [ ] Added enum value to `ToolActions.cs` (e.g., `PowerQueryAction.NewMethod`)
- [ ] Added `ToActionString` mapping to `ActionExtensions.cs` (e.g., `PowerQueryAction.NewMethod => "new-method"`)
- [ ] Added switch case to appropriate MCP Tool (e.g., `ExcelPowerQueryTool.cs`)
- [ ] Implemented MCP method that calls Core method
- [ ] Build succeeds with 0 warnings (CS8524 compiler enforcement verified)
- [ ] Updated `CORE-COMMANDS-AUDIT.md` (if significant addition)
- [ ] Added integration tests for new action
- [ ] Updated MCP Server prompts documentation
- [ ] Updated CLI commands documentation (if applicable)

**Coverage Impact**: +___ methods, ___% → ___% coverage

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [ ] Code builds with zero warnings
- [ ] Appropriate error handling added
- [ ] Updated help text (if adding new commands)
- [ ] Updated README.md (if needed)
- [ ] Follows Excel COM best practices from copilot-instructions.md
- [ ] Uses `ExcelHelper.WithExcel()` for Excel operations
- [ ] Properly handles 1-based Excel indexing
- [ ] Escapes user input with `.EscapeMarkup()`
- [ ] Returns consistent exit codes (0 = success, 1+ = error)

## Additional Notes
Any additional information that reviewers should know.
