### PR TITLE
feat: Add Application Insights telemetry via OpenTelemetry

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -7,8 +7,9 @@ name: Release MCP Server & CLI
 # Unified Versioning: MCP Server and CLI always release together with the same version
 # Tag pattern: v1.2.3 (removes mcp-v prefix, CLI and MCP Server share version)
 #
-# Required GitHub Secret:
+# Required GitHub Secrets:
 # - NUGET_USER: Your NuGet.org username (profile name, NOT email)
+# - APPINSIGHTS_CONNECTION_STRING: Application Insights connection string for telemetry
 #
 # Required NuGet.org Configuration:
 # - Package: Sbroenne.ExcelMcp.McpServer
@@ -94,6 +95,22 @@ jobs:
       run: |
         dotnet restore src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
         dotnet restore src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+
+    - name: Inject Application Insights Connection String
+      run: |
+        $telemetryFile = "src/ExcelMcp.McpServer/Telemetry/ExcelMcpTelemetry.cs"
+        $connectionString = "${{ secrets.APPINSIGHTS_CONNECTION_STRING }}"
+
+        if ([string]::IsNullOrWhiteSpace($connectionString)) {
+          Write-Output "⚠️ APPINSIGHTS_CONNECTION_STRING secret not configured - telemetry will be disabled"
+        } else {
+          Write-Output "Injecting Application Insights connection string..."
+          $content = Get-Content $telemetryFile -Raw
+          $content = $content -replace '__APPINSIGHTS_CONNECTION_STRING__', $connectionString
+          Set-Content $telemetryFile $content
+          Write-Output "✅ Telemetry connection string injected"
+        }
+      shell: pwsh
 
     - name: Build MCP Server & CLI
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ gh-pages/vendor
 gh-pages/_site/*
 
 codeql-db/*
+infrastructure/azure/appinsights.secrets.local

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <!-- OpenTelemetry for Application Insights -->
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />

--- a/infrastructure/azure/appinsights-resources.bicep
+++ b/infrastructure/azure/appinsights-resources.bicep
@@ -1,0 +1,51 @@
+// Application Insights resources module
+// Called by appinsights.bicep - deploys into an existing resource group
+
+param location string
+param logAnalyticsName string
+param appInsightsName string
+param retentionInDays int
+param tags object
+
+// Log Analytics Workspace (required backend for Application Insights)
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: logAnalyticsName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: retentionInDays
+    features: {
+      enableLogAccessUsingOnlyResourcePermissions: true
+    }
+    workspaceCapping: {
+      dailyQuotaGb: -1 // No cap
+    }
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+  }
+}
+
+// Application Insights (workspace-based)
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  tags: tags
+  kind: 'other' // 'other' for non-web applications like console apps
+  properties: {
+    Application_Type: 'other'
+    WorkspaceResourceId: logAnalytics.id
+    IngestionMode: 'LogAnalytics'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+    RetentionInDays: retentionInDays
+  }
+}
+
+// Outputs
+output logAnalyticsWorkspaceId string = logAnalytics.id
+output appInsightsName string = appInsights.name
+output appInsightsConnectionString string = appInsights.properties.ConnectionString
+output appInsightsInstrumentationKey string = appInsights.properties.InstrumentationKey

--- a/infrastructure/azure/appinsights.bicep
+++ b/infrastructure/azure/appinsights.bicep
@@ -1,0 +1,57 @@
+// Application Insights infrastructure for ExcelMcp telemetry
+// Deploys: Resource Group, Log Analytics Workspace, Application Insights
+//
+// Deploy with: az deployment sub create --location <location> --template-file appinsights.bicep --parameters appinsights.parameters.json
+
+targetScope = 'subscription'
+
+@description('Name of the resource group to create')
+param resourceGroupName string = 'excelmcp-observability'
+
+@description('Azure region for all resources')
+param location string = 'westeurope'
+
+@description('Name of the Log Analytics workspace')
+param logAnalyticsName string = 'excelmcp-logs'
+
+@description('Name of the Application Insights resource')
+param appInsightsName string = 'excelmcp-appinsights'
+
+@description('Data retention in days (30-730)')
+@minValue(30)
+@maxValue(730)
+param retentionInDays int = 90
+
+@description('Tags to apply to all resources')
+param tags object = {
+  project: 'ExcelMcp'
+  purpose: 'Telemetry'
+  managedBy: 'Bicep'
+}
+
+// Resource Group
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: resourceGroupName
+  location: location
+  tags: tags
+}
+
+// Deploy resources into the resource group
+module observability 'appinsights-resources.bicep' = {
+  name: 'observability-deployment'
+  scope: rg
+  params: {
+    location: location
+    logAnalyticsName: logAnalyticsName
+    appInsightsName: appInsightsName
+    retentionInDays: retentionInDays
+    tags: tags
+  }
+}
+
+// Outputs
+output resourceGroupName string = rg.name
+output logAnalyticsWorkspaceId string = observability.outputs.logAnalyticsWorkspaceId
+output appInsightsName string = observability.outputs.appInsightsName
+output appInsightsConnectionString string = observability.outputs.appInsightsConnectionString
+output appInsightsInstrumentationKey string = observability.outputs.appInsightsInstrumentationKey

--- a/infrastructure/azure/appinsights.parameters.json
+++ b/infrastructure/azure/appinsights.parameters.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceGroupName": {
+      "value": "excelmcp-observability"
+    },
+    "location": {
+      "value": "swedencentral"
+    },
+    "logAnalyticsName": {
+      "value": "excelmcp-logs"
+    },
+    "appInsightsName": {
+      "value": "excelmcp-appinsights"
+    },
+    "retentionInDays": {
+      "value": 90
+    },
+    "tags": {
+      "value": {
+        "project": "ExcelMcp",
+        "purpose": "Telemetry",
+        "managedBy": "Bicep"
+      }
+    }
+  }
+}

--- a/infrastructure/azure/deploy-appinsights.ps1
+++ b/infrastructure/azure/deploy-appinsights.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+    Deploys Application Insights infrastructure for ExcelMcp telemetry.
+
+.DESCRIPTION
+    Deploys a resource group with Log Analytics Workspace and Application Insights
+    for collecting usage analytics and crash reports from the MCP Server.
+
+.PARAMETER Location
+    Azure region for deployment. Default: westeurope
+
+.PARAMETER ParameterFile
+    Path to the parameters JSON file. Default: appinsights.parameters.json
+
+.PARAMETER WhatIf
+    Shows what would be deployed without making changes.
+
+.EXAMPLE
+    .\deploy-appinsights.ps1
+
+.EXAMPLE
+    .\deploy-appinsights.ps1 -Location "eastus" -WhatIf
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter()]
+    [string]$Location = "swedencentral",
+
+    [Parameter()]
+    [string]$ParameterFile = "appinsights.parameters.json"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Ensure we're in the right directory
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $scriptDir
+
+try {
+    Write-Host "`n=== ExcelMcp Application Insights Deployment ===" -ForegroundColor Cyan
+    Write-Host "Location: $Location"
+    Write-Host "Parameters: $ParameterFile`n"
+
+    # Check prerequisites
+    Write-Host "Checking prerequisites..." -ForegroundColor Yellow
+
+    # Check Azure CLI
+    $azVersion = az version 2>$null | ConvertFrom-Json
+    if (-not $azVersion) {
+        throw "Azure CLI not found. Install from: https://aka.ms/installazurecli"
+    }
+    Write-Host "  Azure CLI: $($azVersion.'azure-cli')" -ForegroundColor Green
+
+    # Check logged in
+    $account = az account show 2>$null | ConvertFrom-Json
+    if (-not $account) {
+        Write-Host "  Not logged in. Running 'az login'..." -ForegroundColor Yellow
+        az login
+        $account = az account show | ConvertFrom-Json
+    }
+    Write-Host "  Subscription: $($account.name) ($($account.id))" -ForegroundColor Green
+
+    # Validate template
+    Write-Host "`nValidating Bicep template..." -ForegroundColor Yellow
+    $validation = az deployment sub validate `
+        --location $Location `
+        --template-file "appinsights.bicep" `
+        --parameters $ParameterFile `
+        2>&1
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Template validation failed: $validation"
+    }
+    Write-Host "  Template is valid" -ForegroundColor Green
+
+    # Deploy
+    if ($WhatIf -or $PSCmdlet.ShouldProcess("Azure subscription", "Deploy Application Insights infrastructure")) {
+
+        if ($WhatIf) {
+            Write-Host "`nWhat-If deployment (no changes will be made)..." -ForegroundColor Yellow
+            az deployment sub what-if `
+                --location $Location `
+                --template-file "appinsights.bicep" `
+                --parameters $ParameterFile
+        }
+        else {
+            Write-Host "`nDeploying resources..." -ForegroundColor Yellow
+            $deployment = az deployment sub create `
+                --location $Location `
+                --template-file "appinsights.bicep" `
+                --parameters $ParameterFile `
+                --name "excelmcp-appinsights-$(Get-Date -Format 'yyyyMMdd-HHmmss')" `
+                | ConvertFrom-Json
+
+            if ($LASTEXITCODE -ne 0) {
+                throw "Deployment failed"
+            }
+
+            # Extract outputs
+            $outputs = $deployment.properties.outputs
+            $connectionString = $outputs.appInsightsConnectionString.value
+            $instrumentationKey = $outputs.appInsightsInstrumentationKey.value
+            $resourceGroup = $outputs.resourceGroupName.value
+            $appInsightsName = $outputs.appInsightsName.value
+
+            Write-Host "`n=== Deployment Successful ===" -ForegroundColor Green
+            Write-Host "Resource Group: $resourceGroup"
+            Write-Host "Application Insights: $appInsightsName"
+            Write-Host ""
+            Write-Host "Connection String (for embedding in code):" -ForegroundColor Cyan
+            Write-Host $connectionString -ForegroundColor White
+            Write-Host ""
+            Write-Host "Instrumentation Key (legacy):" -ForegroundColor Cyan
+            Write-Host $instrumentationKey -ForegroundColor White
+            Write-Host ""
+            Write-Host "=== Next Steps ===" -ForegroundColor Yellow
+            Write-Host "1. Copy the connection string above"
+            Write-Host "2. Add it to src/ExcelMcp.McpServer/Telemetry/ExcelMcpTelemetry.cs"
+            Write-Host "3. Build and test the MCP Server"
+            Write-Host "4. View telemetry at: https://portal.azure.com/#@/resource/subscriptions/$($account.id)/resourceGroups/$resourceGroup/providers/Microsoft.Insights/components/$appInsightsName/overview"
+            Write-Host ""
+
+            # Save connection string to file for reference (gitignored)
+            $secretsFile = "appinsights.secrets.local"
+            @{
+                ConnectionString = $connectionString
+                InstrumentationKey = $instrumentationKey
+                ResourceGroup = $resourceGroup
+                AppInsightsName = $appInsightsName
+                DeployedAt = (Get-Date).ToString("o")
+            } | ConvertTo-Json | Out-File $secretsFile -Encoding utf8
+
+            Write-Host "Connection string saved to: $secretsFile (add to .gitignore!)" -ForegroundColor Yellow
+        }
+    }
+}
+catch {
+    Write-Host "`nError: $_" -ForegroundColor Red
+    exit 1
+}
+finally {
+    Pop-Location
+}

--- a/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
+++ b/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
@@ -79,6 +79,10 @@
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+    <!-- OpenTelemetry for Application Insights telemetry -->
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -1,6 +1,9 @@
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Trace;
+using Sbroenne.ExcelMcp.McpServer.Telemetry;
 
 namespace Sbroenne.ExcelMcp.McpServer;
 
@@ -13,6 +16,9 @@ public class Program
 {
     public static async Task Main(string[] args)
     {
+        // Register global exception handlers for unhandled exceptions (telemetry)
+        RegisterGlobalExceptionHandlers();
+
         var builder = Host.CreateApplicationBuilder(args);
 
         // Configure logging to stderr for MCP protocol compliance
@@ -20,6 +26,9 @@ public class Program
         {
             consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
         });
+
+        // Configure OpenTelemetry for Application Insights (if not opted out)
+        ConfigureTelemetry(builder);
 
         // MCP Server architecture:
         // - Batch session management: LLM controls workbook lifecycle via begin/commit tools
@@ -39,5 +48,72 @@ public class Program
         await host.RunAsync();
     }
 
+    /// <summary>
+    /// Configures OpenTelemetry with Azure Monitor exporter for Application Insights.
+    /// Respects opt-out via EXCELMCP_TELEMETRY_OPTOUT environment variable.
+    /// </summary>
+    private static void ConfigureTelemetry(HostApplicationBuilder builder)
+    {
+        // Check if telemetry is enabled
+        if (ExcelMcpTelemetry.IsOptedOut())
+        {
+            return; // User opted out
+        }
 
+        // Debug mode: log telemetry to stderr instead of Azure (for local testing)
+        var isDebugMode = ExcelMcpTelemetry.IsDebugMode();
+
+        var connectionString = ExcelMcpTelemetry.GetConnectionString();
+        if (string.IsNullOrEmpty(connectionString) && !isDebugMode)
+        {
+            return; // No connection string available and not in debug mode
+        }
+
+        // Configure OpenTelemetry
+        builder.Services.AddOpenTelemetry()
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddSource(ExcelMcpTelemetry.ActivitySource.Name)
+                    .AddProcessor(new SensitiveDataRedactingProcessor());
+
+                if (isDebugMode)
+                {
+                    // Debug mode: write to stderr (console) for local testing
+                    tracing.AddConsoleExporter();
+                    Console.Error.WriteLine("[Telemetry] Debug mode enabled - logging to stderr");
+                }
+                else
+                {
+                    // Production: send to Azure Monitor
+                    tracing.AddAzureMonitorTraceExporter(options =>
+                    {
+                        options.ConnectionString = connectionString;
+                    });
+                }
+            });
+    }
+
+    /// <summary>
+    /// Registers global exception handlers to capture unhandled exceptions.
+    /// </summary>
+    private static void RegisterGlobalExceptionHandlers()
+    {
+        // Handle exceptions that escape all catch blocks
+        AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
+        {
+            if (e.ExceptionObject is Exception ex)
+            {
+                ExcelMcpTelemetry.TrackUnhandledException(ex, "AppDomain.UnhandledException");
+            }
+        };
+
+        // Handle unobserved task exceptions
+        TaskScheduler.UnobservedTaskException += (sender, e) =>
+        {
+            ExcelMcpTelemetry.TrackUnhandledException(e.Exception, "TaskScheduler.UnobservedTaskException");
+            // Don't observe it - let the runtime handle it
+        };
+    }
 }
+

--- a/src/ExcelMcp.McpServer/Telemetry/ExcelMcpTelemetry.cs
+++ b/src/ExcelMcp.McpServer/Telemetry/ExcelMcpTelemetry.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Sbroenne.ExcelMcp.McpServer.Telemetry;
+
+/// <summary>
+/// Centralized telemetry helper for ExcelMcp MCP Server.
+/// Provides usage tracking and unhandled exception reporting via OpenTelemetry.
+/// </summary>
+public static class ExcelMcpTelemetry
+{
+    /// <summary>
+    /// The ActivitySource for creating traces.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new("ExcelMcp.McpServer", GetVersion());
+
+    /// <summary>
+    /// Environment variable to opt-out of telemetry.
+    /// Set to "true" or "1" to disable telemetry.
+    /// </summary>
+    public const string OptOutEnvironmentVariable = "EXCELMCP_TELEMETRY_OPTOUT";
+
+    /// <summary>
+    /// Environment variable to enable debug mode (console output instead of Azure).
+    /// Set to "true" or "1" for local testing without Azure resources.
+    /// </summary>
+    public const string DebugTelemetryEnvironmentVariable = "EXCELMCP_DEBUG_TELEMETRY";
+
+    /// <summary>
+    /// Application Insights connection string (embedded at build time).
+    /// </summary>
+    /// <remarks>
+    /// This value is replaced during CI/CD build from the APPINSIGHTS_CONNECTION_STRING secret.
+    /// Format: InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/;...
+    /// </remarks>
+    private const string ConnectionString = "__APPINSIGHTS_CONNECTION_STRING__";
+
+    /// <summary>
+    /// Unique session ID for correlating telemetry within a single MCP server process.
+    /// </summary>
+    public static readonly string SessionId = Guid.NewGuid().ToString("N")[..8];
+
+    private static bool? _isEnabled;
+
+    /// <summary>
+    /// Gets whether telemetry is enabled (not opted out and either debug mode or connection string available).
+    /// </summary>
+    public static bool IsEnabled
+    {
+        get
+        {
+            _isEnabled ??= !IsOptedOut() && (IsDebugMode() || !string.IsNullOrEmpty(GetConnectionString()));
+            return _isEnabled.Value;
+        }
+    }
+
+    /// <summary>
+    /// Checks if debug telemetry mode is enabled (console output for local testing).
+    /// </summary>
+    public static bool IsDebugMode()
+    {
+        var debug = Environment.GetEnvironmentVariable(DebugTelemetryEnvironmentVariable);
+        return string.Equals(debug, "true", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(debug, "1", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Gets the Application Insights connection string (embedded at build time).
+    /// </summary>
+    public static string? GetConnectionString()
+    {
+        // Connection string is embedded at build time via CI/CD
+        // Returns null if placeholder wasn't replaced (local dev builds)
+        return ConnectionString.StartsWith("__", StringComparison.Ordinal) ? null : ConnectionString;
+    }
+
+    /// <summary>
+    /// Checks if user has opted out of telemetry via environment variable.
+    /// </summary>
+    public static bool IsOptedOut()
+    {
+        var optOut = Environment.GetEnvironmentVariable(OptOutEnvironmentVariable);
+        return string.Equals(optOut, "true", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(optOut, "1", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Tracks a tool invocation with usage metrics.
+    /// </summary>
+    /// <param name="toolName">The MCP tool name (e.g., "excel_range")</param>
+    /// <param name="action">The action performed (e.g., "get-values")</param>
+    /// <param name="durationMs">Duration in milliseconds</param>
+    /// <param name="success">Whether the operation succeeded</param>
+    public static void TrackToolInvocation(string toolName, string action, long durationMs, bool success)
+    {
+        if (!IsEnabled) return;
+
+        using var activity = ActivitySource.StartActivity("ToolInvocation", ActivityKind.Internal);
+        if (activity == null) return;
+
+        activity.SetTag("tool.name", toolName);
+        activity.SetTag("tool.action", action);
+        activity.SetTag("tool.duration_ms", durationMs);
+        activity.SetTag("tool.success", success);
+        activity.SetTag("session.id", SessionId);
+        activity.SetTag("app.version", GetVersion());
+
+        activity.SetStatus(success ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
+    }
+
+    /// <summary>
+    /// Tracks an unhandled exception.
+    /// Only call this for exceptions that escape all catch blocks (true bugs/crashes).
+    /// </summary>
+    /// <param name="exception">The unhandled exception</param>
+    /// <param name="source">Source of the exception (e.g., "AppDomain.UnhandledException")</param>
+    public static void TrackUnhandledException(Exception exception, string source)
+    {
+        if (!IsEnabled || exception == null) return;
+
+        using var activity = ActivitySource.StartActivity("UnhandledException", ActivityKind.Internal);
+        if (activity == null) return;
+
+        // Redact sensitive data from exception
+        var (type, message, stackTrace) = SensitiveDataRedactingProcessor.RedactException(exception);
+
+        activity.SetTag("exception.type", type);
+        activity.SetTag("exception.message", message);
+        activity.SetTag("exception.source", source);
+        activity.SetTag("session.id", SessionId);
+        activity.SetTag("app.version", GetVersion());
+
+        if (stackTrace != null)
+        {
+            // Truncate stack trace to avoid exceeding limits
+            const int maxStackTraceLength = 4096;
+            if (stackTrace.Length > maxStackTraceLength)
+            {
+                stackTrace = stackTrace[..maxStackTraceLength] + "... [truncated]";
+            }
+            activity.SetTag("exception.stacktrace", stackTrace);
+        }
+
+        activity.SetStatus(ActivityStatusCode.Error, message);
+
+        // Record as exception event
+        activity.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
+        {
+            { "exception.type", type },
+            { "exception.message", message }
+        }));
+    }
+
+    /// <summary>
+    /// Gets the application version from assembly metadata.
+    /// </summary>
+    private static string GetVersion()
+    {
+        return Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+            ?? "1.0.0";
+    }
+}

--- a/src/ExcelMcp.McpServer/Telemetry/SensitiveDataRedactingProcessor.cs
+++ b/src/ExcelMcp.McpServer/Telemetry/SensitiveDataRedactingProcessor.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using OpenTelemetry;
+
+namespace Sbroenne.ExcelMcp.McpServer.Telemetry;
+
+/// <summary>
+/// OpenTelemetry processor that redacts sensitive data from all telemetry
+/// before it leaves the process. Removes file paths, connection strings,
+/// credentials, and other PII.
+/// </summary>
+public sealed partial class SensitiveDataRedactingProcessor : BaseProcessor<Activity>
+{
+    // Patterns for sensitive data detection
+    private static readonly Regex FilePathPattern = CreateFilePathRegex();
+    private static readonly Regex UncPathPattern = CreateUncPathRegex();
+    private static readonly Regex ConnectionStringSecretPattern = CreateConnectionStringSecretRegex();
+    private static readonly Regex CredentialPattern = CreateCredentialRegex();
+    private static readonly Regex EmailPattern = CreateEmailRegex();
+
+    // Redaction markers
+    private const string RedactedPath = "[REDACTED_PATH]";
+    private const string RedactedSecret = "[REDACTED]";
+    private const string RedactedEmail = "[REDACTED_EMAIL]";
+
+    /// <inheritdoc/>
+    public override void OnEnd(Activity activity)
+    {
+        if (activity == null) return;
+
+        // Redact display name
+        if (!string.IsNullOrEmpty(activity.DisplayName))
+        {
+            activity.DisplayName = RedactSensitiveData(activity.DisplayName);
+        }
+
+        // Redact all tags (custom properties)
+        foreach (var tag in activity.TagObjects.ToList())
+        {
+            if (tag.Value is string stringValue && !string.IsNullOrEmpty(stringValue))
+            {
+                var redacted = RedactSensitiveData(stringValue);
+                if (redacted != stringValue)
+                {
+                    activity.SetTag(tag.Key, redacted);
+                }
+            }
+        }
+
+        // Note: Activity events are immutable structs, so we cannot modify exception details
+        // in events. Exception messages are already redacted through tags above.
+
+        base.OnEnd(activity);
+    }
+
+    /// <summary>
+    /// Redacts all sensitive data from the given string.
+    /// </summary>
+    public static string RedactSensitiveData(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        var result = value;
+
+        // Redact file paths (Windows drive letters)
+        result = FilePathPattern.Replace(result, RedactedPath);
+
+        // Redact UNC paths
+        result = UncPathPattern.Replace(result, RedactedPath);
+
+        // Redact connection string secrets (Password=, pwd=, secret=, key=, token=)
+        result = ConnectionStringSecretPattern.Replace(result, match =>
+            $"{match.Groups[1].Value}={RedactedSecret}");
+
+        // Redact credentials in URLs (user:pass@host)
+        result = CredentialPattern.Replace(result, match =>
+            $"{match.Groups[1].Value}{RedactedSecret}@{match.Groups[2].Value}");
+
+        // Redact email addresses
+        result = EmailPattern.Replace(result, RedactedEmail);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Redacts sensitive data from an exception for safe logging.
+    /// Returns exception type and redacted message.
+    /// </summary>
+    public static (string Type, string Message, string? StackTrace) RedactException(Exception ex)
+    {
+        var type = ex.GetType().Name;
+        var message = RedactSensitiveData(ex.Message);
+        var stackTrace = ex.StackTrace != null ? RedactSensitiveData(ex.StackTrace) : null;
+
+        return (type, message, stackTrace);
+    }
+
+    // Source-generated regex for better performance
+
+    [GeneratedRegex(@"[A-Za-z]:\\[^\s""'<>|*?\r\n]+", RegexOptions.Compiled)]
+    private static partial Regex CreateFilePathRegex();
+
+    [GeneratedRegex(@"\\\\[^\s""'<>|*?\r\n]+", RegexOptions.Compiled)]
+    private static partial Regex CreateUncPathRegex();
+
+    [GeneratedRegex(@"(Password|pwd|secret|key|token|apikey|api_key|access_token|connectionstring)\s*=\s*[^;""'\s]+", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex CreateConnectionStringSecretRegex();
+
+    [GeneratedRegex(@"(https?://)[^:]+:[^@]+@([^\s/]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex CreateCredentialRegex();
+
+    [GeneratedRegex(@"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", RegexOptions.Compiled)]
+    private static partial Regex CreateEmailRegex();
+}

--- a/src/ExcelMcp.McpServer/Tools/ExcelChartTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelChartTool.cs
@@ -87,6 +87,7 @@ public static class ExcelChartTool
         int? styleId = null)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_chart",
             action.ToActionString(),
             excelPath,
             () =>

--- a/src/ExcelMcp.McpServer/Tools/ExcelConditionalFormatTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelConditionalFormatTool.cs
@@ -88,6 +88,7 @@ Example: Highlight cells > 100 in red:
         string? borderColor = null)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_conditionalformat",
             action.ToActionString(),
             excelPath,
             () =>

--- a/src/ExcelMcp.McpServer/Tools/ExcelConnectionTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelConnectionTool.cs
@@ -96,6 +96,7 @@ TIMEOUT SAFEGUARD:
         int? refreshPeriod = null)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_connection",
             action.ToActionString(),
             excelPath,
             () =>

--- a/src/ExcelMcp.McpServer/Tools/ExcelDataModelTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelDataModelTool.cs
@@ -84,46 +84,41 @@ public static class ExcelDataModelTool
         bool? isActive = null)
     {
         _ = excelPath; // retained for schema compatibility (operations require open session)
-        try
-        {
-            var dataModelCommands = new DataModelCommands();
 
-            // Switch directly on enum for compile-time exhaustiveness checking (CS8524)
-            return action switch
+        return ExcelToolsBase.ExecuteToolAction(
+            "excel_datamodel",
+            action.ToActionString(),
+            () =>
             {
-                // Discovery operations
-                DataModelAction.ListTables => ListTablesAsync(dataModelCommands, sessionId),
-                DataModelAction.ListMeasures => ListMeasuresAsync(dataModelCommands, sessionId),
-                DataModelAction.Read => ReadMeasureAsync(dataModelCommands, sessionId, measureName),
-                DataModelAction.ListRelationships => ListRelationshipsAsync(dataModelCommands, sessionId),
-                DataModelAction.Refresh => RefreshAsync(dataModelCommands, sessionId),
-                DataModelAction.DeleteMeasure => DeleteMeasureAsync(dataModelCommands, sessionId, measureName),
-                DataModelAction.DeleteRelationship => DeleteRelationshipAsync(dataModelCommands, sessionId, fromTable, fromColumn, toTable, toColumn),
-                DataModelAction.ReadTable => ReadTableAsync(dataModelCommands, sessionId, tableName),
-                DataModelAction.ListColumns => ListColumnsAsync(dataModelCommands, sessionId, tableName),
-                DataModelAction.ReadInfo => ReadModelInfoAsync(dataModelCommands, sessionId),
+                var dataModelCommands = new DataModelCommands();
 
-                // DAX measures (requires Office 2016+)
-                DataModelAction.CreateMeasure => CreateMeasureComAsync(dataModelCommands, sessionId, tableName, measureName, daxFormula, formatString, description),
-                DataModelAction.UpdateMeasure => UpdateMeasureComAsync(dataModelCommands, sessionId, measureName, daxFormula, formatString, description),
+                // Switch directly on enum for compile-time exhaustiveness checking (CS8524)
+                return action switch
+                {
+                    // Discovery operations
+                    DataModelAction.ListTables => ListTablesAsync(dataModelCommands, sessionId),
+                    DataModelAction.ListMeasures => ListMeasuresAsync(dataModelCommands, sessionId),
+                    DataModelAction.Read => ReadMeasureAsync(dataModelCommands, sessionId, measureName),
+                    DataModelAction.ListRelationships => ListRelationshipsAsync(dataModelCommands, sessionId),
+                    DataModelAction.Refresh => RefreshAsync(dataModelCommands, sessionId),
+                    DataModelAction.DeleteMeasure => DeleteMeasureAsync(dataModelCommands, sessionId, measureName),
+                    DataModelAction.DeleteRelationship => DeleteRelationshipAsync(dataModelCommands, sessionId, fromTable, fromColumn, toTable, toColumn),
+                    DataModelAction.ReadTable => ReadTableAsync(dataModelCommands, sessionId, tableName),
+                    DataModelAction.ListColumns => ListColumnsAsync(dataModelCommands, sessionId, tableName),
+                    DataModelAction.ReadInfo => ReadModelInfoAsync(dataModelCommands, sessionId),
 
-                // Relationships (requires Office 2016+)
-                DataModelAction.CreateRelationship => CreateRelationshipComAsync(dataModelCommands, sessionId, fromTable, fromColumn, toTable, toColumn, isActive),
-                DataModelAction.UpdateRelationship => UpdateRelationshipComAsync(dataModelCommands, sessionId, fromTable, fromColumn, toTable, toColumn, isActive),
+                    // DAX measures (requires Office 2016+)
+                    DataModelAction.CreateMeasure => CreateMeasureComAsync(dataModelCommands, sessionId, tableName, measureName, daxFormula, formatString, description),
+                    DataModelAction.UpdateMeasure => UpdateMeasureComAsync(dataModelCommands, sessionId, measureName, daxFormula, formatString, description),
 
-                _ => throw new ArgumentException(
-                    $"Unknown action: {action} ({action.ToActionString()})", nameof(action))
-            };
-        }
-        catch (Exception ex)
-        {
-            return JsonSerializer.Serialize(new
-            {
-                success = false,
-                errorMessage = $"{action.ToActionString()} failed: {ex.Message}",
-                isError = true
-            }, ExcelToolsBase.JsonOptions);
-        }
+                    // Relationships (requires Office 2016+)
+                    DataModelAction.CreateRelationship => CreateRelationshipComAsync(dataModelCommands, sessionId, fromTable, fromColumn, toTable, toColumn, isActive),
+                    DataModelAction.UpdateRelationship => UpdateRelationshipComAsync(dataModelCommands, sessionId, fromTable, fromColumn, toTable, toColumn, isActive),
+
+                    _ => throw new ArgumentException(
+                        $"Unknown action: {action} ({action.ToActionString()})", nameof(action))
+                };
+            });
     }
 
     private static string ListTablesAsync(DataModelCommands commands, string sessionId)

--- a/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
@@ -57,6 +57,7 @@ FILE FORMATS:
         bool save = false)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_file",
             action.ToActionString(),
             excelPath,
             () =>

--- a/src/ExcelMcp.McpServer/Tools/ExcelNamedRangeTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelNamedRangeTool.cs
@@ -40,6 +40,7 @@ public static class ExcelNamedRangeTool
         string? value = null)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_namedrange",
             action.ToActionString(),
             excelPath,
             () =>

--- a/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
@@ -108,49 +108,45 @@ public static class ExcelPivotTableTool
         [Description("Show/hide column grand totals: true=show right summary column, false=hide")]
         bool? showColumnGrandTotals = null)
     {
-        var commands = new PivotTableCommands();
+        _ = excelPath; // retained for schema compatibility (operations require open session)
 
-        try
-        {
-            return action switch
+        return ExcelToolsBase.ExecuteToolAction(
+            "excel_pivottable",
+            action.ToActionString(),
+            () =>
             {
-                PivotTableAction.List => List(commands, sessionId),
-                PivotTableAction.Read => Read(commands, sessionId, pivotTableName),
-                PivotTableAction.CreateFromRange => CreateFromRange(commands, sessionId, sheetName, range, destinationSheet, destinationCell, pivotTableName),
-                PivotTableAction.CreateFromTable => CreateFromTable(commands, sessionId, tableName, destinationSheet, destinationCell, pivotTableName),
-                PivotTableAction.CreateFromDataModel => CreateFromDataModel(commands, sessionId, dataModelTableName, destinationSheet, destinationCell, pivotTableName),
-                PivotTableAction.Delete => Delete(commands, sessionId, pivotTableName),
-                PivotTableAction.Refresh => Refresh(commands, sessionId, pivotTableName),
-                PivotTableAction.ListFields => ListFields(commands, sessionId, pivotTableName),
-                PivotTableAction.AddRowField => AddRowField(commands, sessionId, pivotTableName, fieldName, position),
-                PivotTableAction.AddColumnField => AddColumnField(commands, sessionId, pivotTableName, fieldName, position),
-                PivotTableAction.AddValueField => AddValueField(commands, sessionId, pivotTableName, fieldName, aggregationFunction, customName),
-                PivotTableAction.AddFilterField => AddFilterField(commands, sessionId, pivotTableName, fieldName),
-                PivotTableAction.RemoveField => RemoveField(commands, sessionId, pivotTableName, fieldName),
-                PivotTableAction.SetFieldFunction => SetFieldFunction(commands, sessionId, pivotTableName, fieldName, aggregationFunction),
-                PivotTableAction.SetFieldName => SetFieldName(commands, sessionId, pivotTableName, fieldName, customName),
-                PivotTableAction.SetFieldFormat => SetFieldFormat(commands, sessionId, pivotTableName, fieldName, numberFormat),
-                PivotTableAction.GetData => GetData(commands, sessionId, pivotTableName),
-                PivotTableAction.SetFieldFilter => SetFieldFilter(commands, sessionId, pivotTableName, fieldName, filterValues),
-                PivotTableAction.SortField => SortField(commands, sessionId, pivotTableName, fieldName, sortDirection),
-                PivotTableAction.GroupByDate => GroupByDate(commands, sessionId, pivotTableName, fieldName, dateGroupingInterval),
-                PivotTableAction.GroupByNumeric => GroupByNumeric(commands, sessionId, pivotTableName, fieldName, numericGroupingStart, numericGroupingEnd, numericGroupingInterval),
-                PivotTableAction.CreateCalculatedField => CreateCalculatedField(commands, sessionId, pivotTableName, fieldName, formula),
-                PivotTableAction.SetLayout => SetLayout(commands, sessionId, pivotTableName, layout),
-                PivotTableAction.SetSubtotals => SetSubtotals(commands, sessionId, pivotTableName, fieldName, subtotalsVisible),
-                PivotTableAction.SetGrandTotals => SetGrandTotals(commands, sessionId, pivotTableName, showRowGrandTotals, showColumnGrandTotals),
-                _ => throw new ArgumentException($"Unknown action: {action} ({action.ToActionString()})", nameof(action))
-            };
-        }
-        catch (Exception ex)
-        {
-            return JsonSerializer.Serialize(new
-            {
-                success = false,
-                errorMessage = $"{action.ToActionString()} failed for '{excelPath}': {ex.Message}",
-                isError = true
-            }, ExcelToolsBase.JsonOptions);
-        }
+                var commands = new PivotTableCommands();
+
+                return action switch
+                {
+                    PivotTableAction.List => List(commands, sessionId),
+                    PivotTableAction.Read => Read(commands, sessionId, pivotTableName),
+                    PivotTableAction.CreateFromRange => CreateFromRange(commands, sessionId, sheetName, range, destinationSheet, destinationCell, pivotTableName),
+                    PivotTableAction.CreateFromTable => CreateFromTable(commands, sessionId, tableName, destinationSheet, destinationCell, pivotTableName),
+                    PivotTableAction.CreateFromDataModel => CreateFromDataModel(commands, sessionId, dataModelTableName, destinationSheet, destinationCell, pivotTableName),
+                    PivotTableAction.Delete => Delete(commands, sessionId, pivotTableName),
+                    PivotTableAction.Refresh => Refresh(commands, sessionId, pivotTableName),
+                    PivotTableAction.ListFields => ListFields(commands, sessionId, pivotTableName),
+                    PivotTableAction.AddRowField => AddRowField(commands, sessionId, pivotTableName, fieldName, position),
+                    PivotTableAction.AddColumnField => AddColumnField(commands, sessionId, pivotTableName, fieldName, position),
+                    PivotTableAction.AddValueField => AddValueField(commands, sessionId, pivotTableName, fieldName, aggregationFunction, customName),
+                    PivotTableAction.AddFilterField => AddFilterField(commands, sessionId, pivotTableName, fieldName),
+                    PivotTableAction.RemoveField => RemoveField(commands, sessionId, pivotTableName, fieldName),
+                    PivotTableAction.SetFieldFunction => SetFieldFunction(commands, sessionId, pivotTableName, fieldName, aggregationFunction),
+                    PivotTableAction.SetFieldName => SetFieldName(commands, sessionId, pivotTableName, fieldName, customName),
+                    PivotTableAction.SetFieldFormat => SetFieldFormat(commands, sessionId, pivotTableName, fieldName, numberFormat),
+                    PivotTableAction.GetData => GetData(commands, sessionId, pivotTableName),
+                    PivotTableAction.SetFieldFilter => SetFieldFilter(commands, sessionId, pivotTableName, fieldName, filterValues),
+                    PivotTableAction.SortField => SortField(commands, sessionId, pivotTableName, fieldName, sortDirection),
+                    PivotTableAction.GroupByDate => GroupByDate(commands, sessionId, pivotTableName, fieldName, dateGroupingInterval),
+                    PivotTableAction.GroupByNumeric => GroupByNumeric(commands, sessionId, pivotTableName, fieldName, numericGroupingStart, numericGroupingEnd, numericGroupingInterval),
+                    PivotTableAction.CreateCalculatedField => CreateCalculatedField(commands, sessionId, pivotTableName, fieldName, formula),
+                    PivotTableAction.SetLayout => SetLayout(commands, sessionId, pivotTableName, layout),
+                    PivotTableAction.SetSubtotals => SetSubtotals(commands, sessionId, pivotTableName, fieldName, subtotalsVisible),
+                    PivotTableAction.SetGrandTotals => SetGrandTotals(commands, sessionId, pivotTableName, showRowGrandTotals, showColumnGrandTotals),
+                    _ => throw new ArgumentException($"Unknown action: {action} ({action.ToActionString()})", nameof(action))
+                };
+            });
     }
 
     private static string List(

--- a/src/ExcelMcp.McpServer/Tools/ExcelPowerQueryTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelPowerQueryTool.cs
@@ -70,6 +70,7 @@ public static class ExcelPowerQueryTool
         int? refreshTimeoutSeconds = null)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_powerquery",
             action.ToActionString(),
             () =>
             {

--- a/src/ExcelMcp.McpServer/Tools/ExcelRangeTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelRangeTool.cs
@@ -205,6 +205,7 @@ DATA FORMAT:
         bool? locked = null)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_range",
             action.ToActionString(),
             excelPath,
             () =>

--- a/src/ExcelMcp.McpServer/Tools/ExcelTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelTableTool.cs
@@ -74,6 +74,7 @@ public static class TableTool
         bool visibleOnly = false)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_table",
             action.ToActionString(),
             excelPath,
             () =>

--- a/src/ExcelMcp.McpServer/Tools/ExcelVbaTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelVbaTool.cs
@@ -57,6 +57,7 @@ public static class ExcelVbaTool
         string? parameters = null)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_vba",
             action.ToActionString(),
             excelPath,
             () =>

--- a/src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs
@@ -94,6 +94,7 @@ POSITIONING (move, copy, copy-to-workbook, move-to-workbook):
         string? visibility = null)
     {
         return ExcelToolsBase.ExecuteToolAction(
+            "excel_worksheet",
             action.ToActionString(),
             () =>
             {

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., 'Directory.Build.props'))\Directory.Build.props" />
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Use test.runsettings for all test projects (enables debug telemetry) -->
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 </Project>

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/TelemetryIntegrationTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/TelemetryIntegrationTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using Sbroenne.ExcelMcp.McpServer.Models;
+using Sbroenne.ExcelMcp.McpServer.Telemetry;
+using Sbroenne.ExcelMcp.McpServer.Tools;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+/// <summary>
+/// Integration test that demonstrates telemetry output during tool invocations.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Telemetry")]
+public class TelemetryIntegrationTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly TracerProvider _tracerProvider;
+    private readonly List<Activity> _capturedActivities = [];
+
+    public TelemetryIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+
+        // Configure OpenTelemetry to capture activities for testing
+        _tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ExcelMcpTelemetry.ActivitySource.Name)
+            .AddProcessor(new SensitiveDataRedactingProcessor())
+            .AddProcessor(new TestActivityProcessor(_capturedActivities, _output))
+            .Build()!;
+    }
+
+    public void Dispose()
+    {
+        _tracerProvider.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void ToolInvocation_TracksToTelemetry()
+    {
+        _output.WriteLine("=== TELEMETRY INTEGRATION TEST ===\n");
+
+        // Act - call a tool method that uses ExecuteToolAction
+        // Using Test action since it doesn't require an actual file
+        var result = ExcelFileTool.ExcelFile(
+            FileAction.Test,
+            excelPath: "C:\\fake\\test.xlsx",
+            sessionId: null);
+
+        _output.WriteLine($"\nTool result: {result[..Math.Min(200, result.Length)]}...\n");
+
+        // Assert - telemetry was captured
+        Assert.NotEmpty(_capturedActivities);
+
+        var activity = _capturedActivities.First();
+        _output.WriteLine("=== CAPTURED TELEMETRY ===");
+        _output.WriteLine($"Activity Name: {activity.DisplayName}");
+        _output.WriteLine($"Duration: {activity.Duration.TotalMilliseconds:F2}ms");
+        _output.WriteLine($"Status: {activity.Status}");
+        _output.WriteLine("Tags:");
+        foreach (var tag in activity.TagObjects)
+        {
+            _output.WriteLine($"  {tag.Key}: {tag.Value}");
+        }
+    }
+
+    /// <summary>
+    /// Simple processor that captures activities and logs them to test output.
+    /// </summary>
+    private sealed class TestActivityProcessor(List<Activity> activities, ITestOutputHelper output)
+        : BaseProcessor<Activity>
+    {
+        public override void OnEnd(Activity activity)
+        {
+            activities.Add(activity);
+            output.WriteLine($"[TELEMETRY] {activity.DisplayName} - {activity.Duration.TotalMilliseconds:F2}ms - {activity.Status}");
+            base.OnEnd(activity);
+        }
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Unit/TelemetryTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/TelemetryTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using Sbroenne.ExcelMcp.McpServer.Telemetry;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
+
+/// <summary>
+/// Tests for telemetry configuration and sensitive data redaction.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Telemetry")]
+public class TelemetryTests
+{
+    #region ExcelMcpTelemetry Tests
+
+    [Fact]
+    public void SessionId_IsNotEmpty()
+    {
+        // Session ID should be generated on startup
+        Assert.False(string.IsNullOrEmpty(ExcelMcpTelemetry.SessionId));
+    }
+
+    [Fact]
+    public void SessionId_IsEightCharacters()
+    {
+        // Session ID should be first 8 chars of GUID
+        Assert.Equal(8, ExcelMcpTelemetry.SessionId.Length);
+    }
+
+    [Fact]
+    public void GetConnectionString_ReturnsNullForPlaceholder()
+    {
+        // The placeholder should not be treated as a valid connection string
+        // (In dev builds, it's "__APPINSIGHTS_CONNECTION_STRING__")
+        var connectionString = ExcelMcpTelemetry.GetConnectionString();
+
+        // Either null (placeholder) or a real connection string (CI build)
+        // We can't assert null directly because CI might inject a real one
+        if (connectionString != null)
+        {
+            Assert.DoesNotContain("__", connectionString);
+        }
+    }
+
+    [Fact]
+    public void ActivitySource_HasCorrectName()
+    {
+        Assert.Equal("ExcelMcp.McpServer", ExcelMcpTelemetry.ActivitySource.Name);
+    }
+
+    [Fact]
+    public void OptOutEnvironmentVariable_HasCorrectName()
+    {
+        Assert.Equal("EXCELMCP_TELEMETRY_OPTOUT", ExcelMcpTelemetry.OptOutEnvironmentVariable);
+    }
+
+    [Fact]
+    public void DebugTelemetryEnvironmentVariable_HasCorrectName()
+    {
+        Assert.Equal("EXCELMCP_DEBUG_TELEMETRY", ExcelMcpTelemetry.DebugTelemetryEnvironmentVariable);
+    }
+
+    #endregion
+
+    #region SensitiveDataRedactingProcessor Tests
+
+    [Theory]
+    [InlineData(@"C:\Users\john\Documents\file.xlsx", "[REDACTED_PATH]")]
+    [InlineData(@"D:\source\project\data.csv", "[REDACTED_PATH]")]
+    [InlineData(@"E:\folder\subfolder\test.txt", "[REDACTED_PATH]")]
+    public void RedactSensitiveData_RedactsWindowsPaths(string input, string expected)
+    {
+        var result = SensitiveDataRedactingProcessor.RedactSensitiveData(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(@"\\server\share\file.xlsx", "[REDACTED_PATH]")]
+    [InlineData(@"\\192.168.1.1\data\report.csv", "[REDACTED_PATH]")]
+    [InlineData(@"\\company.local\shared\docs\file.txt", "[REDACTED_PATH]")]
+    public void RedactSensitiveData_RedactsUncPaths(string input, string expected)
+    {
+        var result = SensitiveDataRedactingProcessor.RedactSensitiveData(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("Password=secret123", "Password=[REDACTED]")]
+    [InlineData("pwd=mypassword", "pwd=[REDACTED]")]
+    [InlineData("User Id=admin;Password=secret", "User Id=admin;Password=[REDACTED]")]
+    public void RedactSensitiveData_RedactsPasswords(string input, string expected)
+    {
+        var result = SensitiveDataRedactingProcessor.RedactSensitiveData(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("user@example.com", "[REDACTED_EMAIL]")]
+    [InlineData("john.doe@company.org", "[REDACTED_EMAIL]")]
+    [InlineData("Contact: admin@test.co.uk for help", "Contact: [REDACTED_EMAIL] for help")]
+    public void RedactSensitiveData_RedactsEmails(string input, string expected)
+    {
+        var result = SensitiveDataRedactingProcessor.RedactSensitiveData(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("https://user:pass@server.com/api", "https://[REDACTED]@server.com/api")]
+    [InlineData("http://admin:secret123@localhost:8080", "http://[REDACTED]@localhost:8080")]
+    public void RedactSensitiveData_RedactsUrlCredentials(string input, string expected)
+    {
+        var result = SensitiveDataRedactingProcessor.RedactSensitiveData(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("Operation completed successfully", "Operation completed successfully")]
+    [InlineData("Error code 500", "Error code 500")]
+    [InlineData("Range A1:B10", "Range A1:B10")]
+    public void RedactSensitiveData_PreservesNonSensitiveData(string input, string expected)
+    {
+        var result = SensitiveDataRedactingProcessor.RedactSensitiveData(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void RedactSensitiveData_HandlesEmptyInput()
+    {
+        var result = SensitiveDataRedactingProcessor.RedactSensitiveData(string.Empty);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void RedactSensitiveData_RedactsMultipleSensitiveItems()
+    {
+        var input = @"Error accessing C:\Users\john\file.xlsx: user@example.com failed with Password=secret";
+        var result = SensitiveDataRedactingProcessor.RedactSensitiveData(input);
+
+        Assert.DoesNotContain(@"C:\Users", result);
+        Assert.DoesNotContain("user@example.com", result);
+        Assert.DoesNotContain("Password=secret", result);
+        Assert.Contains("[REDACTED_PATH]", result);
+        Assert.Contains("[REDACTED_EMAIL]", result);
+        Assert.Contains("[REDACTED]", result);
+    }
+
+    [Fact]
+    public void RedactException_RedactsExceptionMessage()
+    {
+        var exception = new InvalidOperationException(@"Failed to open C:\Users\admin\secret.xlsx");
+
+        var (type, message, _) = SensitiveDataRedactingProcessor.RedactException(exception);
+
+        Assert.Equal("InvalidOperationException", type);
+        Assert.Contains("[REDACTED_PATH]", message);
+        Assert.DoesNotContain(@"C:\Users", message);
+    }
+
+    [Fact]
+    public void RedactException_PreservesExceptionType()
+    {
+        var exception = new ArgumentException("Test error");
+
+        var (type, message, _) = SensitiveDataRedactingProcessor.RedactException(exception);
+
+        Assert.Equal("ArgumentException", type);
+        Assert.Equal("Test error", message);
+    }
+
+    [Fact]
+    public void RedactException_RedactsStackTrace()
+    {
+        InvalidOperationException caughtException;
+        try
+        {
+            // Create exception with stack trace containing path
+            throw new InvalidOperationException(@"Error at C:\Users\test\file.cs line 42");
+        }
+        catch (InvalidOperationException ex)
+        {
+            caughtException = ex;
+        }
+
+        var (_, message, stackTrace) = SensitiveDataRedactingProcessor.RedactException(caughtException);
+
+        Assert.Contains("[REDACTED_PATH]", message);
+        // Stack trace will contain the actual test file path which should be redacted
+        if (stackTrace != null)
+        {
+            // The stack trace contains this test file's path
+            Assert.DoesNotContain(@"C:\Users", stackTrace);
+        }
+    }
+
+    #endregion
+}

--- a/tests/test.runsettings
+++ b/tests/test.runsettings
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Enable debug telemetry during test runs (logs to console instead of Azure) -->
+    <EnvironmentVariables>
+      <EXCELMCP_DEBUG_TELEMETRY>true</EXCELMCP_DEBUG_TELEMETRY>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
## Summary

Adds Application Insights telemetry to MCP Server using OpenTelemetry, following Microsoft recommendations.

## What's Included

### Telemetry Infrastructure
- **OpenTelemetry + Azure Monitor** - Industry-standard telemetry via \Azure.Monitor.OpenTelemetry.Exporter\
- **SensitiveDataRedactingProcessor** - Protects file paths, connection strings, and user data
- **Opt-out support** - \EXCELMCP_TELEMETRY_OPTOUT=true\ to disable
- **Debug mode** - \EXCELMCP_DEBUG_TELEMETRY=true\ for local console output

### Tracked Metrics
- Tool invocations (tool name, action, duration, success)
- Unhandled exceptions (type, redacted message, source)
- Session correlation (per-process session ID)
- App version tracking

### Build & Deploy
- Build-time connection string injection (no runtime override)
- GitHub secret \APPINSIGHTS_CONNECTION_STRING\ configured
- Bicep templates for Azure resource deployment

### Tests
- 28 unit tests for telemetry components
- 1 integration test demonstrating telemetry capture
- test.runsettings for auto-enabling debug telemetry in tests

### Documentation
- Developer docs updated in DEVELOPMENT.md
- Azure deployment scripts in infrastructure/azure/

## Privacy & Security
- **No confidential data logged** - Only tool names, actions, durations, success flags
- **Sensitive data redaction** - File paths, connection strings, passwords redacted
- **Write-only access** - Connection string only allows sending telemetry
- **Opt-out model** - Users can disable via environment variable

## Files Changed
- 29 files changed, 1217 insertions(+), 83 deletions(-)

Closes #239