### PR TITLE
fix: auto-detect and cleanup dead Excel sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This changelog covers all components:
 
 ## [Unreleased]
 
+## [1.6.4] - 2026-02-03
+
+
 ### Fixed
 
 - **COM Timeout with Data Model Dependencies** (#412): Fixed timeout when setting formulas/values that trigger Data Model recalculation

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -426,6 +426,16 @@ internal sealed class ExcelBatch : IExcelBatch
     {
         ObjectDisposedException.ThrowIf(_disposed != 0, nameof(ExcelBatch));
 
+        // Check if Excel process is still alive before attempting operation
+        if (!IsExcelProcessAlive())
+        {
+            _logger.LogError("Excel process is no longer running for workbook {FileName}", Path.GetFileName(_workbookPath));
+            throw new InvalidOperationException(
+                $"Excel process is no longer running for workbook '{Path.GetFileName(_workbookPath)}'. " +
+                "The Excel application may have been closed manually or crashed. " +
+                "Please close this session and create a new one.");
+        }
+
         var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         // Post operation to STA thread synchronously


### PR DESCRIPTION
## Summary

Fixes #414 - Dead Excel sessions cause confusing timeout errors instead of clear feedback.

## Problem

When an Excel process dies (crashed or closed manually), the CLI session remains in the \SessionManager\ dictionary. Subsequent operations timeout with confusing messages like \The operation was canceled\ instead of telling the user that Excel is gone.

Dead sessions also:
- Block the daemon idle timeout (thinks sessions exist)
- Prevent reopening the same file (file path still tracked)

## Solution

**SessionManager changes:**
- \GetSession()\ now checks if Excel process is alive before returning the batch
- \GetActiveSessions()\ filters out dead sessions and auto-cleans them
- \IsSessionAlive()\ auto-cleans dead sessions when checking
- New \CleanupDeadSession()\ helper ensures consistent cleanup
- Added \ILogger\ support for diagnostics

**ExcelBatch changes:**
- \Execute<T>()\ validates Excel process is alive before queueing operations
- Clear error message: \Excel process is no longer running for workbook 'file.xlsx'\

## Testing

- All 79 ComInterop tests pass
- Full solution builds with 0 warnings
- Pre-commit checks pass (COM leaks, coverage, smoke tests)

## User Impact

Before: Confusing timeout errors when Excel dies
After: Clear error message + ability to reopen the same file