### PR TITLE
fix: bump engines.vscode to match @types/vscode ^1.109.0

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://excelmcpserver.dev/",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.106.0"
+    "vscode": "^1.109.0"
   },
   "os": [
     "win32"


### PR DESCRIPTION
The devDependency @types/vscode was bumped to ^1.109.0 but engines.vscode was left at ^1.106.0. vsce packaging fails with: @types/vscode ^1.109.0 greater than engines.vscode ^1.106.0.