### PR TITLE
Fix VS Code extension engines.vscode version compatibility

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/sbroenne/mcp-server-excel#readme",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.105.0"
+    "vscode": "^1.106.0"
   },
   "os": [
     "win32"


### PR DESCRIPTION
## Problem
VS Code extension packaging fails with error:
\\\
@types/vscode ^1.106.1 greater than engines.vscode ^1.105.0
\\\

## Root Cause
Dependency updates in PR #197 (commit 90ace8a) upgraded \@types/vscode\ to 1.106.1 but missed updating the \ngines.vscode\ constraint.

## Solution
- Upgrade \ngines.vscode\ from \^1.105.0\ to \^1.106.0\
- Aligns engine requirement with TypeScript type definitions
- Ensures \sce package\ command succeeds

## Testing
✅ Tested locally with \
pm run package\ - packaging succeeds
✅ Pre-commit checks passed (COM leaks, success flags, MCP smoke test)

## Files Changed
- \scode-extension/package.json\ - Updated engines.vscode version

## Related
- Fixes packaging error introduced in PR #197