### PR TITLE
feat: publish CLI NuGet separately with service version negotiation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release All Components
 
 # Unified release workflow for all ExcelMcp components:
 # - MCP Server (NuGet + ZIP) - includes CLI as bundled dependency
-# - CLI (NuGet) - deprecated, points to MCP Server package
+# - CLI (NuGet) - standalone dotnet tool for coding agents
 # - VS Code Extension (VSIX + Marketplace)
 # - MCPB (Claude Desktop bundle)
 # - Agent Skills (ZIP package)
@@ -144,17 +144,26 @@ jobs:
     - name: Build CLI
       run: dotnet build src/ExcelMcp.CLI/ExcelMcp.CLI.csproj --configuration Release --no-restore
 
+    - name: Pack CLI NuGet
+      run: dotnet pack src/ExcelMcp.CLI/ExcelMcp.CLI.csproj --configuration Release --no-build --output ./cli-nupkg
+
     - name: Upload CLI Build Output
       uses: actions/upload-artifact@v4
       with:
         name: cli-build
         path: src/ExcelMcp.CLI/bin/Release/net10.0-windows/
 
+    - name: Upload CLI NuGet Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: cli-nupkg
+        path: cli-nupkg/*.nupkg
+
   # =============================================================================
-  # Job 2: Build and Publish MCP Server (includes CLI bundle)
+  # Job 2: Build MCP Server (includes CLI bundle for service)
   # =============================================================================
   build-mcp-server:
-    name: MCP Server (Unified Package)
+    name: MCP Server
     needs: [version, build-cli]
     runs-on: windows-latest
     permissions:
@@ -625,6 +634,12 @@ jobs:
         name: mcp-server-nupkg
         path: nupkg
 
+    - name: Download CLI NuGet Package
+      uses: actions/download-artifact@v4
+      with:
+        name: cli-nupkg
+        path: cli-nupkg
+
     - name: Download VS Code VSIX
       uses: actions/download-artifact@v4
       with:
@@ -645,6 +660,12 @@ jobs:
           --source https://api.nuget.org/v3/index.json `
           --skip-duplicate
         Write-Output "Published Sbroenne.ExcelMcp.McpServer.$version to NuGet.org"
+
+        dotnet nuget push "cli-nupkg/Sbroenne.ExcelMcp.CLI.$version.nupkg" `
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} `
+          --source https://api.nuget.org/v3/index.json `
+          --skip-duplicate
+        Write-Output "Published Sbroenne.ExcelMcp.CLI.$version to NuGet.org"
       shell: pwsh
 
     - name: Publish to VS Code Marketplace
@@ -729,8 +750,10 @@ jobs:
 
         **NuGet (.NET Tool)**
         ```powershell
-        # Unified Package (MCP Server + CLI)
+        # MCP Server (for AI assistants)
         dotnet tool install --global Sbroenne.ExcelMcp.McpServer
+        # CLI (for coding agents and scripting)
+        dotnet tool install --global Sbroenne.ExcelMcp.CLI
         ```
 
         **Agent Skills** (for AI coding assistants)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@ This changelog covers all components:
 
 ## [Unreleased]
 
+### Added
+
+- **Service version negotiation**: MCP Server and CLI now validate that the running service version matches the client version. On any version mismatch, the client fails with a clear error message instructing the user to restart the service. This prevents silent failures when different versions share the same service process.
+- **CLI NuGet package re-published**: The CLI is now published as a separate NuGet package (`Sbroenne.ExcelMcp.CLI`) alongside the MCP Server package. Both packages are always released with the same version.
+
 ### Changed
 
 - **Core Commands return OperationResult**: All 82 void-returning Core command methods now return `OperationResult` with `Success=true` and `FilePath`, giving LLMs confirmation metadata instead of bare `{"success": true}` responses. Affects 16 interfaces across all command domains (Range, Sheet, Table, Chart, Connection, DataModel, PowerQuery, VBA, NamedRange, ConditionalFormatting).
+- **Two NuGet packages**: MCP Server (`mcp-excel`) and CLI (`excelcli`) are separate .NET tool packages. Install both for full functionality. They must be the same version.
 
 ### Improved
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ This package provides both **CLI** and **MCP Server** interfaces. Choose based o
 
 **Manual Installation:**
 ```powershell
-# Step 1: Install the unified package (MCP Server + CLI)
+# Step 1: Install MCP Server and CLI
 dotnet tool install --global Sbroenne.ExcelMcp.McpServer
+dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 # Step 2: Auto-configure all your coding agents (requires Node.js)
 npx add-mcp "mcp-excel" --name excel-mcp

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -76,11 +76,14 @@ winget install Microsoft.DotNet.Runtime.10
 
 **Manual Download:** [.NET 10 Downloads](https://dotnet.microsoft.com/download/dotnet/10.0)
 
-### Step 2: Install ExcelMcp MCP Server
+### Step 2: Install ExcelMcp
 
 ```powershell
-# Install globally as a .NET tool
+# Install MCP Server (for AI assistants)
 dotnet tool install --global Sbroenne.ExcelMcp.McpServer
+
+# Install CLI (for coding agents and scripting)
+dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 # Verify installation
 dotnet tool list --global | Select-String "ExcelMcp"
@@ -245,17 +248,17 @@ This opens Excel visibly so you can see every change in real-time - great for de
 
 **Best for:** Scripting, RPA, CI/CD pipelines, automation without AI
 
-> **📦 Bundled with MCP Server:** The CLI (`excelcli`) is included in the unified package. Install once, get both tools!
-
-### Install Unified Package
+### Install CLI
 
 ```powershell
-# Install unified package (includes MCP Server + CLI)
-dotnet tool install --global Sbroenne.ExcelMcp.McpServer
+# Install CLI as a separate .NET tool
+dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 # Verify CLI is available
 excelcli --version
 ```
+
+> **⚠️ Version Sync Required:** MCP Server and CLI share a background service. Both packages must be the same version. Always update them together.
 
 ### Quick Test
 
@@ -313,11 +316,12 @@ excelcli --version
 
 ### Update (MCP Server + CLI)
 
-> **📦 Unified Package:** Updating the MCP Server also updates the CLI - they're bundled together!
+> **⚠️ Always update both packages together** to avoid version mismatch errors.
 
-**Step 1: Update the tool**
+**Step 1: Update both tools**
 ```powershell
 dotnet tool update --global Sbroenne.ExcelMcp.McpServer
+dotnet tool update --global Sbroenne.ExcelMcp.CLI
 ```
 
 **Step 2: Verify update**

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -149,8 +149,9 @@ This package provides both **CLI** and **MCP Server** interfaces. Choose based o
 
 **Manual Installation:**
 ```powershell
-# Step 1: Install the unified package (MCP Server + CLI)
+# Step 1: Install MCP Server and CLI
 dotnet tool install --global Sbroenne.ExcelMcp.McpServer
+dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 # Step 2: Auto-configure all your coding agents
 npx add-mcp "mcp-excel" --name excel-mcp

--- a/src/ExcelMcp.CLI/Infrastructure/ToolInstallationDetector.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/ToolInstallationDetector.cs
@@ -39,35 +39,45 @@ internal static class ToolInstallationDetector
     }
 
     /// <summary>
-    /// Gets the update command for the current installation type.
+    /// Gets the update commands for the current installation type.
+    /// Returns commands for both MCP Server and CLI packages.
     /// </summary>
     public static string GetUpdateCommand()
     {
         var installType = GetInstallationType();
-        return installType switch
-        {
-            InstallationType.Global => "dotnet tool update --global Sbroenne.ExcelMcp.CLI",
-            InstallationType.Local => "dotnet tool update Sbroenne.ExcelMcp.CLI",
-            _ => "dotnet tool update --global Sbroenne.ExcelMcp.CLI"
-        };
+        var flag = installType == InstallationType.Global ? " --global" : "";
+        return $"dotnet tool update{flag} Sbroenne.ExcelMcp.McpServer && dotnet tool update{flag} Sbroenne.ExcelMcp.CLI";
     }
 
     /// <summary>
-    /// Attempts to update the CLI tool.
+    /// Attempts to update both MCP Server and CLI tool packages.
     /// </summary>
-    /// <returns>True if update succeeded, false otherwise.</returns>
+    /// <returns>True if both updates succeeded, false otherwise.</returns>
     public static async Task<(bool Success, string Output)> TryUpdateAsync()
+    {
+        var installType = GetInstallationType();
+        var flag = installType == InstallationType.Global ? " --global" : "";
+        var packages = new[] { "Sbroenne.ExcelMcp.McpServer", "Sbroenne.ExcelMcp.CLI" };
+        var allOutput = new List<string>();
+
+        foreach (var package in packages)
+        {
+            var (success, output) = await RunUpdateCommandAsync($"tool update{flag} {package}");
+            allOutput.Add($"{package}: {(success ? "OK" : "FAILED")} - {output}");
+            if (!success)
+                return (false, string.Join("\n", allOutput));
+        }
+
+        return (true, string.Join("\n", allOutput));
+    }
+
+    private static async Task<(bool Success, string Output)> RunUpdateCommandAsync(string arguments)
     {
         try
         {
-            var command = GetUpdateCommand();
-            var parts = command.Split(' ', 2);
-            var fileName = parts[0];
-            var arguments = parts.Length > 1 ? parts[1] : string.Empty;
-
             var psi = new ProcessStartInfo
             {
-                FileName = fileName,
+                FileName = "dotnet",
                 Arguments = arguments,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -83,10 +93,9 @@ internal static class ToolInstallationDetector
             var error = await process.StandardError.ReadToEndAsync();
             await process.WaitForExitAsync();
 
-            if (process.ExitCode == 0)
-                return (true, output);
-
-            return (false, error);
+            return process.ExitCode == 0
+                ? (true, output)
+                : (false, error);
         }
         catch (Exception ex)
         {

--- a/src/ExcelMcp.ComInterop/ServiceClient/ServiceProtocol.cs
+++ b/src/ExcelMcp.ComInterop/ServiceClient/ServiceProtocol.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -10,6 +11,22 @@ namespace Sbroenne.ExcelMcp.ComInterop.ServiceClient;
 /// </summary>
 public static class ServiceProtocol
 {
+    /// <summary>
+    /// Gets the protocol version from the assembly's informational version.
+    /// Returns Major.Minor.Patch (strips build metadata if present).
+    /// </summary>
+    public static string Version { get; } = GetAssemblyVersion();
+
+    private static string GetAssemblyVersion()
+    {
+        var attr = typeof(ServiceProtocol).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        var version = attr?.InformationalVersion ?? "0.0.0";
+        // Strip build metadata (e.g., "1.7.1+abc123" → "1.7.1")
+        var plusIndex = version.IndexOf('+');
+        return plusIndex >= 0 ? version[..plusIndex] : version;
+    }
+
     /// <summary>
     /// JSON serializer options for service protocol messages.
     /// </summary>

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -329,6 +329,7 @@ public sealed class ExcelMcpService : IDisposable
         return action switch
         {
             "ping" => new ServiceResponse { Success = true },
+            "version" => HandleVersion(),
             "shutdown" => HandleShutdown(),
             "status" => HandleStatus(),
             _ => new ServiceResponse { Success = false, ErrorMessage = $"Unknown service action: {action}" }
@@ -339,6 +340,15 @@ public sealed class ExcelMcpService : IDisposable
     {
         _shutdownCts.Cancel();
         return new ServiceResponse { Success = true };
+    }
+
+    private static ServiceResponse HandleVersion()
+    {
+        return new ServiceResponse
+        {
+            Success = true,
+            Result = JsonSerializer.Serialize(new { version = ComInterop.ServiceClient.ServiceProtocol.Version }, ServiceProtocol.JsonOptions)
+        };
     }
 
     private ServiceResponse HandleStatus()

--- a/src/ExcelMcp.Service/Infrastructure/UpdateInfo.cs
+++ b/src/ExcelMcp.Service/Infrastructure/UpdateInfo.cs
@@ -31,7 +31,9 @@ public sealed class UpdateInfo
     /// </summary>
     public string GetNotificationMessage() =>
         $"Version {LatestVersion} is available (current: {CurrentVersion}).\n" +
-        "Update via: dotnet tool update --global Sbroenne.ExcelMcp.McpServer";
+        "Update both packages:\n" +
+        "dotnet tool update --global Sbroenne.ExcelMcp.McpServer\n" +
+        "dotnet tool update --global Sbroenne.ExcelMcp.CLI";
 }
 
 

--- a/tests/ExcelMcp.CLI.Tests/Integration/ServiceVersionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/ServiceVersionTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.Service;
+using SharedProtocol = Sbroenne.ExcelMcp.ComInterop.ServiceClient.ServiceProtocol;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+/// <summary>
+/// Integration tests for service version negotiation.
+/// Validates that the service reports its version and that version matching works.
+/// </summary>
+[Collection("Service")]
+[Trait("Layer", "CLI")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "ServiceVersion")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class ServiceVersionTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public ServiceVersionTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task ServiceVersion_ReturnsVersion()
+    {
+        using var client = new ServiceClient(connectTimeout: TimeSpan.FromSeconds(5));
+        var response = await client.SendAsync(
+            new Sbroenne.ExcelMcp.Service.ServiceRequest { Command = "service.version" });
+
+        _output.WriteLine($"Response: Success={response.Success}, Result={response.Result}");
+
+        Assert.True(response.Success);
+        Assert.NotNull(response.Result);
+
+        using var doc = JsonDocument.Parse(response.Result);
+        var version = doc.RootElement.GetProperty("version").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(version));
+        _output.WriteLine($"Service version: {version}");
+    }
+
+    [Fact]
+    public async Task ServiceVersion_MatchesClientVersion()
+    {
+        using var client = new ServiceClient(connectTimeout: TimeSpan.FromSeconds(5));
+        var response = await client.SendAsync(
+            new Sbroenne.ExcelMcp.Service.ServiceRequest { Command = "service.version" });
+
+        Assert.True(response.Success);
+        Assert.NotNull(response.Result);
+
+        using var doc = JsonDocument.Parse(response.Result);
+        var serviceVersion = doc.RootElement.GetProperty("version").GetString();
+        var clientVersion = SharedProtocol.Version;
+
+        _output.WriteLine($"Service: {serviceVersion}, Client: {clientVersion}");
+        Assert.Equal(clientVersion, serviceVersion);
+    }
+
+    [Fact]
+    public async Task ValidateServiceVersion_SucceedsWhenVersionsMatch()
+    {
+        // Should not throw when versions match (same build)
+        await ServiceManager.ValidateServiceVersionAsync();
+    }
+
+    [Fact]
+    public void ClientVersion_IsNotEmpty()
+    {
+        var version = SharedProtocol.Version;
+        _output.WriteLine($"Client version: {version}");
+        Assert.False(string.IsNullOrWhiteSpace(version));
+    }
+}

--- a/tests/ExcelMcp.CLI.Tests/Unit/ActionValidatorTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/ActionValidatorTests.cs
@@ -44,7 +44,7 @@ public sealed class ActionValidatorTests
         "conditionalformat",
         "vba",
         "datamodel",
-        "datamodelrel",
+        "datamodelrelationship",
         "slicer"
     ];
 

--- a/tests/ExcelMcp.ComInterop.Tests/Unit/ServiceProtocolTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Unit/ServiceProtocolTests.cs
@@ -1,0 +1,45 @@
+using Sbroenne.ExcelMcp.ComInterop.ServiceClient;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ServiceProtocol version negotiation.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "ComInterop")]
+public class ServiceProtocolTests
+{
+    [Fact]
+    public void Version_ReturnsNonEmptyString()
+    {
+        var version = ServiceProtocol.Version;
+        Assert.False(string.IsNullOrWhiteSpace(version));
+    }
+
+    [Fact]
+    public void Version_HasMajorMinorPatchFormat()
+    {
+        var version = ServiceProtocol.Version;
+        var parts = version.Split('.');
+        Assert.True(parts.Length >= 2, $"Version '{version}' should have at least Major.Minor format");
+        Assert.True(int.TryParse(parts[0], out _), $"Major version '{parts[0]}' should be numeric");
+        Assert.True(int.TryParse(parts[1], out _), $"Minor version '{parts[1]}' should be numeric");
+    }
+
+    [Fact]
+    public void Version_DoesNotContainBuildMetadata()
+    {
+        var version = ServiceProtocol.Version;
+        Assert.DoesNotContain("+", version);
+    }
+
+    [Fact]
+    public void Version_IsConsistentAcrossCalls()
+    {
+        var version1 = ServiceProtocol.Version;
+        var version2 = ServiceProtocol.Version;
+        Assert.Equal(version1, version2);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the broken 'unified package' claim. MCP Server and CLI are now published as **two separate NuGet packages** with **service version negotiation** to prevent version drift.

### Problem

- `dotnet tool install --global Sbroenne.ExcelMcp.McpServer` only registered `mcp-excel`, not `excelcli`
- .NET tool packages only support one `ToolCommandName` per package
- CLI NuGet was deprecated but users need it
- No version check between client and service — mismatched versions could cause silent failures
- Service tray update notification only updated one package

### Changes

**Service Version Negotiation:**
- Added `ServiceProtocol.Version` (from assembly informational version)
- Added `service.version` command to the named pipe protocol
- `ServiceManager.EnsureServiceRunningAsync()` now validates exact version match on first connect
- Hard fail with clear error message on any mismatch

**Release Workflow:**
- CLI NuGet package (`Sbroenne.ExcelMcp.CLI`) is now packed, uploaded as artifact, and published alongside MCP Server
- Both packages always get the same version from the unified version calculation

**Service Tray Update Notification:**
- Both `ToolInstallationDetector` classes (Service and CLI) now update BOTH packages when running `TryUpdateAsync()`
- `UpdateInfo.GetNotificationMessage()` shows both update commands
- `GetUpdateCommand()` returns combined command for both packages

**Documentation:**
- Removed misleading 'unified package' claims from INSTALLATION.md, README.md, gh-pages/index.md, release.yml
- Two install commands: `dotnet tool install --global Sbroenne.ExcelMcp.McpServer` + `dotnet tool install --global Sbroenne.ExcelMcp.CLI`
- Version sync warning in docs

**Test Fix:**
- Fixed pre-existing `ActionValidatorTests` failure: expected `datamodelrel` but generated CLI command is `datamodelrelationship`

### Test Results

- Build: 0 warnings, 0 errors
- ComInterop unit tests: 26/26 pass (4 new ServiceProtocolTests)
- CLI tests: 51/51 pass (4 new ServiceVersionTests + 1 pre-existing fix)
- All 10 pre-commit hooks pass (COM leaks, coverage, success flag, CLI smoke, MCP smoke)

### Files Changed (14)

| File | Change |
|------|--------|
| `ServiceProtocol.cs` | Added `Version` property from assembly info |
| `ExcelMcpService.cs` | Added `service.version` handler |
| `ServiceManager.cs` | Added `ValidateServiceVersionAsync()` called from `EnsureServiceRunningAsync` |
| `Service/ToolInstallationDetector.cs` | Update both packages in tray notification |
| `Service/UpdateInfo.cs` | Show both update commands in notification |
| `CLI/ToolInstallationDetector.cs` | Update both packages from CLI self-update |
| `release.yml` | CLI NuGet pack + publish, updated comments and release notes |
| `INSTALLATION.md` | Two packages, version sync warning |
| `README.md` | Two install commands |
| `gh-pages/index.md` | Two install commands |
| `CHANGELOG.md` | Documented changes |
| `ActionValidatorTests.cs` | Fixed `datamodelrel` → `datamodelrelationship` |
| `ServiceVersionTests.cs` | New: 4 integration tests for version negotiation |
| `ServiceProtocolTests.cs` | New: 4 unit tests for version property |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>