### PR TITLE
fix(seo): Remove duplicate site name from page titles

### DIFF
--- a/gh-pages/404.md
+++ b/gh-pages/404.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Page Not Found - Excel MCP Server"
+title: "Page Not Found"
 permalink: /404.html
 ---
 

--- a/gh-pages/changelog.md
+++ b/gh-pages/changelog.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Changelog - Excel MCP Server"
+title: "Changelog"
 description: "Release notes and changelog for ExcelMcp VS Code extension and MCP Server. Track new features, bug fixes, and improvements."
 keywords: "Excel MCP changelog, release notes, version history, updates"
 permalink: /changelog/

--- a/gh-pages/contributing.md
+++ b/gh-pages/contributing.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Contributing - Excel MCP Server"
+title: "Contributing"
 description: "How to contribute to Excel MCP Server development. Guidelines for pull requests, code style, and community participation."
 permalink: /contributing/
 ---

--- a/gh-pages/features.md
+++ b/gh-pages/features.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Complete Feature Reference - Excel MCP Server"
+title: "Complete Feature Reference"
 description: "12 specialized tools with 182 operations for comprehensive Excel automation. Power Query, DAX, VBA, Charts, PivotTables, and more."
 keywords: "Excel MCP features, Power Query automation, DAX measures, VBA macros, Excel tools, MCP operations"
 permalink: /features/

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Excel MCP Server - Automate Power Query, DAX & VBA with AI"
+title: "Automate Power Query, DAX & VBA with AI"
 description: "Control Microsoft Excel with natural language through AI assistants like GitHub Copilot and Claude. Automate Power Query, DAX, VBA, PivotTables, and more. One-click install for Visual Studio Code."
 keywords: "Excel automation, MCP server, AI Excel, Power Query, DAX measures, VBA macros, GitHub Copilot Excel, Claude Excel, Excel CLI, M code, REPL"
 canonical_url: "https://excelmcpserver.dev/"

--- a/gh-pages/installation.md
+++ b/gh-pages/installation.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Installation Guide - Excel MCP Server
+title: "Installation Guide"
 description: Complete installation instructions for Excel MCP Server - VS Code Extension, MCP Server, and CLI tool.
 permalink: /installation/
 ---

--- a/gh-pages/security.md
+++ b/gh-pages/security.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Security Policy - Excel MCP Server"
+title: "Security Policy"
 description: "Security policy for Excel MCP Server. How to report vulnerabilities, supported versions, and security features."
 permalink: /security/
 ---


### PR DESCRIPTION
## Summary

Fixes duplicate site name in page titles per Bing's SEO guidelines for avoiding duplicate content signals.

## Problem

Page titles had redundant site name:
- `Changelog - Excel MCP Server | Excel MCP Server`
- `Complete Feature Reference - Excel MCP Server | Excel MCP Server`

The jekyll-seo-tag plugin automatically appends `| {site.title}` to all page titles, but page front matter already included `- Excel MCP Server`.

## Solution

Remove `- Excel MCP Server` from individual page titles. The jekyll-seo-tag plugin adds the site name automatically.

## Result

| Page | Before | After |
|------|--------|-------|
| Homepage | `Excel MCP Server - Automate Power Query... \| Excel MCP Server` | `Automate Power Query, DAX & VBA with AI \| Excel MCP Server` |
| Features | `Complete Feature Reference - Excel MCP Server \| Excel MCP Server` | `Complete Feature Reference \| Excel MCP Server` |
| Installation | `Installation Guide - Excel MCP Server \| Excel MCP Server` | `Installation Guide \| Excel MCP Server` |
| Changelog | `Changelog - Excel MCP Server \| Excel MCP Server` | `Changelog \| Excel MCP Server` |

## Related

Per Bing Webmaster Blog: [Does Duplicate Content Hurt SEO and AI Search Visibility?](https://blogs.bing.com/webmaster/December-2025/Does-Duplicate-Content-Hurt-SEO-and-AI-Search-Visibility)