### PR TITLE
fix(datamodel): Better error message for missing MSOLAP provider

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -9,6 +9,11 @@ Complete installation instructions for the ExcelMcp MCP Server and CLI tool.
 - **Microsoft Excel 2016 or later** (Desktop version - Office 365, Professional Plus, or Standalone)
 - **.NET 10 Runtime or SDK** (not required for VS Code Extension or MCPB - they bundle it)
 
+### Optional (for specific features)
+- **Microsoft Analysis Services OLE DB Provider (MSOLAP)** - Required for DAX query execution (`evaluate`, `execute-dmv` actions)
+  - Easiest: Install [Power BI Desktop](https://powerbi.microsoft.com/desktop) (includes MSOLAP)
+  - Alternative: [Microsoft OLE DB Driver for Analysis Services](https://learn.microsoft.com/analysis-services/client-libraries)
+
 ### Recommended
 - Windows 11 for best performance
 - Office 365 with latest updates

--- a/skills/shared/excel_datamodel.md
+++ b/skills/shared/excel_datamodel.md
@@ -5,6 +5,17 @@
 The Data Model (Power Pivot) only contains tables that were explicitly added.
 You CANNOT create DAX measures on tables that aren't in the Data Model.
 
+## MSOLAP Prerequisite (for evaluate/execute-dmv)
+
+**The `evaluate` and `execute-dmv` actions require Microsoft Analysis Services OLE DB Provider (MSOLAP).**
+
+If you see "Class not registered" (0x80040154) error, install one of:
+1. **Power BI Desktop** (recommended - includes MSOLAP): https://powerbi.microsoft.com/desktop
+2. **Microsoft OLE DB Driver for Analysis Services**: https://learn.microsoft.com/analysis-services/client-libraries
+3. **SQL Server Analysis Services client tools**
+
+After installation, restart Excel and try again.
+
 ## CRITICAL: Data Model Sync (Worksheet Tables)
 
 **Worksheet tables and Data Model tables are SEPARATE copies!**

--- a/src/ExcelMcp.Core/Commands/DataModel/DataModelErrorMessages.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/DataModelErrorMessages.cs
@@ -45,4 +45,27 @@ public static class DataModelErrorMessages
     {
         return $"{operation} failed: {details}";
     }
+
+    /// <summary>
+    /// Error message when MSOLAP provider is not installed (Class not registered).
+    /// This occurs when trying to execute DAX queries via ADOConnection.
+    /// </summary>
+    public static string MsolapProviderNotInstalled()
+    {
+        return "DAX query execution requires the Microsoft Analysis Services OLE DB Provider (MSOLAP), which is not installed. " +
+               "To fix this, install one of the following:\n" +
+               "  1. Power BI Desktop (recommended - includes MSOLAP): https://powerbi.microsoft.com/desktop\n" +
+               "  2. Microsoft OLE DB Driver for Analysis Services: https://learn.microsoft.com/analysis-services/client-libraries\n" +
+               "  3. SQL Server Analysis Services (SSAS) client tools\n" +
+               "After installation, restart Excel and try again.";
+    }
+
+    /// <summary>
+    /// Error message when ADO connection to Data Model fails
+    /// </summary>
+    public static string AdoConnectionFailed(string details)
+    {
+        return $"Failed to connect to Data Model for DAX query execution: {details}. " +
+               "Ensure Power Pivot is enabled in Excel (File > Options > Add-ins > COM Add-ins > Microsoft Power Pivot for Excel).";
+    }
 }


### PR DESCRIPTION
## Summary
Improves error messages when DAX query execution (evaluate, execute-dmv) fails due to missing MSOLAP provider.

## Changes
- Added MsolapProviderNotInstalled() error message with actionable installation instructions
- Catches COMException with HResult 