### PR TITLE
fix: address remaining code scanning alerts

### DIFF
--- a/src/ExcelMcp.Core/Commands/DataModel/DataModelCommands.Write.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/DataModelCommands.Write.cs
@@ -474,9 +474,6 @@ public partial class DataModelCommands
                         throw new InvalidOperationException(DataModelErrorMessages.RelationshipNotFound(fromTable, fromColumn, toTable, toColumn));
                     }
 
-                    // Get current state
-                    bool wasActive = relationship.Active ?? false;
-
                     // Update active state
                     // Reference: https://learn.microsoft.com/en-us/office/vba/api/excel.modelrelationship (Active property is Read/Write)
                     relationship.Active = active;

--- a/src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.CalculatedMembers.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.CalculatedMembers.cs
@@ -53,8 +53,8 @@ public partial class PivotTableCommands
                         };
 
                         // Try to get optional properties (may not exist on all calculated member types)
-                        try { memberInfo.DisplayFolder = member.DisplayFolder?.ToString(); } catch (System.Runtime.InteropServices.COMException) { }
-                        try { memberInfo.NumberFormat = member.NumberFormat?.ToString(); } catch (System.Runtime.InteropServices.COMException) { }
+                        try { memberInfo.DisplayFolder = member.DisplayFolder?.ToString(); } catch (System.Runtime.InteropServices.COMException) { /* Property not available */ }
+                        try { memberInfo.NumberFormat = member.NumberFormat?.ToString(); } catch (System.Runtime.InteropServices.COMException) { /* Property not available */ }
 
                         result.CalculatedMembers.Add(memberInfo);
                     }
@@ -159,8 +159,8 @@ public partial class PivotTableCommands
                 };
 
                 // Try to get optional properties (may not exist on all calculated member types)
-                try { result.DisplayFolder = newMember.DisplayFolder?.ToString(); } catch (System.Runtime.InteropServices.COMException) { }
-                try { result.NumberFormat = newMember.NumberFormat?.ToString(); } catch (System.Runtime.InteropServices.COMException) { }
+                try { result.DisplayFolder = newMember.DisplayFolder?.ToString(); } catch (System.Runtime.InteropServices.COMException) { /* Property not available */ }
+                try { result.NumberFormat = newMember.NumberFormat?.ToString(); } catch (System.Runtime.InteropServices.COMException) { /* Property not available */ }
 
                 return result;
             }


### PR DESCRIPTION
## Summary

Addresses remaining code scanning alerts after PR #319.

## Changes

- **PivotTableCommands.CalculatedMembers.cs**: Add comments to empty catch blocks for COM property probing (lines 56-57, 162-163)
- **DataModelCommands.Write.cs**: Remove unused \wasActive\ variable (line 478)

## Note

Some alerts on main reference line numbers from before PR #319 merge and may auto-resolve on next CodeQL scan. The test file alerts have pragmas but CodeQL may be showing stale line numbers.

## Verification

- Build: 0 warnings, 0 errors
- Pre-commit checks: All passed