### PR TITLE
fix(seo): Fix robots.txt sitemap URL and add Bing verification

### DIFF
--- a/gh-pages/BingSiteAuth.xml
+++ b/gh-pages/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>C043BE1CE650BCF122B8139C77889186</user>
+</users>

--- a/gh-pages/CNAME
+++ b/gh-pages/CNAME
@@ -1,0 +1,1 @@
+excelmcpserver.dev

--- a/gh-pages/_config.yml
+++ b/gh-pages/_config.yml
@@ -21,6 +21,11 @@ author: "Stefan Broenne"
 twitter:
   username: sbroenne
   card: summary_large_image
+social:
+  name: Stefan Broenne
+  links:
+    - https://github.com/sbroenne
+    - https://twitter.com/sbroenne
 
 logo: /assets/images/excel-mcp-icon-256.png
 

--- a/gh-pages/_layouts/default.html
+++ b/gh-pages/_layouts/default.html
@@ -4,7 +4,12 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="index, follow">
+    <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+    <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+    <meta name="theme-color" content="#157878">
     <meta name="google-site-verification" content="7BSNb2Q6rNfwdJCSGEUs9_2o3NOK09tBy4svR9A1bUg" />
+    <meta name="msvalidate.01" content="C043BE1CE650BCF122B8139C77889186" />
     
     <!-- Canonical URL -->
     <link rel="canonical" href="{{ page.canonical_url | default: page.url | absolute_url }}">
@@ -23,10 +28,14 @@
     <meta property="og:image" content="{{ '/assets/images/icon.png' | absolute_url }}">
     <meta property="og:image:width" content="256">
     <meta property="og:image:height" content="256">
+    <meta property="og:image:alt" content="Excel MCP Server - AI-Powered Excel Automation">
     <meta property="og:site_name" content="Excel MCP Server">
+    <meta property="og:locale" content="en_US">
     
     <!-- Twitter Card Meta Tags -->
-    <meta name="twitter:card" content="summary">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@sbroenne">
+    <meta name="twitter:creator" content="@sbroenne">
     <meta name="twitter:title" content="{% if page.title %}{{ page.title }} | {% endif %}Excel MCP Server - AI-Powered Excel Automation">
     <meta name="twitter:description" content="Control Microsoft Excel with Natural Language through AI assistants like GitHub Copilot and Claude. Automate Power Query, DAX, VBA, PivotTables, and more.">
     <meta name="twitter:image" content="{{ '/assets/images/icon.png' | absolute_url }}">

--- a/gh-pages/robots.txt
+++ b/gh-pages/robots.txt
@@ -1,19 +1,8 @@
 # robots.txt for Excel MCP Server documentation
+# https://excelmcpserver.dev/
+
 User-agent: *
 Allow: /
-Sitemap: https://sbroenne.github.io/mcp-server-excel/sitemap.xml
-
-# Prioritize important pages
-User-agent: Googlebot
-Allow: /
-Crawl-delay: 1
-
-User-agent: Bingbot
-Allow: /
-Crawl-delay: 1
 
 # Sitemap location
-Sitemap: https://sbroenne.github.io/mcp-server-excel/sitemap.xml
-
-# Crawl-delay (optional, helps prevent overloading)
-Crawl-delay: 1
+Sitemap: https://excelmcpserver.dev/sitemap.xml


### PR DESCRIPTION
## Summary
Fixes SEO issues for https://excelmcpserver.dev/

## Changes
- **robots.txt**: Fixed sitemap URL from old GitHub Pages URL to `https://excelmcpserver.dev/sitemap.xml`
- **CNAME**: Added for custom domain configuration
- **BingSiteAuth.xml**: Added Bing Webmaster Tools verification file
- **default.html**: Enhanced SEO meta tags:
  - Added `robots`, `googlebot`, `bingbot` meta tags with max snippet/image directives
  - Added `theme-color` meta tag (#157878)
  - Added `msvalidate.01` Bing verification meta tag
  - Upgraded Twitter card from `summary` to `summary_large_image`
  - Added `twitter:site` and `twitter:creator` (@sbroenne)
  - Added `og:image:alt` and `og:locale` (en_US)
- **_config.yml**: Added social links for structured data

## Testing
After merge, verify:
- https://excelmcpserver.dev/robots.txt shows correct sitemap URL
- https://excelmcpserver.dev/sitemap.xml is accessible
- https://excelmcpserver.dev/BingSiteAuth.xml is accessible
- Bing Webmaster Tools verification succeeds

Closes #291