### PR TITLE
feat(datamodel): improve LLM guidance and reduce timeout to 2 minutes

### DIFF
--- a/specs/003-datamodel-llm-guidance/checklists/requirements.md
+++ b/specs/003-datamodel-llm-guidance/checklists/requirements.md
@@ -1,0 +1,19 @@
+# Specification Quality Checklist: Data Model LLM Guidance
+
+**Feature**: [spec.md](../spec.md)
+
+## Validation
+
+- [x] Problem is clear and specific
+- [x] Solution is simple (2 deliverables)
+- [x] Requirements are minimal and testable
+- [x] No overengineering
+
+## Deliverables
+
+1. [x] Update `ExcelDataModelTool.cs` XML comments with warnings
+2. [x] Create `src/ExcelMcp.McpServer/Prompts/Content/excel_datamodel.md`
+
+## Ready for Implementation
+
+✅ Implementation complete - ready for PR

--- a/specs/003-datamodel-llm-guidance/plan.md
+++ b/specs/003-datamodel-llm-guidance/plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan: Data Model LLM Guidance
+
+## Overview
+
+Simple documentation-only change: update tool description and create prompt file.
+
+## Tech Stack
+
+- C# XML comments (tool descriptions)
+- Markdown (MCP prompt file)
+
+## Files to Modify/Create
+
+1. `src/ExcelMcp.McpServer/Tools/ExcelDataModelTool.cs` - Update XML summary
+2. `src/ExcelMcp.McpServer/Prompts/Content/excel_datamodel.md` - Create new file
+
+## No Tests Required
+
+This is documentation-only - no code logic changes.

--- a/specs/003-datamodel-llm-guidance/spec.md
+++ b/specs/003-datamodel-llm-guidance/spec.md
@@ -1,0 +1,36 @@
+# Feature Specification: Data Model LLM Guidance Enhancement
+
+**Feature Branch**: `003-datamodel-llm-guidance`  
+**Created**: December 14, 2025  
+**Status**: Draft
+
+## Problem
+
+LLMs get stuck when Data Model operations fail. Their recovery instinct is to "start fresh" by deleting and recreating tables. **But deleting a table cascades to delete ALL its measures** - potentially hours of user work lost.
+
+Secondary issue: LLMs "forget" the MCP tools exist in long conversations and suggest manual Power Pivot steps instead.
+
+## Solution
+
+Two simple changes:
+
+1. **Update `excel_datamodel` tool description** - Add clear warnings about destructive operations and a quick recovery guide
+2. **Create `excel_datamodel.md` prompt file** - Troubleshooting reference LLMs can consult when stuck
+
+## Requirements
+
+- **FR-001**: Tool description warns that delete-table also deletes all associated measures
+- **FR-002**: Tool description includes quick recovery tips (use update-measure, check list-measures first)
+- **FR-003**: Create prompt file with common error scenarios and non-destructive fixes
+
+## Success Criteria
+
+- **SC-001**: Tool description contains "DESTRUCTIVE" warning for delete-table
+- **SC-002**: Prompt file exists with at least 5 common error recovery patterns
+- **SC-003**: No delete-table suggestion in any recovery guidance
+
+## Out of Scope
+
+- Changing Excel COM behavior (cascade delete is baked in)
+- Blocking delete operations (users may legitimately need them)
+- Complex error response modifications (keep it simple)

--- a/specs/003-datamodel-llm-guidance/tasks.md
+++ b/specs/003-datamodel-llm-guidance/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: Data Model LLM Guidance
+
+## Setup
+- [x] 1. Create plan.md
+
+## Implementation
+- [x] 2. Update ExcelDataModelTool.cs XML comments with destructive operation warnings
+- [x] 3. Create excel_datamodel.md prompt file with recovery guidance
+
+## Validation
+- [x] 4. Build project to verify no syntax errors

--- a/src/ExcelMcp.Core/Commands/DataModel/DataModelCommands.Read.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/DataModelCommands.Read.cs
@@ -16,7 +16,7 @@ public partial class DataModelCommands
     {
         var result = new DataModelTableListResult { FilePath = batch.WorkbookPath };
 
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
 
         return batch.Execute((ctx, ct) =>
         {
@@ -62,7 +62,7 @@ public partial class DataModelCommands
     {
         var result = new DataModelMeasureListResult { FilePath = batch.WorkbookPath };
 
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
 
         return batch.Execute((ctx, ct) =>
         {
@@ -139,7 +139,7 @@ public partial class DataModelCommands
             MeasureName = measureName
         };
 
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
 
         return batch.Execute((ctx, ct) =>
         {
@@ -455,7 +455,7 @@ public partial class DataModelCommands
     {
         var result = new DataModelInfoResult { FilePath = batch.WorkbookPath };
 
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
 
         return batch.Execute((ctx, ct) =>
         {

--- a/src/ExcelMcp.McpServer/Prompts/Content/excel_datamodel.md
+++ b/src/ExcelMcp.McpServer/Prompts/Content/excel_datamodel.md
@@ -1,0 +1,108 @@
+# Excel Data Model Tool - Troubleshooting Guide
+
+## Quick Reference: Available Actions
+
+**Discovery (safe, read-only):**
+- `list-tables` - See all tables in Data Model
+- `list-measures` - See all measures (call before any delete!)
+- `list-columns` - See columns in a table
+- `list-relationships` - See all relationships
+- `read-table` - Get table details
+- `read` - Get measure formula
+
+**Create/Update (non-destructive):**
+- `create-measure` - Add new DAX measure
+- `update-measure` - Modify existing measure formula/format
+- `create-relationship` - Link tables
+- `update-relationship` - Change relationship active state
+
+**Delete (DESTRUCTIVE - use with caution):**
+- `delete-measure` - Remove single measure (table preserved)
+- `delete-relationship` - Remove relationship (tables preserved)
+- `delete-table` - **DANGER: Removes table AND ALL its measures**
+
+---
+
+## CRITICAL: Never Delete Tables to "Start Fresh"
+
+Deleting a Data Model table **cascades to delete ALL measures** associated with that table. This is Excel behavior that cannot be undone.
+
+**Before considering delete-table, ALWAYS:**
+1. Call `list-measures` to see what will be lost
+2. Consider if you can fix the issue without deletion
+3. Ask the user for explicit confirmation
+
+---
+
+## Common Error Recovery Patterns
+
+### 1. "Measure already exists"
+
+**Error**: Trying to create a measure that already exists.
+
+**Fix**: Use `update-measure` instead of `create-measure`:
+```
+action: update-measure
+measureName: "ExistingMeasure"
+daxFormula: "=SUM(Sales[Amount])"
+```
+
+### 2. "Invalid DAX formula" / Formula syntax error
+
+**Common causes:**
+- Missing quotes around text: `"Category"` not `Category`
+- Wrong column reference: `Table[Column]` format required
+- Missing table prefix: `SUM(Sales[Amount])` not `SUM(Amount)`
+- Locale issues: Use US format with commas, not semicolons
+
+**Fix**: Check formula syntax, verify column names with `list-columns`:
+```
+action: list-columns
+tableName: "Sales"
+```
+
+### 3. "Table not found"
+
+**Fix**: Verify table name with `list-tables`:
+```
+action: list-tables
+```
+
+### 4. "Measure not found"
+
+**Fix**: Verify measure name with `list-measures`:
+```
+action: list-measures
+```
+
+### 5. "Column not found" (for relationships)
+
+**Fix**: Check both tables have the expected columns:
+```
+action: list-columns
+tableName: "SourceTable"
+```
+
+---
+
+## Recommended Workflow Pattern
+
+**Always: Discovery → Action → Verify**
+
+1. **Before creating**: `list-measures` to avoid duplicates
+2. **Before updating**: `read` to see current formula
+3. **Before deleting**: `list-measures` to understand impact
+4. **After any change**: Verify with appropriate list action
+
+---
+
+## When Truly Stuck
+
+If operations keep failing:
+
+1. **Check session is valid** - reopen file if needed
+2. **Verify object names exactly** - case-sensitive, check spelling
+3. **Check for hidden objects** - user may need to unhide in Power Pivot UI
+4. **DAX locale** - formulas should use US format (commas, not semicolons)
+
+**Do NOT delete and recreate tables** - you will lose all measures.

--- a/src/ExcelMcp.McpServer/Tools/ExcelDataModelTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelDataModelTool.cs
@@ -14,15 +14,29 @@ public static partial class ExcelDataModelTool
 {
     /// <summary>
     /// Manage Excel Power Pivot (Data Model) - DAX measures, relationships, analytical model.
-    /// HIDDEN COLUMNS/RELATIONSHIPS/MEASURES: Objects marked "Hidden from client tools" in Power Pivot are NOT visible via list-columns, list-relationships, or list-measures actions. This is an Excel API limitation with no workaround. If user reports missing columns, relationships, or measures, ask them to unhide them in Power Pivot (Manage Data Model, right-click object, uncheck "Hide from Client Tools").
-    /// CALCULATED COLUMNS: NOT supported via automation. When user asks to create calculated columns, provide step-by-step manual instructions OR suggest using DAX measures instead (measures ARE automated and usually better for aggregations).
-    /// TIMEOUT SAFEGUARD: Listing tables/measures/info auto-timeouts after 5 minutes to prevent Power Pivot hangs.
+    ///
+    /// DESTRUCTIVE OPERATIONS WARNING:
+    /// - delete-table: DELETES TABLE AND ALL ITS MEASURES. Measures cannot be recovered. Use list-measures first to see what will be lost.
+    /// - delete-relationship: Removes relationship only (tables and measures preserved).
+    /// - delete-measure: Removes single measure only (table preserved).
+    ///
+    /// WHEN STUCK - DO NOT DELETE TABLES. Instead:
+    /// 1. Use list-measures to see current state
+    /// 2. Use update-measure to fix existing measures
+    /// 3. Check DAX formula syntax (common: missing quotes, wrong column references)
+    /// 4. Use list-tables and list-columns to verify names
+    ///
+    /// HIDDEN OBJECTS: Objects marked "Hidden from client tools" in Power Pivot are NOT visible via list-columns, list-relationships, or list-measures. If user reports missing items, ask them to unhide in Power Pivot.
+    ///
+    /// CALCULATED COLUMNS: NOT supported via automation. Suggest using DAX measures instead (measures ARE automated and usually better for aggregations).
+    ///
+    /// TIMEOUT: Operations auto-timeout after 2 minutes to prevent hangs.
     /// </summary>
     /// <param name="action">Action to perform</param>
     /// <param name="excelPath">Excel file path (.xlsx or .xlsm)</param>
     /// <param name="sessionId">Session ID from excel_file 'open' action</param>
     /// <param name="measureName">Measure name (for read, export-measure, delete-measure, update-measure)</param>
-    /// <param name="tableName">Table name (for create-measure, read-table)</param>
+    /// <param name="tableName">Table name (for create-measure, read-table, delete-table)</param>
     /// <param name="daxFormula">DAX formula (for create-measure, update-measure)</param>
     /// <param name="description">Description (for create-measure, update-measure)</param>
     /// <param name="formatString">Format string (for create-measure, update-measure), e.g., '#,##0.00', '0.00%'</param>


### PR DESCRIPTION
## Summary

Improves LLM guidance for Data Model operations to prevent destructive table recreation that deletes measures.

## Changes

### Tool Description Updates (ExcelDataModelTool.cs)
- Added **DESTRUCTIVE OPERATIONS WARNING** section explaining cascade delete behavior
- Added **WHEN STUCK - DO NOT DELETE TABLES** recovery guidance
- Reduced timeout from 5 minutes to 2 minutes

### New Prompt File (excel_datamodel.md)
- Troubleshooting guide with 5+ error recovery patterns
- Clear action categorization (safe/create/destructive)
- Explicit warning against deleting tables to 'start fresh'

### Timeout Reduction (DataModelCommands.Read.cs)
- Changed all 4 timeout locations from 5 minutes to 2 minutes
- Affects: ListTables, ListMeasures, Read, ReadInfo

## Problem Solved

LLMs would get stuck on Data Model errors and attempt to 'start fresh' by deleting tables. This cascades to delete ALL associated measures - potentially losing hours of user work.

## Testing

- Build passes with 0 warnings, 0 errors
- All pre-commit checks pass (COM leaks, coverage, naming, smoke test)