### PR TITLE
fix: Power Query update fails with 0x800A03EC when Data Model is present

### DIFF
--- a/docs/COM-API-BEHAVIOR-FINDINGS.md
+++ b/docs/COM-API-BEHAVIOR-FINDINGS.md
@@ -131,7 +131,31 @@ foreach (Connection in workbook.Connections)
 
 **Implication:** `Unload` method in `PowerQueryCommands.Lifecycle.cs` needs to also remove Data Model connections.
 
-### Scenario 12: Query Renaming
+---
+
+### Scenario 15: Data Model State Blocks Formula Updates (UNRESOLVED)
+
+**FINDING: WorkbookQuery.Formula becomes read-only in certain workbook states**
+
+**Error Code:** `0x800A03EC` (-2146827284) - "Application-defined or object-defined error"
+
+**Symptoms:**
+- `query.Formula = mCode` fails with 0x800A03EC on some workbooks
+- Error affects ALL queries in the workbook, not just Data Model queries
+- Error is workbook-specific - same queries work fine in fresh workbooks
+
+**Attempted Solutions (Did NOT Work):**
+1. **Save-and-retry**: Saving workbook before retry did NOT clear the error state
+2. **Polly retry with backoff**: Error is NOT transient - retries don't help
+3. **File location**: Copying file from OneDrive to local drive did NOT help
+
+**Current Status:** Root cause unknown. The error appears to be related to internal Excel state that cannot be cleared programmatically via COM automation. Workaround: manually save and reopen the workbook in Excel UI.
+
+**See:** GitHub Issue #323
+
+---
+
+### Scenario 16: Query Renaming
 
 **FINDING: Renaming a query breaks the connection to the table**
 

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Update.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Update.cs
@@ -1,4 +1,3 @@
-using Polly;
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 
@@ -203,11 +202,10 @@ public partial class PowerQueryCommands
                     if (existingQueryTable != null) break;
                 }
 
-                // STEP 3: Update the M code with retry for Data Model-connected queries
-                // The 0x800A03EC error can occur when updating queries loaded to Data Model
-                // See GitHub Issue #316 for details
-                ResiliencePipeline pipeline = ResiliencePipelines.CreatePowerQueryPipeline();
-                pipeline.Execute(() => query.Formula = mCode);
+                // STEP 3: Update the M code
+                // Note: 0x800A03EC error can occur in certain workbook states (see Issue #323)
+                // Retry doesn't help - it's a workbook state issue, not transient
+                query.Formula = mCode;
 
                 // STEP 4: Refresh if requested
                 if (refresh)


### PR DESCRIPTION
## Status: Unresolved - Documentation + Code Cleanup

The save-and-retry approach did NOT resolve the issue. This PR documents the issue and removes ineffective retry code.

---

Related to #323

## What Was Tried (Did NOT Work)

1. **Save-and-retry**: Catch 0x800A03EC, save workbook, retry - Failed
2. **Polly retry with backoff**: Error is not transient
3. **File location**: Copying from OneDrive to local - Still fails

## Current Status

Root cause unknown. The error appears to be related to internal Excel state that cannot be cleared via COM automation.

## Changes in This PR

- \docs/COM-API-BEHAVIOR-FINDINGS.md\ - Added Scenario 15 documenting the issue as UNRESOLVED
- \src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Update.cs\ - Removed ineffective Polly retry code

## Workaround

Manually save and reopen the workbook in Excel UI.