### PR TITLE
feat(datamodel): add read-relationship action for viewing individual relationships

### DIFF
--- a/.github/instructions/excel-com-interop.instructions.md
+++ b/.github/instructions/excel-com-interop.instructions.md
@@ -344,6 +344,32 @@ if (connType == 3 || connType == 4) {  // TEXT files report as type 4 (WEB)
 }
 ```
 
+## Data Model (Power Pivot) API Limitations
+
+**⚠️ KNOWN LIMITATION: Hidden columns, relationships, and measures cannot be detected via Excel COM API**
+
+When objects are marked "Hidden from client tools" in Power Pivot, the Excel COM API provides no way to detect this or retrieve them.
+
+**Affected Objects:**
+
+| Object | Available Properties | Missing |
+|--------|---------------------|---------|
+| `ModelTableColumn` | Application, Creator, DataType, Name, Parent | **NO IsHidden** |
+| `ModelRelationship` | Application, Creator, ForeignKeyColumn, ForeignKeyTable, PrimaryKeyColumn, PrimaryKeyTable, Active | **NO IsHidden** |
+| `ModelMeasure` | Application, AssociatedTable, Creator, Description, FormatInformation, Formula, Name, Parent | **NO IsHidden** |
+
+**Alternative APIs that were investigated and DO NOT WORK:**
+
+| Approach | Why It Doesn't Work |
+|----------|---------------------|
+| TOM (Tabular Object Model) | Requires `Microsoft.AnalysisServices.Tabular` library which cannot connect to Excel's embedded Analysis Services engine |
+| XMLA queries | Excel's embedded AS engine doesn't expose a queryable endpoint for external XMLA connections |
+| CubeField.ShowInFieldList | Only applies to PivotTable field visibility, not underlying Data Model hidden status |
+
+**Bottom Line:** If a column, relationship, or measure is hidden in the Data Model, it cannot be seen or listed through the Excel COM API. This is a fundamental limitation of Microsoft's Excel automation interface.
+
+---
+
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -355,5 +381,6 @@ if (connType == 3 || connType == 4) {  // TEXT files report as type 4 (WEB)
 | Not releasing objects | `try/finally` + `ReleaseComObject()` |
 | `int x = field.Property` | Use `Convert.ToInt32()` for ALL numeric properties |
 | Assuming enum types | Numeric properties return `double`, convert to enum |
+| Using TOM/XMLA for Data Model | Not accessible from Excel COM - use only ModelTable/ModelTableColumn APIs |
 
 **📚 Reference:** [Excel Object Model](https://docs.microsoft.com/en-us/office/vba/api/overview/excel)

--- a/.github/instructions/readme-management.instructions.md
+++ b/.github/instructions/readme-management.instructions.md
@@ -17,7 +17,7 @@ applyTo: "**/*.md,README.md,**/README.md"
 ### Tool Counts Must Match
 ### Tool & Action Counts Must Match
 - All READMEs: **12 specialized tools**
-- Current total actions: **172 operations** (update if tool schema changes)
+- Current total actions: **173 operations** (update if tool schema changes)
 - Sync counts across:
 	- `/README.md`
 	- `/src/ExcelMcp.McpServer/README.md`
@@ -29,7 +29,7 @@ applyTo: "**/*.md,README.md,**/README.md"
 # Check READMEs/sites have same tool count
 git grep "12 specialized tools" README.md src/ExcelMcp.McpServer/README.md src/ExcelMcp.CLI/README.md vscode-extension/README.md gh-pages/index.md
 
-# Check total operations text (172)
+# Check total operations text (173)
 - All READMEs mention: **COM API** (not "Excel's internal API")
 - Highlight: zero corruption, interactive development, growing features
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # ExcelMcp - Complete Feature Reference
 
-**12 specialized tools with 172 operations for comprehensive Excel automation**
+**12 specialized tools with 173 operations for comprehensive Excel automation**
 
 ---
 
@@ -21,10 +21,10 @@
 
 ---
 
-## 📊 Data Model & DAX (Power Pivot) (14 operations)
+## 📊 Data Model & DAX (Power Pivot) (15 operations)
 
 - Create/update/delete DAX measures with format types (Currency, Percentage, Decimal, General)
-- Manage table relationships (create, toggle active/inactive, delete)
+- Manage table relationships (create, read, toggle active/inactive, delete)
 - Discover model structure (tables, columns, measures, relationships)
 - Get comprehensive model information
 - Refresh data model
@@ -180,7 +180,7 @@
 | Category | Operations |
 |----------|-----------|
 | Power Query | 9 |
-| Data Model/DAX | 14 |
+| Data Model/DAX | 15 |
 | Excel Tables | 24 |
 | PivotTables | 25 |
 | Charts | 14 |
@@ -191,7 +191,7 @@
 | Named Ranges | 6 |
 | File Operations | 5 |
 | Conditional Formatting | 2 |
-| **Total** | **172** |
+| **Total** | **173** |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **💡 Interactive Development** - See results instantly in Excel. Create a query, run it, inspect the output, refine and repeat. Excel becomes your AI-powered workspace for rapid development and testing.
 
-**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 172 operations.
+**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 173 operations.
 
 ## 🚀 Quick Start (1 Minute)
 
@@ -43,7 +43,7 @@ The extension opens automatically after installation with a quick start guide!
 
 ## 🎯 What You Can Do
 
-**12 specialized tools with 172 operations:**
+**12 specialized tools with 173 operations:**
 
 - 🔄 **Power Query** (9 ops) - Atomic workflows, M code management, load destinations
 - 📊 **Data Model/DAX** (14 ops) - Measures, relationships, model structure
@@ -58,7 +58,7 @@ The extension opens automatically after installation with a quick start guide!
 - 📁 **Files** (5 ops) - Session management and workbook creation
 - 🎨 **Conditional Formatting** (2 ops) - Rules and clearing
 
-📚 **[Complete Feature Reference →](FEATURES.md)** - Detailed documentation of all 172 operations
+📚 **[Complete Feature Reference →](FEATURES.md)** - Detailed documentation of all 173 operations
 
 
 ## 💬 Example Prompts

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -39,7 +39,7 @@ canonical_url: "https://sbroenne.github.io/mcp-server-excel/"
 
 **💡 Interactive Development** - See results instantly in Excel. Create a query, run it, inspect the output, refine and repeat. Excel becomes your AI-powered workspace for rapid development and testing.
 
-**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 172 operations.
+**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 173 operations.
 
 ## 🚀 Visual Studio Code Quick Start (1 Minute)
 
@@ -50,8 +50,8 @@ canonical_url: "https://sbroenne.github.io/mcp-server-excel/"
 
 <div class="features-grid">
 <div class="feature-card">
-<h3>172 Operations</h3>
-<p>12 specialized tools with 172 operations covering Power Query, DAX, Charts, VBA, PivotTables, ranges, conditional formatting, and more</p>
+<h3>173 Operations</h3>
+<p>12 specialized tools with 173 operations covering Power Query, DAX, Charts, VBA, PivotTables, ranges, conditional formatting, and more</p>
 <p><a href="https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md">Complete Feature Reference →</a></p>
 </div>
 
@@ -73,7 +73,7 @@ canonical_url: "https://sbroenne.github.io/mcp-server-excel/"
 
 <div class="feature-card">
 <h3>Comprehensive Automation</h3>
-<p>172 operations covering Power Query, DAX, Charts, VBA, Tables, and more</p>
+<p>173 operations covering Power Query, DAX, Charts, VBA, Tables, and more</p>
 </div>
 
 <div class="feature-card">
@@ -169,7 +169,7 @@ excel-mcp vba-export --file "macro-workbook.xlsm" --module "Module1" --output "s
 <li><strong>Natural Language Control:</strong> Describe tasks in plain English</li>
 <li><strong>Safe:</strong> Official COM API - zero corruption risk</li>
 <li><strong>Interactive:</strong> See changes in real-time in Excel</li>
-<li><strong>Comprehensive:</strong> 172 operations across 12 tools</li>
+<li><strong>Comprehensive:</strong> 173 operations across 12 tools</li>
 <li><strong>Works with:</strong> GitHub Copilot, Claude, ChatGPT, and any MCP client</li>
 </ul>
 </div>
@@ -188,12 +188,12 @@ excel-mcp vba-export --file "macro-workbook.xlsm" --module "Module1" --output "s
 
 <div class="callout">
 <strong>Both Share the Same Core</strong>
-Same 172 operations available via CLI and MCP. Consistent behavior across interfaces.
+Same 173 operations available via CLI and MCP. Consistent behavior across interfaces.
 </div>
 
 ## Complete Tool & Action Reference
 
-**12 specialized tools with 172 operations:**
+**12 specialized tools with 173 operations:**
 
 <div class="tools-reference" markdown="1">
 
@@ -211,7 +211,7 @@ Same 172 operations available via CLI and MCP. Consistent behavior across interf
 | `get-load-config` | Get load destination settings for a query |
 | `load-to` | Load query data to worksheet, data model, or both |
 
-### 🔢 Power Pivot / Data Model (14 actions)
+### 🔢 Power Pivot / Data Model (15 actions)
 
 | Action | Description |
 |--------|-------------|
@@ -224,6 +224,7 @@ Same 172 operations available via CLI and MCP. Consistent behavior across interf
 | `update-measure` | Update existing DAX measure formula or format |
 | `delete-measure` | Delete a DAX measure |
 | `list-relationships` | List all table relationships |
+| `read-relationship` | Read details of a specific relationship |
 | `create-relationship` | Create relationship between tables |
 | `update-relationship` | Update relationship properties |
 | `delete-relationship` | Delete a relationship |

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -6,7 +6,7 @@
 
 **Optional command-line interface for Excel automation without AI assistance.**
 
-For advanced users who prefer direct scripting control, the CLI provides the same 172 operations as the MCP Server. Perfect for RPA workflows, CI/CD pipelines, batch processing, and automated testing.
+For advanced users who prefer direct scripting control, the CLI provides the same 173 operations as the MCP Server. Perfect for RPA workflows, CI/CD pipelines, batch processing, and automated testing.
 
 **Note:** Most users should use the [MCP Server with AI assistants](../ExcelMcp.McpServer/README.md) for natural language automation.
 
@@ -78,7 +78,7 @@ Descriptions are kept in sync with the CLI source so the help output always refl
 
 ## 📋 Command Categories
 
-ExcelMcp.CLI provides **172 operations** across 12 categories:
+ExcelMcp.CLI provides **173 operations** across 12 categories:
 
 📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all operations
 

--- a/src/ExcelMcp.Core/Commands/DataModel/IDataModelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/IDataModelCommands.cs
@@ -63,6 +63,17 @@ public interface IDataModelCommands
     DataModelRelationshipListResult ListRelationships(IExcelBatch batch);
 
     /// <summary>
+    /// Gets a specific relationship by its table/column identifiers
+    /// </summary>
+    /// <param name="batch">Excel batch context for accessing workbook</param>
+    /// <param name="fromTable">Source table name</param>
+    /// <param name="fromColumn">Source column name</param>
+    /// <param name="toTable">Target table name</param>
+    /// <param name="toColumn">Target column name</param>
+    /// <returns>Result containing relationship details</returns>
+    DataModelRelationshipViewResult ReadRelationship(IExcelBatch batch, string fromTable, string fromColumn, string toTable, string toColumn);
+
+    /// <summary>
     /// Deletes a DAX measure from the Data Model
     /// </summary>
     /// <param name="batch">Excel batch context for accessing workbook</param>

--- a/src/ExcelMcp.Core/Models/ResultTypes.cs
+++ b/src/ExcelMcp.Core/Models/ResultTypes.cs
@@ -1322,6 +1322,17 @@ public class DataModelRelationshipListResult : ResultBase
 }
 
 /// <summary>
+/// Result for reading a single relationship
+/// </summary>
+public class DataModelRelationshipViewResult : ResultBase
+{
+    /// <summary>
+    /// The relationship details
+    /// </summary>
+    public DataModelRelationshipInfo? Relationship { get; set; }
+}
+
+/// <summary>
 /// Information about a table relationship
 /// </summary>
 public class DataModelRelationshipInfo

--- a/src/ExcelMcp.McpServer/Models/ActionExtensions.cs
+++ b/src/ExcelMcp.McpServer/Models/ActionExtensions.cs
@@ -156,6 +156,7 @@ public static class ActionExtensions
         DataModelAction.DeleteMeasure => "delete-measure",
         DataModelAction.DeleteTable => "delete-table",
         DataModelAction.ListRelationships => "list-relationships",
+        DataModelAction.ReadRelationship => "read-relationship",
         DataModelAction.CreateRelationship => "create-relationship",
         DataModelAction.UpdateRelationship => "update-relationship",
         DataModelAction.DeleteRelationship => "delete-relationship",

--- a/src/ExcelMcp.McpServer/Models/ToolActions.cs
+++ b/src/ExcelMcp.McpServer/Models/ToolActions.cs
@@ -222,6 +222,7 @@ public enum DataModelAction
     DeleteMeasure,
     DeleteTable,
     ListRelationships,
+    ReadRelationship,
     CreateRelationship,
     UpdateRelationship,
     DeleteRelationship,

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -15,7 +15,7 @@ mcp-name: io.github.sbroenne/mcp-server-excel
 
 Unlike third-party libraries that manipulate `.xlsx` files (risking corruption), ExcelMcp uses **Excel's official COM automation API**. This guarantees zero risk of file corruption while you work interactively with live Excel files - see your changes happen in real-time.
 
-**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 172 operations.
+**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 173 operations.
 
 **Requirements:** Windows OS + Excel 2016+
 
@@ -51,7 +51,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**12 specialized tools with 172 operations:**
+**12 specialized tools with 173 operations:**
 
 - 🔄 **Power Query** (9 ops) - Atomic workflows, M code management, load destinations
 - 📊 **Data Model/DAX** (14 ops) - Measures, relationships, model structure
@@ -66,7 +66,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 - 📁 **Files** (5 ops) - Session management and workbook creation
 - 🎨 **Conditional Formatting** (2 ops) - Rules and clearing
 
-📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 172 operations
+📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 173 operations
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/src/ExcelMcp.McpServer/Tools/ExcelDataModelTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelDataModelTool.cs
@@ -14,6 +14,7 @@ public static partial class ExcelDataModelTool
 {
     /// <summary>
     /// Manage Excel Power Pivot (Data Model) - DAX measures, relationships, analytical model.
+    /// HIDDEN COLUMNS/RELATIONSHIPS/MEASURES: Objects marked "Hidden from client tools" in Power Pivot are NOT visible via list-columns, list-relationships, or list-measures actions. This is an Excel API limitation with no workaround. If user reports missing columns, relationships, or measures, ask them to unhide them in Power Pivot (Manage Data Model, right-click object, uncheck "Hide from Client Tools").
     /// CALCULATED COLUMNS: NOT supported via automation. When user asks to create calculated columns, provide step-by-step manual instructions OR suggest using DAX measures instead (measures ARE automated and usually better for aggregations).
     /// TIMEOUT SAFEGUARD: Listing tables/measures/info auto-timeouts after 5 minutes to prevent Power Pivot hangs.
     /// </summary>
@@ -64,6 +65,7 @@ public static partial class ExcelDataModelTool
                     DataModelAction.ListMeasures => ListMeasuresAsync(dataModelCommands, sessionId),
                     DataModelAction.Read => ReadMeasureAsync(dataModelCommands, sessionId, measureName),
                     DataModelAction.ListRelationships => ListRelationshipsAsync(dataModelCommands, sessionId),
+                    DataModelAction.ReadRelationship => ReadRelationshipAsync(dataModelCommands, sessionId, fromTable, fromColumn, toTable, toColumn),
                     DataModelAction.Refresh => RefreshAsync(dataModelCommands, sessionId),
                     DataModelAction.DeleteMeasure => DeleteMeasureAsync(dataModelCommands, sessionId, measureName),
                     DataModelAction.DeleteTable => DeleteTableAsync(dataModelCommands, sessionId, tableName),
@@ -169,6 +171,35 @@ public static partial class ExcelDataModelTool
         {
             result.Success,
             result.Relationships,
+            result.ErrorMessage
+        }, ExcelToolsBase.JsonOptions);
+    }
+
+    private static string ReadRelationshipAsync(DataModelCommands commands, string sessionId, string? fromTable, string? fromColumn, string? toTable, string? toColumn)
+    {
+        if (string.IsNullOrWhiteSpace(fromTable))
+        {
+            throw new ArgumentException("Parameter 'fromTable' is required for read-relationship action", nameof(fromTable));
+        }
+        if (string.IsNullOrWhiteSpace(fromColumn))
+        {
+            throw new ArgumentException("Parameter 'fromColumn' is required for read-relationship action", nameof(fromColumn));
+        }
+        if (string.IsNullOrWhiteSpace(toTable))
+        {
+            throw new ArgumentException("Parameter 'toTable' is required for read-relationship action", nameof(toTable));
+        }
+        if (string.IsNullOrWhiteSpace(toColumn))
+        {
+            throw new ArgumentException("Parameter 'toColumn' is required for read-relationship action", nameof(toColumn));
+        }
+
+        var result = ExcelToolsBase.WithSession(sessionId, batch => commands.ReadRelationship(batch, fromTable, fromColumn, toTable, toColumn));
+
+        return JsonSerializer.Serialize(new
+        {
+            result.Success,
+            result.Relationship,
             result.ErrorMessage
         }, ExcelToolsBase.JsonOptions);
     }

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -14,7 +14,7 @@
 
 ## Features
 
-The Excel MCP Server provides **12 specialized tools with 172 operations** for comprehensive Excel automation:
+The Excel MCP Server provides **12 specialized tools with 173 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query** (9 ops) - Atomic workflows, M code management, load destinations
 - 📊 **Data Model/DAX** (14 ops) - Measures, relationships, model structure


### PR DESCRIPTION
## Summary

Adds the read-relationship action to the excel_datamodel tool, completing full CRUD coverage for relationships in the Data Model.

Closes #277

## Changes

### Core Layer
- Add DataModelRelationshipViewResult result type
- Add ReadRelationship method signature to IDataModelCommands
- Implement ReadRelationship in DataModelCommands.Read.cs

### MCP Server Layer
- Add ReadRelationship enum value to ToolActions.cs
- Add action string mapping in ActionExtensions.cs
- Add ReadRelationshipAsync handler in ExcelDataModelTool.cs

### Documentation
- Update FEATURES.md with 15 Data Model operations (was 14)
- Update all READMEs with 173 total operations (was 172)
- Update gh-pages/index.md with new action in reference table
- Document hidden columns/relationships/measures API limitation

## CRUD Coverage

| Object | Create | Read | Update | Delete | List |
|--------|--------|------|--------|--------|------|
| Relationships | Yes | Yes (NEW) | Yes | Yes | Yes |

## Testing
- Build passes with 0 warnings
- Pre-commit checks pass
- Integration tests run in CI/CD