### PR TITLE
Add LLM workflow guidance to tool XML documentation

### DIFF
--- a/src/ExcelMcp.McpServer/Tools/ExcelDataModelRelTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelDataModelRelTool.cs
@@ -15,6 +15,12 @@ public static partial class ExcelDataModelRelTool
     /// <summary>
     /// Data Model relationships - link tables for cross-table DAX calculations.
     ///
+    /// CRITICAL: Deleting or recreating tables (via excel_datamodel delete-table or excel_table delete)
+    /// removes ALL their relationships. Use 'list-relationships' before table operations to backup,
+    /// then recreate relationships after schema changes.
+    ///
+    /// BEST PRACTICE: Use 'list-relationships' to check existing relationships before creating.
+    ///
     /// RELATIONSHIP REQUIREMENTS:
     /// - Both tables must exist in the Data Model first
     /// - Columns must have compatible data types

--- a/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
@@ -16,6 +16,9 @@ public static partial class ExcelFileTool
     ///
     /// WORKFLOW: open → use sessionId with other tools → close (save=true to persist changes).
     ///
+    /// SESSION REUSE: Call 'list' first to check for existing sessions.
+    /// If file is already open, reuse existing sessionId instead of opening again.
+    ///
     /// IMPORTANT: Before closing, check 'list' action - wait for canClose=true (no active operations).
     /// If showExcel=true was used, confirm with user before closing visible Excel windows.
     /// </summary>

--- a/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
@@ -17,6 +17,11 @@ public static partial class ExcelPivotTableTool
     /// <summary>
     /// PivotTable lifecycle management: create from various sources, list, read details, refresh, and delete.
     ///
+    /// BEST PRACTICE: Use 'list' before creating. Prefer 'refresh' or field modifications over delete+recreate.
+    /// Delete+recreate loses field configurations, filters, sorting, and custom layouts.
+    ///
+    /// LAYOUT: Use excel_pivottable_calc set-layout action (0=Compact, 1=Tabular, 2=Outline).
+    ///
     /// CREATE OPTIONS:
     /// - create-from-range: Use sourceSheetName and sourceRangeAddress for data range
     /// - create-from-table: Use sourceTableName for an Excel Table (ListObject)

--- a/src/ExcelMcp.McpServer/Tools/ExcelPowerQueryTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelPowerQueryTool.cs
@@ -15,6 +15,12 @@ public static partial class ExcelPowerQueryTool
     /// <summary>
     /// Power Query M code and data loading.
     ///
+    /// BEST PRACTICE: Use 'list' before creating. Prefer 'update' over delete+recreate to preserve load settings.
+    ///
+    /// DATETIME COLUMNS: Always include Table.TransformColumnTypes() in M code to set column types explicitly.
+    /// Without explicit types, dates may be stored as numbers and Data Model relationships may fail.
+    /// Example: Table.TransformColumnTypes(Source, {{"OrderDate", type datetime}, {"Amount", type number}})
+    ///
     /// M-CODE FORMATTING: Create and Update automatically format M code using powerqueryformatter.com API.
     /// Formatting adds ~100-500ms latency but improves readability. Graceful fallback on API failure.
     ///

--- a/src/ExcelMcp.McpServer/Tools/ExcelRangeTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelRangeTool.cs
@@ -15,6 +15,10 @@ public static partial class ExcelRangeTool
     /// <summary>
     /// Core range operations: get/set values and formulas, copy ranges, clear content, and discover data regions.
     ///
+    /// BEST PRACTICE: Use 'get-values' to check existing data before overwriting.
+    /// Use 'clear-contents' (not 'clear-all') to preserve cell formatting when clearing data.
+    /// set-values preserves existing formatting; use set-number-format after if format change needed.
+    ///
     /// DATA FORMAT: values and formulas are 2D JSON arrays representing rows and columns.
     /// Example: [[row1col1, row1col2], [row2col1, row2col2]]
     /// Single cell returns [[value]] (always 2D).

--- a/src/ExcelMcp.McpServer/Tools/ExcelTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelTableTool.cs
@@ -15,6 +15,11 @@ public static partial class TableTool
     /// <summary>
     /// Excel Tables (ListObjects) - lifecycle and data operations.
     ///
+    /// BEST PRACTICE: Use 'list' to check existing tables before creating.
+    /// Prefer 'append'/'resize'/'rename' over delete+recreate to preserve references.
+    ///
+    /// WARNING: Deleting tables used as PivotTable sources or in Data Model relationships will break those objects.
+    ///
     /// CREATING TABLES: Specify sheetName, tableName, and rangeAddress. Set hasHeaders=true if first row contains headers.
     ///
     /// DATA MODEL WORKFLOW: To analyze worksheet data with DAX/Power Pivot:


### PR DESCRIPTION
Fixes #362

Add best practice and workflow guidance directly to XML /// <summary> documentation so LLMs see it in tool schemas without requesting prompts:

- ExcelFileTool: SESSION REUSE - check 'list' before opening files
- ExcelTableTool: BEST PRACTICE + WARNING - prefer append/resize, warns about breaking PivotTables and Data Model relationships when deleting tables
- ExcelPivotTableTool: BEST PRACTICE + LAYOUT - prefer refresh over rebuild, documents layout styles (0=Compact, 1=Tabular, 2=Outline)
- ExcelDataModelRelTool: CRITICAL warning - deleting tables removes ALL relationships, suggests backup before table operations
- ExcelPowerQueryTool: BEST PRACTICE + DATETIME COLUMNS - prefer update over delete+recreate, must use Table.TransformColumnTypes() for proper types
- ExcelRangeTool: BEST PRACTICE - check existing data, use clear-contents (not clear-all) to preserve formatting

Addresses user feedback about LLMs frequently deleting and rebuilding objects instead of making incremental changes.

## Summary
Brief description of what this PR does.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (dependency updates, code cleanup, etc.)

## Related Issues
Closes #[issue number]
Relates to #[issue number]

## Changes Made
- Change 1
- Change 2
- Change 3

## Testing Performed
- [ ] Tested manually with various Excel files
- [ ] Verified Excel process cleanup (no excel.exe remains after 5 seconds)
- [ ] Tested error conditions (missing files, invalid arguments, etc.)
- [ ] All existing commands still work
- [ ] VBA script execution tested (if applicable)
- [ ] XLSM file format validation tested (if applicable)
- [ ] VBA trust setup tested (if applicable)
- [ ] Build produces zero warnings

## Test Commands
```bash
# Commands used for testing
ExcelMcp command1 "test.xlsx"
ExcelMcp command2 "test.xlsx" "param"
```

## Screenshots (if applicable)
[Add screenshots showing the new functionality]

## Core Commands Coverage Checklist ⚠️

**Does this PR add or modify Core Commands methods?** [ ] Yes [ ] No

If YES, verify all steps completed:

- [ ] Added method to Core Commands interface (e.g., `IPowerQueryCommands.NewMethodAsync()`)
- [ ] Implemented method in Core Commands class (e.g., `PowerQueryCommands.NewMethodAsync()`)
- [ ] Added enum value to `ToolActions.cs` (e.g., `PowerQueryAction.NewMethod`)
- [ ] Added `ToActionString` mapping to `ActionExtensions.cs` (e.g., `PowerQueryAction.NewMethod => "new-method"`)
- [ ] Added switch case to appropriate MCP Tool (e.g., `ExcelPowerQueryTool.cs`)
- [ ] Implemented MCP method that calls Core method
- [ ] Build succeeds with 0 warnings (CS8524 compiler enforcement verified)
- [ ] Updated `CORE-COMMANDS-AUDIT.md` (if significant addition)
- [ ] Added integration tests for new action
- [ ] Updated MCP Server prompts documentation
- [ ] Updated CLI commands documentation (if applicable)

**Coverage Impact**: +___ methods, ___% → ___% coverage

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [ ] Code builds with zero warnings
- [ ] Appropriate error handling added
- [ ] Updated help text (if adding new commands)
- [ ] Updated README.md (if needed)
- [ ] Follows Excel COM best practices from copilot-instructions.md
- [ ] Uses batch API with proper disposal (`using var batch` or `await using var batch`)
- [ ] Properly handles 1-based Excel indexing
- [ ] Escapes user input with `.EscapeMarkup()`
- [ ] Returns consistent exit codes (0 = success, 1+ = error)

## Additional Notes
Any additional information that reviewers should know.
