### PR TITLE
fix: Remove RefreshTable() from PivotTable field operations (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This changelog covers all components:
 
 ## [Unreleased]
 
+### Fixed
+
+- **PivotTable RPC Disconnection** (#426): Fixed "RPC server is unavailable (0x800706BA)" error during rapid OLAP PivotTable field operations
+  - ROOT CAUSE: `RefreshTable()` called after each field operation triggered synchronous Analysis Services queries
+  - FIX: Removed RefreshTable() from field manipulation methods (AddRowField, AddColumnField, AddFilterField, RemoveField, SetFieldFunction)
+  - Field changes now take effect immediately without blocking AS queries
+  - Call `excel_pivottable(refresh)` explicitly to update visual display after configuring fields
+  - Applies to both OLAP (Data Model) and regular PivotTables for consistency
+
+## [1.6.8] - 2026-02-03
+
 ### Changed
 
 - **JSON Property Names Reverted** (#417): Removed short property name mappings for better readability

--- a/skills/shared/excel_pivottable.md
+++ b/skills/shared/excel_pivottable.md
@@ -70,6 +70,9 @@ When creating PivotTables, configure fields in order:
 2. Add Column fields: `excel_pivottable_field(AddColumnField, fieldName="Year")`  
 3. Add Value fields: `excel_pivottable_field(AddValueField, fieldName="Amount", aggregationFunction="Sum")`
 4. Add filters: `excel_pivottable_field(AddFilterField, fieldName="Status")`
+5. **Refresh to update display**: `excel_pivottable(refresh, pivotTableName="...")`
+
+**IMPORTANT**: Field operations are structural only - they modify the PivotTable layout but don't trigger visual refresh. Call `excel_pivottable(refresh)` after configuring all fields to update the display. This is especially important for OLAP/Data Model PivotTables.
 
 ### Aggregation Functions for Value Fields
 

--- a/src/ExcelMcp.Core/Commands/PivotTable/OlapPivotTableFieldStrategy.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/OlapPivotTableFieldStrategy.cs
@@ -159,8 +159,8 @@ public class OlapPivotTableFieldStrategy : IPivotTableFieldStrategy
                 cubeField.Position = (double)position.Value;
             }
 
-            // Refresh and validate
-            pivot.RefreshTable();
+            // NOTE: No RefreshTable() needed - orientation change takes effect immediately
+            // RefreshTable() causes RPC disconnection on rapid operations (issue #426)
 
             if (cubeField.Orientation != XlPivotFieldOrientation.xlRowField)
             {
@@ -215,7 +215,8 @@ public class OlapPivotTableFieldStrategy : IPivotTableFieldStrategy
                 cubeField.Position = (double)position.Value;
             }
 
-            pivot.RefreshTable();
+            // NOTE: No RefreshTable() needed - orientation change takes effect immediately
+            // RefreshTable() causes RPC disconnection on rapid operations (issue #426)
 
             if (cubeField.Orientation != XlPivotFieldOrientation.xlColumnField)
             {
@@ -521,7 +522,9 @@ public class OlapPivotTableFieldStrategy : IPivotTableFieldStrategy
             }
 
             cubeField.Orientation = XlPivotFieldOrientation.xlPageField;
-            pivot.RefreshTable();
+
+            // NOTE: No RefreshTable() needed - orientation change takes effect immediately
+            // RefreshTable() causes RPC disconnection on rapid operations (issue #426)
 
             if (cubeField.Orientation != XlPivotFieldOrientation.xlPageField)
             {
@@ -571,7 +574,9 @@ public class OlapPivotTableFieldStrategy : IPivotTableFieldStrategy
             }
 
             cubeField.Orientation = XlPivotFieldOrientation.xlHidden;
-            pivot.RefreshTable();
+
+            // NOTE: No RefreshTable() needed - orientation change takes effect immediately
+            // RefreshTable() causes RPC disconnection on rapid operations (issue #426)
 
             return new PivotFieldResult
             {
@@ -693,8 +698,8 @@ public class OlapPivotTableFieldStrategy : IPivotTableFieldStrategy
             // Update the measure's formula
             measure.Formula = newFormula;
 
-            // Refresh the PivotTable to reflect the change
-            pivot.RefreshTable();
+            // NOTE: No RefreshTable() needed - formula change takes effect immediately
+            // RefreshTable() causes RPC disconnection on rapid operations (issue #426)
 
             return new PivotFieldResult
             {

--- a/src/ExcelMcp.Core/Commands/PivotTable/RegularPivotTableFieldStrategy.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/RegularPivotTableFieldStrategy.cs
@@ -129,8 +129,8 @@ public class RegularPivotTableFieldStrategy : IPivotTableFieldStrategy
                 field.Position = (double)position.Value;
             }
 
-            // Refresh and validate
-            pivot.RefreshTable();
+            // NOTE: No RefreshTable() needed - orientation change takes effect immediately
+            // Removed for consistency with OLAP strategy and improved performance (issue #426)
 
             if (field.Orientation != XlPivotFieldOrientation.xlRowField)
             {
@@ -175,7 +175,8 @@ public class RegularPivotTableFieldStrategy : IPivotTableFieldStrategy
                 field.Position = (double)position.Value;
             }
 
-            pivot.RefreshTable();
+            // NOTE: No RefreshTable() needed - orientation change takes effect immediately
+            // Removed for consistency with OLAP strategy and improved performance (issue #426)
 
             if (field.Orientation != XlPivotFieldOrientation.xlColumnField)
             {
@@ -231,7 +232,8 @@ public class RegularPivotTableFieldStrategy : IPivotTableFieldStrategy
                 field.Caption = customName;
             }
 
-            pivot.RefreshTable();
+            // NOTE: No RefreshTable() needed - field changes take effect immediately
+            // Removed for consistency with OLAP strategy and improved performance (issue #426)
 
             return new PivotFieldResult
             {
@@ -265,7 +267,9 @@ public class RegularPivotTableFieldStrategy : IPivotTableFieldStrategy
             }
 
             field.Orientation = XlPivotFieldOrientation.xlPageField;
-            pivot.RefreshTable();
+
+            // NOTE: No RefreshTable() needed - orientation change takes effect immediately
+            // Removed for consistency with OLAP strategy and improved performance (issue #426)
 
             if (field.Orientation != XlPivotFieldOrientation.xlPageField)
             {
@@ -305,7 +309,9 @@ public class RegularPivotTableFieldStrategy : IPivotTableFieldStrategy
             }
 
             field.Orientation = XlPivotFieldOrientation.xlHidden;
-            pivot.RefreshTable();
+
+            // NOTE: No RefreshTable() needed - orientation change takes effect immediately
+            // Removed for consistency with OLAP strategy and improved performance (issue #426)
 
             return new PivotFieldResult
             {

--- a/src/ExcelMcp.McpServer/Tools/ExcelPivotTableFieldTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelPivotTableFieldTool.cs
@@ -17,6 +17,9 @@ public static partial class ExcelPivotTableFieldTool
     /// <summary>
     /// PivotTable field management: add/remove/configure fields, filtering, sorting, and grouping.
     ///
+    /// IMPORTANT: Field operations modify structure only. Call excel_pivottable(refresh) after
+    /// configuring fields to update the visual display, especially for OLAP/Data Model PivotTables.
+    ///
     /// FIELD AREAS:
     /// - Row fields: Group data by categories (add-row-field)
     /// - Column fields: Create column headers (add-column-field)

--- a/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelPivotTableTool.cs
@@ -20,6 +20,10 @@ public static partial class ExcelPivotTableTool
     /// BEST PRACTICE: Use 'list' before creating. Prefer 'refresh' or field modifications over delete+recreate.
     /// Delete+recreate loses field configurations, filters, sorting, and custom layouts.
     ///
+    /// REFRESH: Call 'refresh' after configuring fields with excel_pivottable_field to update the visual
+    /// display. This is especially important for OLAP/Data Model PivotTables where field operations
+    /// are structural only and don't automatically trigger a visual refresh.
+    ///
     /// LAYOUT (for create operations):
     /// - 0 = Compact (default - row fields in single column with indentation)
     /// - 1 = Tabular (each row field in separate column - best for export/analysis)


### PR DESCRIPTION
## Problem

When adding multiple fields to an OLAP/Data Model PivotTable in rapid succession, the operation fails with:
```
RPC server is unavailable. (0x800706BA)
```

## Root Cause

`OlapPivotTableFieldStrategy` called `pivot.RefreshTable()` after each field operation (AddRowField, AddColumnField, AddFilterField, RemoveField, SetFieldFunction). For Data Model PivotTables:

1. RefreshTable() triggers a synchronous query to the embedded Analysis Services engine
2. For large Data Models (thousands of rows), this can take several seconds
3. When operations are issued rapidly, the RPC proxy can become disconnected

## Solution

Remove RefreshTable() from field manipulation methods. Field operations are now structural only - the COM property change takes effect immediately. Call `excel_pivottable(refresh)` explicitly to update the visual display after configuring fields.

**Files Changed:**
- `OlapPivotTableFieldStrategy.cs` - Remove RefreshTable() from 5 operations
- `RegularPivotTableFieldStrategy.cs` - Same pattern for consistency
- `ExcelPivotTableTool.cs` - Add REFRESH documentation section
- `ExcelPivotTableFieldTool.cs` - Add IMPORTANT note about structural operations
- `skills/shared/excel_pivottable.md` - Add refresh workflow guidance
- `CHANGELOG.md` - Document the fix

**Exception:** RefreshTable() is kept in AddValueField when creating new DAX measures, as it's needed for the measure to appear in CubeFields.

## Workflow After Fix

```powershell
# Fast - no AS queries during field setup
excel_pivottable_field add-row-field --pivot "PT" --field "[Table].[Region]"
excel_pivottable_field add-value-field --pivot "PT" --field "[Measures].[ACR]"
excel_pivottable_field add-value-field --pivot "PT" --field "[Measures].[ACR_MoM]"

# One refresh at the end
excel_pivottable refresh --pivot "PT"
```

## Test Results

✅ 99 PivotTable tests pass

Fixes #426
