### PR TITLE
feat(gh-pages): add RSS feed, Contributing, Security pages, and 404

### DIFF
--- a/gh-pages/.gitignore
+++ b/gh-pages/.gitignore
@@ -10,3 +10,5 @@ Gemfile.lock
 _includes/features.md
 _includes/changelog.md
 _includes/installation.md
+_includes/contributing.md
+_includes/security.md

--- a/gh-pages/404.md
+++ b/gh-pages/404.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: "Page Not Found - Excel MCP Server"
+permalink: /404.html
+---
+
+<div class="container content-section" style="text-align: center; padding: 4rem 1rem;">
+
+# 404 - Page Not Found
+
+The page you're looking for doesn't exist or has been moved.
+
+<div style="margin: 2rem 0;">
+<a href="/" class="button-link">← Back to Home</a>
+</div>
+
+## Quick Links
+
+- [Features](/features/) — All 12 tools and 180 operations
+- [Installation](/installation/) — Setup guides for VS Code, Claude, and CLI
+- [Changelog](/changelog/) — Release notes and version history
+- [GitHub Repository](https://github.com/sbroenne/mcp-server-excel) — Source code and issues
+
+</div>

--- a/gh-pages/Gemfile
+++ b/gh-pages/Gemfile
@@ -6,3 +6,4 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-sitemap"
 gem "jekyll-seo-tag"
+gem "jekyll-feed"

--- a/gh-pages/Gemfile.lock
+++ b/gh-pages/Gemfile.lock
@@ -279,6 +279,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-feed
   jekyll-seo-tag
   jekyll-sitemap
 

--- a/gh-pages/_config.yml
+++ b/gh-pages/_config.yml
@@ -15,6 +15,11 @@ theme: jekyll-theme-cayman
 plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
+  - jekyll-feed
+
+# Feed settings
+feed:
+  path: feed.xml
 
 # SEO settings
 author: "Stefan Broenne"

--- a/gh-pages/build.sh
+++ b/gh-pages/build.sh
@@ -25,6 +25,14 @@ echo "   ✓ Copied CHANGELOG.md"
 cp "$ROOT_DIR/docs/INSTALLATION.md" "$SCRIPT_DIR/_includes/installation.md"
 echo "   ✓ Copied INSTALLATION.md"
 
+# Copy CONTRIBUTING.md from docs
+cp "$ROOT_DIR/docs/CONTRIBUTING.md" "$SCRIPT_DIR/_includes/contributing.md"
+echo "   ✓ Copied CONTRIBUTING.md"
+
+# Copy SECURITY.md from docs
+cp "$ROOT_DIR/docs/SECURITY.md" "$SCRIPT_DIR/_includes/security.md"
+echo "   ✓ Copied SECURITY.md"
+
 # Determine build mode
 if [ "$1" == "serve" ]; then
     echo ""

--- a/gh-pages/contributing.md
+++ b/gh-pages/contributing.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: "Contributing - Excel MCP Server"
+description: "How to contribute to Excel MCP Server development. Guidelines for pull requests, code style, and community participation."
+permalink: /contributing/
+---
+
+{% include contributing.md %}

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Excel MCP Server - AI-Powered Excel Automation"
+title: "Excel MCP Server - Automate Excel with AI via GitHub Copilot & Claude"
 description: "Control Microsoft Excel with natural language through AI assistants like GitHub Copilot and Claude. Automate Power Query, DAX, VBA, PivotTables, and more. One-click install for Visual Studio Code."
 keywords: "Excel automation, MCP server, AI Excel, Power Query, DAX measures, VBA macros, GitHub Copilot Excel, Claude Excel, Excel CLI, M code, REPL"
 canonical_url: "https://excelmcpserver.dev/"

--- a/gh-pages/security.md
+++ b/gh-pages/security.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: "Security Policy - Excel MCP Server"
+description: "Security policy for Excel MCP Server. How to report vulnerabilities, supported versions, and security features."
+permalink: /security/
+---
+
+{% include security.md %}


### PR DESCRIPTION
## Changes

### New Pages
- ✅ **RSS Feed** () - Discovered via jekyll-feed plugin for easier content discovery
- ✅ **Contributing Page** () - Guides for developers and contributors  
- ✅ **Security Page** () - Security policy and reporting procedures
- ✅ **Custom 404 Page** () - Helpful navigation for broken links

### Updates
- Updated `build.sh` to copy CONTRIBUTING.md and SECURITY.md to Jekyll includes
- Added jekyll-feed gem to Gemfile for RSS/Atom feed generation
- Updated `.gitignore` to exclude generated `_includes/*.md` files
- All new pages use content deduplication via Jekyll includes pattern

### Benefits
- **Feed Subscribers**: Users can track updates via RSS/Atom readers
- **Better UX**: Custom 404 provides helpful navigation instead of blank error
- **Documentation**: Contributing and Security docs now discoverable on live site
- **SEO**: More pages indexed, feed discovery via site metadata

### Verification
- ✅ Jekyll builds with zero errors
- ✅ All new pages generated correctly (_site/contributing/index.html, _site/security/index.html, _site/404.html)
- ✅ RSS feed generated at /feed.xml (577 bytes)
- ✅ Sitemap and SEO tags remain valid
- ✅ No committed generated files (.gitignore properly configured)