### PR TITLE
fix: extend office.dll AssemblyResolve to search GAC and Office 365 install dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This changelog covers all components:
 
 ## [Unreleased]
 
+### Fixed
+
+- **office.dll not found when opening workbooks with connections/data model** (#487 follow-up): The `AssemblyResolve` handler only searched `AppContext.BaseDirectory` for `office.dll`. In NuGet-installed tool deployments, `office.dll` is never copied there (it is only present in local dev builds via `Directory.Build.targets`). Opening workbooks with external connections, Power Query, or a Data Model triggered code paths that caused the CLR to load `Microsoft.Office.Interop.Excel.dll`, which in turn requested `office.dll v16`. The handler returned `null` → `FileNotFoundException`. Fixed by adding fallback search order: (1) `AppContext.BaseDirectory`, (2) .NET Framework GAC v16, (3) GAC v15 (accepted by CLR as substitute), (4) Office 365 click-to-run installation directories. `Directory.Build.targets` also updated to prefer v16 GAC when available.
+
 ### Changed
 
 - **Migrated Excel COM interop to strongly-typed Microsoft Office PIA**: Replaced dynamic late-binding throughout the codebase with strongly-typed `Microsoft.Office.Interop.Excel` types for improved reliability and compile-time error detection. Power Query APIs (`Workbook.Queries`) and VBA project access remain as dynamic calls where PIA coverage is unavailable.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,9 +3,17 @@
   <!-- Copy office.dll (Microsoft.Office.Core) from the .NET Framework GAC to every project's
        output directory. Microsoft.Office.Interop.Excel.dll references office.dll, which .NET Core
        cannot find automatically in the .NET Framework GAC. office.dll is present when Office is
-       installed (required for this Windows-only COM automation project). -->
-  <Target Name="CopyOfficeDllToOutput" AfterTargets="Build"
-          Condition="Exists('C:\Windows\assembly\GAC_MSIL\office\15.0.0.0__71e9bce111e9429c\OFFICE.DLL')">
+       installed (required for this Windows-only COM automation project).
+       Prefers v16 (Office 2016+/365), falls back to v15 (Office 2013). -->
+  <Target Name="CopyOfficeDllToOutput_v16" AfterTargets="Build"
+          Condition="Exists('C:\Windows\assembly\GAC_MSIL\office\16.0.0.0__71e9bce111e9429c\OFFICE.DLL')">
+    <Copy SourceFiles="C:\Windows\assembly\GAC_MSIL\office\16.0.0.0__71e9bce111e9429c\OFFICE.DLL"
+          DestinationFiles="$(OutputPath)office.dll"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="CopyOfficeDllToOutput_v15" AfterTargets="Build"
+          Condition="!Exists('C:\Windows\assembly\GAC_MSIL\office\16.0.0.0__71e9bce111e9429c\OFFICE.DLL') AND Exists('C:\Windows\assembly\GAC_MSIL\office\15.0.0.0__71e9bce111e9429c\OFFICE.DLL')">
     <Copy SourceFiles="C:\Windows\assembly\GAC_MSIL\office\15.0.0.0__71e9bce111e9429c\OFFICE.DLL"
           DestinationFiles="$(OutputPath)office.dll"
           SkipUnchangedFiles="true" />

--- a/src/ExcelMcp.CLI/Program.cs
+++ b/src/ExcelMcp.CLI/Program.cs
@@ -142,9 +142,56 @@ internal sealed class Program
             if (!string.Equals(name.Name, "office", StringComparison.OrdinalIgnoreCase))
                 return null;
 
-            var path = Path.Combine(AppContext.BaseDirectory, "office.dll");
-            return File.Exists(path) ? Assembly.LoadFrom(path) : null;
+            return ResolveOfficeDll();
         };
+    }
+
+    /// <summary>
+    /// Resolves office.dll (Microsoft.Office.Core) from multiple locations.
+    /// office.dll is a .NET Framework GAC assembly that .NET Core cannot find automatically.
+    /// It is present when Microsoft Office is installed, but not in the .NET Core probing paths.
+    /// Search order:
+    ///   1. AppContext.BaseDirectory (copied by Directory.Build.targets in local dev builds)
+    ///   2. .NET Framework GAC - v16 then v15 (v15 is accepted by the CLR for v16 requests)
+    ///   3. Office installation directory (click-to-run Office 365 doesn't register in GAC)
+    /// </summary>
+    private static Assembly? ResolveOfficeDll()
+    {
+        // 1. Local build output (Directory.Build.targets copies office.dll here in dev builds)
+        var localPath = Path.Combine(AppContext.BaseDirectory, "office.dll");
+        if (File.Exists(localPath))
+            return Assembly.LoadFrom(localPath);
+
+        // 2. .NET Framework GAC — v16 preferred, v15 accepted (CLR honours AssemblyResolve return regardless of version)
+        string[] gacPaths =
+        [
+            @"C:\Windows\assembly\GAC_MSIL\office\16.0.0.0__71e9bce111e9429c\OFFICE.DLL",
+            @"C:\Windows\assembly\GAC_MSIL\office\15.0.0.0__71e9bce111e9429c\OFFICE.DLL",
+        ];
+        foreach (var gacPath in gacPaths)
+        {
+            if (File.Exists(gacPath))
+                return Assembly.LoadFrom(gacPath);
+        }
+
+        // 3. Office 365 click-to-run installation directories (Office registers its own copy)
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+        string[] officeDirs =
+        [
+            Path.Combine(programFiles, @"Microsoft Office\root\Office16\ADDINS\PowerPivot Excel Add-inv16"),
+            Path.Combine(programFiles, @"Microsoft Office\root\Office16\ADDINS\PowerPivot Excel Add-in"),
+            Path.Combine(programFilesX86, @"Microsoft Office\root\Office16\ADDINS\PowerPivot Excel Add-inv16"),
+            Path.Combine(programFilesX86, @"Microsoft Office\root\Office16\ADDINS\PowerPivot Excel Add-in"),
+        ];
+        foreach (var dir in officeDirs)
+        {
+            var officePath = Path.Combine(dir, "OFFICE.dll");
+            if (File.Exists(officePath))
+                return Assembly.LoadFrom(officePath);
+        }
+
+        return null;
     }
 
     private static void RenderHeader()


### PR DESCRIPTION
## Summary

Fixes the lingering crash from #487. The v1.8.5 \(object)\ cast fix prevented one static \MsoAutomationSecurity\ reference, but \Microsoft.Office.Interop.Excel.dll\ (which IS deployed in the NuGet tool) still depends on \office.dll\ v16 at runtime. When workbooks with **Power Query connections or a Data Model** are opened, the CLR loads deeper PIA type metadata and hits the missing assembly, crashing the service.

## Root Cause

The \AssemblyResolve\ handler in both CLI and McpServer only checked \AppContext.BaseDirectory/office.dll\ — present on dev machines via \Directory.Build.targets\, but absent in NuGet tool installs. The handler returned \
ull\, causing a \FileNotFoundException\ (process exit code 3762504530).

## Fix

Extended the resolver to a 4-step fallback chain:
1. \AppContext.BaseDirectory/office.dll\ — dev builds
2. GAC v16 (\16.0.0.0\) — Office 365 on-demand install  
3. GAC v15 (\15.0.0.0\) — older Office installs
4. Office 365 click-to-run ADDINS dirs — when not in GAC

Also updated \Directory.Build.targets\ to prefer v16 over v15 when copying \office.dll\ to output in local dev builds.

## Verification

Tested locally with \MSXI Baseline.xlsx\ (Power BI XMLA connection + Power Query + Data Model) — session opens successfully with the patched build. Previously crashed on every attempt with this file.