### PR TITLE
Add housekeeping workflow for automated tag/release cleanup

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,220 @@
+name: Housekeeping - Cleanup Old Releases
+
+on:
+  schedule:
+    # Run every Sunday at 2 AM UTC
+    - cron: '0 2 * * 0'
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: write  # Required to delete tags
+  
+jobs:
+  cleanup-releases:
+    name: Cleanup Old Tags and Releases
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all tags
+      
+      - name: Setup GitHub CLI
+        run: |
+          type -p gh >/dev/null || (echo "GitHub CLI already installed" && gh --version)
+      
+      - name: Cleanup old releases and tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "🧹 Starting housekeeping - cleanup old tags and releases"
+          echo "========================================================"
+          echo ""
+          
+          KEEP_COUNT=3
+          
+          # Function to get releases from GitHub API
+          get_github_releases() {
+            local pattern=$1
+            gh api repos/${{ github.repository }}/releases \
+              --paginate \
+              --jq "[.[] | select(.tag_name | test(\"^${pattern}\")) | {tag: .tag_name, created: .created_at, id: .id}] | sort_by(.created) | reverse"
+          }
+          
+          # Function to get tags from GitHub API
+          get_github_tags() {
+            local pattern=$1
+            gh api repos/${{ github.repository }}/tags \
+              --paginate \
+              --jq "[.[] | select(.name | test(\"^${pattern}\")) | {tag: .name, commit: .commit.sha}]"
+          }
+          
+          # Function to delete release
+          delete_release() {
+            local tag=$1
+            local release_id=$2
+            echo "  🗑️  Deleting release: $tag (ID: $release_id)"
+            gh api -X DELETE repos/${{ github.repository }}/releases/$release_id
+          }
+          
+          # Function to delete tag
+          delete_tag() {
+            local tag=$1
+            echo "  🗑️  Deleting tag: $tag"
+            gh api -X DELETE repos/${{ github.repository }}/git/refs/tags/$tag
+          }
+          
+          # Process VSCode Extension releases and tags
+          echo "📦 Processing VS Code Extension (vscode-v*)"
+          echo "--------------------------------------------"
+          
+          vscode_releases=$(get_github_releases "vscode-v")
+          vscode_count=$(echo "$vscode_releases" | jq 'length')
+          
+          if [ "$vscode_count" -gt 0 ]; then
+            echo "  Found $vscode_count releases"
+            
+            # Get releases to keep and delete
+            keep_releases=$(echo "$vscode_releases" | jq -r ".[0:$KEEP_COUNT] | .[] | .tag")
+            delete_releases=$(echo "$vscode_releases" | jq -r ".[$KEEP_COUNT:] | .[] | {tag: .tag, id: .id} | @json")
+            
+            echo "  ✅ Keeping $(echo "$keep_releases" | wc -l) most recent:"
+            echo "$keep_releases" | sed 's/^/     - /'
+            
+            delete_count=$(echo "$delete_releases" | grep -c "^{" || echo "0")
+            if [ "$delete_count" -gt 0 ]; then
+              echo "  ❌ Deleting $delete_count old releases:"
+              
+              while IFS= read -r release_json; do
+                if [ -n "$release_json" ]; then
+                  tag=$(echo "$release_json" | jq -r '.tag')
+                  id=$(echo "$release_json" | jq -r '.id')
+                  echo "     - $tag"
+                  delete_release "$tag" "$id"
+                  delete_tag "$tag"
+                fi
+              done <<< "$delete_releases"
+            else
+              echo "  ✅ No old releases to delete"
+            fi
+          else
+            echo "  ℹ️  No vscode-v* releases found"
+          fi
+          
+          echo ""
+          
+          # Process MCP Server & CLI releases and tags (excluding vscode-v*)
+          echo "📦 Processing MCP Server & CLI (v* excluding vscode-v*)"
+          echo "--------------------------------------------------------"
+          
+          # Get all v* releases
+          all_v_releases=$(get_github_releases "v")
+          # Filter out vscode-v* releases
+          mcp_releases=$(echo "$all_v_releases" | jq '[.[] | select(.tag | test("^vscode-v") | not)]')
+          mcp_count=$(echo "$mcp_releases" | jq 'length')
+          
+          if [ "$mcp_count" -gt 0 ]; then
+            echo "  Found $mcp_count releases"
+            
+            # Get releases to keep and delete
+            keep_releases=$(echo "$mcp_releases" | jq -r ".[0:$KEEP_COUNT] | .[] | .tag")
+            delete_releases=$(echo "$mcp_releases" | jq -r ".[$KEEP_COUNT:] | .[] | {tag: .tag, id: .id} | @json")
+            
+            echo "  ✅ Keeping $(echo "$keep_releases" | wc -l) most recent:"
+            echo "$keep_releases" | sed 's/^/     - /'
+            
+            delete_count=$(echo "$delete_releases" | grep -c "^{" || echo "0")
+            if [ "$delete_count" -gt 0 ]; then
+              echo "  ❌ Deleting $delete_count old releases:"
+              
+              while IFS= read -r release_json; do
+                if [ -n "$release_json" ]; then
+                  tag=$(echo "$release_json" | jq -r '.tag')
+                  id=$(echo "$release_json" | jq -r '.id')
+                  echo "     - $tag"
+                  delete_release "$tag" "$id"
+                  delete_tag "$tag"
+                fi
+              done <<< "$delete_releases"
+            else
+              echo "  ✅ No old releases to delete"
+            fi
+          else
+            echo "  ℹ️  No v* releases found (excluding vscode-v*)"
+          fi
+          
+          echo ""
+          
+          # Cleanup orphaned tags (tags without releases)
+          echo "🏷️  Checking for orphaned tags (tags without releases)"
+          echo "-------------------------------------------------------"
+          
+          # Get all tags from GitHub
+          all_tags=$(gh api repos/${{ github.repository }}/tags --paginate --jq '.[].name')
+          
+          # Get all release tags
+          all_release_tags=$(gh api repos/${{ github.repository }}/releases --paginate --jq '.[].tag_name')
+          
+          # Find orphaned tags
+          orphaned_tags=$(comm -23 <(echo "$all_tags" | sort) <(echo "$all_release_tags" | sort))
+          orphaned_count=$(echo "$orphaned_tags" | grep -v '^$' | wc -l)
+          
+          if [ "$orphaned_count" -gt 0 ]; then
+            echo "  Found $orphaned_count orphaned tags"
+            
+            # Process vscode-v* orphaned tags
+            vscode_orphaned=$(echo "$orphaned_tags" | grep "^vscode-v" || echo "")
+            if [ -n "$vscode_orphaned" ]; then
+              vscode_orphaned_array=($(echo "$vscode_orphaned"))
+              vscode_orphaned_count=${#vscode_orphaned_array[@]}
+              
+              if [ "$vscode_orphaned_count" -gt "$KEEP_COUNT" ]; then
+                echo "  ❌ Deleting $((vscode_orphaned_count - KEEP_COUNT)) old vscode-v* orphaned tags"
+                # Keep the last N, delete the rest
+                for ((i=KEEP_COUNT; i<vscode_orphaned_count; i++)); do
+                  tag="${vscode_orphaned_array[$i]}"
+                  echo "     - $tag"
+                  delete_tag "$tag"
+                done
+              fi
+            fi
+            
+            # Process v* orphaned tags (excluding vscode-v*)
+            mcp_orphaned=$(echo "$orphaned_tags" | grep "^v" | grep -v "^vscode-v" || echo "")
+            if [ -n "$mcp_orphaned" ]; then
+              mcp_orphaned_array=($(echo "$mcp_orphaned"))
+              mcp_orphaned_count=${#mcp_orphaned_array[@]}
+              
+              if [ "$mcp_orphaned_count" -gt "$KEEP_COUNT" ]; then
+                echo "  ❌ Deleting $((mcp_orphaned_count - KEEP_COUNT)) old v* orphaned tags"
+                # Keep the last N, delete the rest
+                for ((i=KEEP_COUNT; i<mcp_orphaned_count; i++)); do
+                  tag="${mcp_orphaned_array[$i]}"
+                  echo "     - $tag"
+                  delete_tag "$tag"
+                done
+              fi
+            fi
+            
+            if [ -z "$vscode_orphaned" ] && [ -z "$mcp_orphaned" ]; then
+              echo "  ℹ️  No v* or vscode-v* orphaned tags found"
+            fi
+          else
+            echo "  ✅ No orphaned tags found"
+          fi
+          
+          echo ""
+          echo "✅ Housekeeping complete!"
+      
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Housekeeping Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Cleaned up old tags and releases" >> $GITHUB_STEP_SUMMARY
+          echo "- Kept last 3 vscode-v* releases" >> $GITHUB_STEP_SUMMARY
+          echo "- Kept last 3 v* releases (MCP/CLI)" >> $GITHUB_STEP_SUMMARY
+          echo "- Removed orphaned tags" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📅 Next run: Every Sunday at 2 AM UTC" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Housekeeping Workflow - Automated Tag & Release Cleanup

### Purpose
Automatically clean up old Git tags and GitHub releases to prevent repository bloat while maintaining recent version history.

### Schedule
- **Automated:** Runs every Sunday at 2 AM UTC
- **Manual:** Can be triggered via workflow_dispatch in GitHub Actions UI

### What It Does

**Keeps:**
- Last 3 `vscode-v*` releases (VS Code Extension)
- Last 3 `v*` releases (MCP Server & CLI)

**Deletes:**
- Older releases beyond the keep count
- Corresponding Git tags for deleted releases
- Orphaned tags (tags without releases)

### Implementation Details

**Technology:**
- Uses GitHub CLI (`gh`) and GitHub REST API
- Bash script for better GitHub Actions integration
- Queries actual releases/tags from GitHub (not just local git)

**Process:**
1. Fetches all releases via GitHub API
2. Sorts by creation date (newest first)
3. Identifies releases to keep (last 3 of each type)
4. Deletes old releases and their tags
5. Cleans up orphaned tags

**Safety:**
- Proper deletion order (release first, then tag)
- Comprehensive logging
- Summary output in GitHub Actions

### Benefits
✅ Reduces clutter on releases page  
✅ Maintains clean tag history  
✅ Automated maintenance (no manual work)  
✅ Preserves recent versions for rollback  
✅ Configurable keep count (currently 3)

### Example Output

When run, the workflow will show:
```
📦 Processing VS Code Extension (vscode-v*)
  Found 20 releases
  ✅ Keeping 3 most recent:
     - vscode-v1.3.3
     - vscode-v1.3.2
     - vscode-v1.3.1
  ❌ Deleting 17 old releases

📦 Processing MCP Server & CLI (v*)
  Found 7 releases
  ✅ Keeping 3 most recent:
     - v1.3.3
     - v1.3.2
     - v1.3.1
  ❌ Deleting 4 old releases
```

### Testing
After merge, you can:
1. Go to Actions → Housekeeping - Cleanup Old Releases
2. Click "Run workflow" to test manually
3. Check the logs to verify proper operation

---

**Current State:** Would clean up 21 old releases (17 VSCode + 4 MCP/CLI) on first run