### PR TITLE
fix: exclude 404 page from search engine indexing

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -61,9 +61,9 @@ jobs:
 
       - name: Notify IndexNow (Bing/Yandex)
         run: |
-          # Get list of all HTML pages from the built site
+          # Get list of all HTML pages from the built site (excluding 404.html which should not be indexed)
           cd gh-pages/_site
-          URLS=$(find . -name "*.html" -type f | sed 's|^\./||' | sed 's|index\.html$||' | sed 's|^|https://excelmcpserver.dev/|' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          URLS=$(find . -name "*.html" -type f ! -name "404.html" | sed 's|^\./||' | sed 's|index\.html$||' | sed 's|^|https://excelmcpserver.dev/|' | jq -R -s -c 'split("\n") | map(select(length > 0))')
           
           # Submit to IndexNow API
           curl -X POST "https://api.indexnow.org/IndexNow" \

--- a/gh-pages/404.md
+++ b/gh-pages/404.md
@@ -2,6 +2,7 @@
 layout: default
 title: "Page Not Found"
 permalink: /404.html
+sitemap: false
 ---
 
 <div class="container content-section" style="text-align: center; padding: 4rem 1rem;">


### PR DESCRIPTION
## Problem
Google Search Console reported 'Page with redirect' warning preventing some pages from being indexed.

## Root Cause
The IndexNow notification script in the GitHub Pages deployment workflow was submitting `https://excelmcpserver.dev/404.html` to search engines. The 404 error page should never be indexed.

## Solution

### 1. deploy-gh-pages.yml
- Added `! -name "404.html"` filter to the `find` command in IndexNow URL generation
- Updated comment to clarify the exclusion

### 2. 404.md
- Added `sitemap: false` to the front matter
- This tells the `jekyll-sitemap` plugin to exclude the 404 page from `sitemap.xml`

## Testing
Verified locally that the URL generation now excludes 404.html:
```
https://excelmcpserver.dev/features/
https://excelmcpserver.dev/security/
https://excelmcpserver.dev/
https://excelmcpserver.dev/contributing/
https://excelmcpserver.dev/changelog/
https://excelmcpserver.dev/installation/
```