### PR TITLE
chore(gh-pages): refine hero subtitle and fix installation permalink

### DIFF
--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -11,8 +11,7 @@ canonical_url: "https://excelmcpserver.dev/"
     <div class="hero-content">
       <img src="{{ '/assets/images/icon.png' | relative_url }}" alt="Excel MCP Server Icon" class="hero-icon">
       <h1 class="hero-title">Excel MCP Server</h1>
-      <p class="hero-subtitle">AI-Powered Excel Automation</p>
-      <p class="hero-description">Control Microsoft Excel with Natural Language through AI assistants like GitHub Copilot and Claude. One-click install for Visual Studio Code.</p>
+      <p class="hero-subtitle">Automate Excel with AI via GitHub Copilot, Claude, and other MCP clients — including Power Query, DAX, VBA, PowerPivot, and Tables.</p>
     </div>
   </div>
 </div>

--- a/gh-pages/installation.md
+++ b/gh-pages/installation.md
@@ -2,6 +2,7 @@
 layout: default
 title: Installation Guide - Excel MCP Server
 description: Complete installation instructions for Excel MCP Server - VS Code Extension, MCP Server, and CLI tool.
+permalink: /installation/
 ---
 
 {% include installation.md %}


### PR DESCRIPTION
## Summary

Refine the GitHub Pages hero subtitle to better describe MCP-driven Excel automation and fix the broken installation guide link.

Closes #295

## Changes

### Hero Subtitle
- Updated the hero subtitle in `gh-pages/index.md` to:
  > Automate Excel with AI via GitHub Copilot, Claude, and other MCP clients — including Power Query, DAX, VBA, PowerPivot, and Tables.
- Removes awkward phrasing and makes MCP client usage + key Excel capabilities explicit.

### Installation Permalink
- Added an explicit permalink to `gh-pages/installation.md`:
  - `permalink: /installation/`
- Ensures the installation guide is consistently available at `https://excelmcpserver.dev/installation/`.

## Files Changed

| File | Change |
|------|--------|
| `gh-pages/index.md` | Hero subtitle refined to mention MCP clients + key Excel features |
| `gh-pages/installation.md` | Added `permalink: /installation/` frontmatter |

## Testing

- [x] Local Jekyll build via `./build.sh`
- [x] Verified `_site/installation/index.html` exists
- [x] Checked that the hero subtitle renders correctly on the homepage