### PR TITLE
docs: update tool/operation counts and lists to match code

### DIFF
--- a/.github/instructions/readme-management.instructions.md
+++ b/.github/instructions/readme-management.instructions.md
@@ -1,52 +1,75 @@
 ---
-applyTo: "**/*.md,README.md,**/README.md"
+applyTo: "**/*.md,README.md,**/README.md, **/index.md"
 ---
 
 # README Management - Quick Reference
 
-## Three READMEs
+## Four READMEs
 
 | File | Lines | Audience | Purpose |
 |------|-------|----------|---------|
 | `/README.md` | 250-300 | All users | Comprehensive reference |
 | `/src/ExcelMcp.McpServer/README.md` | 80-100 | .NET devs | Concise NuGet gateway |
 | `/vscode-extension/README.md` | 100-120 | VS Code users | User benefits focus |
+| `/gh-pages/index.md` | 450-5000 | All users | Comprehensive reference |
+
+## Features.md
+
+You need to make sure that the `Features.md` file is up-to-date with the latest features of the project. This file should be updated whenever a new feature is added or an existing feature is modified.
 
 ## Critical Rules
 
-### Tool Counts Must Match
 ### Tool & Action Counts Must Match
-- All READMEs: **12 specialized tools**
-- Current total actions: **173 operations** (update if tool schema changes)
-- Sync counts across:
-	- `/README.md`
-	- `/src/ExcelMcp.McpServer/README.md`
-	- `/src/ExcelMcp.CLI/README.md`
-	- `/vscode-extension/README.md`
-	- `/gh-pages/index.md`
-- Verify against code: `git grep "case.*:" src/ExcelMcp.McpServer/Tools/`
 
-# Check READMEs/sites have same tool count
-git grep "12 specialized tools" README.md src/ExcelMcp.McpServer/README.md src/ExcelMcp.CLI/README.md vscode-extension/README.md gh-pages/index.md
+**⚠️ IMPORTANT: CLI has FEWER tools/operations than MCP Server!**
 
-# Check total operations text (173)
-- All READMEs mention: **COM API** (not "Excel's internal API")
-- Highlight: zero corruption, interactive development, growing features
+**ALWAYS count tools/operations BEFORE updating any README. Never use hardcoded numbers from memory.**
+
+Before updating counts, verify by counting:
+
+- **MCP Server**: Count tool files (excel_batch handled via ExcelTools.cs, not separate tool file)
+- **CLI**: Count command group folders (includes Session commands)
+- **Operations**: Count separately for each - they differ!
+
+Sync counts across:
+  - GitHub Project About: https://github.com/sbroenne/mcp-server-excel (use the GitHub CLI to update)
+  - `/README.md`
+  - `/src/ExcelMcp.McpServer/README.md`
+  - `/src/ExcelMcp.CLI/README.md`
+  - `/vscode-extension/README.md`
+  - `/gh-pages/index.md`
+  - `/FEATURES.md`
+
+### Operation Lists Must Be Complete
+
+**⚠️ IMPORTANT: Where operation lists are documented, they MUST match the actual code!**
+
+The `gh-pages/index.md` file contains detailed tables of all operations for each tool. When adding/removing operations:
+
+1. **Verify section header count** matches actual operation count in code
+2. **Verify each operation is listed** in the table - no missing or extra entries
+3. **Verify operation names** match the code (kebab-case in docs, PascalCase in code)
+
+**Common discrepancies found:**
+- Section header says "25 actions" but code has 30
+- Table lists operations that don't exist (stale documentation)
+- Table is missing newly added operations
 
 ### Version Numbers
 - **NEVER** manually update versions in README files
 - Versions auto-managed by release workflow
 - See `docs/RELEASE-STRATEGY.md`
 
-## Before Committing README Changes
+## Verification Checklist
 
-```bash
-# Verify tool counts match code
-git grep -A 100 "switch.*action" src/ExcelMcp.McpServer/Tools/*.cs | grep "case" | wc -l
+Before committing README changes:
 
-# Check all 3 READMEs have same tool count
-git grep "12 specialized tools" README.md src/ExcelMcp.McpServer/README.md vscode-extension/README.md
-```
+- [ ] Tool counts match actual code (count, don't assume)
+- [ ] Operation counts match actual code per tool
+- [ ] Operation LISTS in tables match actual code (no missing/extra entries)
+- [ ] All READMEs updated (not just one)
+- [ ] FEATURES.md updated if applicable
+- [ ] gh-pages/index.md section headers match table row counts
 
 ## Common Mistakes
 
@@ -54,8 +77,8 @@ git grep "12 specialized tools" README.md src/ExcelMcp.McpServer/README.md vscod
 |---------|-----|
 | Duplicate tool entries | List each tool once |
 | Unverified action counts | Count actual switch cases in code |
-| Overclaiming features | Use "80+ operations" not "all features" |
+| Incomplete operation lists | Compare each table row against code |
+| Stale operation names | Operations get renamed - verify current names |
+| Overclaiming features | Use actual counts, not estimates |
 | Missing safety callout | Add COM API benefits |
 | Manual version updates | Let workflow handle it |
-
-**Full details**: See old backup if needed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,177 +1,323 @@
 # ExcelMcp - Complete Feature Reference
 
-**12 specialized tools with 173 operations for comprehensive Excel automation**
+**12 specialized tools with 180 operations for comprehensive Excel automation**
+
+---
+
+## 📁 File Operations (6 operations)
+
+- **List Sessions:** View all active Excel sessions
+- **Open:** Open workbook and create session (returns session ID for all subsequent operations)
+- **Close:** Close session with optional save
+- **Close Workbook:** Close workbook without closing Excel
+- **Create Empty:** Create new .xlsx or .xlsm workbook
+- **Test:** Verify workbook can be opened and is accessible
 
 ---
 
 ## 🔄 Power Query & M Code (9 operations)
 
-**✨ Atomic Operations** - Single-call workflows replace multi-step patterns:
-- **Create** - Import + load in one operation (replaces import → load workflow)
-- **Update & Refresh** - Update M code + refresh data atomically
-- **Refresh All** - Batch refresh all queries in workbook
-- **Update M Code** - Stage code changes without refreshing data
-- **Unload** - Convert loaded query to connection-only
-
-**Core Operations:**
-- List, view, delete Power Query transformations
-- Manage query load destinations (worksheet/data model/connection-only/both)
-- Get load configuration for existing queries
-- List Excel workbook sources for Power Query integration
+**Atomic Operations** - Single-call workflows:
+- **List:** List all Power Query queries in workbook
+- **View:** View the M code of a Power Query
+- **Create:** Import + load in one operation (atomic workflow)
+- **Update:** Update M code and auto-refresh
+- **Refresh:** Refresh a Power Query with timeout detection
+- **Refresh All:** Batch refresh all queries in workbook
+- **Load To:** Configure load destination and refresh (atomic)
+- **Get Load Config:** Get current load configuration
+- **Delete:** Remove Power Query from workbook
 
 ---
 
-## 📊 Data Model & DAX (Power Pivot) (15 operations)
+## 📊 Data Model & DAX (Power Pivot) (16 operations)
 
-- Create/update/delete DAX measures with format types (Currency, Percentage, Decimal, General)
-- Manage table relationships (create, read, toggle active/inactive, delete)
-- Discover model structure (tables, columns, measures, relationships)
-- Get comprehensive model information
-- Refresh data model
-- **Note:** DAX calculated columns are not supported (use Excel UI for calculated columns)
+- **List Tables:** Discover all tables in the Data Model
+- **Read Table:** Get specific table information
+- **List Columns:** List columns for a table
+- **List Measures:** List all DAX measures
+- **Read Info:** Get comprehensive model information
+- **Create Measure:** Create new DAX measure (with format types: Currency, Percentage, Decimal, General)
+- **Update Measure:** Modify existing measure
+- **Delete Measure:** Remove measure from model
+- **Delete Table:** Remove table from Data Model
+- **List Relationships:** View all table relationships
+- **Read Relationship:** Get specific relationship info
+- **Create Relationship:** Create relationship between tables
+- **Update Relationship:** Modify relationship (toggle active/inactive)
+- **Delete Relationship:** Remove relationship
+- **Refresh:** Refresh entire Data Model
+- **List Workbook Connections:** List Power Query sources available for integration
+
+**Note:** DAX calculated columns not supported - use Excel UI for calculated columns
 
 ---
 
 ## 🎨 Excel Tables (ListObjects) (24 operations)
 
-- **Lifecycle:** create, resize, rename, delete, get info
-- **Styling:** apply table styles, toggle totals row, set column totals
-- **Column Management:** add, remove, rename columns
-- **Data Operations:** append rows, apply filters (criteria/values), clear filters, get filter state
-- **Sorting:** single-column sort, multi-column sort (up to 3 levels)
-- **Number Formatting:** get/set column number formats
-- **Advanced Features:** structured references, Data Model integration, get table data with optional visible-only filtering
+**Lifecycle:**
+- List, read, create, rename, resize, delete tables
+
+**Styling & Formatting:**
+- Apply table styles
+- Toggle totals row
+- Set column totals
+
+**Data Operations:**
+- Append rows
+- Get table data (with optional visible-only filtering)
+- Add to Data Model
+
+**Filter Operations:**
+- Apply filter (criteria)
+- Apply filter (values)
+- Clear filters
+- Get filter state
+
+**Column Management:**
+- Add, remove, rename columns
+
+**Structured References:**
+- Get structured reference (formula syntax for table columns/ranges)
+
+**Sorting:**
+- Single-column sort
+- Multi-column sort (up to 3 levels)
+
+**Number Formatting:**
+- Get column number formats
+- Set column number formats
 
 ---
 
-## 📈 PivotTables (25 operations)
+## 📈 PivotTables (30 operations)
 
-- **Creation:** create from ranges, Excel Tables, or Data Model
-- **Field Management:** add/remove fields to Row, Column, Value, Filter areas
-- **Aggregation Functions:** Sum, Average, Count, Min, Max, etc. with validation
-- **Advanced Features:** field filters, sorting, custom field names, number formatting
-- **Data Extraction:** get PivotTable data as 2D arrays for further analysis
-- **Lifecycle:** list, get info, delete, refresh
+**Creation:**
+- Create from range
+- Create from Excel Table
+- Create from Data Model
+
+**Field Management:**
+- List all fields (row, column, value, filter areas)
+- Add row field, column field, value field, filter field
+- Remove field
+
+**Field Configuration:**
+- Set field aggregation function (Sum, Average, Count, Min, Max, etc.)
+- Set custom field name
+- Set field number format
+- Set field filter criteria
+- Sort field (ascending/descending)
+
+**Calculated Fields (Regular PivotTables):**
+- List calculated fields
+- Create calculated field
+- Delete calculated field
+
+**Calculated Members (OLAP/Data Model PivotTables):**
+- List calculated members
+- Create calculated member
+- Delete calculated member
+
+**Layout & Formatting:**
+- Set layout (table or outline)
+- Set subtotals display
+- Set grand totals display
+
+**Data Operations:**
+- Get PivotTable data as 2D array
+- Refresh PivotTable
+
+**Lifecycle:**
+- List PivotTables
+- Read PivotTable info
+- Delete PivotTable
 
 ---
 
 ## 📉 Charts (14 operations)
 
-- Create charts from ranges, tables, or PivotTables
-- Move charts across worksheets or to dedicated chart sheets
-- Manage series (add, update, delete) with category name/values control
-- Configure data sources, chart types, and set dynamic ranges
-- Update chart titles, axes, legend, plot area, and formatting
-- List charts, retrieve chart info, and delete when no longer needed
+**Creation:**
+- Create from range
+- Create from PivotTable
 
----
+**Series Management:**
+- Add series
+- Remove series
+- Update series data
 
-## 📝 VBA Macros (6 operations)
+**Configuration:**
+- Set data source range
+- Set chart type
+- Show/hide legend
+- Set style
 
-- List all VBA modules and procedures
-- View module code without exporting
-- Export/import VBA modules to/from files
-- Update existing modules
-- Execute macros with parameters
-- Delete modules
-- Version control VBA code through file exports
+**Formatting:**
+- Set chart title
+- Set axis title
+- Set axis properties
+- Set plot area properties
+
+**Lifecycle:**
+- List charts
+- Read chart info
+- Move chart (to different worksheet or new sheet)
+- Delete chart
 
 ---
 
 ## 📋 Ranges (42 operations)
 
-### Data Operations (10 actions)
-- Get/set values and formulas
-- Clear (all/contents/formats)
-- Copy/paste (all/values/formulas)
-- Insert/delete rows/columns/cells
-- Find/replace
+**Data Operations:**
+- Get values
+- Set values
+- Get formulas
+- Set formulas
+- Clear all
+- Clear contents
+- Clear formats
+- Copy
+- Copy values
+- Copy formulas
+- Insert cells
+- Delete cells
+- Insert rows
+- Delete rows
+- Insert columns
+- Delete columns
+- Find
+- Replace
 - Sort
 
-### Number Formatting (3 actions)
-- Get formats as 2D arrays
-- Apply uniform format
-- Set individual cell formats
+**Discovery & Utilities:**
+- Get used range
+- Get current region
+- Get range info (address, dimensions)
 
-### Visual Formatting (1 action)
-- Font (name, size, bold, italic, underline, color)
-- Fill color
-- Borders (style, weight, color)
-- Alignment (horizontal, vertical, wrap text, orientation)
+**Hyperlinks:**
+- Add hyperlink
+- Remove hyperlink
+- List hyperlinks
+- Get specific hyperlink
 
-### Data Validation (3 actions)
+**Number Formatting:**
+- Get number formats (as 2D array)
+- Set number format (uniform)
+- Set number formats (individual)
+
+**Visual Formatting:**
+- Get style
+- Set style (built-in Excel styles)
+- Format range (font, color, borders, alignment, orientation)
+
+**Data Validation:**
 - Add validation rules (dropdowns, number/date/text rules)
 - Get validation info
 - Remove validation
 
-### Hyperlinks (4 actions)
-- Add, remove, list all, get specific hyperlink
+**Merge Operations:**
+- Merge cells
+- Unmerge cells
+- Get merge info
 
-### Smart Range Operations (3 actions)
-- UsedRange, CurrentRegion, get range info (address, dimensions, format)
-
-### Merge Operations (3 actions)
-- Merge cells, unmerge cells, get merge info
-
-### Auto-Sizing (2 actions)
-- Auto-fit columns, auto-fit rows
-
-### Conditional Formatting (2 actions)
-- Add conditional formatting rules
-- Clear conditional formatting
-
-### Cell Protection (2 actions)
+**Cell Protection:**
 - Set cell lock status
 - Get cell lock status
 
-### Formatting & Styling (3 actions)
-- Get style, set style, format range
+**Auto-Sizing:**
+- Auto-fit columns
+- Auto-fit rows
 
 ---
 
 ## 📄 Worksheets (16 operations)
 
-- **Lifecycle:** create, rename, copy, move, delete
-- **Copy/Move Between Workbooks:** cross-workbook operations
-- **Tab Colors:** set, get, clear (RGB values)
-- **Visibility Controls:** show, hide, very-hide, get/set status
+**Lifecycle:**
+- List worksheets
+- Create worksheet
+- Rename worksheet
+- Copy worksheet
+- Move worksheet
+- Delete worksheet
+
+**Cross-Workbook Operations:**
+- Copy worksheet to file (atomic)
+- Move worksheet to file (atomic)
+
+**Tab Colors:**
+- Set tab color (RGB)
+- Get tab color
+- Clear tab color
+
+**Visibility:**
+- Show worksheet
+- Hide worksheet
+- Very hide worksheet (hidden from UI)
+- Get visibility status
+- Set visibility status
 
 ---
 
 ## 🔌 Data Connections (9 operations)
 
-- Create and manage OLEDB/ODBC connections (when provider is installed)
-- Refresh connections, test connectivity, and control refresh settings
-- Load connection-only sources to worksheet tables when supported
-- Update connection strings, command text, and metadata
-- Automatically redirect TEXT/WEB scenarios to `excel_powerquery` for reliable imports
+- **List:** View all data connections
+- **View:** Get connection details
+- **Create:** Create OLEDB/ODBC connections (requires provider installed)
+- **Test:** Verify connection validity
+- **Refresh:** Refresh connection data
+- **Delete:** Remove connection
+- **Load To:** Load connection data to worksheet (when supported)
+- **Get Properties:** Get connection string and metadata
+- **Set Properties:** Update connection string, command text, and settings
 
-**Note:** OLEDB/ODBC creation requires the provider to be installed (e.g., Microsoft.ACE.OLEDB.16.0, SQLOLEDB)
+**Supported Types:**
+- OLEDB (requires Microsoft.ACE.OLEDB.16.0 or similar)
+- ODBC (requires ODBC driver installed)
+- Power Query connections (atomic redirect to excel_powerquery)
+
+**Automatic Fallback:**
+- TEXT/WEB connections automatically redirect to excel_powerquery for reliable imports
 
 ---
 
-## 🏷️ Named Ranges (6 operations)
+## 🏷️ Named Ranges (Parameters) (6 operations)
 
-- List all named ranges with references
-- Get or set single values (ideal for parameter automation)
-- Create, update, or delete named ranges individually or in bulk
-- Maintain workbook parameters without touching worksheets
+- **List:** List all named ranges with references
+- **Read:** Get value of a named range
+- **Write:** Set value of a named range (ideal for parameter automation)
+- **Create:** Create new named range
+- **Update:** Modify existing named range
+- **Delete:** Remove named range
+
+**Use Cases:**
+- Workbook parameter management without touching worksheets
+- Ideal for automation: update parameter → Power Query refreshes automatically
 
 ---
 
-## 📁 File Operations (5 operations)
+## 📝 VBA Macros (6 operations)
 
-- **Session Management:** open, close (with optional save)
-- **Create Empty:** new .xlsx or .xlsm workbooks
-- **Test:** verify workbook can be opened
-- **💡 Show Excel Mode:** Open with `showExcel:true` to watch AI changes live - perfect for debugging, demos, and learning
+- **List:** List all VBA modules and procedures
+- **View:** Display module code without exporting
+- **Import:** Add VBA module from file
+- **Update:** Modify existing VBA module
+- **Delete:** Remove VBA module
+- **Run:** Execute macro with optional parameters
+
+**Features:**
+- Version control through file exports
+- Parameter passing to macros
+- Full module lifecycle management
 
 ---
 
 ## 🎨 Conditional Formatting (2 operations)
 
-- **Add Rules:** cell value comparisons, expression-based formulas
-- **Clear Rules:** remove formatting from ranges
+- **Add Rule:** Create conditional formatting rules
+  - Cell value comparisons (>, <, =, etc.)
+  - Expression-based formulas (custom DAX/Excel formulas)
+  - Color scales, data bars, icons
+- **Clear Rules:** Remove formatting from ranges
 
 ---
 
@@ -179,32 +325,62 @@
 
 | Category | Operations |
 |----------|-----------|
+| File Operations | 6 |
 | Power Query | 9 |
-| Data Model/DAX | 15 |
+| Data Model/DAX | 16 |
 | Excel Tables | 24 |
-| PivotTables | 25 |
+| PivotTables | 30 |
 | Charts | 14 |
-| VBA Macros | 6 |
 | Ranges | 42 |
 | Worksheets | 16 |
 | Connections | 9 |
 | Named Ranges | 6 |
-| File Operations | 5 |
+| VBA Macros | 6 |
 | Conditional Formatting | 2 |
-| **Total** | **173** |
+| **Total** | **180** |
 
 ---
 
-## 🚀 Growing Feature Set
+## 🚀 Key Capabilities
 
-ExcelMcp is actively developed with new features added regularly. Check the [releases page](https://github.com/sbroenne/mcp-server-excel/releases) for the latest additions.
+**Data Transformation:**
+- Comprehensive Power Query M code management
+- Atomic import + load workflows
+- Calculated fields and members for analysis
 
-**Recent Additions:**
-- Chart automation (14 operations)
-- Atomic Power Query operations (create, update-and-refresh)
-- PivotTable data extraction
+**Data Model:**
+- Full DAX measure lifecycle
+- Relationship management
+- Multi-table integration
+
+**Analysis & Visualization:**
+- PivotTable creation and configuration
+- Chart automation
+- Custom calculations
+
+**Automation:**
+- VBA macro execution and management
+- Named range parameter automation
 - Conditional formatting rules
-- Cross-workbook worksheet operations
+
+**Data Loading:**
+- Multiple connection type support
+- OLEDB/ODBC management
+- Power Query atomic workflows
+
+---
+
+## 🔧 Tool Selection Quick Reference
+
+| Task | Tool |
+|------|------|
+| Import data | `excel_powerquery` or `excel_connection` |
+| Create analysis | `excel_pivottable` (data model-based for OLAP) |
+| Visualize data | `excel_chart` |
+| Update parameters | `excel_namedrange` (write operation) |
+| Manage formulas | `excel_range` (set-formulas) |
+| Format data | `excel_range` (format-range, validate-range) |
+| Script automation | `excel_vba` (run macro) |
 
 ---
 
@@ -214,3 +390,4 @@ ExcelMcp is actively developed with new features added regularly. Check the [rel
 - **[MCP Server Guide](src/ExcelMcp.McpServer/README.md)** - Tool documentation and examples
 - **[CLI Guide](src/ExcelMcp.CLI/README.md)** - Command-line reference
 - **[Contributing](docs/CONTRIBUTING.md)** - Development guidelines
+- **[Releases](https://github.com/sbroenne/mcp-server-excel/releases)** - Latest updates and features

--- a/README.md
+++ b/README.md
@@ -15,19 +15,15 @@
 [![Platform](https://img.shields.io/badge/platform-Windows-lightgrey.svg)](https://github.com/sbroenne/mcp-server-excel)
 [![Built with Copilot](https://img.shields.io/badge/Built%20with-GitHub%20Copilot-0366d6.svg)](https://copilot.github.com/)
 
-<a href="https://glama.ai/mcp/servers/@sbroenne/mcp-server-excel">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sbroenne/mcp-server-excel/badge" alt="mcp-server-excel MCP server" />
-</a>
-
 **Automate Excel with AI - A Model Context Protocol (MCP) server for comprehensive Excel automation through conversational AI.**
 
-**MCP Server for Excel** enables AI assistants (GitHub Copilot, Claude, ChatGPT) to automate Excel through natural language commands. Automate Power Query, DAX measures, VBA macros, PivotTables, Charts, formatting, and data transformations - no Excel programming knowledge required. 
+**MCP Server for Excel** enables AI assistants (GitHub Copilot, Claude, ChatGPT) to automate Excel through natural language commands. Automate Power Query, DAX measures, VBA macros, PivotTables, Charts, formatting, and data transformations (12 tools with 180 operations).
 
 **🛡️ 100% Safe - Uses Excel's Native COM API** - Zero risk of file corruption. Unlike third-party libraries that manipulate `.xlsx` files directly, this project uses Excel's official API ensuring complete safety and compatibility.
 
 **💡 Interactive Development** - See results instantly in Excel. Create a query, run it, inspect the output, refine and repeat. Excel becomes your AI-powered workspace for rapid development and testing.
 
-**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 173 operations.
+**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. 
 
 ## 🚀 Quick Start (1 Minute)
 
@@ -47,22 +43,22 @@ The extension opens automatically after installation with a quick start guide!
 
 ## 🎯 What You Can Do
 
-**12 specialized tools with 173 operations:**
+**12 specialized tools with 180 operations:**
 
 - 🔄 **Power Query** (9 ops) - Atomic workflows, M code management, load destinations
-- 📊 **Data Model/DAX** (14 ops) - Measures, relationships, model structure
+- 📊 **Data Model/DAX** (16 ops) - Measures, relationships, model structure
 - 🎨 **Excel Tables** (24 ops) - Lifecycle, filtering, sorting, structured references
-- 📈 **PivotTables** (25 ops) - Creation, fields, aggregations, data extraction
+- 📈 **PivotTables** (30 ops) - Creation, fields, aggregations, calculated members/fields
 - 📉 **Charts** (14 ops) - Create, configure, manage series and formatting
 - 📝 **VBA** (6 ops) - Modules, execution, version control
 - 📋 **Ranges** (42 ops) - Values, formulas, formatting, validation, protection
 - 📄 **Worksheets** (16 ops) - Lifecycle, colors, visibility, cross-workbook moves
 - 🔌 **Connections** (9 ops) - OLEDB/ODBC management and refresh
 - 🏷️ **Named Ranges** (6 ops) - Parameters and configuration
-- 📁 **Files** (5 ops) - Session management and workbook creation
+- 📁 **Files** (6 ops) - Session management and workbook creation
 - 🎨 **Conditional Formatting** (2 ops) - Rules and clearing
 
-📚 **[Complete Feature Reference →](FEATURES.md)** - Detailed documentation of all 173 operations
+📚 **[Complete Feature Reference →](FEATURES.md)** - Detailed documentation of all 180 operations
 
 
 ## 💬 Example Prompts

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -39,7 +39,7 @@ canonical_url: "https://excelmcpserver.dev/"
 
 **💡 Interactive Development** - See results instantly in Excel. Create a query, run it, inspect the output, refine and repeat. Excel becomes your AI-powered workspace for rapid development and testing.
 
-**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 173 operations.
+**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. CLI has 13 command categories with 172 operations (MCP Server has 12 tools with 180 operations).
 
 ## 🚀 Visual Studio Code Quick Start (1 Minute)
 
@@ -50,8 +50,8 @@ canonical_url: "https://excelmcpserver.dev/"
 
 <div class="features-grid">
 <div class="feature-card">
-<h3>173 Operations</h3>
-<p>12 specialized tools with 173 operations covering Power Query, DAX, Charts, VBA, PivotTables, ranges, conditional formatting, and more</p>
+<h3>180 Operations</h3>
+<p>12 specialized tools with 180 operations covering Power Query, DAX, Charts, VBA, PivotTables, ranges, conditional formatting, and more</p>
 <p><a href="https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md">Complete Feature Reference →</a></p>
 </div>
 
@@ -73,7 +73,7 @@ canonical_url: "https://excelmcpserver.dev/"
 
 <div class="feature-card">
 <h3>Comprehensive Automation</h3>
-<p>173 operations covering Power Query, DAX, Charts, VBA, Tables, and more</p>
+<p>180 operations covering Power Query, DAX, Charts, VBA, Tables, and more</p>
 </div>
 
 <div class="feature-card">
@@ -169,7 +169,7 @@ excel-mcp vba-export --file "macro-workbook.xlsm" --module "Module1" --output "s
 <li><strong>Natural Language Control:</strong> Describe tasks in plain English</li>
 <li><strong>Safe:</strong> Official COM API - zero corruption risk</li>
 <li><strong>Interactive:</strong> See changes in real-time in Excel</li>
-<li><strong>Comprehensive:</strong> 173 operations across 12 tools</li>
+<li><strong>Comprehensive:</strong> 180 operations across 12 tools</li>
 <li><strong>Works with:</strong> GitHub Copilot, Claude, ChatGPT, and any MCP client</li>
 </ul>
 </div>
@@ -188,12 +188,12 @@ excel-mcp vba-export --file "macro-workbook.xlsm" --module "Module1" --output "s
 
 <div class="callout">
 <strong>Both Share the Same Core</strong>
-Same 173 operations available via CLI and MCP. Consistent behavior across interfaces.
+CLI provides 172 operations, MCP Server provides 180 operations. Both share the same Core layer for consistent behavior.
 </div>
 
 ## Complete Tool & Action Reference
 
-**12 specialized tools with 173 operations:**
+**12 specialized tools with 180 operations:**
 
 <div class="tools-reference" markdown="1">
 
@@ -211,12 +211,13 @@ Same 173 operations available via CLI and MCP. Consistent behavior across interf
 | `get-load-config` | Get load destination settings for a query |
 | `load-to` | Load query data to worksheet, data model, or both |
 
-### 🔢 Power Pivot / Data Model (15 actions)
+### 🔢 Power Pivot / Data Model (16 actions)
 
 | Action | Description |
 |--------|-------------|
 | `list-tables` | List all tables in Data Model |
 | `read-table` | Read data from a Data Model table |
+| `delete-table` | Delete a table from the Data Model |
 | `list-columns` | List all columns in a table |
 | `list-measures` | List all DAX measures in a table |
 | `read` | Read details of a specific measure |
@@ -260,7 +261,7 @@ Same 173 operations available via CLI and MCP. Consistent behavior across interf
 | `get-column-number-format` | Get number format for column |
 | `set-column-number-format` | Set number format for column |
 
-### 📈 PivotTables (25 actions)
+### 📈 PivotTables (30 actions)
 
 | Action | Description |
 |--------|-------------|
@@ -284,11 +285,16 @@ Same 173 operations available via CLI and MCP. Consistent behavior across interf
 | `sort-field` | Sort field values |
 | `get-data` | Extract PivotTable data as values |
 | `set-grand-totals` | Configure grand totals display |
-| `set-column-grand-totals` | Show/hide column grand totals |
-| `set-row-grand-totals` | Show/hide row grand totals |
-| `get-grand-totals` | Get grand totals configuration |
 | `set-subtotals` | Configure subtotals for fields |
-| `get-subtotals` | Get subtotals configuration |
+| `set-layout` | Set PivotTable layout style |
+| `group-by-date` | Group field by date periods |
+| `group-by-numeric` | Group field by numeric ranges |
+| `create-calculated-field` | Create calculated field with formula |
+| `delete-calculated-field` | Delete a calculated field |
+| `list-calculated-fields` | List all calculated fields |
+| `create-calculated-member` | Create calculated member (OLAP) |
+| `delete-calculated-member` | Delete a calculated member |
+| `list-calculated-members` | List all calculated members |
 
 ### 📊 Charts (14 actions)
 
@@ -406,6 +412,7 @@ Same 173 operations available via CLI and MCP. Consistent behavior across interf
 | `hide` | Hide worksheet from UI (visible in VBA) |
 | `very-hide` | Hide from UI and VBA |
 | `show` | Make worksheet visible |
+| `set-visibility` | Set worksheet visibility state |
 | `get-visibility` | Get current visibility state |
 | `set-visibility` | Set visibility state |
 
@@ -420,10 +427,11 @@ Same 173 operations available via CLI and MCP. Consistent behavior across interf
 | `update` | Update named range reference |
 | `delete` | Delete named range |
 
-### 📁 File Operations (5 actions)
+### 📁 File Operations (6 actions)
 
 | Action | Description |
 |--------|-------------|
+| `list` | List all open workbook sessions |
 | `open` | Open workbook session |
 | `close` | Close workbook session without saving |
 | `create-empty` | Create new empty workbook (.xlsx or .xlsm) |

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -6,7 +6,7 @@
 
 **Optional command-line interface for Excel automation without AI assistance.**
 
-For advanced users who prefer direct scripting control, the CLI provides the same 173 operations as the MCP Server. Perfect for RPA workflows, CI/CD pipelines, batch processing, and automated testing.
+For advanced users who prefer direct scripting control, the CLI provides 13 command categories with 172 operations (the MCP Server has 12 tools with 180 operations). Perfect for RPA workflows, CI/CD pipelines, batch processing, and automated testing.
 
 **Note:** Most users should use the [MCP Server with AI assistants](../ExcelMcp.McpServer/README.md) for natural language automation.
 
@@ -78,9 +78,9 @@ Descriptions are kept in sync with the CLI source so the help output always refl
 
 ## 📋 Command Categories
 
-ExcelMcp.CLI provides **173 operations** across 12 categories:
+ExcelMcp.CLI provides **172 operations** across 13 categories:
 
-📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all operations
+📚 **[Complete Feature Reference →](../../FEATURES.md)** - Full MCP Server documentation (180 operations)
 
 **Quick Reference:**
 
@@ -94,10 +94,12 @@ ExcelMcp.CLI provides **173 operations** across 12 categories:
 | **Excel Tables** | 24 | `table create`, `table apply-filter`, `table get-data`, `table sort`, `table add-column` |
 | **Charts** | 14 | `chart create-from-range`, `chart add-series`, `chart set-chart-type`, `chart show-legend` |
 | **PivotTables** | 25 | `pivottable create-from-range`, `pivottable add-row-field`, `pivottable refresh`, `pivottable delete` |
-| **Data Model** | 14 | `datamodel create-measure`, `datamodel create-relationship`, `datamodel refresh` |
+| **Data Model** | 15 | `datamodel create-measure`, `datamodel create-relationship`, `datamodel refresh` |
 | **Connections** | 9 | `connection list`, `connection refresh`, `connection test` |
 | **Named Ranges** | 6 | `namedrange create`, `namedrange read`, `namedrange write`, `namedrange update` |
-| **VBA** | 6 | `vba list`, `vba import`, `vba run`, `vba update`
+| **VBA** | 6 | `vba list`, `vba import`, `vba run`, `vba update` |
+
+**Note:** CLI uses session commands for multi-operation workflows.
 
 ---
 

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -15,7 +15,7 @@ mcp-name: io.github.sbroenne/mcp-server-excel
 
 Unlike third-party libraries that manipulate `.xlsx` files (risking corruption), ExcelMcp uses **Excel's official COM automation API**. This guarantees zero risk of file corruption while you work interactively with live Excel files - see your changes happen in real-time.
 
-**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. Both interfaces share the same 173 operations.
+**Optional CLI Tool:** For advanced users who prefer command-line scripting, ExcelMcp includes a CLI interface for RPA workflows, CI/CD pipelines, and batch automation. CLI has 13 command categories with 172 operations (MCP Server has 12 tools with 180 operations).
 
 **Requirements:** Windows OS + Excel 2016+
 
@@ -51,22 +51,22 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**12 specialized tools with 173 operations:**
+**12 specialized tools with 180 operations:**
 
 - 🔄 **Power Query** (9 ops) - Atomic workflows, M code management, load destinations
-- 📊 **Data Model/DAX** (14 ops) - Measures, relationships, model structure
+- 📊 **Data Model/DAX** (16 ops) - Measures, relationships, model structure
 - 🎨 **Excel Tables** (24 ops) - Lifecycle, filtering, sorting, structured references
-- 📈 **PivotTables** (25 ops) - Creation, fields, aggregations, data extraction
+- 📈 **PivotTables** (30 ops) - Creation, fields, aggregations, calculated members/fields
 - 📉 **Charts** (14 ops) - Create, configure, manage series and formatting
 - 📝 **VBA** (6 ops) - Modules, execution, version control
 - 📋 **Ranges** (42 ops) - Values, formulas, formatting, validation, protection
 - 📄 **Worksheets** (16 ops) - Lifecycle, colors, visibility, cross-workbook moves
 - 🔌 **Connections** (9 ops) - OLEDB/ODBC management and refresh
 - 🏷️ **Named Ranges** (6 ops) - Parameters and configuration
-- 📁 **Files** (5 ops) - Session management and workbook creation
+- 📁 **Files** (6 ops) - Session management and workbook creation
 - 🎨 **Conditional Formatting** (2 ops) - Rules and clearing
 
-📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 173 operations
+📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 180 operations
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -14,19 +14,19 @@
 
 ## Features
 
-The Excel MCP Server provides **12 specialized tools with 173 operations** for comprehensive Excel automation:
+The Excel MCP Server provides **12 specialized tools with 180 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query** (9 ops) - Atomic workflows, M code management, load destinations
-- 📊 **Data Model/DAX** (14 ops) - Measures, relationships, model structure
+- 📊 **Data Model/DAX** (16 ops) - Measures, relationships, model structure
 - 🎨 **Excel Tables** (24 ops) - Lifecycle, filtering, sorting, structured references
-- 📈 **PivotTables** (25 ops) - Creation, fields, aggregations, data extraction
+- 📈 **PivotTables** (30 ops) - Creation, fields, aggregations, calculated members/fields
 - 📉 **Charts** (14 ops) - Create, configure, manage series and formatting
 - 📝 **VBA** (6 ops) - Modules, execution, version control
 - 📋 **Ranges** (42 ops) - Values, formulas, formatting, validation, protection
 - 📄 **Worksheets** (16 ops) - Lifecycle, colors, visibility, cross-workbook moves
 - 🔌 **Connections** (9 ops) - OLEDB/ODBC management and refresh
 - 🏷️ **Named Ranges** (6 ops) - Parameters and configuration
-- 📁 **Files** (5 ops) - Session management and workbook creation
+- 📁 **Files** (6 ops) - Session management and workbook creation
 - 🎨 **Conditional Formatting** (2 ops) - Rules and clearing
 
 📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)**


### PR DESCRIPTION
## Summary
Fixes #289

Updates all documentation to accurately reflect the current implementation.

## Changes

### Count Updates
- **MCP Server**: 12 tools, 180 operations
- **CLI**: 13 command groups, 172 operations

### gh-pages/index.md Operation Tables Fixed
| Section | Before | After | Changes |
|---------|--------|-------|---------|
| PivotTables | 25 | 30 | Added calculated fields/members, grouping, layout |
| DataModel | 15 | 16 | Added delete-table |
| File | 5 | 6 | Added list |
| Worksheets | 15 | 16 | Added set-visibility |

Also removed non-existent operations that were listed.

### Instructions Updated
- Updated readme-management.instructions.md with verification guidance
- Added checklist for operation list completeness

### GitHub Repository
- Updated description and topics with correct counts and Excel features

## Files Changed
- README.md
- FEATURES.md  
- src/ExcelMcp.McpServer/README.md
- src/ExcelMcp.CLI/README.md
- vscode-extension/README.md
- gh-pages/index.md
- .github/instructions/readme-management.instructions.md