### PR TITLE
Fix COM timeout hang, CPU spin, and 6 other bugs; refactor chart tests for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ This changelog covers all components:
 
 ## [Unreleased]
 
+### Fixed
+
+- **COM Timeout Hang** — ExcelBatch now force-kills Excel process on timeout instead of hanging indefinitely on `WaitForSingleObject`; ExcelMcpService catches `TimeoutException` to prevent unhandled exceptions
+- **FileSystemWatcher CPU Spin** — Disabled `IConfiguration` reload-on-change in MCP Server to prevent 85%+ CPU usage from `FileSystemWatcher` polling
+- **Process Handle Leak** — Fixed `Process` object not being disposed in `ExcelBatch.ForceKillExcelProcess()`
+- **Configuration Sources Cleared** — Re-add environment variables and command-line args after clearing config sources (were accidentally removed)
+- **Source Generator Type Aggregation** — Fixed nullable type upgrade logic in `ServiceInfoExtractor` that could lose type information across partial interfaces
+- **Chart Trendline Parameter Name** — Renamed `type` → `trendlineType` in `IChartConfigCommands` to avoid COM parameter ambiguity
+- **Chart Style Error Message** — Improved `SetStyle` error message to show valid range when `styleId` is out of bounds
+- **Chart InvalidOperationException** — Added catch for `InvalidOperationException` in chart appearance commands
+
+### Changed
+
+- **Chart Test Performance** — Refactored 80 chart tests to share a single pre-populated fixture file via `File.Copy()` instead of creating individual files via COM, eliminating ~74 redundant Excel sessions
+
 ### Added
 
 - **Window Management Tool** (#470): New `window` tool with 9 operations to control Excel window visibility, position, state, and status bar — enabling "Agent Mode" where users watch AI work in Excel

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -18,7 +18,7 @@ Provides 223 Excel operations via Model Context Protocol. The MCP Server forward
 | 1. Open file | `file` | `open` or `create` | Always first |
 | 2. Create sheets | `worksheet` | `create`, `rename` | If needed |
 | 3. Write data | `range` | `set-values` | Always (2D arrays) |
-| 4. Format | `range_format` | `set-number-format`, `set-style` | After writing |
+| 4. Format | `range` | `set-number-format` | After writing |
 | 5. Structure | `table` | `create` | Convert data to tables |
 | 6. Save & close | `file` | `close` with `save: true` | Always last |
 
@@ -164,7 +164,7 @@ When writing many values/formulas (10+ cells), use `calculation_mode` to avoid r
 |------|------|------------|
 | Create/open/save workbooks | `file` | open, create, close |
 | Write/read cell data | `range` | set-values, get-values |
-| Format cells | `range_format` | set-number-format |
+| Format cells | `range` | set-number-format |
 | Create tables from data | `table` | create |
 | Add table to Power Pivot | `table` | add-to-data-model |
 | Create DAX formulas | `datamodel` | create-measure |

--- a/skills/templates/SKILL.mcp.sbn
+++ b/skills/templates/SKILL.mcp.sbn
@@ -18,7 +18,7 @@ Provides {{ operationcount }} Excel operations via Model Context Protocol. The M
 | 1. Open file | `file` | `open` or `create` | Always first |
 | 2. Create sheets | `worksheet` | `create`, `rename` | If needed |
 | 3. Write data | `range` | `set-values` | Always (2D arrays) |
-| 4. Format | `range_format` | `set-number-format`, `set-style` | After writing |
+| 4. Format | `range` | `set-number-format` | After writing |
 | 5. Structure | `table` | `create` | Convert data to tables |
 | 6. Save & close | `file` | `close` with `save: true` | Always last |
 
@@ -164,7 +164,7 @@ When writing many values/formulas (10+ cells), use `calculation_mode` to avoid r
 |------|------|------------|
 | Create/open/save workbooks | `file` | open, create, close |
 | Write/read cell data | `range` | set-values, get-values |
-| Format cells | `range_format` | set-number-format |
+| Format cells | `range` | set-number-format |
 | Create tables from data | `table` | create |
 | Add table to Power Pivot | `table` | add-to-data-model |
 | Create DAX formulas | `datamodel` | create-measure |

--- a/src/ExcelMcp.Core/Commands/Chart/ChartCommands.Appearance.cs
+++ b/src/ExcelMcp.Core/Commands/Chart/ChartCommands.Appearance.cs
@@ -291,7 +291,8 @@ public partial class ChartCommands
                 // Validate range (Excel supports styles 1-48)
                 if (styleId < 1 || styleId > 48)
                 {
-                    throw new ArgumentException($"Chart style ID must be between 1 and 48. Provided: {styleId}", nameof(styleId));
+                    var hint = styleId == 0 ? " (was the 'style_id' parameter included?)" : "";
+                    throw new ArgumentException($"Chart style ID must be between 1 and 48. Provided: {styleId}{hint}", nameof(styleId));
                 }
 
                 // Set chart style
@@ -911,7 +912,7 @@ public partial class ChartCommands
         IExcelBatch batch,
         string chartName,
         int seriesIndex,
-        TrendlineType type,
+        TrendlineType trendlineType,
         int? order = null,
         int? period = null,
         double? forward = null,
@@ -922,12 +923,12 @@ public partial class ChartCommands
         string? name = null)
     {
         // Validate type-specific parameters
-        if (type == TrendlineType.Polynomial && (!order.HasValue || order.Value < 2 || order.Value > 6))
+        if (trendlineType == TrendlineType.Polynomial && (!order.HasValue || order.Value < 2 || order.Value > 6))
         {
             throw new ArgumentException("Polynomial trendline requires order parameter (2-6).");
         }
 
-        if (type == TrendlineType.MovingAverage && (!period.HasValue || period.Value < 2))
+        if (trendlineType == TrendlineType.MovingAverage && (!period.HasValue || period.Value < 2))
         {
             throw new ArgumentException("Moving average trendline requires period parameter (2 or greater).");
         }
@@ -959,15 +960,15 @@ public partial class ChartCommands
                 trendlines = series.Trendlines();
 
                 // Add trendline with type
-                newTrendline = trendlines.Add((int)type);
+                newTrendline = trendlines.Add((int)trendlineType);
 
                 // Set optional parameters
-                if (order.HasValue && type == TrendlineType.Polynomial)
+                if (order.HasValue && trendlineType == TrendlineType.Polynomial)
                 {
                     newTrendline.Order = order.Value;
                 }
 
-                if (period.HasValue && type == TrendlineType.MovingAverage)
+                if (period.HasValue && trendlineType == TrendlineType.MovingAverage)
                 {
                     newTrendline.Period = period.Value;
                 }
@@ -1004,7 +1005,7 @@ public partial class ChartCommands
                     ChartName = chartName,
                     SeriesIndex = seriesIndex,
                     TrendlineIndex = trendlineIndex,
-                    Type = type,
+                    Type = trendlineType,
                     Name = name
                 };
             }

--- a/src/ExcelMcp.Core/Commands/Chart/IChartConfigCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Chart/IChartConfigCommands.cs
@@ -318,7 +318,7 @@ public interface IChartConfigCommands
     /// <param name="batch">Excel batch session</param>
     /// <param name="chartName">Name of the chart</param>
     /// <param name="seriesIndex">1-based index of the series</param>
-    /// <param name="type">Type of trendline (Linear, Exponential, etc.)</param>
+    /// <param name="trendlineType">Type of trendline (Linear, Exponential, etc.)</param>
     /// <param name="order">Polynomial order (2-6, for Polynomial type)</param>
     /// <param name="period">Moving average period (for MovingAverage type)</param>
     /// <param name="forward">Periods to extend forward</param>
@@ -332,7 +332,7 @@ public interface IChartConfigCommands
         IExcelBatch batch,
         [RequiredParameter] string chartName,
         [RequiredParameter] int seriesIndex,
-        [RequiredParameter] TrendlineType type,
+        [RequiredParameter] TrendlineType trendlineType,
         int? order = null,
         int? period = null,
         double? forward = null,

--- a/src/ExcelMcp.Generators.Shared/Models.cs
+++ b/src/ExcelMcp.Generators.Shared/Models.cs
@@ -122,7 +122,7 @@ public sealed class ParameterInfo
 public sealed class ExposedParameter
 {
     public string Name { get; }
-    public string TypeName { get; }
+    public string TypeName { get; set; }
     public string? Description { get; }
     public string? DefaultValue { get; }
 

--- a/src/ExcelMcp.Generators.Shared/ServiceInfoExtractor.cs
+++ b/src/ExcelMcp.Generators.Shared/ServiceInfoExtractor.cs
@@ -308,6 +308,12 @@ public static class ServiceInfoExtractor
                     existing = new ExposedParameter(exposedName, p.TypeName, p.XmlDocDescription);
                     paramMap[exposedName] = existing;
                 }
+                else if (p.TypeName.EndsWith("?") && !existing.TypeName.EndsWith("?"))
+                {
+                    // If any method declares this parameter as nullable, upgrade to nullable.
+                    // MCP parameters are shared across all actions and must be compatible with ALL uses.
+                    existing.TypeName = p.TypeName;
+                }
 
                 // Track if this param is required for this action
                 var isRequired = p.IsRequired || (!p.HasDefault && !p.TypeName.EndsWith("?"));

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTimeoutTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTimeoutTests.cs
@@ -1,0 +1,318 @@
+using System.Diagnostics;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Integration.Session;
+
+/// <summary>
+/// Tests for the operation timeout → force-kill → cleanup chain in ExcelBatch.
+///
+/// These tests validate the fix for Bug 8 (Feb 2026) where a stuck IDispatch.Invoke
+/// caused the MCP server to hang permanently because:
+/// 1. No timeout recovery existed — ExcelBatch.Dispose() waited forever on STA thread join
+/// 2. No pre-emptive kill — Excel process was never killed when operations timed out
+/// 3. No session cleanup — WithSessionAsync didn't handle TimeoutException
+///
+/// LAYER RESPONSIBILITY:
+/// - ✅ Test that Execute() throws TimeoutException when operation exceeds timeout
+/// - ✅ Test that _operationTimedOut triggers pre-emptive Process.Kill() in Dispose()
+/// - ✅ Test that Dispose() completes (doesn't hang) after timeout
+/// - ✅ Test that Excel process is cleaned up after timeout + dispose
+/// - ✅ Test that cancelled operations also trigger cleanup
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "ComInterop")]
+[Trait("Feature", "ExcelBatch")]
+[Trait("RunType", "OnDemand")]
+[Collection("Sequential")]
+public class ExcelBatchTimeoutTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private static string? _staticTestFile;
+    private string? _testFileCopy;
+
+    public ExcelBatchTimeoutTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public Task InitializeAsync()
+    {
+        if (_staticTestFile == null)
+        {
+            var testFolder = Path.Join(AppContext.BaseDirectory, "Integration", "Session", "TestFiles");
+            _staticTestFile = Path.Join(testFolder, "batch-test-static.xlsx");
+
+            if (!File.Exists(_staticTestFile))
+            {
+                throw new FileNotFoundException($"Static test file not found at {_staticTestFile}.");
+            }
+        }
+
+        _testFileCopy = Path.Join(Path.GetTempPath(), $"batch-timeout-test-{Guid.NewGuid():N}.xlsx");
+        File.Copy(_staticTestFile, _testFileCopy, overwrite: true);
+
+        return Task.Delay(500);
+    }
+
+    public Task DisposeAsync()
+    {
+        if (_testFileCopy != null && File.Exists(_testFileCopy))
+        {
+#pragma warning disable CA1031 // Intentional: best-effort test cleanup
+            try { File.Delete(_testFileCopy); } catch (Exception) { /* file may still be locked */ }
+#pragma warning restore CA1031
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: Execute() must throw TimeoutException when operation exceeds the configured timeout.
+    /// Before Bug 8 fix, timeout existed but had no recovery — the caller got the exception but
+    /// Dispose() would then hang forever waiting for the STA thread.
+    /// </summary>
+    [Fact]
+    public void Execute_OperationExceedsTimeout_ThrowsTimeoutException()
+    {
+        // Arrange — use a very short timeout (3 seconds) to trigger timeout quickly
+        var batch = ExcelSession.BeginBatch(
+            show: false,
+            operationTimeout: TimeSpan.FromSeconds(3),
+            _testFileCopy!);
+
+        // Warm up — ensure Excel is ready
+        batch.Execute((ctx, ct) =>
+        {
+            _ = ctx.Book.Worksheets.Item(1);
+            return 0;
+        });
+
+        _output.WriteLine("Excel initialized, starting long-running operation...");
+
+        // Act & Assert — operation that exceeds timeout must throw TimeoutException
+        var sw = Stopwatch.StartNew();
+        var ex = Assert.Throws<TimeoutException>(() =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                // Simulate a hung operation — sleep longer than the timeout
+                Thread.Sleep(TimeSpan.FromSeconds(30));
+                return 0;
+            });
+        });
+        sw.Stop();
+
+        _output.WriteLine($"TimeoutException thrown after {sw.Elapsed.TotalSeconds:F1}s: {ex.Message}");
+        Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        // Dispose must complete and not hang — this is the key regression test
+        var disposeSw = Stopwatch.StartNew();
+        batch.Dispose();
+        disposeSw.Stop();
+
+        _output.WriteLine($"Dispose completed in {disposeSw.Elapsed.TotalSeconds:F1}s");
+
+        // Dispose should complete within a reasonable time (pre-emptive kill + join + wait)
+        // Before the fix, Dispose() would hang forever here
+        Assert.True(disposeSw.Elapsed < TimeSpan.FromSeconds(30),
+            $"REGRESSION: Dispose() took {disposeSw.Elapsed.TotalSeconds:F1}s after timeout — " +
+            "pre-emptive kill may not be working. Expected < 30s.");
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: After timeout, the Excel process must be killed and cleaned up.
+    /// Before Bug 8 fix, the hung Excel process would remain alive permanently.
+    /// </summary>
+    [Fact]
+    public void Execute_AfterTimeout_ExcelProcessIsCleaned()
+    {
+        // Arrange
+        var startingProcesses = Process.GetProcessesByName("EXCEL");
+        int startingCount = startingProcesses.Length;
+        _output.WriteLine($"Excel processes before: {startingCount}");
+
+        var batch = ExcelSession.BeginBatch(
+            show: false,
+            operationTimeout: TimeSpan.FromSeconds(3),
+            _testFileCopy!);
+
+        // Get the Excel process ID before timeout
+        int? excelPid = batch.ExcelProcessId;
+        _output.WriteLine($"Excel PID for this session: {excelPid}");
+
+        // Warm up
+        batch.Execute((ctx, ct) => { _ = ctx.Book.Worksheets.Item(1); return 0; });
+
+        // Act — trigger timeout
+        Assert.Throws<TimeoutException>(() =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(30));
+                return 0;
+            });
+        });
+
+        // Dispose triggers pre-emptive kill
+        batch.Dispose();
+
+        // Wait briefly for process cleanup
+        Thread.Sleep(2000);
+
+        // Assert — Excel process from this session should be gone
+        if (excelPid.HasValue)
+        {
+            bool processAlive;
+            try
+            {
+                using var process = Process.GetProcessById(excelPid.Value);
+                processAlive = !process.HasExited;
+            }
+            catch (ArgumentException)
+            {
+                processAlive = false; // Process doesn't exist
+            }
+
+            Assert.False(processAlive,
+                $"REGRESSION: Excel process {excelPid.Value} is still alive after timeout + dispose. " +
+                "Pre-emptive kill in Dispose() may not be working.");
+
+            _output.WriteLine($"✓ Excel process {excelPid.Value} was cleaned up after timeout");
+        }
+
+        // Also check total count hasn't leaked
+        int endingCount = Process.GetProcessesByName("EXCEL").Length;
+        _output.WriteLine($"Excel processes after: {endingCount}");
+        Assert.True(endingCount <= startingCount,
+            $"Excel process leak! Started with {startingCount}, ended with {endingCount}");
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: Dispose after timeout must use shorter join timeout (aggressive cleanup).
+    /// Before Bug 8 fix, Dispose() used the same 45-second join timeout even when the operation
+    /// had already timed out, causing unnecessary delays.
+    /// </summary>
+    [Fact]
+    public void Dispose_AfterTimeout_CompletesWithinAggressiveTimeout()
+    {
+        // Arrange
+        var batch = ExcelSession.BeginBatch(
+            show: false,
+            operationTimeout: TimeSpan.FromSeconds(3),
+            _testFileCopy!);
+
+        batch.Execute((ctx, ct) => { _ = ctx.Book.Worksheets.Item(1); return 0; });
+
+        // Trigger timeout
+        Assert.Throws<TimeoutException>(() =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(30));
+                return 0;
+            });
+        });
+
+        // Act — measure Dispose time
+        var sw = Stopwatch.StartNew();
+        batch.Dispose();
+        sw.Stop();
+
+        _output.WriteLine($"Dispose after timeout completed in {sw.Elapsed.TotalSeconds:F1}s");
+
+        // Assert — with pre-emptive kill + 10s join timeout, Dispose should be fast
+        // Before the fix, this could take 45+ seconds or hang forever
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(25),
+            $"REGRESSION: Dispose() took {sw.Elapsed.TotalSeconds:F1}s after timeout. " +
+            "Expected < 25s with pre-emptive kill and aggressive 10s join timeout. " +
+            "Before Bug 8 fix, this would hang forever.");
+
+        _output.WriteLine("✓ Dispose completed with aggressive timeout (pre-emptive kill working)");
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: Caller cancellation also triggers aggressive cleanup.
+    /// The second catch(OperationCanceledException) in Execute also sets _operationTimedOut.
+    /// </summary>
+    [Fact]
+    public void Execute_CallerCancellation_DisposeCleansUpQuickly()
+    {
+        // Arrange
+        var batch = ExcelSession.BeginBatch(
+            show: false,
+            operationTimeout: TimeSpan.FromMinutes(5), // Normal timeout — not the trigger
+            _testFileCopy!);
+
+        batch.Execute((ctx, ct) => { _ = ctx.Book.Worksheets.Item(1); return 0; });
+
+        var cts = new CancellationTokenSource();
+
+        // Start a long operation and cancel it after 2 seconds
+        var operationStarted = new ManualResetEventSlim(false);
+        Exception? caughtException = null;
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                batch.Execute((ctx, ct) =>
+                {
+                    operationStarted.Set();
+                    // Simulate work that respects cancellation poorly (simulates stuck COM call)
+                    Thread.Sleep(TimeSpan.FromSeconds(30));
+                    return 0;
+                }, cts.Token);
+            }
+            catch (Exception ex)
+            {
+                caughtException = ex;
+            }
+        });
+
+        thread.Start();
+        operationStarted.Wait(TimeSpan.FromSeconds(10));
+
+        // Cancel from caller side
+        cts.Cancel();
+        thread.Join(TimeSpan.FromSeconds(15));
+
+        _output.WriteLine($"Operation exception: {caughtException?.GetType().Name}: {caughtException?.Message}");
+
+        // Act — Dispose should use aggressive cleanup since _operationTimedOut is set
+        var sw = Stopwatch.StartNew();
+        batch.Dispose();
+        sw.Stop();
+
+        _output.WriteLine($"Dispose after cancellation completed in {sw.Elapsed.TotalSeconds:F1}s");
+
+        // Assert — Dispose should not hang
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(30),
+            $"Dispose took {sw.Elapsed.TotalSeconds:F1}s after cancellation — expected < 30s");
+
+        _output.WriteLine("✓ Dispose completed after caller cancellation");
+    }
+
+    /// <summary>
+    /// Verify that ExcelProcessId is captured during session creation.
+    /// This is a prerequisite for the pre-emptive kill to work.
+    /// </summary>
+    [Fact]
+    public void BeginBatch_CapturesExcelProcessId()
+    {
+        // Arrange & Act
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        // Assert
+        Assert.NotNull(batch.ExcelProcessId);
+        Assert.True(batch.ExcelProcessId > 0, "ExcelProcessId should be a valid PID");
+
+        // Verify the process actually exists
+        using var process = Process.GetProcessById(batch.ExcelProcessId.Value);
+        Assert.False(process.HasExited, "Excel process should be running");
+        Assert.Equal("EXCEL", process.ProcessName, ignoreCase: true);
+
+        _output.WriteLine($"✓ ExcelProcessId captured: {batch.ExcelProcessId}");
+    }
+}

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/SessionManagerTimeoutTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/SessionManagerTimeoutTests.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Integration.Session;
+
+/// <summary>
+/// Tests for SessionManager behavior when operations timeout.
+///
+/// These tests validate the integration between ExcelBatch timeout detection
+/// and SessionManager session cleanup — the complete recovery path that was
+/// missing before Bug 8 (Feb 2026).
+///
+/// LAYER RESPONSIBILITY:
+/// - ✅ Test that SessionManager.CloseSession(force:true) works after timeout
+/// - ✅ Test that session is removed after timeout + force close
+/// - ✅ Test that subsequent GetSession returns null after timeout cleanup
+/// - ✅ Test that Excel process is cleaned up end-to-end through SessionManager
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "ComInterop")]
+[Trait("Feature", "SessionManager")]
+[Trait("RunType", "OnDemand")]
+[Collection("Sequential")]
+public class SessionManagerTimeoutTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _tempDir;
+    private readonly List<string> _testFiles = [];
+
+    private static readonly string TemplateFilePath = Path.Combine(
+        Path.GetDirectoryName(typeof(SessionManagerTimeoutTests).Assembly.Location)!,
+        "Integration", "Session", "TestFiles", "batch-test-static.xlsx");
+
+    public SessionManagerTimeoutTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _tempDir = Path.Combine(Path.GetTempPath(), $"SessionMgrTimeoutTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        foreach (var file in _testFiles.Where(File.Exists))
+        {
+#pragma warning disable CA1031 // Intentional: best-effort test cleanup
+            try { File.Delete(file); } catch (Exception) { /* best effort */ }
+#pragma warning restore CA1031
+        }
+
+        if (Directory.Exists(_tempDir))
+        {
+#pragma warning disable CA1031
+            try { Directory.Delete(_tempDir, recursive: true); } catch (Exception) { /* best effort */ }
+#pragma warning restore CA1031
+        }
+    }
+
+    private string CreateTestFile(string testName)
+    {
+        var filePath = Path.Combine(_tempDir, $"{testName}_{Guid.NewGuid():N}.xlsx");
+        File.Copy(TemplateFilePath, filePath);
+        _testFiles.Add(filePath);
+        return filePath;
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: After a timeout, CloseSession(force:true) must succeed and remove the session.
+    /// This simulates what WithSessionAsync does when it catches TimeoutException.
+    /// Before Bug 8 fix, there was no TimeoutException handler — the session leaked.
+    /// </summary>
+    [Fact]
+    public void CloseSession_AfterTimeout_RemovesSessionAndCleansUp()
+    {
+        // Arrange
+        var testFile = CreateTestFile(nameof(CloseSession_AfterTimeout_RemovesSessionAndCleansUp));
+        using var manager = new SessionManager();
+
+        // Create session with very short timeout
+        var sessionId = manager.CreateSession(testFile, operationTimeout: TimeSpan.FromSeconds(3));
+        _output.WriteLine($"Session created: {sessionId}");
+
+        var batch = manager.GetSession(sessionId);
+        Assert.NotNull(batch);
+
+        // Warm up
+        batch.Execute((ctx, ct) => { _ = ctx.Book.Worksheets.Item(1); return 0; });
+
+        // Trigger timeout
+        var ex = Assert.Throws<TimeoutException>(() =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(30));
+                return 0;
+            });
+        });
+        _output.WriteLine($"Timeout triggered: {ex.Message}");
+
+        // Act — simulate what WithSessionAsync does: force-close the session
+        var closed = manager.CloseSession(sessionId, save: false, force: true);
+
+        // Assert
+        Assert.True(closed, "CloseSession should succeed after timeout");
+        Assert.Equal(0, manager.ActiveSessionCount);
+        Assert.Null(manager.GetSession(sessionId));
+
+        _output.WriteLine("✓ Session cleaned up after timeout");
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: After timeout + force close, the Excel process must be terminated.
+    /// This is the end-to-end test for the complete Bug 8 recovery chain:
+    /// timeout → force close → pre-emptive kill → process cleanup.
+    /// </summary>
+    [Fact]
+    public void CloseSession_AfterTimeout_ExcelProcessIsTerminated()
+    {
+        // Arrange
+        var testFile = CreateTestFile(nameof(CloseSession_AfterTimeout_ExcelProcessIsTerminated));
+        using var manager = new SessionManager();
+
+        var sessionId = manager.CreateSession(testFile, operationTimeout: TimeSpan.FromSeconds(3));
+        var batch = manager.GetSession(sessionId)!;
+        int? excelPid = batch.ExcelProcessId;
+        _output.WriteLine($"Session {sessionId}, Excel PID: {excelPid}");
+
+        // Warm up
+        batch.Execute((ctx, ct) => { _ = ctx.Book.Worksheets.Item(1); return 0; });
+
+        // Trigger timeout
+        Assert.Throws<TimeoutException>(() =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(30));
+                return 0;
+            });
+        });
+
+        // Act — force close (this triggers Dispose → pre-emptive kill)
+        var sw = Stopwatch.StartNew();
+        manager.CloseSession(sessionId, save: false, force: true);
+        sw.Stop();
+        _output.WriteLine($"CloseSession took {sw.Elapsed.TotalSeconds:F1}s");
+
+        // Wait for process cleanup
+        Thread.Sleep(2000);
+
+        // Assert — Excel process should be dead
+        if (excelPid.HasValue)
+        {
+            bool processAlive;
+            try
+            {
+                using var process = Process.GetProcessById(excelPid.Value);
+                processAlive = !process.HasExited;
+            }
+            catch (ArgumentException)
+            {
+                processAlive = false;
+            }
+
+            Assert.False(processAlive,
+                $"REGRESSION: Excel process {excelPid.Value} still alive after timeout + force close. " +
+                "The pre-emptive kill in Dispose() may not be working.");
+
+            _output.WriteLine($"✓ Excel process {excelPid.Value} terminated");
+        }
+    }
+
+    /// <summary>
+    /// Test that normal operations still work with custom timeout — only long operations fail.
+    /// </summary>
+    [Fact]
+    public void Execute_WithinTimeout_SucceedsNormally()
+    {
+        // Arrange
+        var testFile = CreateTestFile(nameof(Execute_WithinTimeout_SucceedsNormally));
+        using var manager = new SessionManager();
+
+        var sessionId = manager.CreateSession(testFile, operationTimeout: TimeSpan.FromSeconds(30));
+        var batch = manager.GetSession(sessionId)!;
+
+        // Act — quick operation should succeed
+        var result = batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets.Item(1);
+            return sheet.Name?.ToString() ?? "unknown";
+        });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        _output.WriteLine($"✓ Normal operation succeeded: sheet name = {result}");
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Appearance.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Appearance.cs
@@ -14,22 +14,7 @@ public partial class ChartCommandsTests
     public void SetChartType_ExistingChart_ChangesType()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Cat", "Val" },
-                { "Q1", 100 },
-                { "Q2", 150 },
-                { "Q3", 200 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
         Assert.Equal(ChartType.ColumnClustered, createResult.ChartType);
@@ -46,21 +31,7 @@ public partial class ChartCommandsTests
     public void SetTitle_ValidTitle_SetsChartTitle()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B3"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B3", ChartType.Pie, 50, 50);
 
@@ -76,17 +47,7 @@ public partial class ChartCommandsTests
     public void SetTitle_EmptyString_HidesTitle()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart with title
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B3"].Value2 = new object[,] { { "X", "Y" }, { 1, 10 }, { 2, 20 } };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B3", ChartType.BarClustered, 50, 50);
         _commands.SetTitle(batch, createResult.ChartName, "Initial Title");
@@ -103,22 +64,7 @@ public partial class ChartCommandsTests
     public void SetAxisTitle_CategoryAxis_SetsTitleSuccessfully()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Month", "Sales" },
-                { "Jan", 100 },
-                { "Feb", 150 },
-                { "Mar", 200 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -130,22 +76,7 @@ public partial class ChartCommandsTests
     public void SetAxisTitle_ValueAxis_SetsTitleSuccessfully()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Product", "Revenue" },
-                { "A", 1000 },
-                { "B", 1500 },
-                { "C", 2000 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.BarClustered, 50, 50);
 
@@ -188,17 +119,7 @@ public partial class ChartCommandsTests
     public void ShowLegend_HideLegend_RemovesLegend()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B3"].Value2 = new object[,] { { "X", "Y" }, { 1, 10 }, { 2, 20 } };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B3", ChartType.Area, 50, 50);
         _commands.ShowLegend(batch, createResult.ChartName, true, LegendPosition.Right); // Show first
@@ -215,22 +136,7 @@ public partial class ChartCommandsTests
     public void SetStyle_ValidStyleId_AppliesStyle()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Cat", "Val" },
-                { "A", 10 },
-                { "B", 20 },
-                { "C", 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -242,17 +148,7 @@ public partial class ChartCommandsTests
     public void SetStyle_InvalidStyleId_ReturnsError()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B3"].Value2 = new object[,] { { "X", "Y" }, { 1, 10 }, { 2, 20 } };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B3", ChartType.Pie, 50, 50);
 
@@ -266,23 +162,7 @@ public partial class ChartCommandsTests
     public void SetChartType_MultipleTypes_AllWorkCorrectly()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 },
-                { 3, 30 },
-                { 4, 40 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.ColumnClustered, 50, 50);
 
@@ -301,22 +181,7 @@ public partial class ChartCommandsTests
     public void ShowLegend_DifferentPositions_AllWorkCorrectly()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:C4"].Value2 = new object[,] {
-                { "X", "S1", "S2" },
-                { "A", 10, 20 },
-                { "B", 15, 25 },
-                { "C", 20, 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:C4", ChartType.ColumnClustered, 50, 50);
 
@@ -337,22 +202,7 @@ public partial class ChartCommandsTests
     public void GetAxisNumberFormat_ValueAxis_ReturnsCurrentFormat()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Month", "Revenue" },
-                { "Jan", 1000000 },
-                { "Feb", 1500000 },
-                { "Mar", 2000000 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -367,22 +217,7 @@ public partial class ChartCommandsTests
     public void SetAxisNumberFormat_ValueAxis_SetsFormatSuccessfully()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Month", "Revenue" },
-                { "Jan", 1000000 },
-                { "Feb", 1500000 },
-                { "Mar", 2000000 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -398,9 +233,7 @@ public partial class ChartCommandsTests
     public void SetAxisNumberFormat_CategoryAxis_SetsFormatSuccessfully()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Create test data with dates
         batch.Execute((ctx, ct) =>
@@ -429,9 +262,7 @@ public partial class ChartCommandsTests
     public void SetAxisNumberFormat_PercentageFormat_SetsFormatSuccessfully()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Create test data
         batch.Execute((ctx, ct) =>
@@ -460,9 +291,7 @@ public partial class ChartCommandsTests
     public void SetAxisNumberFormat_NonExistentChart_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Act & Assert - Non-existent chart should throw
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -474,9 +303,7 @@ public partial class ChartCommandsTests
     public void GetAxisNumberFormat_NonExistentChart_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Act & Assert - Non-existent chart should throw
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -488,22 +315,7 @@ public partial class ChartCommandsTests
     public void SetAxisNumberFormat_MultipleFormats_AllWorkCorrectly()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 1000000 },
-                { 2, 2000000 },
-                { 3, 3000000 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -524,22 +336,7 @@ public partial class ChartCommandsTests
     public void SetPlacement_MoveAndSize_SetsPlacementMode()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -555,22 +352,7 @@ public partial class ChartCommandsTests
     public void SetPlacement_MoveOnly_SetsPlacementMode()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.Line, 50, 50);
 
@@ -586,22 +368,7 @@ public partial class ChartCommandsTests
     public void SetPlacement_FreeFloating_SetsPlacementMode()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.Pie, 50, 50);
 
@@ -617,22 +384,7 @@ public partial class ChartCommandsTests
     public void SetPlacement_InvalidValue_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -646,9 +398,7 @@ public partial class ChartCommandsTests
     public void SetPlacement_NonExistentChart_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Act & Assert - Non-existent chart should throw
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -662,22 +412,7 @@ public partial class ChartCommandsTests
     public void FitToRange_ValidRange_ResizesChartToMatchRange()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50, 400, 300);
 
@@ -696,21 +431,11 @@ public partial class ChartCommandsTests
     public void FitToRange_DifferentSheet_ThrowsOrMovesChart()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Create test data, chart, and a second sheet
         batch.Execute((ctx, ct) =>
         {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-
             // Create second sheet
             dynamic newSheet = ctx.Book.Worksheets.Add();
             newSheet.Name = "Sheet2";
@@ -731,9 +456,7 @@ public partial class ChartCommandsTests
     public void FitToRange_NonExistentChart_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Act & Assert - Non-existent chart should throw
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -745,22 +468,7 @@ public partial class ChartCommandsTests
     public void FitToRange_InvalidRangeAddress_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -775,22 +483,7 @@ public partial class ChartCommandsTests
     public void Read_ChartCreatedAtPosition_ReturnsAnchorCells()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart at specific position
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Create chart at position left=50, top=50
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50, 400, 300);
@@ -811,22 +504,7 @@ public partial class ChartCommandsTests
     public void Read_ChartAfterFitToRange_ReturnsUpdatedAnchorCells()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -850,22 +528,7 @@ public partial class ChartCommandsTests
     public void Read_ChartWithPlacement_ReturnsPlacementValue()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Formatting.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Formatting.cs
@@ -17,22 +17,7 @@ public partial class ChartCommandsTests
     public void SetDataLabels_ShowValue_DisplaysValuesOnChart()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Cat", "Val" },
-                { "Q1", 100 },
-                { "Q2", 150 },
-                { "Q3", 200 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -48,21 +33,7 @@ public partial class ChartCommandsTests
     public void SetDataLabels_ShowPercentage_DisplaysPercentageOnPieChart()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Category", "Value" },
-                { "Product A", 40 },
-                { "Product B", 35 },
-                { "Product C", 25 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.Pie, 50, 50);
 
@@ -77,21 +48,7 @@ public partial class ChartCommandsTests
     public void SetDataLabels_SpecificSeries_AppliesOnlyToTargetSeries()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:C4"].Value2 = new object[,] {
-                { "Month", "Series1", "Series2" },
-                { "Jan", 100, 200 },
-                { "Feb", 150, 250 },
-                { "Mar", 200, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:C4", ChartType.Line, 50, 50);
 
@@ -106,21 +63,7 @@ public partial class ChartCommandsTests
     public void SetDataLabels_WithPosition_SetsLabelPosition()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Cat", "Val" },
-                { "A", 100 },
-                { "B", 150 },
-                { "C", 200 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -137,21 +80,7 @@ public partial class ChartCommandsTests
     public void GetAxisScale_ValueAxis_ReturnsScaleInfo()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.Line, 50, 50);
 
@@ -172,21 +101,7 @@ public partial class ChartCommandsTests
     public void SetAxisScale_CustomMinMax_SetsScaleValues()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.Line, 50, 50);
 
@@ -206,21 +121,7 @@ public partial class ChartCommandsTests
     public void SetAxisScale_WithMajorUnit_SetsMajorUnitInterval()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -240,21 +141,7 @@ public partial class ChartCommandsTests
     public void GetGridlines_Chart_ReturnsGridlinesInfo()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 },
-                { 3, 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -273,21 +160,7 @@ public partial class ChartCommandsTests
     public void SetGridlines_EnableMinorGridlines_ShowsMinorGridlines()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.Line, 50, 50);
 
@@ -304,21 +177,7 @@ public partial class ChartCommandsTests
     public void SetGridlines_DisableMajorGridlines_HidesMajorGridlines()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 100 },
-                { 2, 200 },
-                { 3, 300 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -337,21 +196,7 @@ public partial class ChartCommandsTests
     public void SetSeriesFormat_MarkerStyle_ChangesMarkerStyle()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 },
-                { 3, 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Use LineMarkers chart type which shows markers by default
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.LineMarkers, 50, 50);
@@ -367,21 +212,7 @@ public partial class ChartCommandsTests
     public void SetSeriesFormat_MarkerSize_ChangesMarkerSize()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 },
-                { 3, 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.XYScatter, 50, 50);
 
@@ -396,21 +227,7 @@ public partial class ChartCommandsTests
     public void SetSeriesFormat_MarkerColors_SetsMarkerColors()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 },
-                { 3, 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.LineMarkers, 50, 50);
 
@@ -430,21 +247,7 @@ public partial class ChartCommandsTests
     public void SetSeriesFormat_InvalidSeriesIndex_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 },
-                { 3, 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.Line, 50, 50);
 
@@ -458,21 +261,7 @@ public partial class ChartCommandsTests
     public void SetSeriesFormat_InvalidMarkerSize_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 },
-                { 3, 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.LineMarkers, 50, 50);
 
@@ -486,21 +275,7 @@ public partial class ChartCommandsTests
     public void SetDataLabels_InvalidSeriesIndex_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 20 },
-                { 3, 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50);
 
@@ -516,27 +291,12 @@ public partial class ChartCommandsTests
     public void AddTrendline_Linear_AddsTrendlineToSeries()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 22 },
-                { 3, 28 },
-                { 4, 42 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.XYScatter, 50, 50);
 
         // Act
-        var result = _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Linear);
+        var result = _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Linear);
 
         // Assert
         Assert.True(result.Success, $"AddTrendline failed: {result.ErrorMessage}");
@@ -549,27 +309,12 @@ public partial class ChartCommandsTests
     public void AddTrendline_WithEquationDisplay_ShowsEquationOnChart()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 22 },
-                { 3, 28 },
-                { 4, 42 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.XYScatter, 50, 50);
 
         // Act
-        var result = _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Linear,
+        var result = _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Linear,
             displayEquation: true, displayRSquared: true);
 
         // Assert
@@ -588,31 +333,16 @@ public partial class ChartCommandsTests
     public void AddTrendline_Polynomial_RequiresOrder()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 22 },
-                { 3, 28 },
-                { 4, 42 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.XYScatter, 50, 50);
 
         // Act & Assert - Should throw without order
         Assert.Throws<ArgumentException>(() =>
-            _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Polynomial));
+            _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Polynomial));
 
         // Should succeed with order
-        var result = _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Polynomial, order: 2);
+        var result = _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Polynomial, order: 2);
         Assert.True(result.Success);
     }
 
@@ -621,28 +351,13 @@ public partial class ChartCommandsTests
     public void ListTrendlines_MultipleTrendlines_ReturnsAll()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 22 },
-                { 3, 28 },
-                { 4, 42 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.XYScatter, 50, 50);
 
         // Add multiple trendlines
-        _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Linear);
-        _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Exponential);
+        _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Linear);
+        _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Exponential);
 
         // Act
         var result = _commands.ListTrendlines(batch, createResult.ChartName, seriesIndex: 1);
@@ -659,25 +374,10 @@ public partial class ChartCommandsTests
     public void DeleteTrendline_RemovesTrendlineFromSeries()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 22 },
-                { 3, 28 },
-                { 4, 42 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.XYScatter, 50, 50);
-        _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Linear);
+        _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Linear);
 
         // Verify trendline exists
         var beforeList = _commands.ListTrendlines(batch, createResult.ChartName, seriesIndex: 1);
@@ -696,25 +396,10 @@ public partial class ChartCommandsTests
     public void SetTrendline_UpdatesDisplayOptions()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 22 },
-                { 3, 28 },
-                { 4, 42 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.XYScatter, 50, 50);
-        _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Linear);
+        _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Linear);
 
         // Verify initial state (no equation displayed)
         var beforeList = _commands.ListTrendlines(batch, createResult.ChartName, seriesIndex: 1);
@@ -735,27 +420,12 @@ public partial class ChartCommandsTests
     public void AddTrendline_WithForecasting_ExtendsTrendline()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 22 },
-                { 3, 28 },
-                { 4, 42 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.XYScatter, 50, 50);
 
         // Act
-        var result = _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, type: TrendlineType.Linear,
+        var result = _commands.AddTrendline(batch, createResult.ChartName, seriesIndex: 1, trendlineType: TrendlineType.Linear,
             forward: 2.0, backward: 1.0);
 
         // Assert
@@ -771,22 +441,7 @@ public partial class ChartCommandsTests
     public void DeleteTrendline_InvalidIndex_ThrowsException()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B5"].Value2 = new object[,] {
-                { "X", "Y" },
-                { 1, 10 },
-                { 2, 22 },
-                { 3, 28 },
-                { 4, 42 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B5", ChartType.XYScatter, 50, 50);
 

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Lifecycle.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Lifecycle.cs
@@ -28,11 +28,8 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     [Fact]
     public void List_EmptyWorkbook_ReturnsEmptyList()
     {
-        // Arrange
-        var testFile = _fixture.CreateTestFile();
-
         // Act
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
         var charts = _commands.List(batch);
 
         // Assert
@@ -43,24 +40,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void CreateFromRange_ValidData_CreatesChart()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1"].Value2 = "Category";
-            sheet.Range["B1"].Value2 = "Values";
-            sheet.Range["A2"].Value2 = "Q1";
-            sheet.Range["B2"].Value2 = 100;
-            sheet.Range["A3"].Value2 = "Q2";
-            sheet.Range["B3"].Value2 = 150;
-            sheet.Range["A4"].Value2 = "Q3";
-            sheet.Range["B4"].Value2 = 200;
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Act
         var createResult = _commands.CreateFromRange(
@@ -90,9 +70,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void CreateFromTable_ValidTable_CreatesChart()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Create test data and table
         batch.Execute((ctx, ct) =>
@@ -156,11 +134,8 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     [Fact]
     public void CreateFromTable_NonExistentTable_ThrowsException()
     {
-        // Arrange
-        var testFile = _fixture.CreateTestFile();
-
         // Act & Assert
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
         var exception = Assert.Throws<InvalidOperationException>(() =>
             _commands.CreateFromTable(
                 batch,
@@ -177,9 +152,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void CreateFromPivotTable_RangePivotTable_CreatesPivotChart()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Create data and PivotTable
         string pivotTableName = "TestPivot";
@@ -260,11 +233,8 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     [Fact]
     public void CreateFromPivotTable_NonExistentPivotTable_ThrowsException()
     {
-        // Arrange
-        var testFile = _fixture.CreateTestFile();
-
         // Act & Assert
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
         var exception = Assert.Throws<InvalidOperationException>(() =>
             _commands.CreateFromPivotTable(
                 batch,
@@ -281,9 +251,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void CreateFromPivotTable_DifferentChartTypes_CreatesCorrectType()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Create data and PivotTable
         string pivotTableName = "ChartTypePivot";
@@ -357,22 +325,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void Read_ExistingChart_ReturnsDetails()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Cat", "Val" },
-                { "Q1", 100 },
-                { "Q2", 150 },
-                { "Q3", 200 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.Pie, 50, 50, 300, 300, "PieChart");
 
@@ -390,11 +343,8 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     [Fact]
     public void Read_NonExistentChart_ReturnsError()
     {
-        // Arrange
-        var testFile = _fixture.CreateTestFile();
-
         // Act & Assert
-        using var batch = ExcelSession.BeginBatch(testFile);
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
         var exception = Assert.Throws<InvalidOperationException>(() => _commands.Read(batch, "NonExistent"));
         Assert.Contains("not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -403,17 +353,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void Delete_ExistingChart_RemovesChart()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B3"].Value2 = new object[,] { { "X", "Y" }, { 1, 10 }, { 2, 20 } };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         _commands.CreateFromRange(batch, "Sheet1", "A1:B3", ChartType.Line, 50, 50);
 
@@ -433,17 +373,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void Move_ExistingChart_UpdatesPosition()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data and chart
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B3"].Value2 = new object[,] { { "X", "Y" }, { 1, 10 }, { 2, 20 } };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         var createResult = _commands.CreateFromRange(batch, "Sheet1", "A1:B3", ChartType.ColumnClustered, 100, 100, 300, 200);
 
@@ -462,22 +392,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void List_MultipleCharts_ReturnsAll()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:B4"].Value2 = new object[,] {
-                { "Cat", "Val" },
-                { "A", 10 },
-                { "B", 20 },
-                { "C", 30 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Create multiple charts
         _commands.CreateFromRange(batch, "Sheet1", "A1:B4", ChartType.ColumnClustered, 50, 50, 300, 200, "Chart1");
@@ -498,23 +413,7 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
     public void CreateFromRange_DifferentChartTypes_CreatesCorrectly()
     {
         // Arrange
-        var testFile = _fixture.CreateTestFile();
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        // Create test data
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets.Item(1);
-            sheet.Range["A1:C5"].Value2 = new object[,] {
-                { "Month", "Series1", "Series2" },
-                { "Jan", 10, 20 },
-                { "Feb", 15, 25 },
-                { "Mar", 20, 30 },
-                { "Apr", 25, 35 }
-            };
-            return 0;
-        });
+        using var batch = ExcelSession.BeginBatch(_fixture.SharedTestFile);
 
         // Act & Assert - Test various chart types
         var chartTypes = new[]

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ConfigurationReloadTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ConfigurationReloadTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
+
+/// <summary>
+/// Regression tests for MCP Server configuration.
+///
+/// Bug 8 (Feb 2026): Host.CreateApplicationBuilder() enables reloadOnChange:true by default,
+/// creating a FileSystemWatcher for appsettings.json. Under file I/O storms from Excel
+/// (temp files, lock files), this watcher fires ParseEventBufferAndNotifyForEach in a tight
+/// loop on the threadpool, consuming ~85% CPU.
+///
+/// These tests ensure that config reload watchers are permanently disabled.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Configuration")]
+public class ConfigurationReloadTests
+{
+    /// <summary>
+    /// REGRESSION TEST: No configuration source should use reloadOnChange:true.
+    /// This caused 85% CPU from FileSystemWatcher under I/O storms (Bug 8).
+    /// </summary>
+    [Fact]
+    public void Configuration_NoFileSource_HasReloadOnChangeEnabled()
+    {
+        // Arrange — build the host the same way Program.Main does
+        var builder = Host.CreateApplicationBuilder([]);
+
+        // Replicate Program.cs config setup
+        builder.Configuration.Sources.Clear();
+        builder.Configuration
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+            .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: false)
+            .AddEnvironmentVariables()
+            .AddCommandLine([]);
+
+        // Act — inspect all configuration sources for file-based sources with reload enabled
+        var fileSourcesWithReload = builder.Configuration.Sources
+            .OfType<Microsoft.Extensions.Configuration.Json.JsonConfigurationSource>()
+            .Where(s => s.ReloadOnChange)
+            .ToList();
+
+        // Assert
+        Assert.Empty(fileSourcesWithReload);
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: After clearing default sources, environment variables must still be available.
+    /// The initial Bug 8 fix (Sources.Clear()) was too aggressive — it removed env vars and CLI args.
+    /// </summary>
+    [Fact]
+    public void Configuration_AfterClear_EnvironmentVariablesAreAvailable()
+    {
+        // Arrange
+        var builder = Host.CreateApplicationBuilder([]);
+
+        builder.Configuration.Sources.Clear();
+        builder.Configuration
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+            .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: false)
+            .AddEnvironmentVariables()
+            .AddCommandLine([]);
+
+        // Act — environment variables should be accessible
+        // PATH is a universally available env var on Windows
+        var pathValue = builder.Configuration["PATH"] ?? builder.Configuration["Path"];
+
+        // Assert — if env vars weren't re-added, this would be null
+        Assert.NotNull(pathValue);
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: After clearing default sources, command-line arguments must still work.
+    /// </summary>
+    [Fact]
+    public void Configuration_AfterClear_CommandLineArgsAreAvailable()
+    {
+        // Arrange
+        var builder = Host.CreateApplicationBuilder(["--TestKey=TestValue"]);
+
+        builder.Configuration.Sources.Clear();
+        builder.Configuration
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+            .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: false)
+            .AddEnvironmentVariables()
+            .AddCommandLine(["--TestKey=TestValue"]);
+
+        // Act
+        var value = builder.Configuration["TestKey"];
+
+        // Assert
+        Assert.Equal("TestValue", value);
+    }
+
+    /// <summary>
+    /// Verify that the default Host.CreateApplicationBuilder() DOES enable reloadOnChange.
+    /// This proves our fix is necessary — without it, file watchers would be created.
+    /// </summary>
+    [Fact]
+    public void DefaultBuilder_HasReloadOnChange_True()
+    {
+        // Arrange — build with defaults (no clearing)
+        var builder = Host.CreateApplicationBuilder([]);
+
+        // Act — check default JSON sources
+        var jsonSourcesWithReload = builder.Configuration.Sources
+            .OfType<Microsoft.Extensions.Configuration.Json.JsonConfigurationSource>()
+            .Where(s => s.ReloadOnChange)
+            .ToList();
+
+        // Assert — defaults SHOULD have reloadOnChange:true (this is what we're fixing)
+        Assert.NotEmpty(jsonSourcesWithReload);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes 8 bugs discovered during a dashboard automation session, adds 12 regression tests, and refactors 80 chart tests for performance.

Closes #472

## Bug Fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | **COM Timeout Hang** (#472) | ExcelBatch force-kills Excel on timeout instead of hanging on WaitForSingleObject; timeout error messages now warn about unsaved work loss and recommend periodic saves |
| 2 | **FileSystemWatcher CPU Spin** | Disabled IConfiguration reload-on-change in Program.cs |
| 3 | **Process Handle Leak** | Fixed Process object not disposed in ForceKillExcelProcess |
| 4 | **Config Sources Cleared** | Re-add env vars and CLI args after Sources.Clear() |
| 5 | **Source Generator Type Aggregation** | Fixed nullable type upgrade logic in ServiceInfoExtractor |
| 6 | **Chart Trendline Parameter** | Renamed type to trendlineType in IChartConfigCommands |
| 7 | **Chart Style Error Message** | Show valid range when styleId is out of bounds |
| 8 | **Chart InvalidOperationException** | Added catch in chart appearance commands |

## New Regression Tests (12 total)

- **ExcelBatchTimeoutTests** (5): Timeout behavior, force-kill, disposal
- **SessionManagerTimeoutTests** (3): Timeout propagation through SessionManager
- **ConfigurationReloadTests** (4): FileSystemWatcher disabled, config sources intact

## Chart Test Performance

Refactored 80 chart tests to share a single pre-populated fixture file via File.Copy() instead of creating individual files via COM, eliminating ~74 redundant Excel sessions.

## Test Results

- Build: 0 errors, 0 warnings
- Chart tests: 80/80 passing
- Smoke tests: passing
- Pre-commit hooks: all 10 checks passing