### PR TITLE
docs: Improve PivotTable layout guidance in tool description

### DIFF
--- a/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
@@ -20,7 +20,12 @@ public static partial class ExcelPivotTableTool
     /// BEST PRACTICE: Use 'list' before creating. Prefer 'refresh' or field modifications over delete+recreate.
     /// Delete+recreate loses field configurations, filters, sorting, and custom layouts.
     ///
-    /// LAYOUT: Use excel_pivottable_calc set-layout action (0=Compact, 1=Tabular, 2=Outline).
+    /// AFTER CREATION - SET LAYOUT:
+    /// New PivotTables default to Compact layout. To change layout immediately after creation:
+    /// Call excel_pivottable_calc(action: 'set-layout', pivotTableName: '...', layoutStyle: N)
+    /// - 0 = Compact (default, row fields in single column)
+    /// - 1 = Tabular (each row field in separate column - best for export/analysis)
+    /// - 2 = Outline (hierarchical with expand/collapse)
     ///
     /// CREATE OPTIONS:
     /// - create-from-range: Use sourceSheetName and sourceRangeAddress for data range


### PR DESCRIPTION
## Summary
Improves tool documentation to help LLMs understand how to set PivotTable layout after creation.

## Changes
- Make layout workaround more prominent in \xcel_pivottable\ tool description
- Explain that new PivotTables default to Compact layout
- Show exact call pattern for \xcel_pivottable_calc set-layout\
- Describe each layout option (Compact/Tabular/Outline)

## Before
\\\
LAYOUT: Use excel_pivottable_calc set-layout action (0=Compact, 1=Tabular, 2=Outline).
\\\

## After
\\\
AFTER CREATION - SET LAYOUT:
New PivotTables default to Compact layout. To change layout immediately after creation:
Call excel_pivottable_calc(action: 'set-layout', pivotTableName: '...', layoutStyle: N)
- 0 = Compact (default, row fields in single column)
- 1 = Tabular (each row field in separate column - best for export/analysis)
- 2 = Outline (hierarchical with expand/collapse)
\\\

Related to #366 (feature request to add layoutStyle parameter directly to create operations)