### PR TITLE
feat(telemetry): Switch to Application Insights SDK for full Usage analytics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,13 +8,13 @@
     <PackageVersion Include="Microsoft.AnalysisServices" Version="19.106.1" />
     <!-- UI Framework -->
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
     <!-- Microsoft Extensions for MCP Server -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <!-- OpenTelemetry for Application Insights -->
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <!-- Application Insights SDK for telemetry (Users, Sessions, Funnels, User Flows) -->
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.414",
+    "version": "8.0.416",
     "rollForward": "latestFeature"
   }
 }

--- a/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
+++ b/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
@@ -79,10 +79,8 @@
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <!-- OpenTelemetry for Application Insights telemetry -->
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <!-- Application Insights SDK for telemetry (Users, Sessions, Funnels, User Flows) -->
+    <PackageReference Include="Microsoft.ApplicationInsights" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/ExcelMcp.McpServer/Telemetry/ExcelMcpTelemetryInitializer.cs
+++ b/src/ExcelMcp.McpServer/Telemetry/ExcelMcpTelemetryInitializer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Sbroenne.ExcelMcp.McpServer.Telemetry;
+
+/// <summary>
+/// Telemetry initializer that sets User.Id and Session.Id for Application Insights.
+/// This enables the Users and Sessions blades in the Azure Portal.
+/// </summary>
+public sealed class ExcelMcpTelemetryInitializer : ITelemetryInitializer
+{
+    private readonly string _userId;
+    private readonly string _sessionId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExcelMcpTelemetryInitializer"/> class.
+    /// </summary>
+    public ExcelMcpTelemetryInitializer()
+    {
+        _userId = ExcelMcpTelemetry.UserId;
+        _sessionId = ExcelMcpTelemetry.SessionId;
+    }
+
+    /// <summary>
+    /// Initializes the telemetry item with user and session context.
+    /// </summary>
+    /// <param name="telemetry">The telemetry item to initialize.</param>
+    public void Initialize(ITelemetry telemetry)
+    {
+        // Set user context for Users blade
+        if (string.IsNullOrEmpty(telemetry.Context.User.Id))
+        {
+            telemetry.Context.User.Id = _userId;
+        }
+
+        // Set session context for Sessions blade
+        if (string.IsNullOrEmpty(telemetry.Context.Session.Id))
+        {
+            telemetry.Context.Session.Id = _sessionId;
+        }
+
+        // Set cloud role for better grouping in Application Map
+        if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+        {
+            telemetry.Context.Cloud.RoleName = "ExcelMcp.McpServer";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replace OpenTelemetry with Application Insights SDK to enable full Usage analytics (Users, Sessions, Funnels, User Flows) in Azure portal.

## Problem

OpenTelemetry Azure Monitor exporter sends telemetry to AppDependencies table, but the Users/Sessions/Funnels blades require customEvents table with user_Id/session_Id context. This caused 'query failed' errors in the Usage analytics blades.

## Solution

Switch to Application Insights SDK's TelemetryClient.TrackEvent() which properly populates customEvents with user/session context via ITelemetryInitializer.

## Changes

### Packages
- **Removed**: Azure.Monitor.OpenTelemetry.Exporter, OpenTelemetry.Exporter.Console, OpenTelemetry.Extensions.Hosting
- **Kept**: Microsoft.ApplicationInsights v2.23.0

### Code
- Program.cs: Simplified ConfigureTelemetry() - removed OpenTelemetry registration
- ExcelMcpTelemetry.cs: Removed ActivitySource, use TelemetryClient directly
- ExcelMcpTelemetryInitializer.cs: **NEW** - Sets User.Id/Session.Id on all telemetry
- SensitiveDataRedactor.cs: Converted from OpenTelemetry processor to static utility

### SDK
- Updated .NET SDK from 8.0.414 to 8.0.416

## Test Results

All 36 telemetry tests pass.

## Benefits

- Simpler: 1 SDK instead of 4 packages
- Full Usage analytics support
- Smaller footprint

Fixes #239