### PR TITLE
fix: add pull-requests write permission for changelog PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -685,6 +685,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Bug Fix: Release Workflow CHANGELOG PR

### Problem
The \create-release\ job's post-release step (creating a PR to rename \[Unreleased]\ in CHANGELOG.md) has been failing since the workflow was introduced with:
\\\
GraphQL: Resource not accessible by integration (createPullRequest)
\\\
This left 17 orphaned \chore/changelog-v*\ branches on the remote (manually cleaned up in this session).

### Root Cause
The \create-release\ job only had \contents: write\ permission. Creating a pull request via the GitHub API requires \pull-requests: write\ as a separate permission.

### Fix
Added \pull-requests: write\ to the \create-release\ job permissions block.

### Branches Cleaned Up
All 17 orphaned \chore/changelog-v*\ branches (v1.6.10 through v1.8.8) deleted from remote.

### Backwards Compatibility
No breaking changes — the release workflow behavior is otherwise identical.