### PR TITLE
Configure gh-pages for custom domain excelmcpserver.dev

### DIFF
--- a/gh-pages/_config.yml
+++ b/gh-pages/_config.yml
@@ -4,8 +4,8 @@
 # Site settings
 title: "Excel MCP Server"
 description: "AI-powered Excel automation through conversational AI"
-url: "https://sbroenne.github.io"
-baseurl: "/mcp-server-excel"
+url: "https://excelmcpserver.dev"
+baseurl: ""
 repository: "sbroenne/mcp-server-excel"
 
 # Theme

--- a/gh-pages/_layouts/default.html
+++ b/gh-pages/_layouts/default.html
@@ -45,7 +45,7 @@
         "priceCurrency": "USD"
       },
       "description": "Control Microsoft Excel with Natural Language through AI assistants like GitHub Copilot and Claude. Automate Power Query, DAX, VBA, PivotTables, and more.",
-      "url": "https://sbroenne.github.io/mcp-server-excel/",
+      "url": "https://excelmcpserver.dev/",
       "softwareVersion": "1.0",
       "programmingLanguage": "C#",
       "downloadUrl": "https://www.nuget.org/packages/Sbroenne.ExcelMcp.McpServer/",

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -3,7 +3,7 @@ layout: default
 title: "Excel MCP Server - AI-Powered Excel Automation"
 description: "Control Microsoft Excel with natural language through AI assistants like GitHub Copilot and Claude. Automate Power Query, DAX, VBA, PivotTables, and more. One-click install for Visual Studio Code."
 keywords: "Excel automation, MCP server, AI Excel, Power Query, DAX measures, VBA macros, GitHub Copilot Excel, Claude Excel, Excel CLI, M code, REPL"
-canonical_url: "https://sbroenne.github.io/mcp-server-excel/"
+canonical_url: "https://excelmcpserver.dev/"
 ---
 
 <div class="hero">


### PR DESCRIPTION
## Problem
Assets (styles.css, icon.png) return 404 when accessing the site via the custom domain https://excelmcpserver.dev/

## Root Cause
The `baseurl` was set to `/mcp-server-excel` which caused asset paths to be prefixed incorrectly when the site is served at the root via the custom domain.

## Changes
- **_config.yml**: Set `url` to `https://excelmcpserver.dev` and `baseurl` to empty string
- **index.md**: Updated `canonical_url` to `https://excelmcpserver.dev/`
- **_layouts/default.html**: Updated structured data URL

## Result
After merging, assets will load correctly on https://excelmcpserver.dev/ and https://www.excelmcpserver.dev/