### PR TITLE
fix: MCP Registry publishing - shorten description and fix README detection

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -309,7 +309,7 @@ jobs:
           try {
             $response = Invoke-WebRequest -Uri $readmeUrl -UseBasicParsing -ErrorAction SilentlyContinue
             if ($response.StatusCode -eq 200) {
-              $content = $response.Content
+              $content = [System.Text.Encoding]::UTF8.GetString($response.Content)
               if ($content -match "mcp-name:\s+io\.github\.sbroenne/mcp-server-excel") {
                 Write-Output "✅ README found and contains mcp-name validation string!"
                 $found = $true
@@ -374,7 +374,8 @@ jobs:
         Write-Output "Checking README at: $readmeUrl"
 
         try {
-          $readmeContent = Invoke-WebRequest -Uri $readmeUrl -UseBasicParsing | Select-Object -ExpandProperty Content
+          $response = Invoke-WebRequest -Uri $readmeUrl -UseBasicParsing
+          $readmeContent = [System.Text.Encoding]::UTF8.GetString($response.Content)
           if ($readmeContent -match "mcp-name:\s+io\.github\.sbroenne/mcp-server-excel") {
             Write-Output "✅ README contains mcp-name validation string"
           } else {

--- a/src/ExcelMcp.McpServer/.mcp/server.json
+++ b/src/ExcelMcp.McpServer/.mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.sbroenne/mcp-server-excel",
   "title": "MCP Server for Excel",
-  "description": "Excel automation for AI assistants - manage Sheets, Power Query, DAX, VBA, Tables, Ranges, Formatting, Validation and more. Requires Excel to be installed. Only runs on Windows.",
+  "description": "Excel automation for AI - Sheets, Power Query, DAX, VBA, Tables, Ranges and more. Windows only.",
   "version": "1.0.0",
   "packages": [
     {


### PR DESCRIPTION
## Summary

Fixes MCP Registry publishing workflow failures from run #19833926694.

## Changes

### 1. Shorten server.json description (184 → 95 characters)

MCP Registry enforces a 100 character limit on the description field. The previous description was 184 characters.

**Before:** Excel automation for AI assistants - manage Sheets, Power Query, DAX, VBA, Tables, Ranges, Formatting, Validation and more. Requires Excel to be installed. Only runs on Windows.

**After:** Excel automation for AI - Sheets, Power Query, DAX, VBA, Tables, Ranges and more. Windows only.

### 2. Fix README mcp-name detection in workflow

The workflow was using Invoke-WebRequest Content property directly, which returns a byte array. The regex match fails on byte arrays. Fixed by decoding as UTF-8 string first.

**Before:**
```powershell
$readmeContent = Invoke-WebRequest -Uri $readmeUrl -UseBasicParsing | Select-Object -ExpandProperty Content
```

**After:**
```powershell
$response = Invoke-WebRequest -Uri $readmeUrl -UseBasicParsing
$readmeContent = [System.Text.Encoding]::UTF8.GetString($response.Content)
```

Fixes #255
