### PR TITLE
Add GitHub Stars badge to gh-pages site

### DIFF
--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -21,6 +21,7 @@ canonical_url: "https://sbroenne.github.io/mcp-server-excel/"
   <div class="container">
     <div class="hero-badges">
       <a href="https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp"><img src="https://img.shields.io/visual-studio-marketplace/i/sbroenne.excel-mcp?label=VS%20Code%20Installs" alt="VS Code Marketplace Installs"></a>
+      <a href="https://github.com/sbroenne/mcp-server-excel"><img src="https://img.shields.io/github/stars/sbroenne/mcp-server-excel?style=flat&label=GitHub%20Stars" alt="GitHub Stars"></a>
       <a href="https://github.com/sbroenne/mcp-server-excel/releases"><img src="https://img.shields.io/github/downloads/sbroenne/mcp-server-excel/total?label=GitHub%20Downloads" alt="GitHub Downloads"></a>
       <a href="https://www.nuget.org/packages/Sbroenne.ExcelMcp.McpServer"><img src="https://img.shields.io/nuget/dt/Sbroenne.ExcelMcp.McpServer.svg?label=NuGet%20MCP%20Installs" alt="NuGet MCP Server Installs"></a>
     </div>


### PR DESCRIPTION
Add GitHub Stars badge to the gh-pages website badges section.

## Changes
- Added GitHub Stars badge to `gh-pages/index.md`

The badge displays the star count and links to the repository.