### PR TITLE
fix: correct MCP Server release package path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
       run: |
         $version = $env:VERSION
         New-Item -ItemType Directory -Path "release/ExcelMcp-MCP-Server-$version" -Force
-        Copy-Item "src/ExcelMcp.McpServer/bin/Release/net10.0/*" "release/ExcelMcp-MCP-Server-$version/" -Recurse
+        Copy-Item "src/ExcelMcp.McpServer/bin/Release/net10.0-windows/*" "release/ExcelMcp-MCP-Server-$version/" -Recurse
         Copy-Item "README.md" "release/ExcelMcp-MCP-Server-$version/"
         Copy-Item "LICENSE" "release/ExcelMcp-MCP-Server-$version/"
         Compress-Archive -Path "release/ExcelMcp-MCP-Server-$version/*" -DestinationPath "ExcelMcp-MCP-Server-$version-windows.zip"


### PR DESCRIPTION
The release workflow used \
et10.0\ instead of \
et10.0-windows\ for the MCP Server ZIP package path, causing the release to fail at the \Create Release Package\ step.

CLI paths were already correct (\
et10.0-windows\). One-line fix.