### PR TITLE
fix: release workflow - sync root changelog to extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,13 +237,11 @@ jobs:
         $version = $env:VERSION
         cd vscode-extension
         npm version "$version" --no-git-tag-version
+      shell: pwsh
 
-        # Update CHANGELOG.md
-        $date = Get-Date -Format 'yyyy-MM-dd'
-        $changelogPath = 'CHANGELOG.md'
-        $content = Get-Content $changelogPath -Raw
-        $content = $content -replace '## \[Unreleased\]', "## [$version] - $date"
-        Set-Content $changelogPath $content -NoNewline
+    - name: Sync Extension Changelog
+      run: |
+        Copy-Item "CHANGELOG.md" "vscode-extension/CHANGELOG.md" -Force
       shell: pwsh
 
     - name: Install Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This changelog covers all components:
 
 ## [Unreleased]
 
+## [1.5.8] - 2025-01-20
+
+### Added
+- Now available as a Claude Desktop MCPB Extension
+  
 ## [1.5.6] - 2025-01-20
 
 ### Added
@@ -17,9 +22,6 @@ This changelog covers all components:
   - **PivotTable Slicers**: Create, list, filter, and delete slicers for PivotTable fields
   - **Table Slicers**: Create, list, filter, and delete slicers for Excel Table columns
   - 8 new operations for interactive data filtering
-
-### Changed
-- **MCPB**: First release with unified versioning
 
 ## [1.5.5] - 2025-01-19
 


### PR DESCRIPTION
## Summary
- Fix VS Code Extension job failure by syncing root CHANGELOG.md to extension instead of editing non-existent extension-specific changelog
- Add [1.5.8] release notes for MCPB availability
- Restore [Unreleased] section for future changes

## Changes
- **release.yml**: Replace extension changelog editing with \Copy-Item\ from root
- **CHANGELOG.md**: Add 1.5.8 entry and restore Unreleased section