### PR TITLE
feat: switch release to workflow_dispatch with version bump UI and add stale workflow

### DIFF
--- a/.github/instructions/development-workflow.instructions.md
+++ b/.github/instructions/development-workflow.instructions.md
@@ -86,18 +86,18 @@ Quick reference:
 
 ## Release Process (Maintainers)
 
-**Tag Pattern:** `v1.2.3` - Releases ALL components with same version:
+**Release:** Use `workflow_dispatch` on the release workflow with version bump (major/minor/patch) or custom version. Releases ALL components with same version:
 - MCP Server → NuGet + ZIP
 - CLI → NuGet + ZIP
 - VS Code Extension → Marketplace + VSIX
 - MCPB → Claude Desktop bundle
 
-**Before Tagging:**
-1. Update `/CHANGELOG.md` with new version section
-2. Use format: `## [1.2.3] - YYYY-MM-DD`
-3. Release workflow auto-extracts this for GitHub Release notes
+**Before Releasing:**
+1. Ensure all changes are documented under `## [Unreleased]` in `CHANGELOG.md`
+2. Go to Actions → Release All Components → Run workflow
+3. Select version bump type (patch/minor/major) or enter a custom version
 
-Push tag → Workflow builds all 4 components → GitHub release created with all artifacts
+Workflow calculates version → builds all components → creates git tag → GitHub release with all artifacts
 
 ## Key Principles
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,10 @@ name: Release All Components
 # - MCPB (Claude Desktop bundle)
 # - Agent Skills (ZIP package)
 #
-# All components are released with the same version from a single tag.
-# Tag pattern: v1.2.3
+# All components are released with the same version.
+# Trigger: workflow_dispatch with version bump (major/minor/patch) or custom version.
+# The workflow auto-calculates the next version from the latest git tag,
+# creates the git tag after successful builds, then creates the GitHub release.
 #
 # Required GitHub Secrets:
 # - NUGET_USER: Your NuGet.org username (profile name, NOT email)
@@ -16,9 +18,21 @@ name: Release All Components
 # - APPINSIGHTS_CONNECTION_STRING: Application Insights connection string
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - major
+          - minor
+          - patch
+      custom_version:
+        description: 'Custom version (e.g., 1.2.3, overrides version_bump)'
+        required: false
+        type: string
 
 env:
   DOTNET_VERSION: '10.0.x'
@@ -26,16 +40,78 @@ env:
 
 jobs:
   # =============================================================================
+  # Job 0: Calculate Version and Create Tag
+  # =============================================================================
+  version:
+    name: Calculate Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.calculate_version.outputs.version }}
+      tag: ${{ steps.calculate_version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
+
+      - name: Calculate version
+        id: calculate_version
+        run: |
+          # If custom version is provided, use it
+          if [ -n "${{ inputs.custom_version }}" ]; then
+            VERSION="${{ inputs.custom_version }}"
+            echo "Using custom version: ${VERSION}"
+          else
+            # Get the latest tag
+            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+            echo "Latest tag: ${LATEST_TAG}"
+
+            # Remove 'v' prefix if present
+            CURRENT_VERSION="${LATEST_TAG#v}"
+            echo "Current version: ${CURRENT_VERSION}"
+
+            # Parse version components
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+            # Increment based on bump type
+            case "${{ inputs.version_bump }}" in
+              major)
+                MAJOR=$((MAJOR + 1))
+                MINOR=0
+                PATCH=0
+                ;;
+              minor)
+                MINOR=$((MINOR + 1))
+                PATCH=0
+                ;;
+              patch)
+                PATCH=$((PATCH + 1))
+                ;;
+            esac
+
+            VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            echo "New version: ${VERSION}"
+          fi
+
+          TAG="v${VERSION}"
+
+          # Check if tag already exists
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  # =============================================================================
   # Job 1: Build CLI (dependency for MCP Server)
   # =============================================================================
   build-cli:
     name: CLI (Dependency)
+    needs: [version]
     runs-on: windows-latest
     permissions:
       contents: read
-
-    outputs:
-      version: ${{ steps.version.outputs.version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -45,11 +121,9 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    - name: Extract Version
-      id: version
+    - name: Set Version
       run: |
-        $version = "${{ github.ref_name }}" -replace '^v', ''
-        echo "version=$version" >> $env:GITHUB_OUTPUT
+        $version = "${{ needs.version.outputs.version }}"
         echo "VERSION=$version" >> $env:GITHUB_ENV
       shell: pwsh
 
@@ -81,15 +155,12 @@ jobs:
   # =============================================================================
   build-mcp-server:
     name: MCP Server (Unified Package)
-    needs: [build-cli]
+    needs: [version, build-cli]
     runs-on: windows-latest
     permissions:
       contents: read
       packages: write
       id-token: write  # Required for NuGet OIDC
-
-    outputs:
-      version: ${{ steps.version.outputs.version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -105,11 +176,9 @@ jobs:
         name: cli-build
         path: src/ExcelMcp.CLI/bin/Release/net10.0-windows/
 
-    - name: Extract Version
-      id: version
+    - name: Set Version
       run: |
-        $version = "${{ github.ref_name }}" -replace '^v', ''
-        echo "version=$version" >> $env:GITHUB_OUTPUT
+        $version = "${{ needs.version.outputs.version }}"
         echo "VERSION=$version" >> $env:GITHUB_ENV
         Write-Output "Version: $version"
       shell: pwsh
@@ -190,6 +259,7 @@ jobs:
   # =============================================================================
   build-vscode:
     name: VS Code Extension
+    needs: [version]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -207,9 +277,9 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    - name: Extract Version
+    - name: Set Version
       run: |
-        $version = "${{ github.ref_name }}" -replace '^v', ''
+        $version = "${{ needs.version.outputs.version }}"
         echo "VERSION=$version" >> $env:GITHUB_ENV
       shell: pwsh
 
@@ -288,6 +358,7 @@ jobs:
   # =============================================================================
   build-mcpb:
     name: MCPB Bundle
+    needs: [version]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -300,9 +371,9 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    - name: Extract Version
+    - name: Set Version
       run: |
-        $version = "${{ github.ref_name }}" -replace '^v', ''
+        $version = "${{ needs.version.outputs.version }}"
         echo "VERSION=$version" >> $env:GITHUB_ENV
       shell: pwsh
 
@@ -325,6 +396,7 @@ jobs:
   # =============================================================================
   build-agent-skills:
     name: Agent Skills
+    needs: [version]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -337,9 +409,9 @@ jobs:
       with:
         global-json-file: global.json
 
-    - name: Extract Version
+    - name: Set Version
       run: |
-        $version = "${{ github.ref_name }}" -replace '^v', ''
+        $version = "${{ needs.version.outputs.version }}"
         echo "VERSION=$version" >> $env:GITHUB_ENV
       shell: pwsh
 
@@ -441,7 +513,7 @@ jobs:
   # =============================================================================
   publish-mcp-registry:
     name: MCP Registry
-    needs: [build-mcp-server]
+    needs: [version, build-mcp-server]
     runs-on: windows-latest
     permissions:
       id-token: write
@@ -449,9 +521,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Extract Version
+    - name: Set Version
       run: |
-        $version = "${{ github.ref_name }}" -replace '^v', ''
+        $version = "${{ needs.version.outputs.version }}"
         echo "VERSION=$version" >> $env:GITHUB_ENV
       shell: pwsh
 
@@ -511,11 +583,37 @@ jobs:
       continue-on-error: true
 
   # =============================================================================
-  # Job 7: Create Unified GitHub Release
+  # Job 7: Create Git Tag
+  # =============================================================================
+  create-tag:
+    name: Create Git Tag
+    needs: [version, build-mcp-server, build-vscode, build-mcpb, build-agent-skills]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ needs.version.outputs.tag }}"
+          echo "Creating tag: $TAG"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+  # =============================================================================
+  # Job 8: Create Unified GitHub Release
   # =============================================================================
   create-release:
     name: Create GitHub Release
-    needs: [build-mcp-server, build-vscode, build-mcpb, build-agent-skills]
+    needs: [version, create-tag]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -523,10 +621,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Extract Version
+    - name: Set Version
       run: |
-        VERSION="${GITHUB_REF_NAME#v}"
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "VERSION=${{ needs.version.outputs.version }}" >> $GITHUB_ENV
 
     - name: Download All Artifacts
       uses: actions/download-artifact@v4
@@ -562,7 +659,7 @@ jobs:
     - name: Create Release
       run: |
         VERSION=${{ env.VERSION }}
-        TAG=${{ github.ref_name }}
+        TAG=${{ needs.version.outputs.tag }}
 
         # Build release notes
         cat > release_notes.md << 'NOTES'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Run daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs within 7 days.
+            Thank you for your contributions!
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs within 7 days.
+          close-issue-message: >
+            This issue was closed because it has been stale for 7 days with no activity.
+            Feel free to reopen if this is still relevant.
+          close-pr-message: >
+            This pull request was closed because it has been stale for 7 days with no activity.
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          exempt-issue-labels: "pinned,security,bug"
+          exempt-pr-labels: "pinned,security"

--- a/docs/MCP_REGISTRY_PUBLISHING.md
+++ b/docs/MCP_REGISTRY_PUBLISHING.md
@@ -197,10 +197,11 @@ The workflow has `id-token: write` permission enabled for OIDC authentication.
 
 ### Workflow Doesn't Trigger
 
-**Issue**: Tag pushed but workflow doesn't run
+**Issue**: Release workflow doesn't run
 
 **Solution**:
-- Verify tag format is `v*` (e.g., `v1.2.3`)
+- Trigger via **Actions** → **Release All Components** → **Run workflow**
+- Select version bump type or enter custom version
 - Check that the workflow file is on the main branch
 - Look for workflow errors in GitHub Actions
 

--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -17,11 +17,11 @@ All ExcelMcp components are released together with a single version tag:
 ## Unified Release Workflow
 
 **Workflow**: `.github/workflows/release.yml`  
-**Trigger**: Tags matching `v*` (e.g., `v1.5.6`)
+**Trigger**: `workflow_dispatch` with version bump (major/minor/patch) or custom version
 
 ### What Gets Released
 
-When you push a `v*` tag:
+When you run the release workflow:
 
 1. **CLI** → Built as dependency (artifact shared with MCP Server job)
 2. **MCP Server** → Unified NuGet (`Sbroenne.ExcelMcp.McpServer` — includes CLI) + ZIP
@@ -67,17 +67,22 @@ Before creating a release tag, ensure all changes are documented under `## [Unre
 
 > **Important:** Do NOT rename `[Unreleased]` to a version number manually. The release workflow extracts content from `[Unreleased]` for release notes, then creates an auto-PR to rename it to `[X.Y.Z] - date` and add a fresh `[Unreleased]` section.
 
-### 2. Create Release Tag
+### 2. Run the Release Workflow
 
-```powershell
-# Ensure you're on main with latest changes
-git checkout main
-git pull origin main
+1. Go to **Actions** → **Release All Components** → **Run workflow**
+2. Select the version bump type:
+   - **patch** (default): `1.5.6` → `1.5.7`
+   - **minor**: `1.5.6` → `1.6.0`
+   - **major**: `1.5.6` → `2.0.0`
+3. Or enter a **custom version** (e.g., `1.5.7`) to override the bump
 
-# Create and push tag
-git tag v1.5.7
-git push origin v1.5.7
-```
+The workflow will:
+1. Calculate the next version from the latest git tag
+2. Build all components with the new version
+3. Create and push the git tag (`v1.5.7`)
+4. Publish to NuGet, VS Code Marketplace, MCP Registry
+5. Create GitHub Release with all artifacts
+6. Auto-PR to update `CHANGELOG.md`
 
 ### 3. Monitor Workflow
 

--- a/vscode-extension/DEVELOPMENT.md
+++ b/vscode-extension/DEVELOPMENT.md
@@ -281,19 +281,16 @@ npm run package
 ## Versioning
 
 **Automatic Version Management** (Recommended):
-The unified release workflow automatically updates version numbers from git tags:
+The unified release workflow automatically calculates version numbers from the latest git tag:
 
-```powershell
-# Just create and push the tag - workflow does the rest for ALL components
-git tag v1.2.3
-git push --tags
-```
+1. Go to **Actions** → **Release All Components** → **Run workflow**
+2. Select version bump type (patch/minor/major) or enter a custom version
 
 The workflow will:
-- Extract version from tag (`v1.2.3` → `1.2.3`)
+- Calculate the next version from the latest git tag
 - Update `package.json` version for VS Code extension
 - Update all component versions (MCP Server, CLI, MCPB manifest)
-- Create unified GitHub release with all artifacts
+- Create git tag and unified GitHub release with all artifacts
 
 **Manual Version Updates** (if needed):
 If you need to update the version locally before tagging:

--- a/vscode-extension/MARKETPLACE-PUBLISHING.md
+++ b/vscode-extension/MARKETPLACE-PUBLISHING.md
@@ -47,9 +47,10 @@ The release workflow requires the following secret to be configured in your GitH
 
 **Note:** The VS Code extension is now released as part of the unified release workflow (`.github/workflows/release.yml`).
 
-When you push a tag matching `v*` (e.g., `v1.5.7`):
+When you run the release workflow (via `workflow_dispatch`):
 
-1. **Extracts version from tag** and updates `package.json`
+1. **Calculates version** from latest git tag (or custom version input)
+2. **Updates `package.json`** version for VS Code extension
 2. **Updates CHANGELOG.md** with release date
 3. **Builds the extension** from source
 4. **Packages as VSIX** file


### PR DESCRIPTION
## Summary

Adopts the release workflow pattern from [pytest-aitest](https://github.com/sbroenne/pytest-aitest):

### Release Workflow Changes
- **Trigger**: Changed from tag-push (\*\) to \workflow_dispatch\ with version bump UI
- **Version bump selector**: Choose \major\, \minor\, or \patch\ (default) — or enter a custom version
- **Auto version calculation**: Reads latest git tag, increments according to bump type
- **Auto tag creation**: Creates and pushes the git tag after all builds succeed (no manual tagging needed)
- All existing release jobs preserved: CLI, MCP Server, VS Code Extension, MCPB, Agent Skills, MCP Registry, GitHub Release

### New: Stale Workflow
- Marks issues/PRs as stale after 30 days of inactivity
- Auto-closes after 7 additional days with no activity
- Exempts issues labeled \pinned\, \security\, or \ug\

### Documentation Updated
- \development-workflow.instructions.md\ — Release process instructions
- \docs/RELEASE-STRATEGY.md\ — Trigger and step-by-step process
- \scode-extension/DEVELOPMENT.md\ — Version management section
- \scode-extension/MARKETPLACE-PUBLISHING.md\ — Workflow behavior
- \docs/MCP_REGISTRY_PUBLISHING.md\ — Troubleshooting section