### PR TITLE
fix: locale-independent number and date format handling

### DIFF
--- a/src/ExcelMcp.ComInterop/Formatting/DateFormatTranslator.cs
+++ b/src/ExcelMcp.ComInterop/Formatting/DateFormatTranslator.cs
@@ -1,0 +1,330 @@
+using System.Text;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Formatting;
+
+/// <summary>
+/// Translates date/time format codes between US (English) format and the locale-specific format
+/// that Excel expects based on the current system locale.
+/// </summary>
+/// <remarks>
+/// <para><b>Why This Is Needed:</b></para>
+/// <para>
+/// Excel interprets date format code letters based on the system locale. On German systems,
+/// 'd' (day), 'm' (month), 'y' (year) are NOT recognized - Excel expects 'T' (Tag), 'M' (Monat), 'J' (Jahr).
+/// </para>
+/// <para>
+/// This translator reads the locale-specific codes from Excel's <c>Application.International</c> property
+/// and translates US format codes (like "m/d/yyyy") to locale format codes (like "M/T/JJJJ" on German).
+/// </para>
+/// <para><b>Usage:</b></para>
+/// <code>
+/// var translator = new DateFormatTranslator(excelApp);
+/// string localeFormat = translator.TranslateToLocale("m/d/yyyy"); // Returns "M/T/JJJJ" on German Excel
+/// </code>
+/// </remarks>
+public sealed class DateFormatTranslator
+{
+    // XlApplicationInternational enum values
+    private const int XlDayCode = 21;
+    private const int XlMonthCode = 20;
+    private const int XlYearCode = 19;
+    private const int XlHourCode = 22;
+    private const int XlMinuteCode = 23;
+    private const int XlSecondCode = 24;
+    private const int XlDateSeparator = 17;
+    private const int XlTimeSeparator = 18;
+
+    /// <summary>Locale-specific day code (e.g., 'd' for English, 'T' for German)</summary>
+    public string DayCode { get; }
+
+    /// <summary>Locale-specific month code (e.g., 'm' for English, 'M' for German)</summary>
+    public string MonthCode { get; }
+
+    /// <summary>Locale-specific year code (e.g., 'y' for English, 'J' for German)</summary>
+    public string YearCode { get; }
+
+    /// <summary>Locale-specific hour code (typically 'h' across locales)</summary>
+    public string HourCode { get; }
+
+    /// <summary>Locale-specific minute code (typically 'm' across locales - same as month!)</summary>
+    public string MinuteCode { get; }
+
+    /// <summary>Locale-specific second code (typically 's' across locales)</summary>
+    public string SecondCode { get; }
+
+    /// <summary>Locale-specific date separator (e.g., '/' or '.')</summary>
+    public string DateSeparator { get; }
+
+    /// <summary>Locale-specific time separator (typically ':')</summary>
+    public string TimeSeparator { get; }
+
+    /// <summary>True if locale uses same codes as US English (d/m/y)</summary>
+    public bool IsEnglishLocale { get; }
+
+    /// <summary>
+    /// Creates a new DateFormatTranslator by reading locale codes from the Excel Application.
+    /// </summary>
+    /// <param name="excelApp">The Excel.Application COM object (dynamic)</param>
+    public DateFormatTranslator(dynamic excelApp)
+    {
+        // Read locale-specific codes from Excel's International property
+        DayCode = GetInternationalValue(excelApp, XlDayCode) ?? "d";
+        MonthCode = GetInternationalValue(excelApp, XlMonthCode) ?? "m";
+        YearCode = GetInternationalValue(excelApp, XlYearCode) ?? "y";
+        HourCode = GetInternationalValue(excelApp, XlHourCode) ?? "h";
+        MinuteCode = GetInternationalValue(excelApp, XlMinuteCode) ?? "m";
+        SecondCode = GetInternationalValue(excelApp, XlSecondCode) ?? "s";
+        DateSeparator = GetInternationalValue(excelApp, XlDateSeparator) ?? "/";
+        TimeSeparator = GetInternationalValue(excelApp, XlTimeSeparator) ?? ":";
+
+        // Check if this is already English locale (no translation needed)
+        IsEnglishLocale = DayCode.Equals("d", StringComparison.OrdinalIgnoreCase) &&
+                          MonthCode.Equals("m", StringComparison.OrdinalIgnoreCase) &&
+                          YearCode.Equals("y", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Translates a US (English) date format string to the locale-specific format Excel expects.
+    /// </summary>
+    /// <param name="usFormat">US format string (e.g., "m/d/yyyy", "mm/dd/yyyy", "yyyy-mm-dd")</param>
+    /// <returns>Locale-specific format string (e.g., "M/T/JJJJ" on German Excel)</returns>
+    /// <remarks>
+    /// <para>Translation rules:</para>
+    /// <list type="bullet">
+    /// <item>'d' or 'dd' (day) → locale day code (e.g., 'T' or 'TT' on German)</item>
+    /// <item>'ddd' or 'dddd' (weekday names) → kept as-is (Excel handles these)</item>
+    /// <item>'m' or 'mm' (month, when NOT after time separator) → locale month code</item>
+    /// <item>'mmm' or 'mmmm' (month names) → kept as-is (Excel handles these)</item>
+    /// <item>'y' or 'yy' or 'yyyy' (year) → locale year code</item>
+    /// <item>'h', 'm' (after :), 's' (time) → locale time codes</item>
+    /// <item>Literal text in quotes or brackets is preserved</item>
+    /// </list>
+    /// </remarks>
+    public string TranslateToLocale(string usFormat)
+    {
+        if (string.IsNullOrEmpty(usFormat))
+            return usFormat;
+
+        // If already English locale, no translation needed
+        if (IsEnglishLocale)
+            return usFormat;
+
+        // Don't translate if it already contains locale-specific codes
+        // (user might have already used German codes)
+        if (ContainsLocaleSpecificCodes(usFormat))
+            return usFormat;
+
+        // Parse and translate the format string
+        return TranslateFormatString(usFormat);
+    }
+
+    /// <summary>
+    /// Checks if the format string already contains locale-specific date codes.
+    /// </summary>
+    private bool ContainsLocaleSpecificCodes(string format)
+    {
+        // Check for German-style codes (case-insensitive)
+        // T = Tag (day), J = Jahr (year) are unique to German
+        // We check for these to avoid double-translation
+        if (!DayCode.Equals("d", StringComparison.OrdinalIgnoreCase) &&
+            format.Contains(DayCode, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!YearCode.Equals("y", StringComparison.OrdinalIgnoreCase) &&
+            format.Contains(YearCode, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Translates format string character by character, handling context (date vs time).
+    /// </summary>
+    private string TranslateFormatString(string format)
+    {
+        var result = new StringBuilder(format.Length);
+        int i = 0;
+
+        // Track if we're in a time context (after seeing 'h' or ':')
+        bool inTimeContext = false;
+
+        while (i < format.Length)
+        {
+            char c = format[i];
+
+            // Skip content in square brackets (locale prefixes, colors, conditions)
+            if (c == '[')
+            {
+                int bracketEnd = format.IndexOf(']', i);
+                if (bracketEnd > i)
+                {
+                    result.Append(format.AsSpan(i, bracketEnd - i + 1));
+                    i = bracketEnd + 1;
+                    continue;
+                }
+            }
+
+            // Skip content in quotes (literal text)
+            if (c == '"')
+            {
+                int quoteEnd = format.IndexOf('"', i + 1);
+                if (quoteEnd > i)
+                {
+                    result.Append(format.AsSpan(i, quoteEnd - i + 1));
+                    i = quoteEnd + 1;
+                    continue;
+                }
+            }
+
+            // Skip escaped characters (backslash)
+            if (c == '\\' && i + 1 < format.Length)
+            {
+                result.Append(format.AsSpan(i, 2));
+                i += 2;
+                continue;
+            }
+
+            // Time separator - switch to time context
+            if (c == ':')
+            {
+                inTimeContext = true;
+                result.Append(c);
+                i++;
+                continue;
+            }
+
+            // Hour code - switch to time context
+            if (c == 'h' || c == 'H')
+            {
+                inTimeContext = true;
+                int count = CountRepeatingChar(format, i, c);
+                result.Append(HourCode[0], count);
+                i += count;
+                continue;
+            }
+
+            // Second code
+            if (c == 's' || c == 'S')
+            {
+                int count = CountRepeatingChar(format, i, c);
+                result.Append(SecondCode[0], count);
+                i += count;
+                continue;
+            }
+
+            // Day code - 'd' or 'D'
+            if (c == 'd' || c == 'D')
+            {
+                int count = CountRepeatingChar(format, i, c);
+
+                // ddd and dddd are weekday names - keep as-is
+                if (count >= 3)
+                {
+                    result.Append(c, count);
+                }
+                else
+                {
+                    // d or dd = day number
+                    result.Append(DayCode[0], count);
+                }
+                i += count;
+                continue;
+            }
+
+            // Month/Minute code - 'm' or 'M'
+            // This is the tricky one - 'm' means month in date context, minutes in time context
+            if (c == 'm' || c == 'M')
+            {
+                int count = CountRepeatingChar(format, i, c);
+
+                if (inTimeContext)
+                {
+                    // In time context, m = minutes
+                    result.Append(MinuteCode[0], count);
+                }
+                else
+                {
+                    // In date context, m = month
+                    // mmm and mmmm are month names - keep as-is (Excel handles translation)
+                    if (count >= 3)
+                    {
+                        result.Append(c, count);
+                    }
+                    else
+                    {
+                        // m or mm = month number
+                        result.Append(MonthCode[0], count);
+                    }
+                }
+                i += count;
+                continue;
+            }
+
+            // Year code - 'y' or 'Y'
+            if (c == 'y' || c == 'Y')
+            {
+                int count = CountRepeatingChar(format, i, c);
+                result.Append(YearCode[0], count);
+                i += count;
+                continue;
+            }
+
+            // Other characters pass through unchanged
+            result.Append(c);
+            i++;
+
+            // Reset time context on section separator
+            if (c == ';')
+            {
+                inTimeContext = false;
+            }
+        }
+
+        return result.ToString();
+    }
+
+    /// <summary>
+    /// Counts how many times a character repeats starting at position.
+    /// </summary>
+    private static int CountRepeatingChar(string format, int startIndex, char c)
+    {
+        int count = 0;
+        char lowerC = char.ToLowerInvariant(c);
+
+        while (startIndex + count < format.Length &&
+               char.ToLowerInvariant(format[startIndex + count]) == lowerC)
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Gets a value from Excel's International property.
+    /// </summary>
+    private static string? GetInternationalValue(dynamic excelApp, int index)
+    {
+        try
+        {
+            // Access the International property with the index
+            // Excel COM: excelApp.International(index) returns the locale-specific value
+            object? value = excelApp.International[index];
+            return value?.ToString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns a summary of the locale codes for debugging/logging.
+    /// </summary>
+    public override string ToString()
+    {
+        return $"DateFormatTranslator: Day='{DayCode}' Month='{MonthCode}' Year='{YearCode}' " +
+               $"Hour='{HourCode}' Minute='{MinuteCode}' Second='{SecondCode}' " +
+               $"DateSep='{DateSeparator}' TimeSep='{TimeSeparator}' IsEnglish={IsEnglishLocale}";
+    }
+}

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -83,6 +83,12 @@ internal sealed class ExcelBatch : IExcelBatch
                 tempExcel.Visible = _showExcel;
                 tempExcel.DisplayAlerts = false;
 
+                // Use US-style separators (. for decimal, , for thousands) regardless of system locale
+                // This ensures format codes like "$#,##0.00" work consistently across all locales
+                tempExcel.UseSystemSeparators = false;
+                tempExcel.DecimalSeparator = ".";
+                tempExcel.ThousandsSeparator = ",";
+
                 // Disable macro security warnings for unattended automation
                 // msoAutomationSecurityForceDisable = 3 (disable all macros, no prompts)
                 // See: https://learn.microsoft.com/en-us/office/vba/api/word.application.automationsecurity

--- a/src/ExcelMcp.ComInterop/Session/ExcelContext.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelContext.cs
@@ -1,3 +1,5 @@
+using Sbroenne.ExcelMcp.ComInterop.Formatting;
+
 namespace Sbroenne.ExcelMcp.ComInterop.Session;
 
 /// <summary>
@@ -17,6 +19,9 @@ public sealed class ExcelContext
         WorkbookPath = workbookPath ?? throw new ArgumentNullException(nameof(workbookPath));
         App = excel ?? throw new ArgumentNullException(nameof(excel));
         Book = workbook ?? throw new ArgumentNullException(nameof(workbook));
+
+        // Initialize date format translator with locale-specific codes from Excel
+        DateFormatter = new DateFormatTranslator(excel);
     }
 
     /// <summary>
@@ -33,4 +38,21 @@ public sealed class ExcelContext
     /// Gets the Excel.Workbook COM object.
     /// </summary>
     public dynamic Book { get; }
+
+    /// <summary>
+    /// Gets the date format translator for converting US date format codes to locale-specific codes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use this to translate format strings like "m/d/yyyy" to locale-specific codes
+    /// (e.g., "M/T/JJJJ" on German Excel) before setting <c>Range.NumberFormat</c>.
+    /// </para>
+    /// <example>
+    /// <code>
+    /// string localeFormat = ctx.DateFormatter.TranslateToLocale("m/d/yyyy");
+    /// range.NumberFormat = localeFormat;
+    /// </code>
+    /// </example>
+    /// </remarks>
+    public DateFormatTranslator DateFormatter { get; }
 }

--- a/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
@@ -178,6 +178,12 @@ public static class ExcelSession
                 excel.Visible = false;
                 excel.DisplayAlerts = false;
 
+                // Use US-style separators (. for decimal, , for thousands) regardless of system locale
+                // This ensures format codes like "$#,##0.00" work consistently across all locales
+                excel.UseSystemSeparators = false;
+                excel.DecimalSeparator = ".";
+                excel.ThousandsSeparator = ",";
+
                 workbook = excel.Workbooks.Add();
 
                 // SaveAs with 5-minute timeout

--- a/src/ExcelMcp.Core/Commands/FileCommands.cs
+++ b/src/ExcelMcp.Core/Commands/FileCommands.cs
@@ -73,6 +73,12 @@ public class FileCommands : IFileCommands
                 excel.Visible = false;
                 excel.DisplayAlerts = false;
 
+                // Use US-style separators (. for decimal, , for thousands) regardless of system locale
+                // This ensures format codes like "$#,##0.00" work consistently across all locales
+                excel.UseSystemSeparators = false;
+                excel.DecimalSeparator = ".";
+                excel.ThousandsSeparator = ",";
+
                 workbook = excel.Workbooks.Add();
 
                 // Save the workbook with 5-minute timeout (Excel automatically creates Sheet1)

--- a/src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.Fields.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.Fields.cs
@@ -479,9 +479,12 @@ public partial class PivotTableCommands
 
             try
             {
+                // Translate US date format codes to locale-specific codes
+                var translatedFormat = ctx.DateFormatter.TranslateToLocale(numberFormat);
+
                 // Use Strategy Pattern to delegate to appropriate implementation
                 var strategy = PivotTableFieldStrategyFactory.GetStrategy(pivot);
-                return strategy.SetFieldFormat(pivot, fieldName, numberFormat, batch.WorkbookPath);
+                return strategy.SetFieldFormat(pivot, fieldName, translatedFormat, batch.WorkbookPath);
             }
             finally
             {

--- a/src/ExcelMcp.McpServer/Prompts/Content/excel_range.md
+++ b/src/ExcelMcp.McpServer/Prompts/Content/excel_range.md
@@ -1,5 +1,7 @@
 # excel_range - Number Formats
 
+**IMPORTANT: Always use US format codes.** The server automatically translates to the user's locale.
+
 ## Format Codes
 
 | Type | Code | Example |
@@ -17,7 +19,7 @@
 | Time (24h) | `hh:mm:ss` | 14:30:00 |
 | Text | `@` | (as-is) |
 
-Date/time formats auto-handle cross-culture compatibility. Currency symbols are literal.
+All format codes are auto-translated to the user's locale. Use US codes (d/m/y for dates, . for decimal, , for thousands).
 
 ## Actions
 

--- a/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
@@ -32,7 +32,7 @@ public static partial class ExcelPivotTableTool
     /// <param name="fieldName">Field name for field operations (for OLAP add-value-field: use measure name like 'Total Sales' for existing measure OR column name like 'Sales' to create new measure)</param>
     /// <param name="aggregationFunction">Aggregation function: Sum, Count, Average, Max, Min, Product, CountNumbers, StdDev, StdDevP, Var, VarP</param>
     /// <param name="customName">Custom display name for field</param>
-    /// <param name="numberFormat">Number format code (e.g., '#,##0.00', '0.00%', 'm/d/yyyy')</param>
+    /// <param name="numberFormat">Number format code. ALWAYS use US format codes (e.g., '#,##0.00', '0.00%', 'm/d/yyyy'). The server auto-translates to the user's locale.</param>
     /// <param name="position">Position for field (1-based, optional)</param>
     /// <param name="filterValues">JSON array of filter values (e.g., '["value1","value2"]')</param>
     /// <param name="sortDirection">Sort direction: Ascending, Descending</param>

--- a/src/ExcelMcp.McpServer/Tools/ExcelRangeTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelRangeTool.cs
@@ -13,11 +13,6 @@ public static partial class ExcelRangeTool
     /// <summary>
     /// Unified Excel range operations - ALL data manipulation.
     /// DATA FORMAT: Values/formulas are JSON 2D arrays [[row1col1, row1col2], [row2col1, row2col2]]. Example single cell: [[100]] or [['=SUM(A:A)']]. Example range: [[1,2,3], [4,5,6], [7,8,9]].
-    ///
-    /// NUMBER FORMATTING - CROSS-CULTURE TIP:
-    /// When setting date/time formats, prefix with [$-409] for universal compatibility.
-    /// Example: formatCode='[$-409]mm/dd/yyyy' works correctly on ALL locales.
-    /// The [$-409] tells Excel to interpret format codes as US English.
     /// </summary>
     /// <param name="action">Action to perform</param>
     /// <param name="excelPath">Excel file path (.xlsx or .xlsm)</param>
@@ -44,7 +39,7 @@ public static partial class ExcelRangeTool
     /// <param name="url">Hyperlink URL (for add-hyperlink)</param>
     /// <param name="displayText">Hyperlink display text (for add-hyperlink, optional)</param>
     /// <param name="tooltip">Hyperlink tooltip (for add-hyperlink, optional)</param>
-    /// <param name="formatCode">Excel format code for set-number-format (e.g., '$#,##0.00', '0.00%', '[$-409]mm/dd/yyyy'). Use [$-409] prefix for cross-culture date/time formats.</param>
+    /// <param name="formatCode">Excel format code for set-number-format. ALWAYS use US format codes (e.g., '$#,##0.00', '0.00%', 'm/d/yyyy'). The server auto-translates to the user's locale.</param>
     /// <param name="formats">2D array of format codes for set-number-formats (JSON array of arrays, e.g., [['$#,##0','0.00%'],['m/d/yyyy','General']])</param>
     /// <param name="styleName">Built-in Excel style name (for set-style: 'Heading 1', 'Accent1', 'Good', 'Total', 'Currency', 'Percent', 'Normal', etc. - recommended for consistent formatting)</param>
     /// <param name="fontName">Font name (for format-range, e.g., 'Arial', 'Calibri')</param>

--- a/src/ExcelMcp.McpServer/Tools/ExcelTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelTableTool.cs
@@ -26,7 +26,7 @@ public static partial class TableTool
     /// <param name="tableStyle">Table style name (e.g., 'TableStyleMedium2') for create/set-style, or total function (sum/avg/count) for set-column-total, or CSV data for append</param>
     /// <param name="filterCriteria">Filter criteria (e.g., '>100', '=Text') for apply-filter, or column position (0-based) for add-column</param>
     /// <param name="filterValues">JSON array of filter values (e.g., '["Value1","Value2"]') for apply-filter-values</param>
-    /// <param name="formatCode">Excel format code for set-column-number-format (e.g., '$#,##0.00', '0.00%', 'm/d/yyyy')</param>
+    /// <param name="formatCode">Excel format code for set-column-number-format. ALWAYS use US format codes (e.g., '$#,##0.00', '0.00%', 'm/d/yyyy'). The server auto-translates to the user's locale.</param>
     /// <param name="visibleOnly">When reading data, return only rows currently visible after filters (default: false)</param>
     [McpServerTool(Name = "excel_table")]
     [McpMeta("category", "data")]

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/DateFormatTranslationTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/DateFormatTranslationTests.cs
@@ -1,0 +1,304 @@
+using Sbroenne.ExcelMcp.ComInterop.Formatting;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
+
+/// <summary>
+/// Tests that date format translation works correctly across locales.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Ranges")]
+[Trait("RequiresExcel", "true")]
+public class DateFormatTranslationTests : IClassFixture<TempDirectoryFixture>
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _tempDir;
+    private readonly RangeCommands _rangeCommands;
+
+    public DateFormatTranslationTests(TempDirectoryFixture fixture, ITestOutputHelper output)
+    {
+        _tempDir = fixture.TempDir;
+        _output = output;
+        _rangeCommands = new RangeCommands();
+    }
+
+    [Fact]
+    public void SetNumberFormat_USDateFormat_DisplaysCorrectly()
+    {
+        // Arrange
+        var testFile = CoreTestHelper.CreateUniqueTestFile(
+            nameof(DateFormatTranslationTests),
+            nameof(SetNumberFormat_USDateFormat_DisplaysCorrectly),
+            _tempDir,
+            ".xlsx");
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Log translator info
+        batch.Execute((ctx, ct) =>
+        {
+            _output.WriteLine($"DateFormatter: {ctx.DateFormatter}");
+        });
+
+        // Set a date value (45000 = March 15, 2023)
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic cell = sheet.Range["A1"];
+            cell.Value2 = 45000; // March 15, 2023
+        });
+
+        // Act - Set format using US format code "m/d/yyyy"
+        var result = _rangeCommands.SetNumberFormat(batch, "Sheet1", "A1", "m/d/yyyy");
+
+        // Assert
+        Assert.True(result.Success, $"SetNumberFormat failed: {result.ErrorMessage}");
+
+        // Verify the display is correct (not "0/d/yyyy" or other broken formats)
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic cell = sheet.Range["A1"];
+
+            string displayedText = cell.Text?.ToString() ?? "null";
+            string appliedFormat = cell.NumberFormat?.ToString() ?? "null";
+            string localFormat = cell.NumberFormatLocal?.ToString() ?? "null";
+
+            _output.WriteLine($"Set US format 'm/d/yyyy':");
+            _output.WriteLine($"  Applied NumberFormat: '{appliedFormat}'");
+            _output.WriteLine($"  NumberFormatLocal: '{localFormat}'");
+            _output.WriteLine($"  Displayed text: '{displayedText}'");
+
+            // The display should contain the date parts (3, 15, 2023 or 15, 3, 2023)
+            // NOT "0/d/yyyy" which happens when 'm' is misinterpreted as minutes (=0)
+            Assert.DoesNotContain("0/", displayedText);
+            Assert.DoesNotContain("/0/", displayedText);
+
+            // Should contain year 2023 (45000 = March 15, 2023)
+            Assert.Contains("2023", displayedText);
+        });
+    }
+
+    [Fact]
+    public void SetNumberFormat_ISODateFormat_DisplaysCorrectly()
+    {
+        // Arrange
+        var testFile = CoreTestHelper.CreateUniqueTestFile(
+            nameof(DateFormatTranslationTests),
+            nameof(SetNumberFormat_ISODateFormat_DisplaysCorrectly),
+            _tempDir,
+            ".xlsx");
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Set a date value (45000 = March 15, 2023)
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic cell = sheet.Range["A1"];
+            cell.Value2 = 45000; // March 15, 2023
+        });
+
+        // Act - Set format using ISO format "yyyy-mm-dd"
+        var result = _rangeCommands.SetNumberFormat(batch, "Sheet1", "A1", "yyyy-mm-dd");
+
+        // Assert
+        Assert.True(result.Success, $"SetNumberFormat failed: {result.ErrorMessage}");
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic cell = sheet.Range["A1"];
+
+            string displayedText = cell.Text?.ToString() ?? "null";
+
+            _output.WriteLine($"Set ISO format 'yyyy-mm-dd':");
+            _output.WriteLine($"  Displayed text: '{displayedText}'");
+
+            // Should display as ISO format: 2023-03-15
+            Assert.Equal("2023-03-15", displayedText);
+        });
+    }
+
+    [Fact]
+    public void SetNumberFormat_MultipleDates_AllDisplayCorrectly()
+    {
+        // Arrange
+        var testFile = CoreTestHelper.CreateUniqueTestFile(
+            nameof(DateFormatTranslationTests),
+            nameof(SetNumberFormat_MultipleDates_AllDisplayCorrectly),
+            _tempDir,
+            ".xlsx");
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Set date values in A1:A3
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            sheet.Range["A1"].Value2 = 45000; // March 15, 2023
+            sheet.Range["A2"].Value2 = 45001; // March 16, 2023
+            sheet.Range["A3"].Value2 = 45002; // March 17, 2023
+        });
+
+        // Act - Set all three cells with different date formats
+        var formats = new List<List<string>>
+        {
+            new() { "m/d/yyyy" },
+            new() { "mm/dd/yyyy" },
+            new() { "d-mmm-yyyy" }
+        };
+
+        var result = _rangeCommands.SetNumberFormats(batch, "Sheet1", "A1:A3", formats);
+
+        // Assert
+        Assert.True(result.Success, $"SetNumberFormats failed: {result.ErrorMessage}");
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+
+            var texts = new[]
+            {
+                sheet.Range["A1"].Text?.ToString() ?? "null",
+                sheet.Range["A2"].Text?.ToString() ?? "null",
+                sheet.Range["A3"].Text?.ToString() ?? "null"
+            };
+
+            _output.WriteLine($"A1 (m/d/yyyy): '{texts[0]}'");
+            _output.WriteLine($"A2 (mm/dd/yyyy): '{texts[1]}'");
+            _output.WriteLine($"A3 (d-mmm-yyyy): '{texts[2]}'");
+
+            // All should contain the year 2023, not broken format codes
+            foreach (var text in texts)
+            {
+                Assert.Contains("2023", text);
+                Assert.DoesNotContain("0/d", text);
+            }
+        });
+    }
+
+    [Fact]
+    public void SetNumberFormat_CurrencyFormat_NotAffected()
+    {
+        // Currency formats should NOT be affected by date translation
+
+        var testFile = CoreTestHelper.CreateUniqueTestFile(
+            nameof(DateFormatTranslationTests),
+            nameof(SetNumberFormat_CurrencyFormat_NotAffected),
+            _tempDir,
+            ".xlsx");
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Set a currency value
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            sheet.Range["A1"].Value2 = 1234.56;
+        });
+
+        // Act - Set currency format
+        var result = _rangeCommands.SetNumberFormat(batch, "Sheet1", "A1", "$#,##0.00");
+
+        // Assert
+        Assert.True(result.Success, $"SetNumberFormat failed: {result.ErrorMessage}");
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            string displayedText = sheet.Range["A1"].Text?.ToString() ?? "null";
+
+            _output.WriteLine($"Currency format '$#,##0.00': '{displayedText}'");
+
+            // Should contain the dollar sign and proper formatting
+            Assert.Contains("$", displayedText);
+            Assert.Contains("1,234.56", displayedText);
+        });
+    }
+
+    [Fact]
+    public void SetNumberFormat_TimeFormat_DisplaysCorrectly()
+    {
+        // Arrange
+        var testFile = CoreTestHelper.CreateUniqueTestFile(
+            nameof(DateFormatTranslationTests),
+            nameof(SetNumberFormat_TimeFormat_DisplaysCorrectly),
+            _tempDir,
+            ".xlsx");
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Set a time value (0.75 = 6:00 PM / 18:00)
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            sheet.Range["A1"].Value2 = 0.75; // 18:00
+        });
+
+        // Act - Set time format
+        var result = _rangeCommands.SetNumberFormat(batch, "Sheet1", "A1", "h:mm");
+
+        // Assert
+        Assert.True(result.Success, $"SetNumberFormat failed: {result.ErrorMessage}");
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            string displayedText = sheet.Range["A1"].Text?.ToString() ?? "null";
+
+            _output.WriteLine($"Time format 'h:mm': '{displayedText}'");
+
+            // Should show time (18:00 or 6:00 PM depending on locale)
+            Assert.True(displayedText.Contains("18:00") || displayedText.Contains("6:00"),
+                $"Expected time display, got '{displayedText}'");
+        });
+    }
+
+    [Fact]
+    public void SetNumberFormat_DateTimeFormat_DisplaysCorrectly()
+    {
+        // Test combined date+time format
+
+        var testFile = CoreTestHelper.CreateUniqueTestFile(
+            nameof(DateFormatTranslationTests),
+            nameof(SetNumberFormat_DateTimeFormat_DisplaysCorrectly),
+            _tempDir,
+            ".xlsx");
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Set a date+time value (45000.75 = March 15, 2023 at 18:00)
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            sheet.Range["A1"].Value2 = 45000.75;
+        });
+
+        // Act - Set date+time format
+        var result = _rangeCommands.SetNumberFormat(batch, "Sheet1", "A1", "m/d/yyyy h:mm");
+
+        // Assert
+        Assert.True(result.Success, $"SetNumberFormat failed: {result.ErrorMessage}");
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            string displayedText = sheet.Range["A1"].Text?.ToString() ?? "null";
+
+            _output.WriteLine($"DateTime format 'm/d/yyyy h:mm': '{displayedText}'");
+
+            // Should contain year (date part works)
+            Assert.Contains("2023", displayedText);
+
+            // Should contain time separator (time part works)
+            Assert.Contains(":", displayedText);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #263 - Format codes corrupted on non-US locales (e.g., German)

## Problem

On non-US locales (e.g., German with decimal=',' and thousands='.'):
- Number formats like `$#,##0.00` were corrupted to `$#.##0,00`
- Date formats like `m/d/yyyy` displayed as literal `M/T/JJJJ` text instead of dates

## Solution

### Number Formats
Force US-style separators at Excel instance creation in 3 files:
- `ExcelBatch.cs`
- `ExcelSession.cs`  
- `FileCommands.cs`

### Date Formats
Created `DateFormatTranslator` that translates US date codes to locale-specific codes:
- Uses `Application.International[index]` to get locale codes
- German: `d` -> `T` (Tag), `m` -> `M` (Monat), `y` -> `J` (Jahr)
- Context-aware: only translates in date contexts, preserves number formats

### PivotTable Fix
Fixed `OlapPivotTableFieldStrategy.SetFieldFormat` to use `PivotField.NumberFormat` directly instead of searching `ModelMeasures` (which failed for pre-existing measures).

## Files Changed

**New Files:**
- `src/ExcelMcp.ComInterop/Formatting/DateFormatTranslator.cs`
- `tests/.../DateFormatTranslationTests.cs` (6 tests)

**Modified:**
- 3 session files (number separator fix)
- `RangeCommands.NumberFormat.cs` (date translation)
- `PivotTableCommands.Fields.cs` (date translation)
- `OlapPivotTableFieldStrategy.cs` (SetFieldFormat fix)
- 3 MCP tool files (LLM documentation updates)
- 1 prompt file (US format guidance)
- 2 test files (new PivotTable format tests)

## Test Coverage

- 6 new date format translation tests (all passing)
- 2 new PivotTable format tests (currency + percent)
- All existing tests pass

## Backwards Compatibility

Fully backwards compatible - LLMs already use US format codes