### PR TITLE
Fix MCP server crashes and CreateEmpty workflow failures

### DIFF
--- a/src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs
@@ -138,7 +138,8 @@ POSITIONING (move, copy-to-workbook, move-to-workbook):
         return JsonSerializer.Serialize(new
         {
             success = result.Success,
-            worksheets = result.Worksheets
+            worksheets = result.Worksheets,
+            errorMessage = result.ErrorMessage
         }, ExcelToolsBase.JsonOptions);
     }
 
@@ -156,7 +157,8 @@ POSITIONING (move, copy-to-workbook, move-to-workbook):
 
         return JsonSerializer.Serialize(new
         {
-            result.Success
+            result.Success,
+            result.ErrorMessage
         }, ExcelToolsBase.JsonOptions);
     }
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.CreateEmptyThenList.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.CreateEmptyThenList.cs
@@ -1,0 +1,104 @@
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.File;
+
+/// <summary>
+/// Tests for CreateEmpty → Open → List workflow (the exact LLM scenario that was failing)
+/// </summary>
+public partial class FileCommandsTests
+{
+    [Fact]
+    public void CreateEmpty_ThenOpenAndList_ReturnsSheet1()
+    {
+        // Arrange
+        string testFile = Path.Join(_tempDir, $"{nameof(CreateEmpty_ThenOpenAndList_ReturnsSheet1)}_{Guid.NewGuid():N}.xlsx");
+
+        // Act 1: CreateEmpty (what LLM called first)
+        var createResult = _fileCommands.CreateEmpty(testFile);
+
+        // Assert CreateEmpty succeeded
+        Assert.True(createResult.Success, $"CreateEmpty failed: {createResult.ErrorMessage}");
+        Assert.True(System.IO.File.Exists(testFile), "File should exist after CreateEmpty");
+
+        // Act 2: Open the file in a new session (what LLM called second)
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Act 3: List worksheets (what LLM called third)
+        var sheetCommands = new SheetCommands();
+        var listResult = sheetCommands.List(batch);
+
+        // Assert List succeeded (this was failing before the fix)
+        Assert.True(listResult.Success, $"List failed: {listResult.ErrorMessage}");
+        Assert.NotNull(listResult.Worksheets);
+        Assert.NotEmpty(listResult.Worksheets);
+
+        // Assert Sheet1 exists (created by CreateEmpty)
+        Assert.Single(listResult.Worksheets);
+        Assert.Equal("Sheet1", listResult.Worksheets[0].Name);
+        Assert.Equal(1, listResult.Worksheets[0].Index);
+    }
+
+    [Fact]
+    public void CreateEmpty_ThenOpenAndListMultipleTimes_ConsistentResults()
+    {
+        // Arrange
+        string testFile = Path.Join(_tempDir, $"{nameof(CreateEmpty_ThenOpenAndListMultipleTimes_ConsistentResults)}_{Guid.NewGuid():N}.xlsx");
+
+        // Act 1: CreateEmpty
+        var createResult = _fileCommands.CreateEmpty(testFile);
+        Assert.True(createResult.Success, $"CreateEmpty failed: {createResult.ErrorMessage}");
+
+        // Act 2: Open and List multiple times to verify consistency
+        var sheetCommands = new SheetCommands();
+
+        for (int i = 0; i < 3; i++)
+        {
+            using var batch = ExcelSession.BeginBatch(testFile);
+            var listResult = sheetCommands.List(batch);
+
+            Assert.True(listResult.Success, $"List iteration {i} failed: {listResult.ErrorMessage}");
+            Assert.Single(listResult.Worksheets);
+            Assert.Equal("Sheet1", listResult.Worksheets[0].Name);
+        }
+    }
+
+    [Fact]
+    public void CreateEmpty_ThenOpenAndCreateMoreSheets_AllSheetsVisible()
+    {
+        // Arrange
+        string testFile = Path.Join(_tempDir, $"{nameof(CreateEmpty_ThenOpenAndCreateMoreSheets_AllSheetsVisible)}_{Guid.NewGuid():N}.xlsx");
+
+        // Act 1: CreateEmpty
+        var createResult = _fileCommands.CreateEmpty(testFile);
+        Assert.True(createResult.Success, $"CreateEmpty failed: {createResult.ErrorMessage}");
+
+        // Act 2: Open session and create multiple sheets (like the LLM tried to do)
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var sheetCommands = new SheetCommands();
+
+        var sheetsToCreate = new[] { "Dashboard", "Azure_IaaS_Analysis", "AVS_Sizing" };
+
+        foreach (var sheetName in sheetsToCreate)
+        {
+            var createSheetResult = sheetCommands.Create(batch, sheetName);
+            Assert.True(createSheetResult.Success, $"Failed to create sheet '{sheetName}': {createSheetResult.ErrorMessage}");
+        }
+
+        // Act 3: List all sheets
+        var listResult = sheetCommands.List(batch);
+
+        // Assert
+        Assert.True(listResult.Success, $"List failed: {listResult.ErrorMessage}");
+        Assert.NotNull(listResult.Worksheets);
+        Assert.Equal(4, listResult.Worksheets.Count); // Sheet1 + 3 new sheets
+
+        // Verify all expected sheets exist
+        Assert.Contains(listResult.Worksheets, s => s.Name == "Sheet1");
+        Assert.Contains(listResult.Worksheets, s => s.Name == "Dashboard");
+        Assert.Contains(listResult.Worksheets, s => s.Name == "Azure_IaaS_Analysis");
+        Assert.Contains(listResult.Worksheets, s => s.Name == "AVS_Sizing");
+    }
+}
+


### PR DESCRIPTION
Fixes #192

## Summary

Three critical fixes for MCP server stability and CreateEmpty workflow:

1. **COM Cleanup Hardening** - Prevents server crashes on session close
2. **Error Message Visibility** - LLMs can now diagnose failures
3. **CreateEmpty Save Fix** - Workbooks properly persist changes

## Changes

### 1. COM Cleanup Hardening (`ExcelBatch.cs`)
**Problem**: Unhandled `MissingMemberException` (COM error `0x80010108` RPC_E_DISCONNECTED) crashed server when closing sessions with disconnected COM proxies.

**Fix**: Wrap `workbook.Close()` and `excel.Quit()` in defensive try/catch blocks:
- Catch `COMException` and `MissingMemberException`
- Log warnings instead of crashing
- Always null out COM references in finally blocks

### 2. Error Message Visibility (`ExcelWorksheetTool.cs`)
**Problem**: `excel_worksheet` actions like `List` and `Create` returned `success: false` without `errorMessage`, leaving LLMs unable to diagnose failures.

**Fix**: Added `errorMessage` to JSON responses:
- `List`: Now returns `{ success, worksheets, errorMessage }`
- `Create`: Now returns `{ success, errorMessage }`

### 3. CreateEmpty Save Fix (`FileCommands.cs`)
**Problem**: `CreateEmpty` didn't save Sheet1 rename and comment, leaving workbooks in corrupt state. Subsequent `Open` → `List` operations failed.

**Fix**: Call `ctx.Book.Save()` before batch disposal to persist all changes.

## Testing

Added comprehensive test suite in `FileCommandsTests.CreateEmptyThenList.cs`:

- ✅ `CreateEmpty_ThenOpenAndList_ReturnsSheet1` - Core workflow (was failing before fix)
- ✅ `CreateEmpty_ThenOpenAndListMultipleTimes_ConsistentResults` - Consistency validation
- ✅ `CreateEmpty_ThenOpenAndCreateMoreSheets_AllSheetsVisible` - Full LLM scenario

**All 15 file-related tests pass** (12 existing + 3 new)

## Impact

### Before
- ❌ LLM workflows fail silently without error messages
- ❌ MCP server crashes require manual restart
- ❌ CreateEmpty creates workbooks that can't be opened reliably

### After
- ✅ LLMs receive detailed error messages for diagnosis
- ✅ Server stays running even with COM disconnections
- ✅ CreateEmpty creates properly saved, consistent workbooks
- ✅ Full LLM workflow (CreateEmpty → Open → List → Create sheets) works reliably

## Pre-commit Validation

All checks passed:
- ✅ No COM object leaks
- ✅ 100% Core Commands coverage
- ✅ All naming consistent
- ✅ All switch statements complete
- ✅ No Success flag violations
- ✅ MCP Server smoke test passed
