### PR TITLE
fix: MCP Registry publishing - update version regex and metadata

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -76,8 +76,8 @@ jobs:
         $serverJsonPath = "src/ExcelMcp.McpServer/.mcp/server.json"
         $serverContent = Get-Content $serverJsonPath -Raw
 
-        # Update main version field (near top of file, not in _meta section)
-        $serverContent = $serverContent -replace '(\s*"version":\s*)"[\d\.]+"(\s*,\s*\n\s*"title")' , "`$1`"$version`"`$2"
+        # Update main version field (the one followed by "packages" on next line)
+        $serverContent = $serverContent -replace '("version":\s*)"[\d\.]+"(\s*,\s*\n\s*"packages")' , "`$1`"$version`"`$2"
 
         # Update package version in packages array (specifically after identifier field)
         $serverContent = $serverContent -replace '("identifier":\s*"Sbroenne\.ExcelMcp\.McpServer",\s*\n\s*"version":\s*)"[\d\.]+"', "`$1`"$version`""
@@ -388,23 +388,23 @@ jobs:
 
         # Check if version already exists in MCP Registry
         Write-Output "Checking if version $version already exists in MCP Registry..."
-        $registryCheckUrl = "https://registry.modelcontextprotocol.io/servers/io.github.sbroenne/mcp-server-excel"
+        $registryCheckUrl = "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.sbroenne%2Fmcp-server-excel/versions/$version"
         try {
-          $registryData = Invoke-RestMethod -Uri $registryCheckUrl -ErrorAction SilentlyContinue
-          $existingVersions = $registryData.versions | Select-Object -ExpandProperty version
-          if ($existingVersions -contains $version) {
-            Write-Output "⚠️ WARNING: Version $version already exists in MCP Registry"
-            Write-Output "   Existing versions: $($existingVersions -join ', ')"
-            Write-Output "   This publish attempt will likely fail with 'duplicate version' error"
-            Write-Output "   If you need to republish, you must either:"
-            Write-Output "   1. Use a new version number (recommended), or"
-            Write-Output "   2. Contact MCP Registry support to remove the existing version"
-            Write-Output ""
-          } else {
-            Write-Output "✅ Version $version not found in registry - proceeding with publish"
-          }
+          $registryData = Invoke-RestMethod -Uri $registryCheckUrl -ErrorAction Stop
+          # If we get here, the version exists (200 response)
+          Write-Output "⚠️ WARNING: Version $version already exists in MCP Registry"
+          Write-Output "   This publish attempt will likely fail with 'duplicate version' error"
+          Write-Output "   If you need to republish, you must either:"
+          Write-Output "   1. Use a new version number (recommended), or"
+          Write-Output "   2. Contact MCP Registry support to remove the existing version"
+          Write-Output ""
         } catch {
-          Write-Output "⚠️ Could not check registry for existing version (this is OK - will attempt publish)"
+          # 404 means version doesn't exist - this is the expected case for new versions
+          if ($_.Exception.Response.StatusCode -eq 404) {
+            Write-Output "✅ Version $version not found in registry - proceeding with publish"
+          } else {
+            Write-Output "⚠️ Could not check registry for existing version (this is OK - will attempt publish)"
+          }
         }
 
         Write-Output ""
@@ -423,7 +423,7 @@ jobs:
         if ($publishExitCode -eq 0) {
           Write-Output ""
           Write-Output "🚀 Published to MCP Registry"
-          Write-Output "🔗 Server available at: https://registry.modelcontextprotocol.io/servers/io.github.sbroenne/mcp-server-excel"
+          Write-Output "🔗 Server available at: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.sbroenne%2Fmcp-server-excel/versions/$version"
         } else {
           Write-Output ""
           Write-Output "❌ MCP Registry publishing failed with exit code $publishExitCode"
@@ -468,7 +468,7 @@ jobs:
 
         if ($publishStatus -eq "success") {
           Write-Output "✅ MCP Registry publishing succeeded!"
-          Write-Output "🔗 Server available at: https://registry.modelcontextprotocol.io/servers/io.github.sbroenne/mcp-server-excel"
+          Write-Output "🔗 Server available at: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.sbroenne%2Fmcp-server-excel/versions/${{ env.PACKAGE_VERSION }}"
         } else {
           Write-Output "❌ MCP Registry publishing failed"
           Write-Output ""
@@ -482,7 +482,7 @@ jobs:
           Write-Output ""
           Write-Output "   To diagnose the issue:"
           Write-Output "   1. Check the 'Publish to MCP Registry' step logs above for specific error messages"
-          Write-Output "   2. For duplicate version errors, check: https://registry.modelcontextprotocol.io/servers/io.github.sbroenne/mcp-server-excel"
+          Write-Output "   2. For duplicate version errors, check: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.sbroenne%2Fmcp-server-excel/versions"
           Write-Output "   3. For README validation errors, verify: https://api.nuget.org/v3-flatcontainer/sbroenne.excelmcp.mcpserver/${{ env.PACKAGE_VERSION }}/readme"
           Write-Output ""
           Write-Output "   For manual retry, see: docs/MCP_REGISTRY_PUBLISHING.md"

--- a/src/ExcelMcp.McpServer/.mcp/server.json
+++ b/src/ExcelMcp.McpServer/.mcp/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.sbroenne/mcp-server-excel",
-  "title": "Excel MCP Server - AI-Powered Excel Automation",
-  "description": "Excel automation for AI: Power Query, DAX, VBA, PivotTables, Tables, ranges, formatting. 165 ops.",
+  "title": "MCP Server for Excel",
+  "description": "Excel automation for AI assistants - manage Sheets, Power Query, DAX, VBA, Tables, Ranges, Formatting, Validation and more. Requires Excel to be installed. Only runs on Windows.",
   "version": "1.0.0",
   "packages": [
     {


### PR DESCRIPTION
## Summary

Fixes #252 - MCP Registry publishing has been silently failing since the workflow was created.

## Problem

The MCP Registry only shows version 1.0.0 (published Oct 30, 2025) while NuGet has versions up to 1.4.24. Every release since then failed with "duplicate version" error because the version in server.json was never updated.

## Root Cause

1. **Broken regex** - Pattern looked for \"title"\ after the version field, but actual JSON has \"packages"\ after version
2. **Stale metadata** - server.json title/description didn't match .csproj
3. **Wrong API URLs** - Workflow used incorrect MCP Registry endpoint format

## Changes

### .github/workflows/release-mcp-server.yml
- Fix regex from \'("version":\s*)"[\d\.]+"(\s*,\s*\n\s*"title")'\ to \'("version":\s*)"[\d\.]+"(\s*,\s*\n\s*"packages")'\
- Fix MCP Registry API URLs to use \/v0.1/servers/\ path with URL encoding

### src/ExcelMcp.McpServer/.mcp/server.json
- Update title: \"Excel COM Automation"\ → \"MCP Server for Excel"\
- Update description to match .csproj metadata

## Testing

- Verified regex locally - correctly updates both version fields from 1.0.0 to test version
- Pre-commit checks pass

## Next Steps

After merge, create a new release tag (e.g., v1.4.25) to test the complete fix.