### PR TITLE
fix: align SKILL.md with official Agent Skills standard

### DIFF
--- a/skills/excel-cli/SKILL.md
+++ b/skills/excel-cli/SKILL.md
@@ -5,16 +5,15 @@ description: >
   or modifying Excel workbooks from scripts, CI/CD, or coding agents.
   Supports Power Query, DAX, PivotTables, Tables, Ranges, Charts, VBA.
   Triggers: Excel, spreadsheet, workbook, xlsx, excelcli, CLI automation.
-compatibility: Windows + Microsoft Excel 2016+ required. Uses COM interop - does NOT work on macOS or Linux.
-allowed-tools: Cmd(excelcli:*),PowerShell(excelcli:*)
-disable-model-invocation: false
-license: MIT
-version: 1.0.0
-repository: https://github.com/sbroenne/mcp-server-excel
-documentation: https://excelmcpserver.dev/
 ---
 
 # Excel Automation with excelcli
+
+## Preconditions
+
+- Windows host with Microsoft Excel installed (2016+)
+- Uses COM interop — does NOT work on macOS or Linux
+- Install: `dotnet tool install --global Sbroenne.ExcelMcp.CLI`
 
 ## Workflow Checklist
 
@@ -737,25 +736,19 @@ Parameters that accept lists (e.g., `--selected-items` for slicers) require JSON
 
 ## Reference Documentation
 
-- @references/behavioral-rules.md - Core execution rules and LLM guidelines
-- @references/anti-patterns.md - Common mistakes to avoid
-- @references/workflows.md - Data Model constraints and patterns
-- @references/chart.md - Charts, positioning, and formatting
-- @references/conditionalformat.md - Conditional formatting operations
-- @references/dashboard.md - Dashboard and report best practices
-- @references/datamodel.md - Data Model/DAX specifics
-- @references/dmv-reference.md - DMV query reference for Data Model analysis
-- @references/m-code-syntax.md - Power Query M code syntax reference
-- @references/pivottable.md - PivotTable operations
-- @references/powerquery.md - Power Query specifics
-- @references/range.md - Range operations and number formats
-- @references/screenshot.md - Screenshot and visual verification
-- @references/slicer.md - Slicer operations
-- @references/table.md - Table operations
-- @references/worksheet.md - Worksheet operations
-
-## Installation
-
-```powershell
-dotnet tool install --global Sbroenne.ExcelMcp.CLI
-```
+- [Core execution rules and LLM guidelines](./references/behavioral-rules.md)
+- [Common mistakes to avoid](./references/anti-patterns.md)
+- [Data Model constraints and patterns](./references/workflows.md)
+- [Charts, positioning, and formatting](./references/chart.md)
+- [Conditional formatting operations](./references/conditionalformat.md)
+- [Dashboard and report best practices](./references/dashboard.md)
+- [Data Model/DAX specifics](./references/datamodel.md)
+- [DMV query reference for Data Model analysis](./references/dmv-reference.md)
+- [Power Query M code syntax reference](./references/m-code-syntax.md)
+- [PivotTable operations](./references/pivottable.md)
+- [Power Query specifics](./references/powerquery.md)
+- [Range operations and number formats](./references/range.md)
+- [Screenshot and visual verification](./references/screenshot.md)
+- [Slicer operations](./references/slicer.md)
+- [Table operations](./references/table.md)
+- [Worksheet operations](./references/worksheet.md)

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -5,11 +5,6 @@ description: >
   or modifying Excel workbooks. Supports Power Query (M code), Data Model (DAX measures),
   PivotTables, Tables, Ranges, Charts, Slicers, Formatting, VBA macros, connections, and calculation mode control.
   Triggers: Excel, spreadsheet, workbook, xlsx, Power Query, DAX, PivotTable, VBA.
-compatibility: Windows + Microsoft Excel 2016+ required. Uses COM interop - does NOT work on macOS or Linux.
-license: MIT
-version: 1.0.0
-repository: https://github.com/sbroenne/mcp-server-excel
-documentation: https://excelmcpserver.dev/
 ---
 
 # Excel MCP Server Skill
@@ -183,19 +178,19 @@ When writing many values/formulas (10+ cells), use `calculation_mode` to avoid r
 
 See `references/` for detailed guidance:
 
-- @references/behavioral-rules.md - Core execution rules and LLM guidelines
-- @references/anti-patterns.md - Common mistakes to avoid
-- @references/workflows.md - Data Model constraints and patterns
-- @references/chart.md - Charts and formatting
-- @references/conditionalformat.md - Conditional formatting operations
-- @references/dashboard.md - Dashboard and report best practices
-- @references/datamodel.md - Data Model/DAX specifics
-- @references/dmv-reference.md - DMV query reference for Data Model analysis
-- @references/m-code-syntax.md - Power Query M code syntax reference
-- @references/pivottable.md - PivotTable operations
-- @references/powerquery.md - Power Query specifics
-- @references/range.md - Range operations and number formats
-- @references/screenshot.md - Screenshot and visual verification
-- @references/slicer.md - Slicer operations
-- @references/table.md - Table operations
-- @references/worksheet.md - Worksheet operations
+- [Core execution rules and LLM guidelines](./references/behavioral-rules.md)
+- [Common mistakes to avoid](./references/anti-patterns.md)
+- [Data Model constraints and patterns](./references/workflows.md)
+- [Charts and formatting](./references/chart.md)
+- [Conditional formatting operations](./references/conditionalformat.md)
+- [Dashboard and report best practices](./references/dashboard.md)
+- [Data Model/DAX specifics](./references/datamodel.md)
+- [DMV query reference for Data Model analysis](./references/dmv-reference.md)
+- [Power Query M code syntax reference](./references/m-code-syntax.md)
+- [PivotTable operations](./references/pivottable.md)
+- [Power Query specifics](./references/powerquery.md)
+- [Range operations and number formats](./references/range.md)
+- [Screenshot and visual verification](./references/screenshot.md)
+- [Slicer operations](./references/slicer.md)
+- [Table operations](./references/table.md)
+- [Worksheet operations](./references/worksheet.md)

--- a/skills/templates/SKILL.cli.sbn
+++ b/skills/templates/SKILL.cli.sbn
@@ -5,16 +5,15 @@ description: >
   or modifying Excel workbooks from scripts, CI/CD, or coding agents.
   Supports Power Query, DAX, PivotTables, Tables, Ranges, Charts, VBA.
   Triggers: Excel, spreadsheet, workbook, xlsx, excelcli, CLI automation.
-compatibility: Windows + Microsoft Excel 2016+ required. Uses COM interop - does NOT work on macOS or Linux.
-allowed-tools: Cmd(excelcli:*),PowerShell(excelcli:*)
-disable-model-invocation: true
-license: MIT
-version: {{ version }}
-repository: {{ repository }}
-documentation: {{ documentation }}
 ---
 
 # Excel Automation with excelcli
+
+## Preconditions
+
+- Windows host with Microsoft Excel installed (2016+)
+- Uses COM interop — does NOT work on macOS or Linux
+- Install: `dotnet tool install --global Sbroenne.ExcelMcp.CLI`
 
 ## Workflow Checklist
 
@@ -218,25 +217,19 @@ Parameters that accept lists (e.g., `--selected-items` for slicers) require JSON
 
 ## Reference Documentation
 
-- @references/behavioral-rules.md - Core execution rules and LLM guidelines
-- @references/anti-patterns.md - Common mistakes to avoid
-- @references/workflows.md - Data Model constraints and patterns
-- @references/chart.md - Charts, positioning, and formatting
-- @references/conditionalformat.md - Conditional formatting operations
-- @references/dashboard.md - Dashboard and report best practices
-- @references/datamodel.md - Data Model/DAX specifics
-- @references/dmv-reference.md - DMV query reference for Data Model analysis
-- @references/m-code-syntax.md - Power Query M code syntax reference
-- @references/pivottable.md - PivotTable operations
-- @references/powerquery.md - Power Query specifics
-- @references/range.md - Range operations and number formats
-- @references/screenshot.md - Screenshot and visual verification
-- @references/slicer.md - Slicer operations
-- @references/table.md - Table operations
-- @references/worksheet.md - Worksheet operations
-
-## Installation
-
-```powershell
-dotnet tool install --global Sbroenne.ExcelMcp.CLI
-```
+- [Core execution rules and LLM guidelines](./references/behavioral-rules.md)
+- [Common mistakes to avoid](./references/anti-patterns.md)
+- [Data Model constraints and patterns](./references/workflows.md)
+- [Charts, positioning, and formatting](./references/chart.md)
+- [Conditional formatting operations](./references/conditionalformat.md)
+- [Dashboard and report best practices](./references/dashboard.md)
+- [Data Model/DAX specifics](./references/datamodel.md)
+- [DMV query reference for Data Model analysis](./references/dmv-reference.md)
+- [Power Query M code syntax reference](./references/m-code-syntax.md)
+- [PivotTable operations](./references/pivottable.md)
+- [Power Query specifics](./references/powerquery.md)
+- [Range operations and number formats](./references/range.md)
+- [Screenshot and visual verification](./references/screenshot.md)
+- [Slicer operations](./references/slicer.md)
+- [Table operations](./references/table.md)
+- [Worksheet operations](./references/worksheet.md)

--- a/skills/templates/SKILL.mcp.sbn
+++ b/skills/templates/SKILL.mcp.sbn
@@ -5,11 +5,6 @@ description: >
   or modifying Excel workbooks. Supports Power Query (M code), Data Model (DAX measures),
   PivotTables, Tables, Ranges, Charts, Slicers, Formatting, VBA macros, connections, and calculation mode control.
   Triggers: Excel, spreadsheet, workbook, xlsx, Power Query, DAX, PivotTable, VBA.
-compatibility: Windows + Microsoft Excel 2016+ required. Uses COM interop - does NOT work on macOS or Linux.
-license: MIT
-version: {{ version }}
-repository: {{ repository }}
-documentation: {{ documentation }}
 ---
 
 # Excel MCP Server Skill
@@ -183,19 +178,19 @@ When writing many values/formulas (10+ cells), use `calculation_mode` to avoid r
 
 See `references/` for detailed guidance:
 
-- @references/behavioral-rules.md - Core execution rules and LLM guidelines
-- @references/anti-patterns.md - Common mistakes to avoid
-- @references/workflows.md - Data Model constraints and patterns
-- @references/chart.md - Charts and formatting
-- @references/conditionalformat.md - Conditional formatting operations
-- @references/dashboard.md - Dashboard and report best practices
-- @references/datamodel.md - Data Model/DAX specifics
-- @references/dmv-reference.md - DMV query reference for Data Model analysis
-- @references/m-code-syntax.md - Power Query M code syntax reference
-- @references/pivottable.md - PivotTable operations
-- @references/powerquery.md - Power Query specifics
-- @references/range.md - Range operations and number formats
-- @references/screenshot.md - Screenshot and visual verification
-- @references/slicer.md - Slicer operations
-- @references/table.md - Table operations
-- @references/worksheet.md - Worksheet operations
+- [Core execution rules and LLM guidelines](./references/behavioral-rules.md)
+- [Common mistakes to avoid](./references/anti-patterns.md)
+- [Data Model constraints and patterns](./references/workflows.md)
+- [Charts and formatting](./references/chart.md)
+- [Conditional formatting operations](./references/conditionalformat.md)
+- [Dashboard and report best practices](./references/dashboard.md)
+- [Data Model/DAX specifics](./references/datamodel.md)
+- [DMV query reference for Data Model analysis](./references/dmv-reference.md)
+- [Power Query M code syntax reference](./references/m-code-syntax.md)
+- [PivotTable operations](./references/pivottable.md)
+- [Power Query specifics](./references/powerquery.md)
+- [Range operations and number formats](./references/range.md)
+- [Screenshot and visual verification](./references/screenshot.md)
+- [Slicer operations](./references/slicer.md)
+- [Table operations](./references/table.md)
+- [Worksheet operations](./references/worksheet.md)

--- a/src/ExcelMcp.Build.Tasks/GenerateSkillFile.cs
+++ b/src/ExcelMcp.Build.Tasks/GenerateSkillFile.cs
@@ -20,18 +20,8 @@ public class GenerateSkillFile : Microsoft.Build.Utilities.Task
     [Required]
     public string OutputPath { get; set; } = "";
 
-    /// <summary>Version number to inject into template</summary>
-    [Required]
-    public string Version { get; set; } = "";
-
     /// <summary>Path to the generated _SkillManifest.g.cs file containing JSON metadata</summary>
     public string? ManifestPath { get; set; }
-
-    /// <summary>Repository URL to inject into template</summary>
-    public string? Repository { get; set; }
-
-    /// <summary>Documentation URL to inject into template</summary>
-    public string? Documentation { get; set; }
 
     /// <summary>Executes the task to generate the skill file from the template.</summary>
     /// <returns>true if the task succeeded; otherwise, false.</returns>
@@ -92,12 +82,7 @@ public class GenerateSkillFile : Microsoft.Build.Utilities.Task
 
     private SkillTemplateModel BuildModelFromManifest()
     {
-        var model = new SkillTemplateModel
-        {
-            Version = Version,
-            Repository = Repository ?? "https://github.com/sbroenne/mcp-server-excel",
-            Documentation = Documentation ?? "https://excelmcpserver.dev/"
-        };
+        var model = new SkillTemplateModel();
 
         if (string.IsNullOrEmpty(ManifestPath) || !File.Exists(ManifestPath))
         {

--- a/src/ExcelMcp.Build.Tasks/SkillTemplateModel.cs
+++ b/src/ExcelMcp.Build.Tasks/SkillTemplateModel.cs
@@ -6,20 +6,11 @@ namespace Sbroenne.ExcelMcp.Build.Tasks;
 /// </summary>
 public class SkillTemplateModel
 {
-    /// <summary>Version from Directory.Build.props</summary>
-    public string Version { get; set; } = "";
-
     /// <summary>Number of CLI commands or MCP tools</summary>
     public int ToolCount { get; set; }
 
     /// <summary>Total number of operations/actions</summary>
     public int OperationCount { get; set; }
-
-    /// <summary>Repository URL</summary>
-    public string Repository { get; set; } = "https://github.com/sbroenne/mcp-server-excel";
-
-    /// <summary>Documentation URL</summary>
-    public string Documentation { get; set; } = "https://excelmcpserver.dev/";
 
     /// <summary>For CLI skill: parsed command reference from --help</summary>
     public List<CliCommand>? CliCommands { get; set; }

--- a/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+++ b/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
@@ -141,10 +141,7 @@
     <GenerateSkillFile
       TemplatePath="$(SkillTemplatePath)"
       OutputPath="$(SkillOutputPath)"
-      Version="$(Version)"
-      ManifestPath="$(SkillManifestPath)"
-      Repository="https://github.com/sbroenne/mcp-server-excel"
-      Documentation="https://excelmcpserver.dev/" />
+      ManifestPath="$(SkillManifestPath)" />
     <Message Text="Generated CLI Skill: $(SkillOutputPath)" Importance="high" />
   </Target>
 

--- a/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
+++ b/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
@@ -342,10 +342,7 @@ internal static class TelemetryConfig
     <GenerateSkillFile
       TemplatePath="$(SkillTemplatePath)"
       OutputPath="$(SkillOutputPath)"
-      Version="$(Version)"
-      ManifestPath="$(SkillManifestPath)"
-      Repository="https://github.com/sbroenne/mcp-server-excel"
-      Documentation="https://excelmcpserver.dev/" />
+      ManifestPath="$(SkillManifestPath)" />
     <Message Text="Generated MCP Skill: $(SkillOutputPath)" Importance="high" />
   </Target>
 


### PR DESCRIPTION
## Summary

Aligns both SKILL.md files (excel-mcp and excel-cli) with the official VS Code Agent Skills standard.

## Changes

- **Remove non-standard frontmatter fields**: compatibility, allowed-tools, license, version, repository, documentation
- **Remove \\disable-model-invocation\\ from CLI skill**: was preventing coding agents from auto-discovering the skill
- **Change reference format**: from \\@references/\\ to spec-compliant markdown links \\[desc](./references/file.md)\\
- **Add Preconditions section to CLI skill**: documents Windows/Excel requirement (replaces removed compatibility field)
- **Remove claude-desktop.md reference from MCP skill**: human setup documentation, not LLM operational guidance
- **Clean up dead build infrastructure**: remove Version, Repository, Documentation from SkillTemplateModel, GenerateSkillFile, and both .csproj files

## Files Changed (8)

- \\skills/templates/SKILL.mcp.sbn\\ - template cleanup
- \\skills/templates/SKILL.cli.sbn\\ - template cleanup + Preconditions
- \\skills/excel-mcp/SKILL.md\\ - regenerated
- \\skills/excel-cli/SKILL.md\\ - regenerated
- \\src/ExcelMcp.Build.Tasks/SkillTemplateModel.cs\\ - remove dead properties
- \\src/ExcelMcp.Build.Tasks/GenerateSkillFile.cs\\ - remove dead task properties
- \\src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj\\ - remove dead task params
- \\src/ExcelMcp.CLI/ExcelMcp.CLI.csproj\\ - remove dead task params