### PR TITLE
perf: replace CreateUniqueTestFile with fixture-based file creation

### DIFF
--- a/tests/ExcelMcp.CLI.Tests/Integration/Commands/SessionCommandIntegrationTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/Commands/SessionCommandIntegrationTests.cs
@@ -16,20 +16,17 @@ namespace Sbroenne.ExcelMcp.CLI.Tests.Integration.Commands;
 [Trait("Speed", "Medium")]
 public sealed class SessionCommandIntegrationTests : IClassFixture<TempDirectoryFixture>
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture;
 
     public SessionCommandIntegrationTests(TempDirectoryFixture fixture)
     {
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
     }
 
     [Fact]
     public void SessionCommands_OpenListClose_ManagesLifecycle()
     {
-        var filePath = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SessionCommandIntegrationTests),
-            nameof(SessionCommands_OpenListClose_ManagesLifecycle),
-            _tempDir);
+        var filePath = _fixture.CreateTestFile();
 
         using var sessionService = new SessionService();
 
@@ -75,10 +72,7 @@ public sealed class SessionCommandIntegrationTests : IClassFixture<TempDirectory
     [Fact]
     public void SheetCommand_CreateAndList_Worksheets()
     {
-        var filePath = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SessionCommandIntegrationTests),
-            nameof(SheetCommand_CreateAndList_Worksheets),
-            _tempDir);
+        var filePath = _fixture.CreateTestFile();
 
         using var sessionService = new SessionService();
 

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Appearance.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Appearance.cs
@@ -14,11 +14,7 @@ public partial class ChartCommandsTests
     public void SetChartType_ExistingChart_ChangesType()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetChartType_ExistingChart_ChangesType),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -50,11 +46,7 @@ public partial class ChartCommandsTests
     public void SetTitle_ValidTitle_SetsChartTitle()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetTitle_ValidTitle_SetsChartTitle),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -84,11 +76,7 @@ public partial class ChartCommandsTests
     public void SetTitle_EmptyString_HidesTitle()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetTitle_EmptyString_HidesTitle),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -115,11 +103,7 @@ public partial class ChartCommandsTests
     public void SetAxisTitle_CategoryAxis_SetsTitleSuccessfully()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetAxisTitle_CategoryAxis_SetsTitleSuccessfully),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -146,11 +130,7 @@ public partial class ChartCommandsTests
     public void SetAxisTitle_ValueAxis_SetsTitleSuccessfully()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetAxisTitle_ValueAxis_SetsTitleSuccessfully),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -177,11 +157,7 @@ public partial class ChartCommandsTests
     public void ShowLegend_WithPosition_DisplaysLegendAtPosition()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(ShowLegend_WithPosition_DisplaysLegendAtPosition),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -212,11 +188,7 @@ public partial class ChartCommandsTests
     public void ShowLegend_HideLegend_RemovesLegend()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(ShowLegend_HideLegend_RemovesLegend),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -243,11 +215,7 @@ public partial class ChartCommandsTests
     public void SetStyle_ValidStyleId_AppliesStyle()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetStyle_ValidStyleId_AppliesStyle),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -274,11 +242,7 @@ public partial class ChartCommandsTests
     public void SetStyle_InvalidStyleId_ReturnsError()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetStyle_InvalidStyleId_ReturnsError),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -302,11 +266,7 @@ public partial class ChartCommandsTests
     public void SetChartType_MultipleTypes_AllWorkCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetChartType_MultipleTypes_AllWorkCorrectly),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -341,11 +301,7 @@ public partial class ChartCommandsTests
     public void ShowLegend_DifferentPositions_AllWorkCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(ShowLegend_DifferentPositions_AllWorkCorrectly),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.DataSource.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.DataSource.cs
@@ -14,11 +14,7 @@ public partial class ChartCommandsTests
     public void SetSourceRange_RegularChart_UpdatesDataSource()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetSourceRange_RegularChart_UpdatesDataSource),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -58,11 +54,7 @@ public partial class ChartCommandsTests
     public void AddSeries_RegularChart_AddsNewSeries()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(AddSeries_RegularChart_AddsNewSeries),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -105,11 +97,7 @@ public partial class ChartCommandsTests
     public void RemoveSeries_RegularChart_RemovesSeries()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(RemoveSeries_RegularChart_RemovesSeries),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -144,11 +132,7 @@ public partial class ChartCommandsTests
     public void AddSeries_WithoutCategoryRange_CreatesSeriesSuccessfully()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(AddSeries_WithoutCategoryRange_CreatesSeriesSuccessfully),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -179,11 +163,7 @@ public partial class ChartCommandsTests
     public void SetSourceRange_NonExistentChart_ReturnsError()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetSourceRange_NonExistentChart_ReturnsError),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         // Act & Assert
         using var batch = ExcelSession.BeginBatch(testFile);
@@ -196,11 +176,7 @@ public partial class ChartCommandsTests
     public void AddSeries_InvalidSeriesIndex_HandlesGracefully()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(AddSeries_InvalidSeriesIndex_HandlesGracefully),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -230,11 +206,7 @@ public partial class ChartCommandsTests
     public void SetSourceRange_ExpandedRange_UpdatesChartData()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(SetSourceRange_ExpandedRange_UpdatesChartData),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Lifecycle.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Lifecycle.cs
@@ -13,26 +13,22 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands;
 [Trait("Layer", "Core")]
 [Trait("Feature", "Charts")]
 [Trait("RequiresExcel", "true")]
-public partial class ChartCommandsTests : IClassFixture<TempDirectoryFixture>
+public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
 {
     private readonly ChartCommands _commands;
-    private readonly string _tempDir;
+    private readonly ChartTestsFixture _fixture;
 
-    public ChartCommandsTests(TempDirectoryFixture fixture)
+    public ChartCommandsTests(ChartTestsFixture fixture)
     {
         _commands = new ChartCommands();
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
     }
 
     [Fact]
     public void List_EmptyWorkbook_ReturnsEmptyList()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(List_EmptyWorkbook_ReturnsEmptyList),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         // Act
         using var batch = ExcelSession.BeginBatch(testFile);
@@ -46,11 +42,7 @@ public partial class ChartCommandsTests : IClassFixture<TempDirectoryFixture>
     public void CreateFromRange_ValidData_CreatesChart()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(CreateFromRange_ValidData_CreatesChart),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -97,11 +89,7 @@ public partial class ChartCommandsTests : IClassFixture<TempDirectoryFixture>
     public void Read_ExistingChart_ReturnsDetails()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(Read_ExistingChart_ReturnsDetails),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -135,11 +123,7 @@ public partial class ChartCommandsTests : IClassFixture<TempDirectoryFixture>
     public void Read_NonExistentChart_ReturnsError()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(Read_NonExistentChart_ReturnsError),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         // Act & Assert
         using var batch = ExcelSession.BeginBatch(testFile);
@@ -151,11 +135,7 @@ public partial class ChartCommandsTests : IClassFixture<TempDirectoryFixture>
     public void Delete_ExistingChart_RemovesChart()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(Delete_ExistingChart_RemovesChart),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -185,11 +165,7 @@ public partial class ChartCommandsTests : IClassFixture<TempDirectoryFixture>
     public void Move_ExistingChart_UpdatesPosition()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(Move_ExistingChart_UpdatesPosition),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -218,11 +194,7 @@ public partial class ChartCommandsTests : IClassFixture<TempDirectoryFixture>
     public void List_MultipleCharts_ReturnsAll()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(List_MultipleCharts_ReturnsAll),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -258,11 +230,7 @@ public partial class ChartCommandsTests : IClassFixture<TempDirectoryFixture>
     public void CreateFromRange_DifferentChartTypes_CreatesCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ChartCommandsTests),
-            nameof(CreateFromRange_DifferentChartTypes_CreatesCorrectly),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 

--- a/tests/ExcelMcp.Core.Tests/Helpers/ChartTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/ChartTestsFixture.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Fixture for Chart tests that need isolated test files.
+/// Provides temp directory and file creation helpers.
+/// - Created ONCE before any tests run
+/// - Each test creates unique files via CreateTestFile()
+/// - Temp directory cleaned up after all tests complete
+/// </summary>
+public class ChartTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private readonly FileCommands _fileCommands = new();
+
+    /// <summary>
+    /// Temp directory for all test files (auto-cleaned on disposal)
+    /// </summary>
+    public string TempDir => _tempDir;
+
+    public ChartTestsFixture()
+    {
+        _tempDir = Path.Join(Path.GetTempPath(), $"ChartTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Creates a unique test file for tests that need their own file.
+    /// File name includes test name + GUID for uniqueness.
+    /// </summary>
+    /// <param name="testName">Test name (auto-populated via CallerMemberName)</param>
+    /// <param name="extension">File extension (default: .xlsx)</param>
+    /// <returns>Path to the new test file</returns>
+    public string CreateTestFile([CallerMemberName] string testName = "", string extension = ".xlsx")
+    {
+        var fileName = $"{testName}_{Guid.NewGuid():N}{extension}";
+        var filePath = Path.Join(_tempDir, fileName);
+        _fileCommands.CreateEmpty(filePath);
+        return filePath;
+    }
+
+    /// <summary>
+    /// Called ONCE before any tests in the class run.
+    /// </summary>
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Called ONCE after all tests in the class complete.
+    /// </summary>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Helpers/ConnectionTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/ConnectionTestsFixture.cs
@@ -1,0 +1,87 @@
+using System.Runtime.CompilerServices;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Fixture for Connection tests that provides efficient test file creation.
+/// Connection tests often need isolated files because they:
+/// - Create/delete connections within a single test
+/// - Need external source files for OLEDB connections
+/// - Modify connection state
+/// 
+/// This fixture provides:
+/// - A shared temp directory (auto-cleaned on disposal)
+/// - Fast test file creation method
+/// - Helper for creating external source files
+/// </summary>
+public class ConnectionTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private readonly FileCommands _fileCommands = new();
+
+    /// <summary>
+    /// Temp directory for all test files (auto-cleaned on disposal)
+    /// </summary>
+    public string TempDir => _tempDir;
+
+    /// <summary>
+    /// Initializes a new instance of the fixture.
+    /// </summary>
+    public ConnectionTestsFixture()
+    {
+        _tempDir = Path.Join(Path.GetTempPath(), $"ConnectionTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <inheritdoc/>
+    public Task InitializeAsync()
+    {
+        // No async initialization needed
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Creates a unique empty test file for the calling test.
+    /// Uses [CallerMemberName] to auto-populate the test name.
+    /// </summary>
+    /// <param name="testName">Auto-populated from caller method name</param>
+    /// <returns>Path to the unique test file</returns>
+    public string CreateTestFile([CallerMemberName] string testName = "")
+    {
+        var guid = Guid.NewGuid().ToString("N")[..8];
+        var testFile = Path.Join(_tempDir, $"Conn_{testName}_{guid}.xlsx");
+        _fileCommands.CreateEmpty(testFile);
+        return testFile;
+    }
+
+    /// <summary>
+    /// Creates a unique source file path (does not create the file).
+    /// Used for OLEDB source workbooks that are created by test helpers.
+    /// </summary>
+    /// <param name="suffix">Optional suffix for the file name</param>
+    /// <param name="testName">Auto-populated from caller method name</param>
+    /// <returns>Path for the source file</returns>
+    public string GetSourceFilePath(string suffix = "Source", [CallerMemberName] string testName = "")
+    {
+        return Path.Join(_tempDir, $"{testName}_{suffix}.xlsx");
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Helpers/DataModelTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/DataModelTestsFixture.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Fixture for Data Model tests that need isolated test files.
+/// Provides temp directory and file creation helpers.
+/// - Created ONCE before any tests run
+/// - Each test creates unique files via CreateTestFile()
+/// - Temp directory cleaned up after all tests complete
+/// </summary>
+public class DataModelTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private readonly FileCommands _fileCommands = new();
+
+    /// <summary>
+    /// Temp directory for all test files (auto-cleaned on disposal)
+    /// </summary>
+    public string TempDir => _tempDir;
+
+    public DataModelTestsFixture()
+    {
+        _tempDir = Path.Join(Path.GetTempPath(), $"DataModelTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Creates a unique test file for tests that need their own file.
+    /// File name includes test name + GUID for uniqueness.
+    /// </summary>
+    /// <param name="testName">Test name (auto-populated via CallerMemberName)</param>
+    /// <param name="extension">File extension (default: .xlsx)</param>
+    /// <returns>Path to the new test file</returns>
+    public string CreateTestFile([CallerMemberName] string testName = "", string extension = ".xlsx")
+    {
+        var fileName = $"{testName}_{Guid.NewGuid():N}{extension}";
+        var filePath = Path.Join(_tempDir, fileName);
+        _fileCommands.CreateEmpty(filePath);
+        return filePath;
+    }
+
+    /// <summary>
+    /// Called ONCE before any tests in the class run.
+    /// </summary>
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Called ONCE after all tests in the class complete.
+    /// </summary>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Helpers/FileTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/FileTestsFixture.cs
@@ -1,0 +1,63 @@
+using System.Runtime.CompilerServices;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Fixture for File tests providing efficient test file creation.
+/// Each test gets a unique .xlsx file via CreateTestFile() method.
+/// </summary>
+public class FileTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private readonly FileCommands _fileCommands = new();
+
+    /// <summary>
+    /// Temp directory for all test files (auto-cleaned on disposal)
+    /// </summary>
+    public string TempDir => _tempDir;
+
+    public FileTestsFixture()
+    {
+        _tempDir = Path.Join(Path.GetTempPath(), $"FileTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <inheritdoc/>
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Creates a unique empty .xlsx test file for the calling test.
+    /// Uses [CallerMemberName] to auto-populate the test name.
+    /// </summary>
+    /// <param name="testName">Auto-populated from caller method name</param>
+    /// <returns>Path to the unique .xlsx test file</returns>
+    public string CreateTestFile([CallerMemberName] string testName = "")
+    {
+        var guid = Guid.NewGuid().ToString("N")[..8];
+        var testFile = Path.Join(_tempDir, $"File_{testName}_{guid}.xlsx");
+        _fileCommands.CreateEmpty(testFile);
+        return testFile;
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Helpers/NamedRangeTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/NamedRangeTestsFixture.cs
@@ -1,0 +1,123 @@
+// <copyright file="NamedRangeTestsFixture.cs" company="Stephan Brenner">
+// Copyright (c) Stephan Brenner. All rights reserved.
+// </copyright>
+
+using System.Diagnostics;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Fixture that creates ONE NamedRange test file per test CLASS.
+/// Each test uses unique named range names for isolation.
+/// - Created ONCE before any tests run (~3-5s)
+/// - Shared by all tests in the class
+/// - Each test creates its own named ranges with unique names
+/// - Reduces file creation overhead by ~95%
+/// </summary>
+public class NamedRangeTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private readonly FileCommands _fileCommands = new();
+    private int _cellCounter;
+
+    /// <summary>
+    /// Path to the shared test file
+    /// </summary>
+    public string TestFilePath { get; private set; } = null!;
+
+    /// <summary>
+    /// Results of fixture creation (exposed for validation)
+    /// </summary>
+    public FixtureCreationResult CreationResult { get; private set; } = null!;
+
+    /// <summary>
+    /// Initializes a new instance of the fixture
+    /// </summary>
+    public NamedRangeTestsFixture()
+    {
+        _tempDir = Path.Join(Path.GetTempPath(), $"NamedRangeTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Gets a unique named range name for test isolation.
+    /// Named range names are limited to 255 chars (Excel limit).
+    /// </summary>
+    public string GetUniqueNamedRangeName([System.Runtime.CompilerServices.CallerMemberName] string testName = "")
+    {
+        // Create a unique name that fits within Excel's 255 character limit
+        var uniqueId = Guid.NewGuid().ToString("N")[..8];
+        var prefix = $"NR_{uniqueId}_";
+        var maxNameLength = 255 - prefix.Length;
+        var shortName = testName.Length > maxNameLength ? testName[..maxNameLength] : testName;
+        return $"{prefix}{shortName}";
+    }
+
+    /// <summary>
+    /// Gets a unique cell reference for the named range (to avoid conflicts).
+    /// Uses incrementing row numbers to avoid conflicts.
+    /// </summary>
+    public string GetUniqueCellReference()
+    {
+        // Use incrementing counter for unique cell references
+        var counter = Interlocked.Increment(ref _cellCounter);
+        var col = ((counter - 1) % 26) + 1; // A-Z
+        var row = ((counter - 1) / 26) + 1; // 1, 2, 3...
+        var colLetter = (char)('A' + col - 1);
+        return $"Sheet1!{colLetter}{row}";
+    }
+
+    /// <summary>
+    /// Called ONCE before any tests in the class run.
+    /// Creates a workbook that tests will add named ranges to.
+    /// </summary>
+    public Task InitializeAsync()
+    {
+        var sw = Stopwatch.StartNew();
+
+        TestFilePath = Path.Join(_tempDir, "NamedRangeTest.xlsx");
+        CreationResult = new FixtureCreationResult();
+
+        try
+        {
+            _fileCommands.CreateEmpty(TestFilePath);
+            CreationResult.FileCreated = true;
+
+            sw.Stop();
+            CreationResult.Success = true;
+            CreationResult.CreationTimeSeconds = sw.Elapsed.TotalSeconds;
+        }
+        catch (Exception ex)
+        {
+            CreationResult.Success = false;
+            CreationResult.ErrorMessage = ex.Message;
+            sw.Stop();
+            throw;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Called ONCE after all tests in the class complete.
+    /// </summary>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Helpers/RangeTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/RangeTestsFixture.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Fixture that creates ONE Range test file per test CLASS.
+/// Each test uses different sheets within the same file for isolation.
+/// - Created ONCE before any tests run (~3-5s)
+/// - Shared by all tests in the class
+/// - Each test gets its own batch AND its own sheet (isolation)
+/// - Reduces file creation overhead by ~95%
+/// </summary>
+public class RangeTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private readonly FileCommands _fileCommands = new();
+    private int _sheetCounter;
+
+    /// <summary>
+    /// Temp directory for all test files (auto-cleaned on disposal)
+    /// </summary>
+    public string TempDir => _tempDir;
+
+    /// <summary>
+    /// Path to the test Range file
+    /// </summary>
+    public string TestFilePath { get; private set; } = null!;
+
+    /// <summary>
+    /// Results of fixture creation (exposed for validation)
+    /// </summary>
+    public FixtureCreationResult CreationResult { get; private set; } = null!;
+
+    /// <summary>
+    /// Initializes a new instance of the fixture
+    /// </summary>
+    public RangeTestsFixture()
+    {
+        _tempDir = Path.Join(Path.GetTempPath(), $"RangeTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Gets a unique sheet name for test isolation.
+    /// Each test should call this to get its own sheet.
+    /// Sheet names are limited to 31 chars (Excel limit).
+    /// </summary>
+    public string GetUniqueSheetName([CallerMemberName] string testName = "")
+    {
+        var counter = Interlocked.Increment(ref _sheetCounter);
+        // Limit sheet name to 31 chars (Excel limit) - format: "T001_TestMethodName"
+        var prefix = $"T{counter:D3}_";
+        var maxNameLength = 31 - prefix.Length;
+        var shortName = testName.Length > maxNameLength ? testName[..maxNameLength] : testName;
+        return $"{prefix}{shortName}";
+    }
+
+    /// <summary>
+    /// Creates a unique sheet for a test and returns its name.
+    /// Call this in the Arrange phase of each test.
+    /// </summary>
+    public string CreateTestSheet(IExcelBatch batch, [CallerMemberName] string testName = "")
+    {
+        var sheetName = GetUniqueSheetName(testName);
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheets = ctx.Book.Worksheets;
+            dynamic newSheet = sheets.Add(After: sheets.Item(sheets.Count));
+            newSheet.Name = sheetName;
+            return 0;
+        });
+
+        return sheetName;
+    }
+
+    /// <summary>
+    /// Creates a unique test file for tests that need their own file.
+    /// File name includes test name + GUID for uniqueness.
+    /// </summary>
+    /// <param name="testName">Test name (auto-populated via CallerMemberName)</param>
+    /// <param name="extension">File extension (default: .xlsx)</param>
+    /// <returns>Path to the new test file</returns>
+    public string CreateTestFile([CallerMemberName] string testName = "", string extension = ".xlsx")
+    {
+        var fileName = $"{testName}_{Guid.NewGuid():N}{extension}";
+        var filePath = Path.Join(_tempDir, fileName);
+        _fileCommands.CreateEmpty(filePath);
+        return filePath;
+    }
+
+    /// <summary>
+    /// Called ONCE before any tests in the class run.
+    /// Creates a workbook that tests will add sheets to.
+    /// </summary>
+    public Task InitializeAsync()
+    {
+        var sw = Stopwatch.StartNew();
+
+        TestFilePath = Path.Join(_tempDir, "RangeTest.xlsx");
+        CreationResult = new FixtureCreationResult();
+
+        try
+        {
+            var fileCommands = new FileCommands();
+            fileCommands.CreateEmpty(TestFilePath);
+            CreationResult.FileCreated = true;
+
+            sw.Stop();
+            CreationResult.Success = true;
+            CreationResult.CreationTimeSeconds = sw.Elapsed.TotalSeconds;
+        }
+        catch (Exception ex)
+        {
+            CreationResult.Success = false;
+            CreationResult.ErrorMessage = ex.Message;
+            sw.Stop();
+            throw;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Called ONCE after all tests in the class complete.
+    /// </summary>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Generic fixture creation result
+/// </summary>
+public class FixtureCreationResult
+{
+    /// <summary>Whether fixture creation succeeded</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Whether the Excel file was created</summary>
+    public bool FileCreated { get; set; }
+
+    /// <summary>Time taken to create the fixture</summary>
+    public double CreationTimeSeconds { get; set; }
+
+    /// <summary>Error message if creation failed</summary>
+    public string? ErrorMessage { get; set; }
+}

--- a/tests/ExcelMcp.Core.Tests/Helpers/SheetTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/SheetTestsFixture.cs
@@ -1,0 +1,121 @@
+// <copyright file="SheetTestsFixture.cs" company="Stephan Brenner">
+// Copyright (c) Stephan Brenner. All rights reserved.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Shared fixture for SheetCommandsTests that provides a single Excel file for single-workbook tests.
+/// Cross-workbook tests (CopyToWorkbook, MoveToWorkbook) still create their own file pairs.
+/// Uses IAsyncLifetime to create file once for all tests, reducing test execution time.
+/// </summary>
+public class SheetTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private readonly FileCommands _fileCommands = new();
+    private int _sheetCounter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SheetTestsFixture"/> class.
+    /// </summary>
+    public SheetTestsFixture()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"SheetTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Gets the path to the shared test file for single-workbook tests.
+    /// </summary>
+    public string TestFilePath { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the temp directory for cross-workbook tests that need their own files.
+    /// </summary>
+    public string TempDir => _tempDir;
+
+    /// <summary>
+    /// Creates the shared Excel file.
+    /// </summary>
+    public Task InitializeAsync()
+    {
+        TestFilePath = Path.Combine(_tempDir, "SheetTests_Shared.xlsx");
+        _fileCommands.CreateEmpty(TestFilePath);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Cleans up the temp directory and all test files.
+    /// </summary>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Creates a unique sheet name for test isolation within the shared workbook.
+    /// Call this at the start of each single-workbook test to get a unique sheet to work with.
+    /// </summary>
+    /// <param name="batch">The Excel batch to create the sheet in.</param>
+    /// <param name="testName">Test method name (auto-captured via CallerMemberName).</param>
+    /// <returns>The name of the created test sheet.</returns>
+    public string CreateTestSheet(IExcelBatch batch, [CallerMemberName] string testName = "")
+    {
+        var sheetNum = Interlocked.Increment(ref _sheetCounter);
+        var sheetName = $"T{sheetNum}_{testName}";
+
+        // Truncate if too long (Excel max is 31 chars)
+        if (sheetName.Length > 31)
+        {
+            sheetName = $"T{sheetNum}_{testName[..(31 - $"T{sheetNum}_".Length)]}";
+        }
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Add();
+            sheet.Name = sheetName;
+        });
+
+        return sheetName;
+    }
+
+    /// <summary>
+    /// Creates a unique test file for cross-workbook tests that need their own isolated files.
+    /// </summary>
+    /// <param name="testName">Test method name.</param>
+    /// <param name="suffix">Optional suffix to distinguish source/target files.</param>
+    /// <returns>Path to the created test file.</returns>
+    public string CreateCrossWorkbookTestFile(string testName, string suffix = "")
+    {
+        var fileName = string.IsNullOrEmpty(suffix)
+            ? $"{testName}_{Guid.NewGuid():N}.xlsx"
+            : $"{testName}_{suffix}_{Guid.NewGuid():N}.xlsx";
+
+        // Truncate filename if too long
+        if (fileName.Length > 200)
+        {
+            fileName = $"{testName[..50]}_{suffix}_{Guid.NewGuid():N}.xlsx";
+        }
+
+        var filePath = Path.Combine(_tempDir, fileName);
+        _fileCommands.CreateEmpty(filePath);
+        return filePath;
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Helpers/TempDirectoryFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/TempDirectoryFixture.cs
@@ -1,3 +1,7 @@
+using System.Runtime.CompilerServices;
+
+using Sbroenne.ExcelMcp.Core.Commands;
+
 namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
 
 /// <summary>
@@ -9,22 +13,38 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
 /// <code>
 /// public partial class MyTests : IClassFixture&lt;TempDirectoryFixture&gt;
 /// {
-///     private readonly string _tempDir;
+///     private readonly TempDirectoryFixture _fixture;
 ///     
 ///     public MyTests(TempDirectoryFixture fixture)
 ///     {
-///         _tempDir = fixture.TempDir;
+///         _fixture = fixture;
 ///     }
 /// }
 /// </code>
 /// </remarks>
 public class TempDirectoryFixture : IDisposable
 {
+    private readonly FileCommands _fileCommands = new();
+
     /// <summary>
     /// Temporary directory for test files. Created in constructor, deleted in Dispose.
     /// Shared across all tests in the test class.
     /// </summary>
     public string TempDir { get; }
+
+    /// <summary>
+    /// Creates a unique test Excel file for the calling test method.
+    /// </summary>
+    /// <param name="testName">Auto-populated with the calling method name.</param>
+    /// <param name="extension">File extension (default: .xlsx).</param>
+    /// <returns>Full path to the created file.</returns>
+    public string CreateTestFile([CallerMemberName] string testName = "", string extension = ".xlsx")
+    {
+        var fileName = $"{testName}_{Guid.NewGuid():N}{extension}";
+        var filePath = Path.Combine(TempDir, fileName);
+        _fileCommands.CreateEmpty(filePath);
+        return filePath;
+    }
 
     private bool _disposed;
 

--- a/tests/ExcelMcp.Core.Tests/Helpers/VbaTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/VbaTestsFixture.cs
@@ -1,0 +1,64 @@
+using System.Runtime.CompilerServices;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Fixture for VBA tests providing efficient test file creation.
+/// Each test gets a unique .xlsm file via CreateTestFile() method.
+/// All files use .xlsm extension for VBA compatibility.
+/// </summary>
+public class VbaTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private readonly FileCommands _fileCommands = new();
+
+    /// <summary>
+    /// Temp directory for all test files (auto-cleaned on disposal)
+    /// </summary>
+    public string TempDir => _tempDir;
+
+    public VbaTestsFixture()
+    {
+        _tempDir = Path.Join(Path.GetTempPath(), $"VbaTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <inheritdoc/>
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Creates a unique empty .xlsm test file for the calling test.
+    /// Uses [CallerMemberName] to auto-populate the test name.
+    /// </summary>
+    /// <param name="testName">Auto-populated from caller method name</param>
+    /// <returns>Path to the unique .xlsm test file</returns>
+    public string CreateTestFile([CallerMemberName] string testName = "")
+    {
+        var guid = Guid.NewGuid().ToString("N")[..8];
+        var testFile = Path.Join(_tempDir, $"Vba_{testName}_{guid}.xlsm");
+        _fileCommands.CreateEmpty(testFile);
+        return testFile;
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.Create.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.Create.cs
@@ -18,12 +18,9 @@ public partial class ConnectionCommandsTests
     public void Create_TextConnection_ThrowsNotSupportedException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Create_TextConnection_ThrowsNotSupportedException),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
-        var csvPath = Path.Combine(_tempDir, "test_data.csv");
+        var csvPath = Path.Combine(_fixture.TempDir, "test_data.csv");
         System.IO.File.WriteAllText(csvPath, "Name,Value\nTest,123");
 
         string connectionString = $"TEXT;{csvPath}";
@@ -42,10 +39,7 @@ public partial class ConnectionCommandsTests
     public void Create_WebConnection_ThrowsNotSupportedException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Create_WebConnection_ThrowsNotSupportedException),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         string connectionString = "URL;https://example.com/data.xml";
         string connectionName = "TestWebConnection";
@@ -63,12 +57,9 @@ public partial class ConnectionCommandsTests
     public void Create_AceOleDbConnection_ReturnsSuccess()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Create_AceOleDbConnection_ReturnsSuccess),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
-        var sourceWorkbook = Path.Combine(_tempDir, "AceOleDbSource.xlsx");
+        var sourceWorkbook = _fixture.GetSourceFilePath("AceOleDbSource");
         AceOleDbTestHelper.CreateExcelDataSource(sourceWorkbook);
 
         string connectionString = AceOleDbTestHelper.GetExcelConnectionString(sourceWorkbook);
@@ -96,10 +87,7 @@ public partial class ConnectionCommandsTests
     public void Create_OdbcConnection_ReturnsSuccess()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Create_OdbcConnection_ReturnsSuccess),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // ODBC connection string - Excel accepts but may not connect without actual DSN
         string connectionString = "ODBC;DSN=Excel Files;DBQ=C:\\temp\\test.xlsx";
@@ -119,10 +107,7 @@ public partial class ConnectionCommandsTests
     public void Create_DuplicateName_CreatesSecondConnection()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Create_DuplicateName_CreatesSecondConnection),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         string connectionString1 = "ODBC;DSN=Source1;DBQ=C:\\temp\\test1.xlsx";
         string connectionString2 = "ODBC;DSN=Source2;DBQ=C:\\temp\\test2.xlsx";
@@ -152,10 +137,7 @@ public partial class ConnectionCommandsTests
     public void Create_WithDescription_CreatesConnection()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Create_WithDescription_CreatesConnection),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         string connectionString = "ODBC;DSN=Excel Files;DBQ=C:\\temp\\test.xlsx";
         string connectionName = "ConnectionWithDescription";

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.Delete.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.Delete.cs
@@ -1,5 +1,4 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Connection;
@@ -13,10 +12,7 @@ public partial class ConnectionCommandsTests
     public void Delete_ExistingTextConnection_ReturnsSuccess()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Delete_ExistingTextConnection_ReturnsSuccess),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Use ODBC connection (doesn't need actual DSN for delete test)
         string connectionString = "ODBC;DSN=TestDSN;DBQ=C:\\temp\\test.xlsx";
@@ -46,10 +42,7 @@ public partial class ConnectionCommandsTests
     public void Delete_NonExistentConnection_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Delete_NonExistentConnection_ThrowsException),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         string connectionName = "NonExistentConnection";
 
@@ -68,10 +61,7 @@ public partial class ConnectionCommandsTests
     public void Delete_AfterCreatingMultiple_RemovesOnlySpecified()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Delete_AfterCreatingMultiple_RemovesOnlySpecified),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Use ODBC connections (don't need actual DSNs for delete test)
         string conn1Name = "Connection1";
@@ -101,10 +91,7 @@ public partial class ConnectionCommandsTests
     public void Delete_ConnectionWithDescription_RemovesSuccessfully()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Delete_ConnectionWithDescription_RemovesSuccessfully),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         string connectionName = "DescribedConnection";
         string description = "Test connection with description";
@@ -127,10 +114,7 @@ public partial class ConnectionCommandsTests
     public void Delete_ImmediatelyAfterCreate_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Delete_ImmediatelyAfterCreate_WorksCorrectly),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         string connectionName = "ImmediateDeleteTest";
         string connectionString = "ODBC;DSN=ImmediateDSN;DBQ=C:\\temp\\immediate.xlsx";
@@ -151,10 +135,7 @@ public partial class ConnectionCommandsTests
     public void Delete_ConnectionAfterViewOperation_RemovesSuccessfully()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Delete_ConnectionAfterViewOperation_RemovesSuccessfully),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         string connectionName = "ViewThenDelete";
         string connectionString = "ODBC;DSN=ViewDeleteDSN;DBQ=C:\\temp\\viewdelete.xlsx";
@@ -180,10 +161,7 @@ public partial class ConnectionCommandsTests
     public void Delete_EmptyConnectionName_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Delete_EmptyConnectionName_ThrowsException),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -200,10 +178,7 @@ public partial class ConnectionCommandsTests
     public void Delete_RepeatedDeleteAttempts_SecondAttemptFails()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Delete_RepeatedDeleteAttempts_SecondAttemptFails),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         string connectionName = "DoubleDeleteTest";
         string connectionString = "ODBC;DSN=DoubleDeleteDSN;DBQ=C:\\temp\\doubledelete.xlsx";

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.List.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.List.cs
@@ -1,5 +1,4 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Connection;
@@ -9,13 +8,11 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Connection;
 /// </summary>
 public partial class ConnectionCommandsTests
 {
-    /// <inheritdoc/>
     [Fact]
     public void List_EmptyWorkbook_ReturnsSuccessWithEmptyList()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests), nameof(List_EmptyWorkbook_ReturnsSuccessWithEmptyList), _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Act
         using var batch = ExcelSession.BeginBatch(testFile);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.Refresh.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.Refresh.cs
@@ -11,15 +11,11 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Connection;
 [Trait("RequiresExcel", "true")]
 public partial class ConnectionCommandsTests
 {
-    /// <inheritdoc/>
     [Fact]
     public void Refresh_ConnectionNotFound_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            nameof(Refresh_ConnectionNotFound_ThrowsException),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Act & Assert
         using var batch = ExcelSession.BeginBatch(testFile);
@@ -33,8 +29,7 @@ public partial class ConnectionCommandsTests
     [Fact]
     public void Refresh_AceOleDbConnection_ReturnsSuccess()
     {
-        var (testFile, sourceWorkbook, connectionName) = SetupAceOleDbConnection(
-            nameof(Refresh_AceOleDbConnection_ReturnsSuccess));
+        var (testFile, sourceWorkbook, connectionName) = SetupAceOleDbConnection();
 
         try
         {
@@ -59,8 +54,7 @@ public partial class ConnectionCommandsTests
     [Fact]
     public void Refresh_AceOleDbConnectionAfterDataUpdate_ReturnsSuccess()
     {
-        var (testFile, sourceWorkbook, connectionName) = SetupAceOleDbConnection(
-            nameof(Refresh_AceOleDbConnectionAfterDataUpdate_ReturnsSuccess));
+        var (testFile, sourceWorkbook, connectionName) = SetupAceOleDbConnection();
 
         try
         {
@@ -87,14 +81,11 @@ public partial class ConnectionCommandsTests
         }
     }
 
-    private (string testFile, string sourceWorkbook, string connectionName) SetupAceOleDbConnection(string testName)
+    private (string testFile, string sourceWorkbook, string connectionName) SetupAceOleDbConnection()
     {
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests),
-            testName,
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
-        var sourceWorkbook = Path.Combine(_tempDir, $"{testName}_Source.xlsx");
+        var sourceWorkbook = _fixture.GetSourceFilePath("AceOleDbSource");
         AceOleDbTestHelper.CreateExcelDataSource(sourceWorkbook);
 
         var connectionName = "TestAceOleDbConnection";

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.View.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.View.cs
@@ -9,13 +9,11 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Connection;
 /// </summary>
 public partial class ConnectionCommandsTests
 {
-    /// <inheritdoc/>
     [Fact]
     public void View_ExistingConnection_ReturnsDetails()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests), nameof(View_ExistingConnection_ReturnsDetails), _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Use ODBC connection (doesn't need actual DSN for view test)
         var connName = "ViewTestConnection";
@@ -32,14 +30,12 @@ public partial class ConnectionCommandsTests
         Assert.NotNull(result.ConnectionString);
         Assert.NotNull(result.Type);
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void View_NonExistentConnection_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(ConnectionCommandsTests), nameof(View_NonExistentConnection_ThrowsException), _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Act & Assert
         using var batch = ExcelSession.BeginBatch(testFile);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.cs
@@ -7,15 +7,15 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Connection;
 /// <summary>
 /// Comprehensive integration tests for ConnectionCommands.
 /// Tests all connection operations with batch API pattern.
-/// Each test uses a unique Excel file for complete test isolation.
+/// Uses ConnectionTestsFixture for efficient test file creation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Speed", "Medium")]
 [Trait("Layer", "Core")]
 [Trait("Feature", "Connections")]
 [Trait("RequiresExcel", "true")]
-public partial class ConnectionCommandsTests(TempDirectoryFixture fixture) : IClassFixture<TempDirectoryFixture>
+public partial class ConnectionCommandsTests(ConnectionTestsFixture fixture) : IClassFixture<ConnectionTestsFixture>
 {
     private readonly ConnectionCommands _commands = new();
-    private readonly string _tempDir = fixture.TempDir;
+    private readonly ConnectionTestsFixture _fixture = fixture;
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/DataModel/DataModelCommandsTests.DeleteTable.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/DataModel/DataModelCommandsTests.DeleteTable.cs
@@ -18,19 +18,19 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.DataModel;
 [Trait("RequiresExcel", "true")]
 [Trait("Feature", "DataModel")]
 [Trait("Speed", "Slow")]
-public class DataModelDeleteTableTests : IClassFixture<TempDirectoryFixture>
+public class DataModelDeleteTableTests : IClassFixture<DataModelTestsFixture>
 {
     private readonly DataModelCommands _dataModelCommands;
     private readonly TableCommands _tableCommands;
     private readonly FileCommands _fileCommands;
-    private readonly string _tempDir;
+    private readonly DataModelTestsFixture _fixture;
 
-    public DataModelDeleteTableTests(TempDirectoryFixture fixture)
+    public DataModelDeleteTableTests(DataModelTestsFixture fixture)
     {
         _dataModelCommands = new DataModelCommands();
         _tableCommands = new TableCommands();
         _fileCommands = new FileCommands();
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
     }
 
     /// <summary>
@@ -38,13 +38,7 @@ public class DataModelDeleteTableTests : IClassFixture<TempDirectoryFixture>
     /// </summary>
     private string CreateTestFileWithDataModelTable(string testName)
     {
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(DataModelDeleteTableTests),
-            testName,
-            _tempDir,
-            ".xlsx");
-
-        _fileCommands.CreateEmpty(testFile, overwriteIfExists: true);
+        var testFile = _fixture.CreateTestFile(testName);
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -144,13 +138,7 @@ public class DataModelDeleteTableTests : IClassFixture<TempDirectoryFixture>
     public void DeleteTable_EmptyDataModel_ThrowsInvalidOperationException()
     {
         // Arrange - Create file without Data Model
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(DataModelDeleteTableTests),
-            nameof(DeleteTable_EmptyDataModel_ThrowsInvalidOperationException),
-            _tempDir,
-            ".xlsx");
-
-        _fileCommands.CreateEmpty(testFile, overwriteIfExists: true);
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.CreateEmpty.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.CreateEmpty.cs
@@ -31,13 +31,11 @@ public partial class FileCommandsTests
             return false;
         }
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void CreateEmpty_ValidXlsx_ReturnsSuccess()
     {
         // Arrange
-        string testFile = Path.Join(_tempDir, $"{nameof(CreateEmpty_ValidXlsx_ReturnsSuccess)}_{Guid.NewGuid():N}.xlsx");
+        string testFile = Path.Join(_fixture.TempDir, $"{nameof(CreateEmpty_ValidXlsx_ReturnsSuccess)}_{Guid.NewGuid():N}.xlsx");
 
         // Act
         _fileCommands.CreateEmpty(testFile);
@@ -49,13 +47,11 @@ public partial class FileCommandsTests
         bool isValidExcel = IsValidExcelFile(testFile);
         Assert.True(isValidExcel, "Created file should be a valid Excel workbook with at least one worksheet");
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void CreateEmpty_ValidXlsm_ReturnsSuccess()
     {
         // Arrange
-        string testFile = Path.Join(_tempDir, $"{nameof(CreateEmpty_ValidXlsm_ReturnsSuccess)}_{Guid.NewGuid():N}.xlsm");
+        string testFile = Path.Join(_fixture.TempDir, $"{nameof(CreateEmpty_ValidXlsm_ReturnsSuccess)}_{Guid.NewGuid():N}.xlsm");
 
         // Act
         _fileCommands.CreateEmpty(testFile);
@@ -67,8 +63,6 @@ public partial class FileCommandsTests
         bool isValidExcel = IsValidExcelFile(testFile);
         Assert.True(isValidExcel, "Created file should be a valid Excel workbook");
     }
-    /// <inheritdoc/>
-
     [Theory]
     [InlineData("TestFile.xls")]
     [InlineData("TestFile.csv")]
@@ -76,7 +70,7 @@ public partial class FileCommandsTests
     public void CreateEmpty_InvalidExtension_ReturnsError(string fileName)
     {
         // Arrange
-        string testFile = Path.Join(_tempDir, $"{Guid.NewGuid():N}_{fileName}");
+        string testFile = Path.Join(_fixture.TempDir, $"{Guid.NewGuid():N}_{fileName}");
 
         // Act
         var exception = Assert.Throws<ArgumentException>(() => _fileCommands.CreateEmpty(testFile));
@@ -85,14 +79,11 @@ public partial class FileCommandsTests
         Assert.Contains("extension", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.False(System.IO.File.Exists(testFile));
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void CreateEmpty_FileExists_WithoutOverwrite_ReturnsError()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(FileCommandsTests), nameof(CreateEmpty_FileExists_WithoutOverwrite_ReturnsError), _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Act - Try to create again without overwrite flag
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -101,14 +92,11 @@ public partial class FileCommandsTests
         // Assert
         Assert.Contains("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void CreateEmpty_FileExists_WithOverwrite_ReturnsSuccess()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(FileCommandsTests), nameof(CreateEmpty_FileExists_WithOverwrite_ReturnsSuccess), _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Act - Overwrite
         _fileCommands.CreateEmpty(testFile, overwriteIfExists: true);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.CreateEmptyThenList.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.CreateEmptyThenList.cs
@@ -13,7 +13,7 @@ public partial class FileCommandsTests
     public void CreateEmpty_ThenOpenAndList_ReturnsSheet1()
     {
         // Arrange
-        string testFile = Path.Join(_tempDir, $"{nameof(CreateEmpty_ThenOpenAndList_ReturnsSheet1)}_{Guid.NewGuid():N}.xlsx");
+        string testFile = Path.Join(_fixture.TempDir, $"{nameof(CreateEmpty_ThenOpenAndList_ReturnsSheet1)}_{Guid.NewGuid():N}.xlsx");
 
         // Act 1: CreateEmpty (what LLM called first)
         _fileCommands.CreateEmpty(testFile);
@@ -43,7 +43,7 @@ public partial class FileCommandsTests
     public void CreateEmpty_ThenOpenAndListMultipleTimes_ConsistentResults()
     {
         // Arrange
-        string testFile = Path.Join(_tempDir, $"{nameof(CreateEmpty_ThenOpenAndListMultipleTimes_ConsistentResults)}_{Guid.NewGuid():N}.xlsx");
+        string testFile = Path.Join(_fixture.TempDir, $"{nameof(CreateEmpty_ThenOpenAndListMultipleTimes_ConsistentResults)}_{Guid.NewGuid():N}.xlsx");
 
         // Act 1: CreateEmpty
         _fileCommands.CreateEmpty(testFile);
@@ -66,7 +66,7 @@ public partial class FileCommandsTests
     public void CreateEmpty_ThenOpenAndCreateMoreSheets_AllSheetsVisible()
     {
         // Arrange
-        string testFile = Path.Join(_tempDir, $"{nameof(CreateEmpty_ThenOpenAndCreateMoreSheets_AllSheetsVisible)}_{Guid.NewGuid():N}.xlsx");
+        string testFile = Path.Join(_fixture.TempDir, $"{nameof(CreateEmpty_ThenOpenAndCreateMoreSheets_AllSheetsVisible)}_{Guid.NewGuid():N}.xlsx");
 
         // Act 1: CreateEmpty
         _fileCommands.CreateEmpty(testFile);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.TestFile.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.TestFile.cs
@@ -8,13 +8,11 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.File;
 /// </summary>
 public partial class FileCommandsTests
 {
-    /// <inheritdoc/>
     [Fact]
     public void Test_ExistingValidFile_ReturnsSuccess()
     {
         // Arrange - Create a valid file
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(FileCommandsTests), nameof(Test_ExistingValidFile_ReturnsSuccess), _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         // Act
         var info = _fileCommands.Test(testFile);
@@ -26,13 +24,11 @@ public partial class FileCommandsTests
         Assert.True(info.Size > 0);
         Assert.Null(info.Message);
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void Test_NonExistent_ReturnsFailure()
     {
         // Arrange
-        string testFile = Path.Join(_tempDir, $"NonExistent_{Guid.NewGuid():N}.xlsx");
+        string testFile = Path.Join(_fixture.TempDir, $"NonExistent_{Guid.NewGuid():N}.xlsx");
 
         // Act
         var info = _fileCommands.Test(testFile);
@@ -43,8 +39,6 @@ public partial class FileCommandsTests
         Assert.NotNull(info.Message);
         Assert.Contains("not found", info.Message, StringComparison.OrdinalIgnoreCase);
     }
-    /// <inheritdoc/>
-
     [Theory]
     [InlineData("TestFile.xls", ".xls")]
     [InlineData("TestFile.csv", ".csv")]
@@ -52,7 +46,7 @@ public partial class FileCommandsTests
     public void Test_InvalidExtension_ReturnsFailure(string fileName, string expectedExt)
     {
         // Arrange
-        string testFile = Path.Join(_tempDir, $"{Guid.NewGuid():N}_{fileName}");
+        string testFile = Path.Join(_fixture.TempDir, $"{Guid.NewGuid():N}_{fileName}");
 
         // Create file with invalid extension
         System.IO.File.WriteAllText(testFile, "test content");

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.cs
@@ -27,16 +27,15 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.File;
 [Trait("Speed", "Medium")]
 [Trait("Feature", "Files")]
 [Trait("RequiresExcel", "true")]
-public partial class FileCommandsTests : IClassFixture<TempDirectoryFixture>
+public partial class FileCommandsTests : IClassFixture<FileTestsFixture>
 {
     // Performance: use concrete type to satisfy CA1859 (test code, not API surface)
     private readonly FileCommands _fileCommands;
-    private readonly string _tempDir;
-    /// <inheritdoc/>
+    private readonly FileTestsFixture _fixture;
 
-    public FileCommandsTests(TempDirectoryFixture fixture)
+    public FileCommandsTests(FileTestsFixture fixture)
     {
         _fileCommands = new FileCommands();
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.Validation.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.Validation.cs
@@ -19,12 +19,8 @@ public partial class NamedRangeCommandsTests
     [Fact]
     public void Create_EmptyParameterName_ReturnsError()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(NamedRangeCommandsTests), nameof(Create_EmptyParameterName_ReturnsError), _tempDir);
-
-        // Act & Assert - Empty parameter name should throw ArgumentException
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act & Assert - Empty parameter name should throw ArgumentException
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
         var exception = Assert.Throws<ArgumentException>(() =>
             _parameterCommands.Create(batch, "", "Sheet1!A1"));
 
@@ -35,12 +31,8 @@ public partial class NamedRangeCommandsTests
     [Fact]
     public void Create_WhitespaceParameterName_ReturnsError()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(NamedRangeCommandsTests), nameof(Create_WhitespaceParameterName_ReturnsError), _tempDir);
-
-        // Act & Assert - Whitespace parameter name should throw ArgumentException
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act & Assert - Whitespace parameter name should throw ArgumentException
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
         var exception = Assert.Throws<ArgumentException>(() =>
             _parameterCommands.Create(batch, "   ", "Sheet1!A1"));
 
@@ -52,13 +44,12 @@ public partial class NamedRangeCommandsTests
     public void Create_ParameterNameExactly255Characters_ReturnsSuccess()
     {
         // Arrange - Create name with exactly 255 characters (Excel's limit)
-        var paramName = new string('A', 255);
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(NamedRangeCommandsTests), nameof(Create_ParameterNameExactly255Characters_ReturnsSuccess), _tempDir);
+        var uniquePrefix = Guid.NewGuid().ToString("N")[..8] + "_";
+        var paramName = uniquePrefix + new string('A', 255 - uniquePrefix.Length);
 
         // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _parameterCommands.Create(batch, paramName, "Sheet1!A1");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        _parameterCommands.Create(batch, paramName, _fixture.GetUniqueCellReference());
 
         // Assert - Verify the parameter was actually created
         var namedRanges = _parameterCommands.List(batch);
@@ -71,11 +62,9 @@ public partial class NamedRangeCommandsTests
     {
         // Arrange - Create name with 256 characters (exceeds Excel's limit)
         var paramName = new string('B', 256);
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(NamedRangeCommandsTests), nameof(Create_ParameterName256Characters_ReturnsError), _tempDir);
 
         // Act & Assert - 256-character name should throw ArgumentException
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
         var exception = Assert.Throws<ArgumentException>(() =>
             _parameterCommands.Create(batch, paramName, "Sheet1!A1"));
 
@@ -89,11 +78,9 @@ public partial class NamedRangeCommandsTests
     {
         // Arrange
         var longParamName = new string('C', 300);
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(NamedRangeCommandsTests), nameof(Update_ParameterNameExceeds255Characters_ReturnsError), _tempDir);
 
         // Act & Assert - 300-character name should throw ArgumentException
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
         var exception = Assert.Throws<ArgumentException>(() =>
             _parameterCommands.Update(batch, longParamName, "Sheet1!B2"));
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.Values.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.Values.cs
@@ -14,20 +14,18 @@ public partial class NamedRangeCommandsTests
     public void Set_ExistingParameter_UpdatesValue()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(NamedRangeCommandsTests), nameof(Set_ExistingParameter_UpdatesValue), _tempDir);
-
-        // Act - Use single batch for create, set, and verify
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var paramName = _fixture.GetUniqueNamedRangeName();
+        var cellRef = _fixture.GetUniqueCellReference();
 
         // Create parameter first
-        _parameterCommands.Create(batch, "SetTestParam", "Sheet1!A1");
+        _parameterCommands.Create(batch, paramName, cellRef);
 
         // Set the parameter value
-        _parameterCommands.Write(batch, "SetTestParam", "TestValue");
+        _parameterCommands.Write(batch, paramName, "TestValue");
 
         // Assert - Verify the parameter value was actually set by reading it back
-        var namedRangeValue = _parameterCommands.Read(batch, "SetTestParam");
+        var namedRangeValue = _parameterCommands.Read(batch, paramName);
         Assert.Equal("TestValue", namedRangeValue.Value?.ToString());
     }
     /// <inheritdoc/>
@@ -36,19 +34,17 @@ public partial class NamedRangeCommandsTests
     public void Get_ExistingParameter_ReturnsValue()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(NamedRangeCommandsTests), nameof(Get_ExistingParameter_ReturnsValue), _tempDir);
         string testValue = "Integration Test Value";
-
-        // Act - Use single batch for create, set, and get
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var paramName = _fixture.GetUniqueNamedRangeName();
+        var cellRef = _fixture.GetUniqueCellReference();
 
         // Create and set parameter value
-        _parameterCommands.Create(batch, "GetTestParam", "Sheet1!A1");
-        _parameterCommands.Write(batch, "GetTestParam", testValue);
+        _parameterCommands.Create(batch, paramName, cellRef);
+        _parameterCommands.Write(batch, paramName, testValue);
 
         // Get the parameter value
-        var namedRangeValue = _parameterCommands.Read(batch, "GetTestParam");
+        var namedRangeValue = _parameterCommands.Read(batch, paramName);
 
         // Assert
         Assert.Equal(testValue, namedRangeValue.Value?.ToString());
@@ -58,13 +54,10 @@ public partial class NamedRangeCommandsTests
     [Fact]
     public void Get_WithNonExistentParameter_ThrowsException()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(NamedRangeCommandsTests), nameof(Get_WithNonExistentParameter_ThrowsException), _tempDir);
-
-        // Act & Assert
-        using var batch = ExcelSession.BeginBatch(testFile);
-        var exception = Assert.Throws<InvalidOperationException>(() => _parameterCommands.Read(batch, "NonExistentParam"));
+        // Arrange & Act & Assert
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _parameterCommands.Read(batch, $"NonExistent_{Guid.NewGuid():N}"));
         Assert.Contains("not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.cs
@@ -7,24 +7,24 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.NamedRange;
 /// <summary>
 /// Integration tests for Parameter Core operations using Excel COM automation.
 /// Tests Core layer directly (not through CLI wrapper).
-/// Each test uses a unique Excel file for complete test isolation.
+/// Uses shared fixture for test isolation - each test uses unique named range names.
 /// </summary>
 [Trait("Layer", "Core")]
 [Trait("Category", "Integration")]
 [Trait("Speed", "Fast")]
 [Trait("Feature", "Parameters")]
 [Trait("RequiresExcel", "true")]
-public partial class NamedRangeCommandsTests : IClassFixture<TempDirectoryFixture>
+public partial class NamedRangeCommandsTests : IClassFixture<NamedRangeTestsFixture>
 {
     private readonly NamedRangeCommands _parameterCommands;
-    private readonly string _tempDir;
+    private readonly NamedRangeTestsFixture _fixture;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NamedRangeCommandsTests"/> class.
     /// </summary>
-    public NamedRangeCommandsTests(TempDirectoryFixture fixture)
+    public NamedRangeCommandsTests(NamedRangeTestsFixture fixture)
     {
         _parameterCommands = new NamedRangeCommands();
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.Grouping.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.Grouping.cs
@@ -341,8 +341,7 @@ public partial class PivotTableCommandsTests
     /// </summary>
     private string CreateTestFileWithNumericData(string testName)
     {
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PivotTableCommandsTests), testName, _tempDir);
+        var testFile = _fixture.CreateTestFile(testName);
 
         using var batch = ExcelSession.BeginBatch(testFile);
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.cs
@@ -20,9 +20,9 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PivotTable;
 public partial class PivotTableCommandsTests : IClassFixture<PivotTableTestsFixture>
 {
     private readonly PivotTableCommands _pivotCommands;
+    private readonly PivotTableTestsFixture _fixture;
     private readonly string _pivotFile;
     private readonly PivotTableCreationResult _creationResult;
-    private readonly string _tempDir;
     private readonly ITestOutputHelper _output;
     private readonly ILoggerFactory _loggerFactory;
 
@@ -32,9 +32,9 @@ public partial class PivotTableCommandsTests : IClassFixture<PivotTableTestsFixt
     public PivotTableCommandsTests(PivotTableTestsFixture fixture, ITestOutputHelper output)
     {
         _pivotCommands = new PivotTableCommands();
+        _fixture = fixture;
         _pivotFile = fixture.TestFilePath;
         _creationResult = fixture.CreationResult;
-        _tempDir = Path.GetDirectoryName(fixture.TestFilePath)!;
         _output = output;
         _loggerFactory = LoggerFactory.Create(builder => builder
             .AddXUnit(output)
@@ -47,8 +47,7 @@ public partial class PivotTableCommandsTests : IClassFixture<PivotTableTestsFixt
     /// </summary>
     private string CreateTestFileWithData(string testName)
     {
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PivotTableCommandsTests), testName, _tempDir);
+        var testFile = _fixture.CreateTestFile(testName);
 
         using var batch = ExcelSession.BeginBatch(testFile);
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.ManualTable.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.ManualTable.cs
@@ -26,11 +26,7 @@ public partial class PowerQueryCommandsTests
     public void List_WorkbookWithManualTable_ReturnsOnlyQueries()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(List_WorkbookWithManualTable_ReturnsOnlyQueries),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         var dataModelCommands = new DataModelCommands();
         var commands = new PowerQueryCommands(dataModelCommands);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.cs
@@ -11,7 +11,7 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PowerQuery;
 /// Integration tests for Power Query operations focusing on LLM use cases.
 /// Tests cover the essential workflows: import, list, view, update, delete, refresh with load destinations.
 /// Uses PowerQueryTestsFixture which creates ONE Power Query file per test class.
-/// Each test uses unique files for complete isolation where needed.
+/// Tests that modify queries use CreateTestFile() for isolation.
 /// </summary>
 [Trait("Layer", "Core")]
 [Trait("Category", "Integration")]
@@ -24,19 +24,19 @@ public partial class PowerQueryCommandsTests : IClassFixture<PowerQueryTestsFixt
     private readonly SheetCommands _sheetCommands;
     private readonly string _powerQueryFile;
     private readonly PowerQueryCreationResult _creationResult;
-    private readonly string _tempDir;
+    private readonly PowerQueryTestsFixture _fixture;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PowerQueryCommandsTests"/> class.
     /// </summary>
     public PowerQueryCommandsTests(PowerQueryTestsFixture fixture)
     {
+        _fixture = fixture;
         var dataModelCommands = new DataModelCommands();
         _powerQueryCommands = new PowerQueryCommands(dataModelCommands);
         _sheetCommands = new SheetCommands();
         _powerQueryFile = fixture.TestFilePath;
         _creationResult = fixture.CreationResult;
-        _tempDir = Path.GetDirectoryName(fixture.TestFilePath)!;
     }
 
     #region Core Lifecycle Tests (6 tests)
@@ -66,10 +66,7 @@ public partial class PowerQueryCommandsTests : IClassFixture<PowerQueryTestsFixt
     public void Import_ValidMCode_ReturnsSuccess()
     {
         // Arrange - Use unique file to avoid polluting fixture
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Import_ValidMCode_ReturnsSuccess),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
         var queryName = "TestQuery";
         var mCode = @"let
     Source = #table(
@@ -135,10 +132,7 @@ in
     public void Update_ExistingQuery_ReturnsSuccess()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Update_ExistingQuery_ReturnsSuccess),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         var queryName = "PQ_Update_" + Guid.NewGuid().ToString("N")[..8];
         var originalMCode = @"let
@@ -180,10 +174,7 @@ in
     public void Update_ExistingQuery_ReplacesNotMergesMCode()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Update_ExistingQuery_ReplacesNotMergesMCode),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         var queryName = "PQ_ReplaceTest_" + Guid.NewGuid().ToString("N")[..8];
 
@@ -242,10 +233,7 @@ in
     public void Update_MultipleSequentialUpdates_EachReplacesCompletely()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Update_MultipleSequentialUpdates_EachReplacesCompletely),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         var queryName = "PQ_MultiUpdate_" + Guid.NewGuid().ToString("N")[..8];
 
@@ -301,10 +289,7 @@ in
     public void Delete_ExistingQuery_ReturnsSuccess()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Delete_ExistingQuery_ReturnsSuccess),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         var queryName = "PQ_Delete_" + Guid.NewGuid().ToString("N")[..8];
         var mCode = @"let
@@ -337,10 +322,7 @@ in
     public void Create_DuplicateQueryName_ReturnsError()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Create_DuplicateQueryName_ReturnsError),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         var queryName = "TestQuery";
         var mCode = @"let
@@ -389,10 +371,7 @@ in
     public void Import_QueryReferencingAnotherQuery_LoadsDataSuccessfully()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Import_QueryReferencingAnotherQuery_LoadsDataSuccessfully),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         // Create M code for the source query (base data)
         string sourceQueryMCode = @"let
@@ -470,10 +449,7 @@ in
     public void Update_QueryLoadedToSheet_PreservesLoadConfiguration()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Update_QueryLoadedToSheet_PreservesLoadConfiguration),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         var queryName = "LoadedQuery_" + Guid.NewGuid().ToString("N")[..8];
         var sheetName = "DataSheet";
@@ -542,10 +518,7 @@ in
     {
         // Arrange
 
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(UpdateMCodeThenRefresh_QueryLoadedToSheet_PreservesLoadConfiguration),
-            _tempDir);
+        var testFile = _fixture.CreateTestFile();
 
         var queryName = "LoadedQuery_" + Guid.NewGuid().ToString("N")[..8];
         var sheetName = "DataSheet";
@@ -627,10 +600,7 @@ in
     public void Update_QueryColumnStructure_UpdatesWorksheetColumns()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Update_QueryColumnStructure_UpdatesWorksheetColumns),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         var queryName = "ColumnStructureQuery_" + Guid.NewGuid().ToString("N")[..8];
         var sheetName = "DataSheet";
@@ -739,10 +709,7 @@ in
     public void Update_QueryColumnStructureWithDeleteRecreate_NoAccumulation()
     {
         // Arrange
-        var testExcelFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(PowerQueryCommandsTests),
-            nameof(Update_QueryColumnStructureWithDeleteRecreate_NoAccumulation),
-            _tempDir);
+        var testExcelFile = _fixture.CreateTestFile();
 
         var queryName = "AccumulationBug_" + Guid.NewGuid().ToString("N")[..8];
         var sheetName = "TestSheet";

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/DateFormatTranslationTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/DateFormatTranslationTests.cs
@@ -15,15 +15,15 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 [Trait("Layer", "Core")]
 [Trait("Feature", "Ranges")]
 [Trait("RequiresExcel", "true")]
-public class DateFormatTranslationTests : IClassFixture<TempDirectoryFixture>
+public class DateFormatTranslationTests : IClassFixture<RangeTestsFixture>
 {
     private readonly ITestOutputHelper _output;
-    private readonly string _tempDir;
+    private readonly RangeTestsFixture _fixture;
     private readonly RangeCommands _rangeCommands;
 
-    public DateFormatTranslationTests(TempDirectoryFixture fixture, ITestOutputHelper output)
+    public DateFormatTranslationTests(RangeTestsFixture fixture, ITestOutputHelper output)
     {
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
         _output = output;
         _rangeCommands = new RangeCommands();
     }
@@ -32,11 +32,7 @@ public class DateFormatTranslationTests : IClassFixture<TempDirectoryFixture>
     public void SetNumberFormat_USDateFormat_DisplaysCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(DateFormatTranslationTests),
-            nameof(SetNumberFormat_USDateFormat_DisplaysCorrectly),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -89,11 +85,7 @@ public class DateFormatTranslationTests : IClassFixture<TempDirectoryFixture>
     public void SetNumberFormat_ISODateFormat_DisplaysCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(DateFormatTranslationTests),
-            nameof(SetNumberFormat_ISODateFormat_DisplaysCorrectly),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -130,11 +122,7 @@ public class DateFormatTranslationTests : IClassFixture<TempDirectoryFixture>
     public void SetNumberFormat_MultipleDates_AllDisplayCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(DateFormatTranslationTests),
-            nameof(SetNumberFormat_MultipleDates_AllDisplayCorrectly),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -189,11 +177,7 @@ public class DateFormatTranslationTests : IClassFixture<TempDirectoryFixture>
     {
         // Currency formats should NOT be affected by date translation
 
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(DateFormatTranslationTests),
-            nameof(SetNumberFormat_CurrencyFormat_NotAffected),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -227,11 +211,7 @@ public class DateFormatTranslationTests : IClassFixture<TempDirectoryFixture>
     public void SetNumberFormat_TimeFormat_DisplaysCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(DateFormatTranslationTests),
-            nameof(SetNumberFormat_TimeFormat_DisplaysCorrectly),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -266,11 +246,7 @@ public class DateFormatTranslationTests : IClassFixture<TempDirectoryFixture>
     {
         // Test combined date+time format
 
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(DateFormatTranslationTests),
-            nameof(SetNumberFormat_DateTimeFormat_DisplaysCorrectly),
-            _tempDir,
-            ".xlsx");
+        var testFile = _fixture.CreateTestFile();
 
         using var batch = ExcelSession.BeginBatch(testFile);
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Advanced.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Advanced.cs
@@ -1,6 +1,5 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Commands.Range;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
@@ -11,21 +10,18 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 /// </summary>
 public partial class RangeCommandsTests
 {
-    /// <inheritdoc/>
     [Fact]
     [Trait("Speed", "Medium")]
     public void ClearFormats_FormattedRange_RemovesFormattingOnly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(ClearFormats_FormattedRange_RemovesFormattingOnly), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set values with formatting
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic sheet = ctx.Book.Worksheets[sheetName];
             sheet.Range["A1"].Value2 = "Test";
             sheet.Range["A1"].Font.Bold = true;
             sheet.Range["A1"].Interior.Color = 255; // Red background
@@ -33,31 +29,28 @@ public partial class RangeCommandsTests
         });
 
         // Act - Clear only formats
-        var result = _commands.ClearFormats(batch, "Sheet1", "A1");
+        var result = _commands.ClearFormats(batch, sheetName, "A1");
 
         // Assert
         Assert.True(result.Success, $"ClearFormats failed: {result.ErrorMessage}");
 
         // Verify value remains but formatting is gone
-        var values = _commands.GetValues(batch, "Sheet1", "A1");
+        var values = _commands.GetValues(batch, sheetName, "A1");
         Assert.Equal("Test", values.Values[0][0]?.ToString());
     }
-    /// <inheritdoc/>
 
     [Fact]
     [Trait("Speed", "Medium")]
     public void CopyFormulas_SourceWithFormulas_CopiesFormulasOnly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(CopyFormulas_SourceWithFormulas_CopiesFormulasOnly), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set up source data with formulas
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic sheet = ctx.Book.Worksheets[sheetName];
             sheet.Range["A1"].Value2 = 10;
             sheet.Range["A2"].Value2 = 20;
             sheet.Range["A3"].Formula = "=A1+A2";
@@ -65,123 +58,111 @@ public partial class RangeCommandsTests
         });
 
         // Act - Copy formulas to B3
-        var result = _commands.CopyFormulas(batch, "Sheet1", "A3", "Sheet1", "B3");
+        var result = _commands.CopyFormulas(batch, sheetName, "A3", sheetName, "B3");
 
         // Assert
         Assert.True(result.Success, $"CopyFormulas failed: {result.ErrorMessage}");
 
         // Verify formula was copied (should adjust references)
-        var formulas = _commands.GetFormulas(batch, "Sheet1", "B3");
+        var formulas = _commands.GetFormulas(batch, sheetName, "B3");
         Assert.NotNull(formulas.Formulas[0][0]);
         Assert.Contains("+", formulas.Formulas[0][0]?.ToString());
     }
-    /// <inheritdoc/>
 
     [Fact]
     [Trait("Speed", "Medium")]
     public void InsertCells_ShiftDown_InsertsAndShiftsExisting()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(InsertCells_ShiftDown_InsertsAndShiftsExisting), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set up initial data
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic sheet = ctx.Book.Worksheets[sheetName];
             sheet.Range["A1"].Value2 = "Original";
             return 0;
         });
 
         // Act - Insert cell at A1, shifting down
-        var result = _commands.InsertCells(batch, "Sheet1", "A1", InsertShiftDirection.Down);
+        var result = _commands.InsertCells(batch, sheetName, "A1", InsertShiftDirection.Down);
 
         // Assert
         Assert.True(result.Success, $"InsertCells failed: {result.ErrorMessage}");
 
         // Verify original value shifted to A2
-        var values = _commands.GetValues(batch, "Sheet1", "A2");
+        var values = _commands.GetValues(batch, sheetName, "A2");
         Assert.Equal("Original", values.Values[0][0]?.ToString());
     }
-    /// <inheritdoc/>
 
     [Fact]
     [Trait("Speed", "Medium")]
     public void DeleteCells_ShiftUp_RemovesAndShifts()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(DeleteCells_ShiftUp_RemovesAndShifts), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set up data in A1 and A2
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic sheet = ctx.Book.Worksheets[sheetName];
             sheet.Range["A1"].Value2 = "Delete Me";
             sheet.Range["A2"].Value2 = "Keep Me";
             return 0;
         });
 
         // Act - Delete A1, shifting up
-        var result = _commands.DeleteCells(batch, "Sheet1", "A1", DeleteShiftDirection.Up);
+        var result = _commands.DeleteCells(batch, sheetName, "A1", DeleteShiftDirection.Up);
 
         // Assert
         Assert.True(result.Success, $"DeleteCells failed: {result.ErrorMessage}");
 
         // Verify A2 value shifted to A1
-        var values = _commands.GetValues(batch, "Sheet1", "A1");
+        var values = _commands.GetValues(batch, sheetName, "A1");
         Assert.Equal("Keep Me", values.Values[0][0]?.ToString());
     }
-    /// <inheritdoc/>
 
     [Fact]
     [Trait("Speed", "Medium")]
     public void InsertRows_BeforeExistingData_InsertsBlankRows()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(InsertRows_BeforeExistingData_InsertsBlankRows), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set up data in row 1
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic sheet = ctx.Book.Worksheets[sheetName];
             sheet.Range["A1"].Value2 = "Row 1";
             return 0;
         });
 
         // Act - Insert 2 rows at row 1
-        var result = _commands.InsertRows(batch, "Sheet1", "1:2");
+        var result = _commands.InsertRows(batch, sheetName, "1:2");
 
         // Assert
         Assert.True(result.Success, $"InsertRows failed: {result.ErrorMessage}");
 
         // Verify original data shifted to row 3
-        var values = _commands.GetValues(batch, "Sheet1", "A3");
+        var values = _commands.GetValues(batch, sheetName, "A3");
         Assert.Equal("Row 1", values.Values[0][0]?.ToString());
     }
-    /// <inheritdoc/>
 
     [Fact]
     [Trait("Speed", "Medium")]
     public void DeleteRows_ExistingRows_RemovesRows()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(DeleteRows_ExistingRows_RemovesRows), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set up data in rows 1-3
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic sheet = ctx.Book.Worksheets[sheetName];
             sheet.Range["A1"].Value2 = "Row 1";
             sheet.Range["A2"].Value2 = "Row 2 - Delete";
             sheet.Range["A3"].Value2 = "Row 3";
@@ -189,61 +170,55 @@ public partial class RangeCommandsTests
         });
 
         // Act - Delete row 2
-        var result = _commands.DeleteRows(batch, "Sheet1", "2:2");
+        var result = _commands.DeleteRows(batch, sheetName, "2:2");
 
         // Assert
         Assert.True(result.Success, $"DeleteRows failed: {result.ErrorMessage}");
 
         // Verify row 3 shifted to row 2
-        var values = _commands.GetValues(batch, "Sheet1", "A2");
+        var values = _commands.GetValues(batch, sheetName, "A2");
         Assert.Equal("Row 3", values.Values[0][0]?.ToString());
     }
-    /// <inheritdoc/>
 
     [Fact]
     [Trait("Speed", "Medium")]
     public void InsertColumns_BeforeExistingData_InsertsBlankColumns()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(InsertColumns_BeforeExistingData_InsertsBlankColumns), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set up data in column A
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic sheet = ctx.Book.Worksheets[sheetName];
             sheet.Range["A1"].Value2 = "Col A";
             return 0;
         });
 
         // Act - Insert 2 columns at column A (column 1)
-        var result = _commands.InsertColumns(batch, "Sheet1", "A:B");
+        var result = _commands.InsertColumns(batch, sheetName, "A:B");
 
         // Assert
         Assert.True(result.Success, $"InsertColumns failed: {result.ErrorMessage}");
 
         // Verify original data shifted to column C
-        var values = _commands.GetValues(batch, "Sheet1", "C1");
+        var values = _commands.GetValues(batch, sheetName, "C1");
         Assert.Equal("Col A", values.Values[0][0]?.ToString());
     }
-    /// <inheritdoc/>
 
     [Fact]
     [Trait("Speed", "Medium")]
     public void DeleteColumns_ExistingColumns_RemovesColumns()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(DeleteColumns_ExistingColumns_RemovesColumns), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set up data in columns A-C
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            dynamic sheet = ctx.Book.Worksheets[sheetName];
             sheet.Range["A1"].Value2 = "Col A";
             sheet.Range["B1"].Value2 = "Col B - Delete";
             sheet.Range["C1"].Value2 = "Col C";
@@ -251,33 +226,30 @@ public partial class RangeCommandsTests
         });
 
         // Act - Delete column B
-        var result = _commands.DeleteColumns(batch, "Sheet1", "B:B");
+        var result = _commands.DeleteColumns(batch, sheetName, "B:B");
 
         // Assert
         Assert.True(result.Success, $"DeleteColumns failed: {result.ErrorMessage}");
 
         // Verify column C shifted to B
-        var values = _commands.GetValues(batch, "Sheet1", "B1");
+        var values = _commands.GetValues(batch, sheetName, "B1");
         Assert.Equal("Col C", values.Values[0][0]?.ToString());
     }
-    /// <inheritdoc/>
 
     [Fact]
     [Trait("Speed", "Medium")]
     public void GetHyperlink_ExistingHyperlink_ReturnsDetails()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests), nameof(GetHyperlink_ExistingHyperlink_ReturnsDetails), _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Add a hyperlink
-        var addResult = _commands.AddHyperlink(batch, "Sheet1", "A1", "https://example.com", "Example Link");
+        var addResult = _commands.AddHyperlink(batch, sheetName, "A1", "https://example.com", "Example Link");
         Assert.True(addResult.Success);
 
         // Act
-        var result = _commands.GetHyperlink(batch, "Sheet1", "A1");
+        var result = _commands.GetHyperlink(batch, sheetName, "A1");
 
         // Assert
         Assert.True(result.Success, $"GetHyperlink failed: {result.ErrorMessage}");

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Discovery.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Discovery.cs
@@ -1,5 +1,4 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
@@ -9,21 +8,20 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 /// </summary>
 public partial class RangeCommandsTests
 {
-    /// <inheritdoc/>
     // === NATIVE EXCEL COM OPERATIONS TESTS ===
 
     [Fact]
     public void GetUsedRange_SheetWithSparseData_ReturnsNonEmptyCells()
     {
-        // Arrange
-        string testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), nameof(GetUsedRange_SheetWithSparseData_ReturnsNonEmptyCells), _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange - use shared file, create unique sheet for this test
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1", [["Start"]]);
-        _commands.SetValues(batch, "Sheet1", "D10", [["End"]]);
+        _commands.SetValues(batch, sheetName, "A1", [["Start"]]);
+        _commands.SetValues(batch, sheetName, "D10", [["End"]]);
 
         // Act
-        var result = _commands.GetUsedRange(batch, "Sheet1");
+        var result = _commands.GetUsedRange(batch, sheetName);
 
         // Assert
         Assert.True(result.Success);
@@ -31,16 +29,15 @@ public partial class RangeCommandsTests
         Assert.True(result.ColumnCount >= 4);
         Assert.Equal("Start", result.Values[0][0]);
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void GetCurrentRegion_CellInPopulated3x3Range_ReturnsContiguousBlock()
     {
-        // Arrange
-        string testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), nameof(GetCurrentRegion_CellInPopulated3x3Range_ReturnsContiguousBlock), _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange - use shared file, create unique sheet for this test
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1:C3",
+        _commands.SetValues(batch, sheetName, "A1:C3",
         [
             [1, 2, 3],
             [4, 5, 6],
@@ -48,7 +45,7 @@ public partial class RangeCommandsTests
         ]);
 
         // Act - Get region from middle cell
-        var result = _commands.GetCurrentRegion(batch, "Sheet1", "B2");
+        var result = _commands.GetCurrentRegion(batch, sheetName, "B2");
 
         // Assert
         Assert.True(result.Success);
@@ -61,22 +58,21 @@ public partial class RangeCommandsTests
             9.0,
             Convert.ToDouble(result.Values[2][2], System.Globalization.CultureInfo.InvariantCulture));
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void GetInfo_ValidAddress_ReturnsMetadata()
     {
-        // Arrange
-        string testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), nameof(GetInfo_ValidAddress_ReturnsMetadata), _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange - use shared file, create unique sheet for this test
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1:D10",
+        _commands.SetValues(batch, sheetName, "A1:D10",
         [
             [1, 2, 3, 4]
         ]);
 
         // Act
-        var result = _commands.GetInfo(batch, "Sheet1", "A1:D10");
+        var result = _commands.GetInfo(batch, sheetName, "A1:D10");
 
         // Assert
         Assert.True(result.Success);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Editing.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Editing.cs
@@ -1,5 +1,4 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
@@ -9,59 +8,56 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 /// </summary>
 public partial class RangeCommandsTests
 {
-    /// <inheritdoc/>
     // === CLEAR OPERATIONS TESTS ===
 
     [Fact]
     public void ClearAll_FormattedRange_RemovesEverything()
     {
-        // Arrange
-        string testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), nameof(ClearAll_FormattedRange_RemovesEverything), _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange - use shared file, create unique sheet for this test
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1", [["Test"]]);
+        _commands.SetValues(batch, sheetName, "A1", [["Test"]]);
 
         // Act
-        var result = _commands.ClearAll(batch, "Sheet1", "A1");
+        var result = _commands.ClearAll(batch, sheetName, "A1");
         // Assert
         Assert.True(result.Success);
 
-        var readResult = _commands.GetValues(batch, "Sheet1", "A1");
+        var readResult = _commands.GetValues(batch, sheetName, "A1");
         Assert.Null(readResult.Values[0][0]);
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void ClearContents_FormattedRange_PreservesFormatting()
     {
-        // Arrange
-        string testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), nameof(ClearContents_FormattedRange_PreservesFormatting), _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange - use shared file, create unique sheet for this test
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1:B2",
+        _commands.SetValues(batch, sheetName, "A1:B2",
         [
             [1, 2],
             [3, 4]
         ]);
 
         // Act
-        var result = _commands.ClearContents(batch, "Sheet1", "A1:B2");
+        var result = _commands.ClearContents(batch, sheetName, "A1:B2");
         // Assert
         Assert.True(result.Success);
 
-        var readResult = _commands.GetValues(batch, "Sheet1", "A1:B2");
+        var readResult = _commands.GetValues(batch, sheetName, "A1:B2");
         Assert.All(readResult.Values, row => Assert.All(row, cell => Assert.Null(cell)));
     }
-    /// <inheritdoc/>
 
     // === COPY OPERATIONS TESTS ===
 
     [Fact]
     public void Copy_CopiesRangeToNewLocation()
     {
-        // Arrange
-        string testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), nameof(Copy_CopiesRangeToNewLocation), _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange - use shared file, create unique sheet for this test
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         var sourceData = new List<List<object?>>
         {
@@ -69,36 +65,35 @@ public partial class RangeCommandsTests
             new() { 1, 2 }
         };
 
-        _commands.SetValues(batch, "Sheet1", "A1:B2", sourceData);
+        _commands.SetValues(batch, sheetName, "A1:B2", sourceData);
 
         // Act
-        var result = _commands.Copy(batch, "Sheet1", "A1:B2", "Sheet1", "D1:E2");
+        var result = _commands.Copy(batch, sheetName, "A1:B2", sheetName, "D1:E2");
         // Assert
         Assert.True(result.Success);
 
-        var readResult = _commands.GetValues(batch, "Sheet1", "D1:E2");
+        var readResult = _commands.GetValues(batch, sheetName, "D1:E2");
         Assert.Equal("A", readResult.Values[0][0]);
         Assert.Equal(2.0, Convert.ToDouble(readResult.Values[1][1], System.Globalization.CultureInfo.InvariantCulture));
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void CopyValues_CopiesOnlyValues()
     {
-        // Arrange
-        string testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), nameof(CopyValues_CopiesOnlyValues), _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange - use shared file, create unique sheet for this test
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1", [[10]]);
-        _commands.SetFormulas(batch, "Sheet1", "B1", [["=A1*2"]]);
+        _commands.SetValues(batch, sheetName, "A1", [[10]]);
+        _commands.SetFormulas(batch, sheetName, "B1", [["=A1*2"]]);
 
         // Act
-        var result = _commands.CopyValues(batch, "Sheet1", "B1", "Sheet1", "C1");
+        var result = _commands.CopyValues(batch, sheetName, "B1", sheetName, "C1");
         // Assert
         Assert.True(result.Success);
 
         // C1 should have value 20 but no formula
-        var formulaResult = _commands.GetFormulas(batch, "Sheet1", "C1");
+        var formulaResult = _commands.GetFormulas(batch, sheetName, "C1");
         Assert.Equal(20.0, Convert.ToDouble(formulaResult.Values[0][0], System.Globalization.CultureInfo.InvariantCulture));
         Assert.Empty(formulaResult.Formulas[0][0]); // No formula
     }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.GetStyle.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.GetStyle.cs
@@ -1,25 +1,17 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 
 public partial class RangeCommandsTests
 {
-    /// <inheritdoc/>
     [Fact]
     public void GetStyle_UnstyledRange_ReturnsNormalStyle()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(GetStyle_UnstyledRange_ReturnsNormalStyle),
-            _tempDir,
-            ".xlsx");
-
-        // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
-        var result = _commands.GetStyle(batch, "Sheet1", "A1");
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var result = _commands.GetStyle(batch, sheetName, "A1");
 
         // Assert
         Assert.True(result.Success, $"GetStyle failed: {result.ErrorMessage}");
@@ -27,26 +19,19 @@ public partial class RangeCommandsTests
         Assert.True(result.IsBuiltInStyle);
         // Note: StyleDescription may be null for some styles
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void GetStyle_AfterSetStyle_ReturnsAppliedStyle()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(GetStyle_AfterSetStyle_ReturnsAppliedStyle),
-            _tempDir,
-            ".xlsx");
-
-        // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set a style first
-        _commands.SetStyle(batch, "Sheet1", "A1", "Heading 1");
+        _commands.SetStyle(batch, sheetName, "A1", "Heading 1");
 
         // Now get the style
-        var getResult = _commands.GetStyle(batch, "Sheet1", "A1");
+        var getResult = _commands.GetStyle(batch, sheetName, "A1");
 
         // Assert
         Assert.True(getResult.Success, $"GetStyle failed: {getResult.ErrorMessage}");
@@ -54,30 +39,23 @@ public partial class RangeCommandsTests
         Assert.True(getResult.IsBuiltInStyle);
         // Note: StyleDescription may be null for some styles
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void GetStyle_MultipleStyles_ReturnsCorrectStyles()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(GetStyle_MultipleStyles_ReturnsCorrectStyles),
-            _tempDir,
-            ".xlsx");
-
-        // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set different styles on different cells
-        _commands.SetStyle(batch, "Sheet1", "A1", "Heading 1");
-        _commands.SetStyle(batch, "Sheet1", "B1", "Accent1");
-        _commands.SetStyle(batch, "Sheet1", "C1", "Currency");
+        _commands.SetStyle(batch, sheetName, "A1", "Heading 1");
+        _commands.SetStyle(batch, sheetName, "B1", "Accent1");
+        _commands.SetStyle(batch, sheetName, "C1", "Currency");
 
         // Get the styles
-        var getHeading1 = _commands.GetStyle(batch, "Sheet1", "A1");
-        var getAccent1 = _commands.GetStyle(batch, "Sheet1", "B1");
-        var getCurrency = _commands.GetStyle(batch, "Sheet1", "C1");
+        var getHeading1 = _commands.GetStyle(batch, sheetName, "A1");
+        var getAccent1 = _commands.GetStyle(batch, sheetName, "B1");
+        var getCurrency = _commands.GetStyle(batch, sheetName, "C1");
 
         // Assert
         Assert.True(getHeading1.Success, $"GetStyle A1 failed: {getHeading1.ErrorMessage}");
@@ -92,48 +70,34 @@ public partial class RangeCommandsTests
         Assert.Equal("Currency", getCurrency.StyleName);
         Assert.True(getCurrency.IsBuiltInStyle);
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void GetStyle_RangeMultipleCells_ReturnsFirstCellStyle()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(GetStyle_RangeMultipleCells_ReturnsFirstCellStyle),
-            _tempDir,
-            ".xlsx");
-
-        // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Set style on entire range (this applies to all cells in the range)
-        _commands.SetStyle(batch, "Sheet1", "A1:C3", "Good");
+        _commands.SetStyle(batch, sheetName, "A1:C3", "Good");
 
         // Get style for entire range (should return first cell's style)
-        var getResult = _commands.GetStyle(batch, "Sheet1", "A1:C3");
+        var getResult = _commands.GetStyle(batch, sheetName, "A1:C3");
 
         // Assert
         Assert.True(getResult.Success, $"GetStyle failed: {getResult.ErrorMessage}");
         Assert.Equal("Good", getResult.StyleName);
         Assert.True(getResult.IsBuiltInStyle);
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void GetStyle_InvalidRange_ThrowsException()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(GetStyle_InvalidRange_ThrowsException),
-            _tempDir,
-            ".xlsx");
-
-        // Act & Assert - Should throw when Excel COM rejects invalid range
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act & Assert - Should throw when Excel COM rejects invalid range
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
         var exception = Assert.ThrowsAny<Exception>(
-            () => _commands.GetStyle(batch, "Sheet1", "InvalidRange"));
+            () => _commands.GetStyle(batch, sheetName, "InvalidRange"));
 
         // Verify exception is related to range access
         Assert.NotNull(exception.Message);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Hyperlinks.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Hyperlinks.cs
@@ -1,5 +1,4 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
@@ -9,72 +8,69 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 /// </summary>
 public partial class RangeCommandsTests
 {
-    /// <inheritdoc/>
     // === HYPERLINK OPERATIONS TESTS ===
 
     [Fact]
     public void AddHyperlink_CreatesHyperlink()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        // Act
         var result = _commands.AddHyperlink(
             batch,
-            "Sheet1",
+            sheetName,
             "A1",
             "https://www.example.com",
             "Example Site",
             "Click to visit");
+
         // Assert
         Assert.True(result.Success);
 
         // Verify hyperlink exists
-        var hyperlinkResult = _commands.GetHyperlink(batch, "Sheet1", "A1");
+        var hyperlinkResult = _commands.GetHyperlink(batch, sheetName, "A1");
         Assert.True(hyperlinkResult.Success);
         Assert.Single(hyperlinkResult.Hyperlinks);
         // Excel normalizes URLs - may add trailing slash
         Assert.StartsWith("https://www.example.com", hyperlinkResult.Hyperlinks[0].Address);
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void RemoveHyperlink_DeletesHyperlink()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.AddHyperlink(batch, "Sheet1", "A1", "https://www.example.com");
+        _commands.AddHyperlink(batch, sheetName, "A1", "https://www.example.com");
 
         // Act
-        var result = _commands.RemoveHyperlink(batch, "Sheet1", "A1");
+        var result = _commands.RemoveHyperlink(batch, sheetName, "A1");
+
         // Assert
         Assert.True(result.Success);
 
-        var hyperlinkResult = _commands.GetHyperlink(batch, "Sheet1", "A1");
+        var hyperlinkResult = _commands.GetHyperlink(batch, sheetName, "A1");
         Assert.Empty(hyperlinkResult.Hyperlinks);
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void ListHyperlinks_ReturnsAllHyperlinks()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.AddHyperlink(batch, "Sheet1", "A1", "https://site1.com");
-        _commands.AddHyperlink(batch, "Sheet1", "B2", "https://site2.com");
-        _commands.AddHyperlink(batch, "Sheet1", "C3", "https://site3.com");
+        _commands.AddHyperlink(batch, sheetName, "A1", "https://site1.com");
+        _commands.AddHyperlink(batch, sheetName, "B2", "https://site2.com");
+        _commands.AddHyperlink(batch, sheetName, "C3", "https://site3.com");
 
         // Act
-        var result = _commands.ListHyperlinks(batch, "Sheet1");
+        var result = _commands.ListHyperlinks(batch, sheetName);
 
         // Assert
         Assert.True(result.Success);
         Assert.Equal(3, result.Hyperlinks.Count);
     }
-
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.NamedRanges.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.NamedRanges.cs
@@ -1,6 +1,5 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Commands;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
@@ -10,22 +9,21 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 /// </summary>
 public partial class RangeCommandsTests
 {
-    /// <inheritdoc/>
     // === NAMED RANGE TRANSPARENCY TESTS ===
 
     [Fact]
     public void GetValues_WithNamedRange_ResolvesProperly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Create a named range pointing to A1:B2
         var paramCommands = new NamedRangeCommands();
-        paramCommands.Create(batch, "TestData", "Sheet1!$A$1:$B$2");
+        paramCommands.Create(batch, "TestData", $"{sheetName}!$A$1:$B$2");
 
         // Set data in the range
-        _commands.SetValues(batch, "Sheet1", "A1:B2",
+        _commands.SetValues(batch, sheetName, "A1:B2",
         [
             [1, 2],
             [3, 4]
@@ -44,19 +42,21 @@ public partial class RangeCommandsTests
         Assert.Equal(
             4.0,
             Convert.ToDouble(result.Values[1][1], System.Globalization.CultureInfo.InvariantCulture));
+
+        // Cleanup named range
+        paramCommands.Delete(batch, "TestData");
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void SetValues_WithNamedRange_WritesProperly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Create a named range
         var paramCommands = new NamedRangeCommands();
-        paramCommands.Create(batch, "SalesData", "Sheet1!$A$1:$C$2");
+        paramCommands.Create(batch, "SalesData", $"{sheetName}!$A$1:$C$2");
 
         // Act - Write using named range
         var result = _commands.SetValues(batch, "", "SalesData",
@@ -64,31 +64,34 @@ public partial class RangeCommandsTests
             ["Product", "Qty", "Price"],
             ["Widget", 10, 29.99]
         ]);
+
         // Assert
         Assert.True(result.Success);
 
         // Verify by reading with regular range address
-        var readResult = _commands.GetValues(batch, "Sheet1", "A1:C2");
+        var readResult = _commands.GetValues(batch, sheetName, "A1:C2");
         Assert.Equal("Product", readResult.Values[0][0]);
         Assert.Equal(
             29.99,
             Convert.ToDouble(readResult.Values[1][2], System.Globalization.CultureInfo.InvariantCulture));
+
+        // Cleanup named range
+        paramCommands.Delete(batch, "SalesData");
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void GetFormulas_WithNamedRange_ReturnsFormulas()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Create named range and set data + formula
         var paramCommands = new NamedRangeCommands();
-        paramCommands.Create(batch, "CalcRange", "Sheet1!$A$1:$B$2");
+        paramCommands.Create(batch, "CalcRange", $"{sheetName}!$A$1:$B$2");
 
-        _commands.SetValues(batch, "Sheet1", "A1", [[10]]);
-        _commands.SetFormulas(batch, "Sheet1", "B1", [["=A1*2"]]);
+        _commands.SetValues(batch, sheetName, "A1", [[10]]);
+        _commands.SetFormulas(batch, sheetName, "B1", [["=A1*2"]]);
 
         // Act - Read formulas using named range
         var result = _commands.GetFormulas(batch, "", "CalcRange");
@@ -100,19 +103,21 @@ public partial class RangeCommandsTests
         Assert.Equal(
             20.0,
             Convert.ToDouble(result.Values[0][1], System.Globalization.CultureInfo.InvariantCulture));
+
+        // Cleanup named range
+        paramCommands.Delete(batch, "CalcRange");
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void ClearContents_WithNamedRange_ClearsData()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Create named range and populate
         var paramCommands = new NamedRangeCommands();
-        paramCommands.Create(batch, "TempData", "Sheet1!$A$1:$B$2");
+        paramCommands.Create(batch, "TempData", $"{sheetName}!$A$1:$B$2");
 
         _commands.SetValues(batch, "", "TempData",
         [
@@ -122,11 +127,15 @@ public partial class RangeCommandsTests
 
         // Act - Clear using named range
         var result = _commands.ClearContents(batch, "", "TempData");
+
         // Assert
         Assert.True(result.Success);
 
         // Verify data is cleared
-        var readResult = _commands.GetValues(batch, "Sheet1", "A1:B2");
+        var readResult = _commands.GetValues(batch, sheetName, "A1:B2");
         Assert.All(readResult.Values, row => Assert.All(row, cell => Assert.Null(cell)));
+
+        // Cleanup named range
+        paramCommands.Delete(batch, "TempData");
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Search.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Search.cs
@@ -1,6 +1,5 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Commands.Range;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
@@ -10,24 +9,23 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 /// </summary>
 public partial class RangeCommandsTests
 {
-    /// <inheritdoc/>
     // === FIND/REPLACE OPERATIONS TESTS ===
 
     [Fact]
     public void Find_FindsMatchingCells()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1:C2",
+        _commands.SetValues(batch, sheetName, "A1:C2",
         [
             ["Apple", "Banana", "Apple"],
             ["Cherry", "Apple", "Banana"]
         ]);
 
         // Act
-        var result = _commands.Find(batch, "Sheet1", "A1:C2", "Apple", new FindOptions
+        var result = _commands.Find(batch, sheetName, "A1:C2", "Apple", new FindOptions
         {
             MatchCase = false,
             MatchEntireCell = true
@@ -37,16 +35,15 @@ public partial class RangeCommandsTests
         Assert.True(result.Success);
         Assert.Equal(3, result.MatchingCells.Count); // Should find 3 "Apple" cells
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void Replace_ReplacesAllOccurrences()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1:A3",
+        _commands.SetValues(batch, sheetName, "A1:A3",
         [
             ["cat"],
             ["dog"],
@@ -54,18 +51,17 @@ public partial class RangeCommandsTests
         ]);
 
         // Act
-        _commands.Replace(batch, "Sheet1", "A1:A3", "cat", "bird", new ReplaceOptions
+        _commands.Replace(batch, sheetName, "A1:A3", "cat", "bird", new ReplaceOptions
         {
             ReplaceAll = true
         });
-        // Assert - void method throws on failure, succeeds silently
 
-        var readResult = _commands.GetValues(batch, "Sheet1", "A1:A3");
+        // Assert - void method throws on failure, succeeds silently
+        var readResult = _commands.GetValues(batch, sheetName, "A1:A3");
         Assert.Equal("bird", readResult.Values[0][0]);
         Assert.Equal("dog", readResult.Values[1][0]);
         Assert.Equal("bird", readResult.Values[2][0]);
     }
-    /// <inheritdoc/>
 
     // === SORT OPERATIONS TESTS ===
 
@@ -73,10 +69,10 @@ public partial class RangeCommandsTests
     public void Sort_SortsRangeByColumn()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(nameof(RangeCommandsTests), $"{Guid.NewGuid():N}", _tempDir);
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        _commands.SetValues(batch, "Sheet1", "A1:B4",
+        _commands.SetValues(batch, sheetName, "A1:B4",
         [
             ["Name", "Age"],
             ["Charlie", 30],
@@ -85,16 +81,15 @@ public partial class RangeCommandsTests
         ]);
 
         // Act - Sort by first column (Name) ascending
-        _commands.Sort(batch, "Sheet1", "A1:B4",
+        _commands.Sort(batch, sheetName, "A1:B4",
         [
             new() { ColumnIndex = 1, Ascending = true }
         ], hasHeaders: true);
-        // Assert - void method throws on failure, succeeds silently
 
-        var readResult = _commands.GetValues(batch, "Sheet1", "A2:A4");
+        // Assert - void method throws on failure, succeeds silently
+        var readResult = _commands.GetValues(batch, sheetName, "A2:A4");
         Assert.Equal("Alice", readResult.Values[0][0]);
         Assert.Equal("Bob", readResult.Values[1][0]);
         Assert.Equal("Charlie", readResult.Values[2][0]);
     }
-
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.SetStyle.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.SetStyle.cs
@@ -1,143 +1,94 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 
 public partial class RangeCommandsTests
 {
-    /// <inheritdoc/>
     [Fact]
     public void SetStyle_Heading1_AppliesSuccessfully()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(SetStyle_Heading1_AppliesSuccessfully),
-            _tempDir,
-            ".xlsx");
-
-        // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _commands.SetStyle(batch, "Sheet1", "A1", "Heading 1");
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetStyle(batch, sheetName, "A1", "Heading 1");
 
         // Assert - void method throws on failure, succeeds silently on success
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void SetStyle_GoodBadNeutral_AllApplySuccessfully()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(SetStyle_GoodBadNeutral_AllApplySuccessfully),
-            _tempDir,
-            ".xlsx");
+        // Arrange & Act & Assert
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        // Act & Assert
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        _commands.SetStyle(batch, "Sheet1", "A1", "Good");
-        _commands.SetStyle(batch, "Sheet1", "A2", "Bad");
-        _commands.SetStyle(batch, "Sheet1", "A3", "Neutral");
+        _commands.SetStyle(batch, sheetName, "A1", "Good");
+        _commands.SetStyle(batch, sheetName, "A2", "Bad");
+        _commands.SetStyle(batch, sheetName, "A3", "Neutral");
         // void methods throw on failure, succeed silently
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void SetStyle_Accent1_AppliesSuccessfully()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(SetStyle_Accent1_AppliesSuccessfully),
-            _tempDir,
-            ".xlsx");
-
-        // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _commands.SetStyle(batch, "Sheet1", "A1:E1", "Accent1");
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetStyle(batch, sheetName, "A1:E1", "Accent1");
 
         // Assert - void method throws on failure, succeeds silently on success
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void SetStyle_TotalStyle_AppliesSuccessfully()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(SetStyle_TotalStyle_AppliesSuccessfully),
-            _tempDir,
-            ".xlsx");
-
-        // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _commands.SetStyle(batch, "Sheet1", "A10:E10", "Total");
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetStyle(batch, sheetName, "A10:E10", "Total");
 
         // Assert - void method throws on failure, succeeds silently on success
     }
-    /// <inheritdoc/>
 
     [Fact]
     public void SetStyle_CurrencyComma_AppliesSuccessfully()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(SetStyle_CurrencyComma_AppliesSuccessfully),
-            _tempDir,
-            ".xlsx");
+        // Arrange & Act & Assert
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
-        // Act & Assert
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        _commands.SetStyle(batch, "Sheet1", "B5:B10", "Currency");
-        _commands.SetStyle(batch, "Sheet1", "C5:C10", "Comma");
+        _commands.SetStyle(batch, sheetName, "B5:B10", "Currency");
+        _commands.SetStyle(batch, sheetName, "C5:C10", "Comma");
         // void methods throw on failure, succeed silently
     }
-    /// <inheritdoc/>
+
     [Fact]
     public void SetStyle_InvalidStyleName_ThrowsException()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(SetStyle_InvalidStyleName_ThrowsException),
-            _tempDir,
-            ".xlsx");
-
-        // Act & Assert - Should throw when Excel COM rejects invalid style name
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act & Assert - Should throw when Excel COM rejects invalid style name
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
         var exception = Assert.Throws<System.Reflection.TargetParameterCountException>(
-            () => _commands.SetStyle(batch, "Sheet1", "A1", "NonExistentStyle"));
+            () => _commands.SetStyle(batch, sheetName, "A1", "NonExistentStyle"));
 
         // Verify exception message contains context about the style operation
         Assert.NotNull(exception.Message);
         Assert.Contains("Style", exception.Message);
     }
 
-    /// <inheritdoc/>
     [Fact]
     public void SetStyle_ResetToNormal_ClearsFormatting()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(SetStyle_ResetToNormal_ClearsFormatting),
-            _tempDir,
-            ".xlsx");
-
-        // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         // Apply fancy style
-        _commands.SetStyle(batch, "Sheet1", "A1", "Accent1");
+        _commands.SetStyle(batch, sheetName, "A1", "Accent1");
 
         // Reset to normal
-        _commands.SetStyle(batch, "Sheet1", "A1", "Normal");
+        _commands.SetStyle(batch, sheetName, "A1", "Normal");
         // void methods throw on failure, succeed silently
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Validation.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Validation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Stefan Broenne. All rights reserved.
 
 using Sbroenne.ExcelMcp.ComInterop.Session;
-using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
@@ -11,18 +10,13 @@ public partial class RangeCommandsTests
     [Fact]
     public void ValidateRange_WithInputMessage_ReturnsSuccess()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(ValidateRange_WithInputMessage_ReturnsSuccess),
-            _tempDir);
-
-        // Act - First write list values to worksheet (required for dropdown)
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act - First write list values to worksheet (required for dropdown)
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         _commands.SetValues(
             batch,
-            "Sheet1",
+            sheetName,
             "B1:B3",
             new List<List<object?>>
             {
@@ -34,7 +28,7 @@ public partial class RangeCommandsTests
         // Apply validation referencing the range (creates dropdown)
         _commands.ValidateRange(
             batch,
-            "Sheet1",
+            sheetName,
             "A1",
             validationType: "list",
             validationOperator: null,
@@ -52,7 +46,7 @@ public partial class RangeCommandsTests
         // void method throws on failure, succeeds silently
 
         // Verify validation is retrieved correctly (same batch)
-        var getResult = _commands.GetValidation(batch, "Sheet1", "A1");
+        var getResult = _commands.GetValidation(batch, sheetName, "A1");
 
         // Assert - Validation retrieved successfully
         Assert.True(getResult.Success, $"Get validation failed: {getResult.ErrorMessage}");
@@ -74,18 +68,13 @@ public partial class RangeCommandsTests
     [Fact]
     public void GetValidation_WithInputMessage_ReturnsInputTitleAndMessage()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(RangeCommandsTests),
-            nameof(GetValidation_WithInputMessage_ReturnsInputTitleAndMessage),
-            _tempDir);
-
-        // Act - First write list values to worksheet (required for dropdown)
-        using var batch = ExcelSession.BeginBatch(testFile);
+        // Arrange & Act - First write list values to worksheet (required for dropdown)
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
 
         _commands.SetValues(
             batch,
-            "Sheet1",
+            sheetName,
             "B1:B3",
             new List<List<object?>>
             {
@@ -97,7 +86,7 @@ public partial class RangeCommandsTests
         // Apply validation using the ValidateRangeAsync API
         _commands.ValidateRange(
             batch,
-            "Sheet1",
+            sheetName,
             "A1",
             validationType: "list",
             validationOperator: null,  // Not used for list type
@@ -115,7 +104,7 @@ public partial class RangeCommandsTests
         // void method throws on failure, succeeds silently
 
         // Act - Get validation to verify InputTitle/InputMessage are returned
-        var result = _commands.GetValidation(batch, "Sheet1", "A1");
+        var result = _commands.GetValidation(batch, sheetName, "A1");
 
         // Assert
         Assert.True(result.Success, $"Get validation failed: {result.ErrorMessage}");

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.cs
@@ -6,24 +6,28 @@ using Xunit.Abstractions;
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 
 /// <summary>
-/// Integration tests for RangeCommands - main partial class with shared fixture
+/// Integration tests for RangeCommands - main partial class with shared fixture.
+/// Uses RangeTestsFixture to create ONE file shared across all tests in this class.
+/// Each test creates its own sheet within that file for isolation.
 /// Other test methods are in partial files: Values.cs, Formulas.cs, Editing.cs, Search.cs, Discovery.cs, Hyperlinks.cs
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Speed", "Medium")]
 [Trait("Feature", "Range")]
 [Trait("RequiresExcel", "true")]
-public partial class RangeCommandsTests : IClassFixture<TempDirectoryFixture>
+public partial class RangeCommandsTests : IClassFixture<RangeTestsFixture>
 {
     private readonly ITestOutputHelper _output;
     private readonly RangeCommands _commands;
-    private readonly string _tempDir;
-    /// <inheritdoc/>
+    private readonly RangeTestsFixture _fixture;
 
-    public RangeCommandsTests(ITestOutputHelper output, TempDirectoryFixture fixture)
+    /// <summary>
+    /// Initializes a new instance of the test class with shared fixture
+    /// </summary>
+    public RangeCommandsTests(ITestOutputHelper output, RangeTestsFixture fixture)
     {
         _output = output;
         _commands = new RangeCommands();
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Sheet/SheetCommandsTests.Move.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Sheet/SheetCommandsTests.Move.cs
@@ -17,9 +17,8 @@ public partial class SheetCommandsTests
     [Fact]
     public void Move_WithBeforeSheet_RepositionsSheet()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), nameof(Move_WithBeforeSheet_RepositionsSheet), _tempDir);
+        // Arrange - Move tests need isolated file to control sheet order
+        var testFile = _fixture.CreateCrossWorkbookTestFile(nameof(Move_WithBeforeSheet_RepositionsSheet));
 
         using var batch = ExcelSession.BeginBatch(testFile);
         _sheetCommands.Create(batch, "MoveMe");
@@ -47,9 +46,8 @@ public partial class SheetCommandsTests
     [Fact]
     public void Move_WithAfterSheet_RepositionsSheet()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), nameof(Move_WithAfterSheet_RepositionsSheet), _tempDir);
+        // Arrange - Move tests need isolated file to control sheet order
+        var testFile = _fixture.CreateCrossWorkbookTestFile(nameof(Move_WithAfterSheet_RepositionsSheet));
 
         using var batch = ExcelSession.BeginBatch(testFile);
         _sheetCommands.Create(batch, "MoveMe");
@@ -77,9 +75,8 @@ public partial class SheetCommandsTests
     [Fact]
     public void Move_NoPositionSpecified_MovesToEnd()
     {
-        // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), nameof(Move_NoPositionSpecified_MovesToEnd), _tempDir);
+        // Arrange - Move tests need isolated file to control sheet order
+        var testFile = _fixture.CreateCrossWorkbookTestFile(nameof(Move_NoPositionSpecified_MovesToEnd));
 
         using var batch = ExcelSession.BeginBatch(testFile);
         _sheetCommands.Create(batch, "Sheet2");
@@ -102,8 +99,7 @@ public partial class SheetCommandsTests
     public void Move_BothBeforeAndAfter_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), nameof(Move_BothBeforeAndAfter_ThrowsException), _tempDir);
+        var testFile = _fixture.CreateCrossWorkbookTestFile(nameof(Move_BothBeforeAndAfter_ThrowsException));
 
         using var batch = ExcelSession.BeginBatch(testFile);
         _sheetCommands.Create(batch, "Sheet2");
@@ -120,8 +116,7 @@ public partial class SheetCommandsTests
     public void Move_NonExistentSheet_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), nameof(Move_NonExistentSheet_ThrowsException), _tempDir);
+        var testFile = _fixture.CreateCrossWorkbookTestFile(nameof(Move_NonExistentSheet_ThrowsException));
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -136,8 +131,7 @@ public partial class SheetCommandsTests
     public void Move_NonExistentTargetSheet_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), nameof(Move_NonExistentTargetSheet_ThrowsException), _tempDir);
+        var testFile = _fixture.CreateCrossWorkbookTestFile(nameof(Move_NonExistentTargetSheet_ThrowsException));
 
         using var batch = ExcelSession.BeginBatch(testFile);
         _sheetCommands.Create(batch, "Sheet2");
@@ -158,10 +152,8 @@ public partial class SheetCommandsTests
     public void CopyToWorkbook_WithTargetName_CopiesAndRenames()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_WithTargetName_CopiesAndRenames)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_WithTargetName_CopiesAndRenames)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_WithTargetName_CopiesAndRenames), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_WithTargetName_CopiesAndRenames), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 
@@ -186,10 +178,8 @@ public partial class SheetCommandsTests
     public void CopyToWorkbook_NoTargetName_CopiesWithOriginalName()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_NoTargetName_CopiesWithOriginalName)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_NoTargetName_CopiesWithOriginalName)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_NoTargetName_CopiesWithOriginalName), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_NoTargetName_CopiesWithOriginalName), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 
@@ -210,10 +200,8 @@ public partial class SheetCommandsTests
     public void CopyToWorkbook_WithBeforeSheet_PositionsCorrectly()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_WithBeforeSheet_PositionsCorrectly)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_WithBeforeSheet_PositionsCorrectly)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_WithBeforeSheet_PositionsCorrectly), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_WithBeforeSheet_PositionsCorrectly), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 
@@ -234,10 +222,8 @@ public partial class SheetCommandsTests
     public void CopyToWorkbook_WithAfterSheet_PositionsCorrectly()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_WithAfterSheet_PositionsCorrectly)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_WithAfterSheet_PositionsCorrectly)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_WithAfterSheet_PositionsCorrectly), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_WithAfterSheet_PositionsCorrectly), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 
@@ -258,10 +244,8 @@ public partial class SheetCommandsTests
     public void CopyToWorkbook_BothBeforeAndAfter_ThrowsException()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_BothBeforeAndAfter_ThrowsException)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(CopyToWorkbook_BothBeforeAndAfter_ThrowsException)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_BothBeforeAndAfter_ThrowsException), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(CopyToWorkbook_BothBeforeAndAfter_ThrowsException), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 
@@ -284,10 +268,8 @@ public partial class SheetCommandsTests
     public void MoveToWorkbook_Default_MovesSheetSuccessfully()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(MoveToWorkbook_Default_MovesSheetSuccessfully)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(MoveToWorkbook_Default_MovesSheetSuccessfully)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(MoveToWorkbook_Default_MovesSheetSuccessfully), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(MoveToWorkbook_Default_MovesSheetSuccessfully), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 
@@ -312,10 +294,8 @@ public partial class SheetCommandsTests
     public void MoveToWorkbook_WithBeforeSheet_PositionsCorrectly()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(MoveToWorkbook_WithBeforeSheet_PositionsCorrectly)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(MoveToWorkbook_WithBeforeSheet_PositionsCorrectly)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(MoveToWorkbook_WithBeforeSheet_PositionsCorrectly), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(MoveToWorkbook_WithBeforeSheet_PositionsCorrectly), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 
@@ -340,10 +320,8 @@ public partial class SheetCommandsTests
     public void MoveToWorkbook_WithAfterSheet_PositionsCorrectly()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(MoveToWorkbook_WithAfterSheet_PositionsCorrectly)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(MoveToWorkbook_WithAfterSheet_PositionsCorrectly)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(MoveToWorkbook_WithAfterSheet_PositionsCorrectly), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(MoveToWorkbook_WithAfterSheet_PositionsCorrectly), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 
@@ -368,10 +346,8 @@ public partial class SheetCommandsTests
     public void MoveToWorkbook_BothBeforeAndAfter_ThrowsException()
     {
         // Arrange
-        var sourceFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(MoveToWorkbook_BothBeforeAndAfter_ThrowsException)}_Source", _tempDir);
-        var targetFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests), $"{nameof(MoveToWorkbook_BothBeforeAndAfter_ThrowsException)}_Target", _tempDir);
+        var sourceFile = _fixture.CreateCrossWorkbookTestFile(nameof(MoveToWorkbook_BothBeforeAndAfter_ThrowsException), "Source");
+        var targetFile = _fixture.CreateCrossWorkbookTestFile(nameof(MoveToWorkbook_BothBeforeAndAfter_ThrowsException), "Target");
 
         using var batch = ExcelSession.BeginBatch(sourceFile, targetFile);
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Sheet/SheetCommandsTests.TabColor.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Sheet/SheetCommandsTests.TabColor.cs
@@ -15,29 +15,23 @@ public partial class SheetCommandsTests
     public void SetTabColor_WithValidRGB_SetsColorCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(SetTabColor_WithValidRGB_SetsColorCorrectly),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "ColorTest");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"Color_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act - Set red color
-        _sheetCommands.SetTabColor(batch, "ColorTest", 255, 0, 0);  // SetTabColor throws on error
+        _sheetCommands.SetTabColor(batch, sheetName, 255, 0, 0);  // SetTabColor throws on error
 
         // Assert - reaching here means set succeeded
 
         // Verify color was actually set by reading it back
-        var getResult = _sheetCommands.GetTabColor(batch, "ColorTest");
+        var getResult = _sheetCommands.GetTabColor(batch, sheetName);
         Assert.True(getResult.Success);
         Assert.True(getResult.HasColor);
         Assert.Equal(255, getResult.Red);
         Assert.Equal(0, getResult.Green);
         Assert.Equal(0, getResult.Blue);
         Assert.Equal("#FF0000", getResult.HexColor);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -45,43 +39,40 @@ public partial class SheetCommandsTests
     public void SetTabColor_WithDifferentColors_AllSetCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(SetTabColor_WithDifferentColors_AllSetCorrectly),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var uniqueId = Guid.NewGuid().ToString("N")[..6];
+        var redSheet = $"Red_{uniqueId}";
+        var greenSheet = $"Green_{uniqueId}";
+        var blueSheet = $"Blue_{uniqueId}";
 
         // Create multiple sheets
-        _sheetCommands.Create(batch, "Red");
-        _sheetCommands.Create(batch, "Green");
-        _sheetCommands.Create(batch, "Blue");
+        _sheetCommands.Create(batch, redSheet);
+        _sheetCommands.Create(batch, greenSheet);
+        _sheetCommands.Create(batch, blueSheet);
 
         // Act - Set different colors
-        _sheetCommands.SetTabColor(batch, "Red", 255, 0, 0);
-        _sheetCommands.SetTabColor(batch, "Green", 0, 255, 0);
-        _sheetCommands.SetTabColor(batch, "Blue", 0, 0, 255);
+        _sheetCommands.SetTabColor(batch, redSheet, 255, 0, 0);
+        _sheetCommands.SetTabColor(batch, greenSheet, 0, 255, 0);
+        _sheetCommands.SetTabColor(batch, blueSheet, 0, 0, 255);
 
         // Assert - Verify each color
-        var redColor = _sheetCommands.GetTabColor(batch, "Red");
+        var redColor = _sheetCommands.GetTabColor(batch, redSheet);
         Assert.True(redColor.HasColor);
         Assert.Equal(255, redColor.Red);
         Assert.Equal(0, redColor.Green);
         Assert.Equal(0, redColor.Blue);
 
-        var greenColor = _sheetCommands.GetTabColor(batch, "Green");
+        var greenColor = _sheetCommands.GetTabColor(batch, greenSheet);
         Assert.True(greenColor.HasColor);
         Assert.Equal(0, greenColor.Red);
         Assert.Equal(255, greenColor.Green);
         Assert.Equal(0, greenColor.Blue);
 
-        var blueColor = _sheetCommands.GetTabColor(batch, "Blue");
+        var blueColor = _sheetCommands.GetTabColor(batch, blueSheet);
         Assert.True(blueColor.HasColor);
         Assert.Equal(0, blueColor.Red);
         Assert.Equal(0, blueColor.Green);
         Assert.Equal(255, blueColor.Blue);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -89,16 +80,12 @@ public partial class SheetCommandsTests
     public void GetTabColor_WithNoColor_ReturnsHasColorFalse()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(GetTabColor_WithNoColor_ReturnsHasColorFalse),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "NoColor");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"NoClr_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act
-        var result = _sheetCommands.GetTabColor(batch, "NoColor");
+        var result = _sheetCommands.GetTabColor(batch, sheetName);
 
         // Assert
         Assert.True(result.Success);
@@ -114,29 +101,23 @@ public partial class SheetCommandsTests
     public void ClearTabColor_RemovesColor()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(ClearTabColor_RemovesColor),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "ClearTest");
-        _sheetCommands.SetTabColor(batch, "ClearTest", 255, 165, 0); // Orange
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"Clear_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
+        _sheetCommands.SetTabColor(batch, sheetName, 255, 165, 0); // Orange
 
         // Verify color is set
-        var beforeClear = _sheetCommands.GetTabColor(batch, "ClearTest");
+        var beforeClear = _sheetCommands.GetTabColor(batch, sheetName);
         Assert.True(beforeClear.HasColor);
 
         // Act - Clear color
-        _sheetCommands.ClearTabColor(batch, "ClearTest");  // ClearTabColor throws on error
+        _sheetCommands.ClearTabColor(batch, sheetName);  // ClearTabColor throws on error
 
         // Assert - reaching here means clear succeeded
 
-        var afterClear = _sheetCommands.GetTabColor(batch, "ClearTest");
+        var afterClear = _sheetCommands.GetTabColor(batch, sheetName);
         Assert.True(afterClear.Success);
         Assert.False(afterClear.HasColor);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -144,21 +125,17 @@ public partial class SheetCommandsTests
     public void SetTabColor_WithInvalidRGB_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(SetTabColor_WithInvalidRGB_ThrowsException),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "InvalidColor");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"Inv_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act & Assert - Should throw ArgumentException for invalid RGB values
         var exception1 = Assert.Throws<ArgumentException>(
-            () => _sheetCommands.SetTabColor(batch, "InvalidColor", 256, 0, 0)); // Red too high
+            () => _sheetCommands.SetTabColor(batch, sheetName, 256, 0, 0)); // Red too high
         Assert.Contains("must be between 0 and 255", exception1.Message);
 
         var exception2 = Assert.Throws<ArgumentException>(
-            () => _sheetCommands.SetTabColor(batch, "InvalidColor", 0, -1, 0)); // Green negative
+            () => _sheetCommands.SetTabColor(batch, sheetName, 0, -1, 0)); // Green negative
         Assert.Contains("must be between 0 and 255", exception2.Message);
     }
     /// <inheritdoc/>
@@ -167,16 +144,11 @@ public partial class SheetCommandsTests
     public void SetTabColor_WithNonExistentSheet_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(SetTabColor_WithNonExistentSheet_ThrowsException),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
 
         // Act & Assert - Non-existent sheet should throw InvalidOperationException
         var exception = Assert.Throws<InvalidOperationException>(() =>
-            _sheetCommands.SetTabColor(batch, "NonExistent", 255, 0, 0));
+            _sheetCommands.SetTabColor(batch, $"NonExistent_{Guid.NewGuid():N}", 255, 0, 0));
 
         Assert.Contains("not found", exception.Message);
     }
@@ -186,26 +158,20 @@ public partial class SheetCommandsTests
     public void TabColor_RGBToBGRConversion_WorksCorrectly()
     {
         // Arrange - Test BGR conversion accuracy
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(TabColor_RGBToBGRConversion_WorksCorrectly),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "ConversionTest");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"Conv_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act - Set a complex color (purple: RGB(128, 0, 128))
-        _sheetCommands.SetTabColor(batch, "ConversionTest", 128, 0, 128);
+        _sheetCommands.SetTabColor(batch, sheetName, 128, 0, 128);
 
         // Assert - Verify conversion accuracy
-        var result = _sheetCommands.GetTabColor(batch, "ConversionTest");
+        var result = _sheetCommands.GetTabColor(batch, sheetName);
         Assert.True(result.Success);
         Assert.True(result.HasColor);
         Assert.Equal(128, result.Red);
         Assert.Equal(0, result.Green);
         Assert.Equal(128, result.Blue);
         Assert.Equal("#800080", result.HexColor);
-
-        // Save changes
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Sheet/SheetCommandsTests.Visibility.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Sheet/SheetCommandsTests.Visibility.cs
@@ -16,26 +16,20 @@ public partial class SheetCommandsTests
     public void SetVisibility_ToHidden_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(SetVisibility_ToHidden_WorksCorrectly),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "HideTest");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"Hide_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act
-        _sheetCommands.SetVisibility(batch, "HideTest", SheetVisibility.Hidden);  // SetVisibility throws on error
+        _sheetCommands.SetVisibility(batch, sheetName, SheetVisibility.Hidden);  // SetVisibility throws on error
 
         // Assert - reaching here means set succeeded
 
         // Verify by reading visibility
-        var getResult = _sheetCommands.GetVisibility(batch, "HideTest");
+        var getResult = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.True(getResult.Success);
         Assert.Equal(SheetVisibility.Hidden, getResult.Visibility);
         Assert.Equal("Hidden", getResult.VisibilityName);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -43,25 +37,19 @@ public partial class SheetCommandsTests
     public void SetVisibility_ToVeryHidden_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(SetVisibility_ToVeryHidden_WorksCorrectly),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "VeryHideTest");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"VHide_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act
-        _sheetCommands.SetVisibility(batch, "VeryHideTest", SheetVisibility.VeryHidden);  // SetVisibility throws on error
+        _sheetCommands.SetVisibility(batch, sheetName, SheetVisibility.VeryHidden);  // SetVisibility throws on error
 
         // Assert - reaching here means set succeeded
 
-        var getResult = _sheetCommands.GetVisibility(batch, "VeryHideTest");
+        var getResult = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.True(getResult.Success);
         Assert.Equal(SheetVisibility.VeryHidden, getResult.Visibility);
         Assert.Equal("VeryHidden", getResult.VisibilityName);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -69,28 +57,22 @@ public partial class SheetCommandsTests
     public void Show_HiddenSheet_MakesVisible()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(Show_HiddenSheet_MakesVisible),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "ShowTest");
-        _sheetCommands.Hide(batch, "ShowTest");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"ShowH_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
+        _sheetCommands.Hide(batch, sheetName);
 
         // Verify it's hidden
-        var hiddenCheck = _sheetCommands.GetVisibility(batch, "ShowTest");
+        var hiddenCheck = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.Hidden, hiddenCheck.Visibility);
 
         // Act - Show the sheet
-        _sheetCommands.Show(batch, "ShowTest");  // Show throws on error
+        _sheetCommands.Show(batch, sheetName);  // Show throws on error
 
         // Assert - reaching here means show succeeded
 
-        var visibleCheck = _sheetCommands.GetVisibility(batch, "ShowTest");
+        var visibleCheck = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.Visible, visibleCheck.Visibility);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -98,28 +80,22 @@ public partial class SheetCommandsTests
     public void Show_VeryHiddenSheet_MakesVisible()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(Show_VeryHiddenSheet_MakesVisible),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "VeryHideShowTest");
-        _sheetCommands.VeryHide(batch, "VeryHideShowTest");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"ShowVH_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
+        _sheetCommands.VeryHide(batch, sheetName);
 
         // Verify it's very hidden
-        var veryHiddenCheck = _sheetCommands.GetVisibility(batch, "VeryHideShowTest");
+        var veryHiddenCheck = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.VeryHidden, veryHiddenCheck.Visibility);
 
         // Act - Show the sheet
-        _sheetCommands.Show(batch, "VeryHideShowTest");  // Show throws on error
+        _sheetCommands.Show(batch, sheetName);  // Show throws on error
 
         // Assert - reaching here means show succeeded
 
-        var visibleCheck = _sheetCommands.GetVisibility(batch, "VeryHideShowTest");
+        var visibleCheck = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.Visible, visibleCheck.Visibility);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -127,23 +103,17 @@ public partial class SheetCommandsTests
     public void Hide_VisibleSheet_MakesHidden()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(Hide_VisibleSheet_MakesHidden),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "HideMe");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"HideMe_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act
-        _sheetCommands.Hide(batch, "HideMe");  // Hide throws on error
+        _sheetCommands.Hide(batch, sheetName);  // Hide throws on error
 
         // Assert - reaching here means hide succeeded
 
-        var getResult = _sheetCommands.GetVisibility(batch, "HideMe");
+        var getResult = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.Hidden, getResult.Visibility);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -151,23 +121,17 @@ public partial class SheetCommandsTests
     public void VeryHide_VeryHidesVisibleSheet()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(VeryHide_VeryHidesVisibleSheet),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "VeryHideMe");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"VHide_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act
-        _sheetCommands.VeryHide(batch, "VeryHideMe");  // VeryHide throws on error
+        _sheetCommands.VeryHide(batch, sheetName);  // VeryHide throws on error
 
         // Assert - reaching here means veryhide succeeded
 
-        var getResult = _sheetCommands.GetVisibility(batch, "VeryHideMe");
+        var getResult = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.VeryHidden, getResult.Visibility);
-
-        // Save changes
     }
     /// <inheritdoc/>
 
@@ -175,16 +139,12 @@ public partial class SheetCommandsTests
     public void GetVisibility_ForVisibleSheet_ReturnsVisible()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(GetVisibility_ForVisibleSheet_ReturnsVisible),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "VisibleSheet");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"Vis_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act
-        var result = _sheetCommands.GetVisibility(batch, "VisibleSheet");
+        var result = _sheetCommands.GetVisibility(batch, sheetName);
 
         // Assert
         Assert.True(result.Success);
@@ -197,16 +157,11 @@ public partial class SheetCommandsTests
     public void SetVisibility_WithNonExistentSheet_ThrowsException()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(SetVisibility_WithNonExistentSheet_ThrowsException),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
 
         // Act & Assert - Should throw InvalidOperationException when sheet not found
         var exception = Assert.Throws<InvalidOperationException>(
-            () => _sheetCommands.SetVisibility(batch, "NonExistent", SheetVisibility.Hidden));
+            () => _sheetCommands.SetVisibility(batch, $"NonExist_{Guid.NewGuid():N}", SheetVisibility.Hidden));
         Assert.Contains("not found", exception.Message);
     }
     /// <inheritdoc/>
@@ -215,35 +170,29 @@ public partial class SheetCommandsTests
     public void Visibility_CompleteWorkflow_AllLevelsWork()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(SheetCommandsTests),
-            nameof(Visibility_CompleteWorkflow_AllLevelsWork),
-            _tempDir);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-        _sheetCommands.Create(batch, "Workflow");
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = $"WFlow_{Guid.NewGuid():N}"[..31];
+        _sheetCommands.Create(batch, sheetName);
 
         // Act & Assert - Test complete visibility workflow
 
         // Start visible
-        var check1 = _sheetCommands.GetVisibility(batch, "Workflow");
+        var check1 = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.Visible, check1.Visibility);
 
         // Hide it
-        _sheetCommands.Hide(batch, "Workflow");
-        var check2 = _sheetCommands.GetVisibility(batch, "Workflow");
+        _sheetCommands.Hide(batch, sheetName);
+        var check2 = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.Hidden, check2.Visibility);
 
         // Very hide it
-        _sheetCommands.VeryHide(batch, "Workflow");
-        var check3 = _sheetCommands.GetVisibility(batch, "Workflow");
+        _sheetCommands.VeryHide(batch, sheetName);
+        var check3 = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.VeryHidden, check3.Visibility);
 
         // Show it again
-        _sheetCommands.Show(batch, "Workflow");
-        var check4 = _sheetCommands.GetVisibility(batch, "Workflow");
+        _sheetCommands.Show(batch, sheetName);
+        var check4 = _sheetCommands.GetVisibility(batch, sheetName);
         Assert.Equal(SheetVisibility.Visible, check4.Visibility);
-
-        // Save changes
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Sheet/SheetCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Sheet/SheetCommandsTests.cs
@@ -8,24 +8,25 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Sheet;
 /// Integration tests for Sheet lifecycle operations.
 /// These tests require Excel installation and validate Core worksheet lifecycle management.
 /// Tests use Core commands directly (not through CLI wrapper).
-/// Each test uses a unique Excel file for complete test isolation.
+/// Single-workbook tests share one Excel file with unique sheets for isolation.
+/// Cross-workbook tests (CopyToWorkbook, MoveToWorkbook) use their own file pairs.
 /// Data operations (read, write, clear) moved to RangeCommandsTests.
 /// </summary>
 [Trait("Layer", "Core")]
 [Trait("Category", "Integration")]
 [Trait("RequiresExcel", "true")]
 [Trait("Feature", "Worksheets")]
-public partial class SheetCommandsTests : IClassFixture<TempDirectoryFixture>
+public partial class SheetCommandsTests : IClassFixture<SheetTestsFixture>
 {
     private readonly SheetCommands _sheetCommands;
-    private readonly string _tempDir;
+    private readonly SheetTestsFixture _fixture;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SheetCommandsTests"/> class.
     /// </summary>
-    public SheetCommandsTests(TempDirectoryFixture fixture)
+    public SheetCommandsTests(SheetTestsFixture fixture)
     {
         _sheetCommands = new SheetCommands();
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Vba/VbaCommandsTests.Trust.ScriptCommands.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Vba/VbaCommandsTests.Trust.ScriptCommands.cs
@@ -9,13 +9,11 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Vba;
 /// </summary>
 public partial class VbaCommandsTests
 {
-    /// <inheritdoc/>
     [Fact]
     public void ScriptCommands_List_WithTrustEnabled_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(VbaCommandsTests), nameof(ScriptCommands_List_WithTrustEnabled_WorksCorrectly), _tempDir, ".xlsm");
+        var testFile = _fixture.CreateTestFile();
 
         // Act
         using var batch = ExcelSession.BeginBatch(testFile);
@@ -25,14 +23,11 @@ public partial class VbaCommandsTests
         Assert.True(result.Success, $"List should succeed with VBA trust enabled. Error: {result.ErrorMessage}");
         Assert.NotNull(result.Scripts);
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void ScriptCommands_Import_WithTrustEnabled_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(VbaCommandsTests), nameof(ScriptCommands_Import_WithTrustEnabled_WorksCorrectly), _tempDir, ".xlsm");
+        var testFile = _fixture.CreateTestFile();
 
         string vbaCode = "Sub TestImport()\nEnd Sub";
 
@@ -44,14 +39,11 @@ public partial class VbaCommandsTests
         var listResult = _scriptCommands.List(batch);
         Assert.Contains(listResult.Scripts, s => s.Name == "TestModule");
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void ScriptCommands_Export_WithTrustEnabled_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(VbaCommandsTests), nameof(ScriptCommands_Export_WithTrustEnabled_WorksCorrectly), _tempDir, ".xlsm");
+        var testFile = _fixture.CreateTestFile();
 
         // First import a module so we have something to export
         string vbaCode = "Sub TestCode()\nEnd Sub";
@@ -67,14 +59,11 @@ public partial class VbaCommandsTests
         Assert.NotNull(result.Code);
         Assert.NotEmpty(result.Code);
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void ScriptCommands_Run_WithTrustEnabled_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(VbaCommandsTests), nameof(ScriptCommands_Run_WithTrustEnabled_WorksCorrectly), _tempDir, ".xlsm");
+        var testFile = _fixture.CreateTestFile();
 
         // Import a test macro first
         string vbaCode = @"Sub TestProcedure()
@@ -91,14 +80,11 @@ End Sub";
         var listResult = _scriptCommands.List(batch);
         Assert.Contains(listResult.Scripts, s => s.Name == "TestModule");
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void ScriptCommands_Delete_WithTrustEnabled_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(VbaCommandsTests), nameof(ScriptCommands_Delete_WithTrustEnabled_WorksCorrectly), _tempDir, ".xlsm");
+        var testFile = _fixture.CreateTestFile();
 
         // Import a module first
         string vbaCode = "Sub TestCode()\nEnd Sub";
@@ -113,14 +99,11 @@ End Sub";
         var listResult = _scriptCommands.List(batch);
         Assert.DoesNotContain(listResult.Scripts, s => s.Name == "TestModule");
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void ScriptCommands_View_WithTrustEnabled_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(VbaCommandsTests), nameof(ScriptCommands_View_WithTrustEnabled_WorksCorrectly), _tempDir, ".xlsm");
+        var testFile = _fixture.CreateTestFile();
 
         // Import a module with known code
         string expectedCode = "Sub ViewTest()\n    MsgBox \"Hello\"\nEnd Sub";
@@ -137,14 +120,11 @@ End Sub";
         Assert.Contains("ViewTest", result.Code);
         Assert.Contains("MsgBox", result.Code);
     }
-    /// <inheritdoc/>
-
     [Fact]
     public void ScriptCommands_Update_WithTrustEnabled_WorksCorrectly()
     {
         // Arrange
-        var testFile = CoreTestHelper.CreateUniqueTestFile(
-            nameof(VbaCommandsTests), nameof(ScriptCommands_Update_WithTrustEnabled_WorksCorrectly), _tempDir, ".xlsm");
+        var testFile = _fixture.CreateTestFile();
 
         // Import initial module
         string initialCode = "Sub OriginalCode()\nEnd Sub";

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Vba/VbaCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Vba/VbaCommandsTests.cs
@@ -14,17 +14,17 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Vba;
 [Trait("Category", "Integration")]
 [Trait("RequiresExcel", "true")]
 [Trait("Feature", "VBA")]
-public partial class VbaCommandsTests : IClassFixture<TempDirectoryFixture>
+public partial class VbaCommandsTests : IClassFixture<VbaTestsFixture>
 {
     private readonly VbaCommands _scriptCommands;
-    private readonly string _tempDir;
+    private readonly VbaTestsFixture _fixture;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="VbaCommandsTests"/> class.
     /// </summary>
-    public VbaCommandsTests(TempDirectoryFixture fixture)
+    public VbaCommandsTests(VbaTestsFixture fixture)
     {
         _scriptCommands = new VbaCommands();
-        _tempDir = fixture.TempDir;
+        _fixture = fixture;
     }
 }


### PR DESCRIPTION
## Summary

Resolves #265 - Test performance optimization

This PR replaces all 205 `CoreTestHelper.CreateUniqueTestFile()` calls with fixture-based `CreateTestFile()` methods, reducing test execution overhead.

## Changes

### New Fixtures (8 files)
- `ChartTestsFixture.cs`
- `ConnectionTestsFixture.cs`
- `DataModelTestsFixture.cs`
- `FileTestsFixture.cs`
- `NamedRangeTestsFixture.cs`
- `RangeTestsFixture.cs`
- `SheetTestsFixture.cs`
- `VbaTestsFixture.cs`

### Enhanced Fixtures (4 files)
- `TempDirectoryFixture.cs` - Added `CreateTestFile()` method
- `PivotTableTestsFixture.cs` - Added `TempDir` property and `CreateTestFile()` method
- `PowerQueryTestsFixture.cs` - Enhanced with `CreateTestFile()`
- `TableTestsFixture.cs` - Enhanced with `CreateTestFile()`

### Updated Test Classes (46 files)
All test classes now use `_fixture.CreateTestFile()` instead of `CoreTestHelper.CreateUniqueTestFile()`

## Testing

- All builds pass (0 warnings, 0 errors)
- Chart tests: 26/26 passed
- Worksheets tests: 36/36 passed
- DateFormat tests: 6/6 passed
- Pre-commit hooks pass (COM leaks, coverage, success flag checks)
