### PR TITLE
feat(vscode): reduce extension size by 89% using framework-dependent deployment

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -71,7 +71,7 @@
   },
   "scripts": {
     "clean": "cd .. && dotnet clean src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj -c Release",
-    "build:mcp-server": "npm run clean && cd .. && dotnet publish src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj -c Release -r win-x64 --self-contained -o vscode-extension/bin --verbosity minimal",
+    "build:mcp-server": "npm run clean && cd .. && dotnet publish src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj -c Release --no-self-contained -o vscode-extension/bin --verbosity minimal",
     "vscode:prepublish": "npm run build:mcp-server && npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -28,7 +28,6 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.lm.registerMcpServerDefinitionProvider('excel-mcp', {
 			provideMcpServerDefinitions: async () => {
 				// Return the MCP server definition for ExcelMcp
-				// Use the bundled executable path
 				const extensionPath = context.extensionPath;
 				const mcpServerPath = path.join(extensionPath, 'bin', 'Sbroenne.ExcelMcp.McpServer.exe');
 


### PR DESCRIPTION
## Summary
Reduces the VS Code extension size by ~89% by switching from self-contained to framework-dependent deployment.

Closes #250

## Changes
- Changed \--self-contained\ to \--no-self-contained\ in build script
- Removed architecture-specific RID (\-r win-x64\) for portable build
- Extension now works on both x64 and ARM64 Windows

## Results
| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Bin folder | 77 MB | 8.4 MB | 89% |
| VSIX package | ~25 MB | 3.5 MB | 86% |
| Architecture | x64 only | x64 + ARM64 | +ARM64 |

## Why This Works
The extension already declares a dependency on \ms-dotnettools.vscode-dotnet-runtime\ which installs the .NET runtime. The self-contained deployment was bundling the entire runtime unnecessarily.

## Testing
- [x] \
pm run package\ produces valid VSIX
- [x] Extension loads and activates
- [x] MCP server starts correctly