### PR TITLE
fix: enable excel-cli skill auto-loading

### DIFF
--- a/skills/excel-cli/SKILL.md
+++ b/skills/excel-cli/SKILL.md
@@ -7,7 +7,7 @@ description: >
   Triggers: Excel, spreadsheet, workbook, xlsx, excelcli, CLI automation.
 compatibility: Windows + Microsoft Excel 2016+ required. Uses COM interop - does NOT work on macOS or Linux.
 allowed-tools: Cmd(excelcli:*),PowerShell(excelcli:*)
-disable-model-invocation: true
+disable-model-invocation: false
 license: MIT
 version: 1.0.0
 repository: https://github.com/sbroenne/mcp-server-excel


### PR DESCRIPTION
## Summary

Fixes #465

The \xcel-cli\ skill was not being auto-loaded by AI coding agents because
\disable-model-invocation: true\ was set in the YAML frontmatter.

## Change

\skills/excel-cli/SKILL.md\: Changed \disable-model-invocation\ from \	rue\ to \alse\

## Impact

- Agents will now automatically discover the excel-cli skill when working with Excel files
- Both \xcel-mcp\ and \xcel-cli\ skills will be available in the skills context
- No breaking changes