### PR TITLE
fix: Worksheet atomic operations and screenshot rendering

### DIFF
--- a/src/ExcelMcp.Core/Commands/Sheet/ISheetCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Sheet/ISheetCommands.cs
@@ -13,10 +13,11 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 ///
 /// POSITIONING: For 'move', 'copy-to-file', 'move-to-file' - use 'before' OR 'after'
 /// (not both) to position the sheet relative to another. If neither specified, moves to end.
+/// 
+/// NOTE: MCP tool is manually implemented in ExcelWorksheetTool.cs to properly handle
+/// mixed session requirements (copy-to-file and move-to-file are atomic and don't need sessions).
 /// </summary>
 [ServiceCategory("sheet", "Sheet")]
-[McpTool("worksheet", Title = "Worksheet Operations", Destructive = true, Category = "structure",
-    Description = "Worksheet lifecycle: create, rename, copy, delete, move. ATOMIC OPERATIONS: copy-to-file and move-to-file don't require a session (open/close automatically). POSITIONING: Use before OR after (not both) to place sheet relative to another. Use worksheet_style for tab colors and visibility.")]
 public interface ISheetCommands
 {
     // === LIFECYCLE OPERATIONS ===

--- a/src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs
@@ -1,0 +1,144 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tools;
+
+/// <summary>
+/// Excel worksheet management tool for MCP server.
+/// Handles both session-based operations (list, create, rename, delete, move, copy)
+/// and atomic cross-file operations (copy-to-file, move-to-file).
+/// </summary>
+[McpServerToolType]
+public static partial class ExcelWorksheetTool
+{
+    /// <summary>
+    /// Worksheet lifecycle: create, rename, copy, delete, move.
+    /// ATOMIC OPERATIONS: copy-to-file and move-to-file don't require a session (open/close automatically).
+    /// POSITIONING: Use before OR after (not both) to place sheet relative to another.
+    /// Use worksheet_style for tab colors and visibility.
+    /// </summary>
+    /// <param name="action">The action to perform</param>
+    /// <param name="session_id">Session ID from file 'open' action (required for: list, create, rename, delete, move, copy. Not required for: copy-to-file, move-to-file)</param>
+    /// <param name="sheet_name">Name of the worksheet (required for: create, rename, delete, move, copy)</param>
+    /// <param name="source_name">Name of the source worksheet (required for: copy)</param>
+    /// <param name="target_name">Name for the target/copied worksheet</param>
+    /// <param name="file_path">Optional file path when batch contains multiple workbooks</param>
+    /// <param name="source_file">Full path to the source workbook (required for: copy-to-file, move-to-file)</param>
+    /// <param name="source_sheet">Name of the sheet to copy (required for: copy-to-file, move-to-file)</param>
+    /// <param name="target_file">Full path to the target workbook (required for: copy-to-file, move-to-file)</param>
+    /// <param name="target_sheet_name">Optional: New name for the copied sheet (default: keeps original name)</param>
+    /// <param name="before_sheet">Optional: Position before this sheet</param>
+    /// <param name="after_sheet">Optional: Position after this sheet</param>
+    [McpServerTool(Name = "worksheet", Title = "Worksheet Operations", Destructive = true)]
+    [McpMeta("category", "structure")]
+    [McpMeta("requiresSession", false)]  // Session is optional - depends on the action
+    public static string ExcelWorksheet(
+        [Description("The action to perform")] SheetAction action,
+        [DefaultValue(null)] string? session_id,
+        [DefaultValue(null)] string? sheet_name,
+        [DefaultValue(null)] string? source_name,
+        [DefaultValue(null)] string? target_name,
+        [DefaultValue(null)] string? file_path,
+        [DefaultValue(null)] string? source_file,
+        [DefaultValue(null)] string? source_sheet,
+        [DefaultValue(null)] string? target_file,
+        [DefaultValue(null)] string? target_sheet_name,
+        [DefaultValue(null)] string? before_sheet,
+        [DefaultValue(null)] string? after_sheet)
+    {
+        return ExcelToolsBase.ExecuteToolAction(
+            "worksheet",
+            ServiceRegistry.Sheet.ToActionString(action),
+            () =>
+            {
+                // Atomic operations don't require a session
+                if (action == SheetAction.CopyToFile || action == SheetAction.MoveToFile)
+                {
+                    return action switch
+                    {
+                        SheetAction.CopyToFile =>
+                            ServiceRegistry.Sheet.RouteAction(
+                                action,
+                                "",  // No session for atomic operation
+                                ExcelToolsBase.ForwardToServiceFunc,
+                                sourceFile: source_file,
+                                sourceSheet: source_sheet,
+                                targetFile: target_file,
+                                targetSheetName: target_sheet_name,
+                                beforeSheet: before_sheet,
+                                afterSheet: after_sheet),
+                        SheetAction.MoveToFile =>
+                            ServiceRegistry.Sheet.RouteAction(
+                                action,
+                                "",  // No session for atomic operation
+                                ExcelToolsBase.ForwardToServiceFunc,
+                                sourceFile: source_file,
+                                sourceSheet: source_sheet,
+                                targetFile: target_file,
+                                beforeSheet: before_sheet,
+                                afterSheet: after_sheet),
+                        _ => throw new ArgumentException($"Unknown atomic action: {action}"),
+                    };
+                }
+
+                // Validate session_id for non-atomic operations
+                if (string.IsNullOrWhiteSpace(session_id))
+                {
+                    return JsonSerializer.Serialize(new
+                    {
+                        success = false,
+                        errorMessage = "session_id is required for this action. Use file 'open' action to start a session.",
+                        isError = true
+                    }, ExcelToolsBase.JsonOptions);
+                }
+
+                // Session-based operations
+                return action switch
+                {
+                    SheetAction.List =>
+                        ServiceRegistry.Sheet.RouteAction(
+                            action,
+                            session_id,
+                            ExcelToolsBase.ForwardToServiceFunc,
+                            filePath: file_path),
+                    SheetAction.Create =>
+                        ServiceRegistry.Sheet.RouteAction(
+                            action,
+                            session_id,
+                            ExcelToolsBase.ForwardToServiceFunc,
+                            sheetName: sheet_name,
+                            filePath: file_path),
+                    SheetAction.Rename =>
+                        ServiceRegistry.Sheet.RouteAction(
+                            action,
+                            session_id,
+                            ExcelToolsBase.ForwardToServiceFunc,
+                            oldName: sheet_name,
+                            newName: target_name),
+                    SheetAction.Delete =>
+                        ServiceRegistry.Sheet.RouteAction(
+                            action,
+                            session_id,
+                            ExcelToolsBase.ForwardToServiceFunc,
+                            sheetName: sheet_name),
+                    SheetAction.Copy =>
+                        ServiceRegistry.Sheet.RouteAction(
+                            action,
+                            session_id,
+                            ExcelToolsBase.ForwardToServiceFunc,
+                            sourceName: source_name,
+                            targetName: target_name),
+                    SheetAction.Move =>
+                        ServiceRegistry.Sheet.RouteAction(
+                            action,
+                            session_id,
+                            ExcelToolsBase.ForwardToServiceFunc,
+                            sheetName: sheet_name,
+                            beforeSheet: before_sheet,
+                            afterSheet: after_sheet),
+                    _ => throw new ArgumentException($"Unknown action: {action} ({ServiceRegistry.Sheet.ToActionString(action)})", nameof(action))
+                };
+            });
+    }
+}


### PR DESCRIPTION
## Issues Fixed

### 1. Worksheet copy-to-file Incorrectly Requires session_id
The MCP \worksheet\ tool's \copy-to-file\ action was incorrectly marked as requiring a \session_id\ parameter, even though it's an atomic operation that manages its own Excel instances internally.

### 2. Screenshots Blank/White After Save Operations
Screenshots were coming back mostly blank when taken after Save operations due to insufficient rendering delays and window focus handling.

## Root Causes

### Issue 1
Auto-generated MCP tool schema couldn't distinguish between session-based operations and atomic operations that manage their own Excel instances.

### Issue 2
The screenshot command lacked post-Save rendering delays. Excel needs time to update its rendering pipeline after Save operations, even when already visible.

## Solutions

### Issue 1: Manual ExcelWorksheetTool
- Created [ExcelWorksheetTool.cs](src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs) to manually define the worksheet MCP tool
- Intelligently routes actions:
  - **Atomic operations** (\copy-to-file\, \move-to-file\): No session validation
  - **Session-based operations** (\list\, \create\, \ename\, \delete\, \move\, \copy\): Require session_id
- Removed \[McpTool]\ attribute from \ISheetCommands\ to prevent auto-generator conflicts

### Issue 2: Enhanced Screenshot Rendering
Updated [ScreenshotCommands.cs](src/ExcelMcp.Core/Commands/Screenshot/ScreenshotCommands.cs):
- Added **500ms automatic delay** when Excel already visible (not just when making visible)
- Added **window activation** via \pp.Activate()\ for proper focus
- Increased **CopyPicture retry attempts** from 5 to 7 (up to 3.5 second timeout with exponential backoff)

## Tests Added
- New test: \WorksheetCopyToFile_WithoutSessionId_Works\ in McpServerSmokeTests
  - Validates \copy-to-file\ MCP tool works correctly without \session_id\ parameter
  - Captures data to target file successfully
  - Prevents regressions if session requirement accidentally re-introduced

## Impact
- ✅ **Atomic worksheet operations now work transparently** - No session required
- ✅ **Screenshots reliably captured after Save operations** - Built-in rendering delays
- ✅ **Fully backward compatible** - Existing code continues to work
- ✅ **No API changes** - Session-based operations unchanged

## Verification
- Full solution builds with 0 errors
- All smoke tests pass
- CLI workflow test passes
- Pre-commit checks validate:
  - ✅ No COM object leaks
  - ✅ Success flag violations checked
  - ✅ Core method coverage maintained
  - ✅ MCP-Core action consistency

## Files Changed
- \src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs\ - NEW
- \src/ExcelMcp.Core/Commands/Screenshot/ScreenshotCommands.cs\ - ENHANCED
- \src/ExcelMcp.Core/Commands/Sheet/ISheetCommands.cs\ - UPDATED
- \	ests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs\ - NEW TEST