### PR TITLE
fix(cli): add workaround for PackAsTool + net10.0-windows

### DIFF
--- a/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+++ b/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
@@ -100,4 +100,19 @@
     <InternalsVisibleTo Include="Sbroenne.ExcelMcp.CLI.Tests" />
   </ItemGroup>
 
+  <!-- Workaround for NETSDK1146: PackAsTool doesn't support net10.0-windows -->
+  <!-- See: https://github.com/dotnet/sdk/issues/12055#issuecomment-2125927648 -->
+  <Target Name="HackBeforePackToolValidation" BeforeTargets="_PackToolValidation">
+    <PropertyGroup>
+      <TargetPlatformIdentifier></TargetPlatformIdentifier>
+      <TargetPlatformMoniker></TargetPlatformMoniker>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="HackAfterPackToolValidation" AfterTargets="_PackToolValidation" BeforeTargets="PackTool">
+    <PropertyGroup>
+      <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+    </PropertyGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Problem
The v1.5.14 and v1.6.0 releases failed at the CLI Pack NuGet step because PackAsTool rejects net10.0-windows.

## Fix
Applied the community workaround from dotnet/sdk#12055 - temporarily clear TargetPlatformIdentifier during pack validation.

## Result
- CLI remains a dotnet tool
- System tray feature preserved
- Pack succeeds