### PR TITLE
fix: quote sheet names in chart/pivot source refs, improve rename param docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to ExcelMcp will be documented in this file.
 - Enhanced daemon security with SID validation and `CurrentUserOnly` pipe access
 
 ### Fixed
+- **Chart `create-from-range`** (#512): sheet names with spaces or special characters now quoted in source data reference — fixes COM error when source sheet name contains spaces
+- **PivotTable `create-from-range`** (#512): same quoting fix for pivot cache source data reference
+- **Worksheet `rename`** (#513): `target_name` parameter description now mentions rename action, improving LLM discoverability
 - Standardized all data operation timeouts to 30 minutes via `ComInteropConstants.DataOperationTimeout`
   - Power Query `load-to` increased from 5 min to 30 min
   - Connection `refresh` and `load-to` increased from 5 min to 30 min

--- a/skills/excel-cli/SKILL.md
+++ b/skills/excel-cli/SKILL.md
@@ -429,7 +429,7 @@ PivotTable field management: add/remove/configure fields, filtering, sorting, an
 
 ### powerquery
 
-Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACTICE): 1. evaluate - Test M code WITHOUT persisting (catches syntax errors, validates sources, shows data preview) 2. create/update - Store VALIDATED query in workbook 3. refresh/load-to - Load data to destination Skip evaluate only for trivial literal tables. IF CREATE/UPDATE FAILS: Use evaluate to get the actual M engine error message, fix code, retry. DATETIME COLUMNS: Always include Table.TransformColumnTypes() in M code to set column types explicitly. Without explicit types, dates may be stored as numbers and Data Model relationships may fail. DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'. Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60. timeout=0 or omitted uses the 30 min default.
+Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACTICE): 1. evaluate - Test M code WITHOUT persisting (catches syntax errors, validates sources, shows data preview) 2. create/update - Store VALIDATED query in workbook 3. refresh/load-to - Load data to destination Skip evaluate only for trivial literal tables. IF CREATE/UPDATE FAILS: Use evaluate to get the actual M engine error message, fix code, retry. DATETIME COLUMNS: Always include Table.TransformColumnTypes() in M code to set column types explicitly. Without explicit types, dates may be stored as numbers and Data Model relationships may fail. DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'. Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60 or similar. timeout=0 or omitted uses the 30 min default.
 
 **Actions:** `list`, `view`, `refresh`, `get-load-config`, `delete`, `create`, `update`, `load-to`, `refresh-all`, `rename`, `unload`, `evaluate`
 
@@ -720,11 +720,11 @@ Control Excel window visibility, position, state, and status bar. Use to show/hi
 
 ### --timeout Must Be Greater Than Zero
 
-When using `--timeout`, the value must be a positive integer (seconds). `--timeout 0` is invalid and will error. Omit `--timeout` entirely to use the default (1800 seconds / 30 min for all data operations).
+When using `--timeout`, the value must be a positive integer (seconds). `--timeout 0` is invalid and will error. Omit `--timeout` entirely to use the default (300 seconds for most operations).
 
 ### Power Query Operations Are Slow
 
-`powerquery create`, `powerquery refresh`, and `powerquery evaluate` may take 30+ seconds depending on data volume. Either omit `--timeout` (uses 30-minute default) or set a shorter value like `--timeout 120` for quick queries.
+`powerquery create`, `powerquery refresh`, and `powerquery evaluate` may take 30+ seconds depending on data volume. Either omit `--timeout` (uses 5-minute default) or set a generous value like `--timeout 120`.
 
 ### JSON Values Format
 

--- a/src/ExcelMcp.Core/Commands/Chart/ChartCommands.Lifecycle.cs
+++ b/src/ExcelMcp.Core/Commands/Chart/ChartCommands.Lifecycle.cs
@@ -227,9 +227,10 @@ public partial class ChartCommands : IChartCommands, IChartConfigCommands
                 {
                     // Get the range object from the address string
                     // If sourceRangeAddress doesn't include sheet name, prefix it
+                    // Sheet names with spaces or special characters must be quoted: 'Sheet Name'!A1:D6
                     string fullRangeAddress = sourceRangeAddress.Contains('!')
                         ? sourceRangeAddress
-                        : $"{sheetName}!{sourceRangeAddress}";
+                        : $"'{sheetName}'!{sourceRangeAddress}";
                     sourceRangeObj = ctx.Book.Application.Range[fullRangeAddress];
                     try
                     {

--- a/src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.Create.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.Create.cs
@@ -42,7 +42,8 @@ public partial class PivotTableCommands
             // STEP 2: Create PivotCache from source range
             // VBA: Set pivot_cache = activeWorkbook.PivotCaches.Create(SourceType:=xlDatabase, SourceData:="csv_data", Version:=xlPivotTableVersion14)
             pivotCaches = ctx.Book.PivotCaches();
-            string sourceDataRef = $"{sourceSheet}!{sourceRange}";
+            // Sheet names with spaces or special characters must be quoted: 'Sheet Name'!A1:D6
+            string sourceDataRef = $"'{sourceSheet}'!{sourceRange}";
 
             // xlDatabase = 1, xlPivotTableVersion14 = 4
             pivotCache = pivotCaches.Create(

--- a/src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs
@@ -22,7 +22,7 @@ public static partial class ExcelWorksheetTool
     /// <param name="session_id">Session ID from file 'open' action (required for: list, create, rename, delete, move, copy. Not required for: copy-to-file, move-to-file)</param>
     /// <param name="sheet_name">Name of the worksheet (required for: create, rename, delete, move, copy)</param>
     /// <param name="source_name">Name of the source worksheet (required for: copy)</param>
-    /// <param name="target_name">Name for the target/copied worksheet</param>
+    /// <param name="target_name">New name for the worksheet (required for: rename, copy)</param>
     /// <param name="file_path">Optional file path when batch contains multiple workbooks</param>
     /// <param name="source_file">Full path to the source workbook (required for: copy-to-file, move-to-file)</param>
     /// <param name="source_sheet">Name of the sheet to copy (required for: copy-to-file, move-to-file)</param>

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.BugRegression.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.BugRegression.cs
@@ -1,0 +1,237 @@
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Chart;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands;
+
+/// <summary>
+/// Regression tests for Bug Report 2026-02-23.
+/// Bug 1: chart(action: 'create-from-range') fails with COM error 0x800A03EC
+/// when data is not at row 1 or sheet name contains spaces.
+/// </summary>
+public partial class ChartCommandsTests
+{
+    /// <summary>
+    /// Regression: create-from-range fails when data starts at a non-first row (e.g., A9:D14).
+    /// The user reported COM error 0x800A03EC when creating a Line chart from A9:D14.
+    /// This reproduces the exact scenario from the bug report.
+    /// </summary>
+    [Fact]
+    public void CreateFromRange_DataAtNonFirstRow_CreatesChart()
+    {
+        // Arrange — isolated file with data only at A9:D14 (rows 1-8 empty)
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Write data at A9:D14 (6 rows: 1 header + 5 data)
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            try
+            {
+                sheet = ctx.Book.Worksheets[1];
+                sheet.Range["A9:D14"].Value2 = new object[,]
+                {
+                    { "Quarter", "Revenue", "Cost", "Profit" },
+                    { "Q1", 1200, 800, 400 },
+                    { "Q2", 1500, 900, 600 },
+                    { "Q3", 1800, 1000, 800 },
+                    { "Q4", 2100, 1100, 1000 },
+                    { "Q5", 2400, 1200, 1200 }
+                };
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheet);
+            }
+        });
+
+        // Act — create Line chart from A9:D14 (exactly as reported)
+        var result = _commands.CreateFromRange(
+            batch,
+            "Sheet1",
+            "A9:D14",
+            ChartType.Line,
+            50, 50, 400, 300,
+            "BugRegression_NonFirstRow");
+
+        // Assert
+        Assert.True(result.Success, $"CreateFromRange failed: chart was not created");
+        Assert.Equal("BugRegression_NonFirstRow", result.ChartName);
+        Assert.Equal(ChartType.Line, result.ChartType);
+
+        // Verify chart actually exists in workbook
+        var charts = _commands.List(batch);
+        Assert.Contains(charts, c => c.Name == "BugRegression_NonFirstRow");
+    }
+
+    /// <summary>
+    /// Regression: create-from-range fails when sheet name contains spaces.
+    /// The range address is constructed as "{sheetName}!{rangeAddress}" but Excel COM
+    /// requires single quotes around sheet names with spaces: "'Sheet Name'!A1:D6".
+    /// Without quoting, Application.Range["Deal Summary!A9:D14"] throws 0x800A03EC.
+    /// </summary>
+    [Fact]
+    public void CreateFromRange_SheetNameWithSpaces_CreatesChart()
+    {
+        // Arrange — create a sheet with spaces in name
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheets = null;
+            dynamic? newSheet = null;
+            try
+            {
+                sheets = ctx.Book.Worksheets;
+                newSheet = sheets.Add();
+                newSheet.Name = "Deal Summary";
+                newSheet.Range["A1:D6"].Value2 = new object[,]
+                {
+                    { "Product", "Q1", "Q2", "Q3" },
+                    { "Widget A", 100, 150, 200 },
+                    { "Widget B", 200, 250, 300 },
+                    { "Widget C", 300, 350, 400 },
+                    { "Widget D", 400, 450, 500 },
+                    { "Widget E", 500, 550, 600 }
+                };
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref newSheet);
+                ComUtilities.Release(ref sheets);
+            }
+        });
+
+        // Act — create chart on sheet with spaces in name
+        var result = _commands.CreateFromRange(
+            batch,
+            "Deal Summary",
+            "A1:D6",
+            ChartType.Line,
+            50, 50, 400, 300,
+            "BugRegression_SpacesInName");
+
+        // Assert
+        Assert.True(result.Success, $"CreateFromRange failed for sheet with spaces in name");
+        Assert.Equal("BugRegression_SpacesInName", result.ChartName);
+        Assert.Equal("Deal Summary", result.SheetName);
+    }
+
+    /// <summary>
+    /// Regression: Combined scenario — sheet name with spaces AND data at non-first row.
+    /// This is the exact scenario from the Bayer AG deal sizing bug report.
+    /// </summary>
+    [Fact]
+    public void CreateFromRange_SheetWithSpacesAndDataAtNonFirstRow_CreatesChart()
+    {
+        // Arrange
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheets = null;
+            dynamic? newSheet = null;
+            try
+            {
+                sheets = ctx.Book.Worksheets;
+                newSheet = sheets.Add();
+                newSheet.Name = "Export Data";
+                // Data starts at row 9, like the bug report
+                newSheet.Range["A9:D14"].Value2 = new object[,]
+                {
+                    { "Service", "Current", "Proposed", "Delta" },
+                    { "Compute", 50000, 45000, -5000 },
+                    { "Storage", 20000, 18000, -2000 },
+                    { "Network", 15000, 14000, -1000 },
+                    { "Database", 30000, 25000, -5000 },
+                    { "AI/ML", 10000, 12000, 2000 }
+                };
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref newSheet);
+                ComUtilities.Release(ref sheets);
+            }
+        });
+
+        // Act
+        var result = _commands.CreateFromRange(
+            batch,
+            "Export Data",
+            "A9:D14",
+            ChartType.Line,
+            50, 50, 400, 300,
+            "BugRegression_Combined");
+
+        // Assert
+        Assert.True(result.Success, $"CreateFromRange failed for combined scenario");
+        Assert.Equal("BugRegression_Combined", result.ChartName);
+        Assert.Equal("Export Data", result.SheetName);
+        Assert.Equal(ChartType.Line, result.ChartType);
+    }
+
+    /// <summary>
+    /// Regression: Verify that create-from-table works as workaround for the same data layout.
+    /// The bug report confirms create-from-table succeeds where create-from-range fails.
+    /// This test validates the workaround and serves as a comparison baseline.
+    /// </summary>
+    [Fact]
+    public void CreateFromTable_DataAtNonFirstRow_SucceedsAsWorkaround()
+    {
+        // Arrange — same data layout as the failing create-from-range scenario
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            dynamic? listObjects = null;
+            dynamic? table = null;
+            try
+            {
+                sheet = ctx.Book.Worksheets[1];
+                sheet.Range["A9:D14"].Value2 = new object[,]
+                {
+                    { "Quarter", "Revenue", "Cost", "Profit" },
+                    { "Q1", 1200, 800, 400 },
+                    { "Q2", 1500, 900, 600 },
+                    { "Q3", 1800, 1000, 800 },
+                    { "Q4", 2100, 1100, 1000 },
+                    { "Q5", 2400, 1200, 1200 }
+                };
+                listObjects = sheet.ListObjects;
+                table = listObjects.Add(1, sheet.Range["A9:D14"], null, 1); // xlYes = 1
+                table.Name = "BugWorkaroundTable";
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref table);
+                ComUtilities.Release(ref listObjects);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+
+        // Act — create chart from table (workaround from bug report)
+        var result = _commands.CreateFromTable(
+            batch,
+            "BugWorkaroundTable",
+            "Sheet1",
+            ChartType.Line,
+            50, 50, 400, 300,
+            "BugWorkaround_Table");
+
+        // Assert — this should always succeed
+        Assert.True(result.Success, $"CreateFromTable (workaround) failed unexpectedly");
+        Assert.Equal("BugWorkaround_Table", result.ChartName);
+        Assert.Equal(ChartType.Line, result.ChartType);
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.BugRegression.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.BugRegression.cs
@@ -1,0 +1,196 @@
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.PivotTable;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PivotTable;
+
+/// <summary>
+/// Regression tests for PivotTable creation with sheet names containing spaces.
+/// Same root cause as Bug 1 from Bug Report 2026-02-23: sourceDataRef is constructed
+/// as $"{sourceSheet}!{sourceRange}" in PivotTableCommands.Create.cs line 45 without
+/// quoting the sheet name. Excel COM requires single quotes around sheet names with
+/// spaces: "'Sheet Name'!A1:D6".
+/// </summary>
+public partial class PivotTableCommandsTests
+{
+    /// <summary>
+    /// Regression: CreateFromRange fails when source sheet name contains spaces.
+    /// The source data reference "$sourceSheet!$sourceRange" is not quoted.
+    /// Expected: PivotCache.Create succeeds with "'Sales Data'!A1:D6".
+    /// Actual: COM error because "Sales Data!A1:D6" is invalid.
+    /// </summary>
+    [Fact]
+    public void CreateFromRange_SourceSheetWithSpaces_CreatesPivotTable()
+    {
+        // Arrange — create file with data on a sheet whose name has spaces
+        var testFile = CreateTestFileWithData_SheetWithSpaces(
+            nameof(CreateFromRange_SourceSheetWithSpaces_CreatesPivotTable));
+
+        // Act
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var result = _pivotCommands.CreateFromRange(
+            batch,
+            "Sales Data", "A1:D6",    // source sheet with space in name
+            "Sales Data", "F1",        // destination on same sheet
+            "SpacePivot");
+
+        // Assert
+        Assert.True(result.Success, $"Expected success but got error: {result.ErrorMessage}");
+        Assert.Equal("SpacePivot", result.PivotTableName);
+        Assert.Equal(4, result.AvailableFields.Count);
+    }
+
+    /// <summary>
+    /// Regression: CreateFromRange fails when destination sheet name contains spaces.
+    /// While the current code may handle the destination correctly (it uses
+    /// Worksheets[name] not a string reference), this test validates the full path.
+    /// </summary>
+    [Fact]
+    public void CreateFromRange_DestinationSheetWithSpaces_CreatesPivotTable()
+    {
+        // Arrange
+        var testFile = CreateTestFileWithData_SheetWithSpaces(
+            nameof(CreateFromRange_DestinationSheetWithSpaces_CreatesPivotTable));
+
+        // Create a second sheet for the PivotTable destination
+        using (var setupBatch = ExcelSession.BeginBatch(testFile))
+        {
+            setupBatch.Execute((ctx, ct) =>
+            {
+                dynamic? sheets = null;
+                dynamic? newSheet = null;
+                try
+                {
+                    sheets = ctx.Book.Worksheets;
+                    newSheet = sheets.Add();
+                    newSheet.Name = "Pivot Output";
+                    return 0;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref newSheet);
+                    ComUtilities.Release(ref sheets);
+                }
+            });
+            setupBatch.Save();
+        } // setupBatch disposed — file lock released
+
+        // Act
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var result = _pivotCommands.CreateFromRange(
+            batch,
+            "Sales Data", "A1:D6",     // source sheet with space
+            "Pivot Output", "A1",       // destination sheet with space
+            "CrossSheetPivot");
+
+        // Assert
+        Assert.True(result.Success, $"Expected success but got error: {result.ErrorMessage}");
+        Assert.Equal("CrossSheetPivot", result.PivotTableName);
+    }
+
+    /// <summary>
+    /// Regression: CreateFromRange fails when source sheet name contains special characters.
+    /// Excel requires single quotes for sheet names with spaces, hyphens, or other specials.
+    /// </summary>
+    [Fact]
+    public void CreateFromRange_SourceSheetWithHyphen_CreatesPivotTable()
+    {
+        // Arrange — sheet name with hyphen (also requires quoting)
+        var testFile = _fixture.CreateTestFile(
+            nameof(CreateFromRange_SourceSheetWithHyphen_CreatesPivotTable));
+
+        using (var setupBatch = ExcelSession.BeginBatch(testFile))
+        {
+            setupBatch.Execute((ctx, ct) =>
+            {
+                dynamic sheet = ctx.Book.Worksheets[1];
+                sheet.Name = "Q1-Sales";
+
+                sheet.Range["A1"].Value2 = "Region";
+                sheet.Range["B1"].Value2 = "Product";
+                sheet.Range["C1"].Value2 = "Sales";
+                sheet.Range["D1"].Value2 = "Date";
+
+                sheet.Range["A2"].Value2 = "North";
+                sheet.Range["B2"].Value2 = "Widget";
+                sheet.Range["C2"].Value2 = 100;
+                sheet.Range["D2"].Value2 = new DateTime(2025, 1, 15);
+
+                sheet.Range["A3"].Value2 = "South";
+                sheet.Range["B3"].Value2 = "Gadget";
+                sheet.Range["C3"].Value2 = 200;
+                sheet.Range["D3"].Value2 = new DateTime(2025, 2, 10);
+
+                return 0;
+            });
+            setupBatch.Save();
+        } // setupBatch disposed — file lock released
+
+        // Act
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var result = _pivotCommands.CreateFromRange(
+            batch,
+            "Q1-Sales", "A1:D3",
+            "Q1-Sales", "F1",
+            "HyphenPivot");
+
+        // Assert
+        Assert.True(result.Success, $"Expected success but got error: {result.ErrorMessage}");
+        Assert.Equal("HyphenPivot", result.PivotTableName);
+    }
+
+    /// <summary>
+    /// Helper: Creates a test file with sales data on a sheet named "Sales Data" (with space).
+    /// </summary>
+    private string CreateTestFileWithData_SheetWithSpaces(string testName)
+    {
+        var testFile = _fixture.CreateTestFile(testName);
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets[1];
+            sheet.Name = "Sales Data";  // Space in name — triggers the bug
+
+            sheet.Range["A1"].Value2 = "Region";
+            sheet.Range["B1"].Value2 = "Product";
+            sheet.Range["C1"].Value2 = "Sales";
+            sheet.Range["D1"].Value2 = "Date";
+
+            sheet.Range["A2"].Value2 = "North";
+            sheet.Range["B2"].Value2 = "Widget";
+            sheet.Range["C2"].Value2 = 100;
+            sheet.Range["D2"].Value2 = new DateTime(2025, 1, 15);
+
+            sheet.Range["A3"].Value2 = "North";
+            sheet.Range["B3"].Value2 = "Widget";
+            sheet.Range["C3"].Value2 = 150;
+            sheet.Range["D3"].Value2 = new DateTime(2025, 1, 20);
+
+            sheet.Range["A4"].Value2 = "South";
+            sheet.Range["B4"].Value2 = "Gadget";
+            sheet.Range["C4"].Value2 = 200;
+            sheet.Range["D4"].Value2 = new DateTime(2025, 2, 10);
+
+            sheet.Range["A5"].Value2 = "North";
+            sheet.Range["B5"].Value2 = "Gadget";
+            sheet.Range["C5"].Value2 = 75;
+            sheet.Range["D5"].Value2 = new DateTime(2025, 2, 15);
+
+            sheet.Range["A6"].Value2 = "South";
+            sheet.Range["B6"].Value2 = "Widget";
+            sheet.Range["C6"].Value2 = 125;
+            sheet.Range["D6"].Value2 = new DateTime(2025, 3, 5);
+
+            sheet.Range["D2:D6"].NumberFormat = "m/d/yyyy";
+
+            return 0;
+        });
+
+        batch.Save();
+        return testFile;
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/WorksheetRenameParameterTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/WorksheetRenameParameterTests.cs
@@ -1,0 +1,370 @@
+using System.IO.Pipelines;
+using System.Text.Json;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+/// <summary>
+/// Regression tests for Bug Report 2026-02-23.
+/// Bug 2: worksheet(action: 'rename') parameters are not discoverable — callers
+/// cannot determine the correct parameter names (sheet_name + target_name) because
+/// target_name is documented as "Name for the target/copied worksheet" with no
+/// mention of rename.
+///
+/// These tests verify:
+/// 1. The correct parameter combination (sheet_name + target_name) works
+/// 2. Incorrect combinations fail with clear error messages
+/// 3. Missing parameters produce actionable errors, not cryptic COM exceptions
+/// </summary>
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Worksheets")]
+[Trait("RequiresExcel", "true")]
+public class WorksheetRenameParameterTests : IAsyncLifetime, IAsyncDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _tempDir;
+    private readonly string _testExcelFile;
+
+    private readonly Pipe _clientToServerPipe = new();
+    private readonly Pipe _serverToClientPipe = new();
+    private readonly CancellationTokenSource _cts = new();
+    private McpClient? _client;
+    private Task? _serverTask;
+    private string? _sessionId;
+
+    public WorksheetRenameParameterTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _tempDir = Path.Join(Path.GetTempPath(), $"WsRenameRegression_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _testExcelFile = Path.Join(_tempDir, "WorksheetRenameTest.xlsx");
+    }
+
+    public async Task InitializeAsync()
+    {
+        Program.ConfigureTestTransport(_clientToServerPipe, _serverToClientPipe);
+        _serverTask = Program.Main([]);
+        await Task.Delay(100);
+
+        _client = await McpClient.CreateAsync(
+            new StreamClientTransport(
+                serverInput: _clientToServerPipe.Writer.AsStream(),
+                serverOutput: _serverToClientPipe.Reader.AsStream()),
+            clientOptions: new McpClientOptions
+            {
+                ClientInfo = new() { Name = "WsRenameRegressionClient", Version = "1.0.0" },
+                InitializationTimeout = TimeSpan.FromSeconds(30)
+            },
+            cancellationToken: _cts.Token);
+
+        // Create a fresh workbook and open session
+        var createJson = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "create",
+            ["path"] = _testExcelFile
+        });
+
+        var createDoc = JsonDocument.Parse(createJson);
+        Assert.True(createDoc.RootElement.GetProperty("success").GetBoolean(),
+            $"Failed to create test file: {createJson}");
+
+        _sessionId = createDoc.RootElement.GetProperty("session_id").GetString();
+        Assert.NotNull(_sessionId);
+    }
+
+    #region Bug 2: Correct parameter combination
+
+    /// <summary>
+    /// Verifies that the correct parameter combination (sheet_name + target_name) works.
+    /// This is the only working combination, but it is not obvious from the parameter descriptions.
+    /// </summary>
+    [Fact]
+    public async Task Rename_WithSheetNameAndTargetName_Succeeds()
+    {
+        // Arrange — create a sheet to rename
+        await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "create",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "OriginalSheet"
+        });
+
+        // Act — rename using the correct (but non-obvious) parameter combination
+        var json = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "rename",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "OriginalSheet",   // Maps to oldName
+            ["target_name"] = "RenamedSheet"     // Maps to newName
+        });
+        _output.WriteLine($"Response: {json}");
+
+        // Assert
+        var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.GetProperty("success").GetBoolean(),
+            $"Rename with sheet_name + target_name should succeed. Response: {json}");
+
+        // Verify the sheet was actually renamed
+        var listJson = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = _sessionId
+        });
+        Assert.Contains("RenamedSheet", listJson);
+        Assert.DoesNotContain("OriginalSheet", listJson);
+    }
+
+    #endregion
+
+    #region Bug 2: Parameter combinations that fail (as reported)
+
+    /// <summary>
+    /// Bug report attempt 1: sheet_name + target_sheet_name fails.
+    /// User guessed target_sheet_name (which is a separate parameter for cross-file ops).
+    /// Expected error: "newName is required" because target_name was not provided.
+    /// </summary>
+    [Fact]
+    public async Task Rename_WithSheetNameAndTargetSheetName_FailsWithNewNameRequired()
+    {
+        // Arrange
+        await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "create",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "TestSheet1"
+        });
+
+        // Act — user's attempt 1 from bug report
+        var json = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "rename",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "TestSheet1",
+            ["target_sheet_name"] = "NewName"  // Wrong param! target_sheet_name is for cross-file ops
+        });
+        _output.WriteLine($"Response: {json}");
+
+        // Assert — should fail because target_name (newName) is null
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        // The response should indicate failure with a meaningful error about the missing parameter
+        Assert.False(root.GetProperty("success").GetBoolean(),
+            "Should fail when target_sheet_name is used instead of target_name");
+        Assert.True(root.TryGetProperty("errorMessage", out var errorMsg),
+            "Expected errorMessage in response");
+        Assert.Contains("newName", errorMsg.GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Bug report attempt 2: source_name + target_name fails.
+    /// User guessed source_name (which is for copy operations).
+    /// Expected error: "oldName is required" because sheet_name was not provided.
+    /// </summary>
+    [Fact]
+    public async Task Rename_WithSourceNameAndTargetName_FailsWithOldNameRequired()
+    {
+        // Arrange
+        await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "create",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "TestSheet2"
+        });
+
+        // Act — user's attempt 2 from bug report
+        var json = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "rename",
+            ["session_id"] = _sessionId,
+            ["source_name"] = "TestSheet2",   // Wrong param! source_name is for copy
+            ["target_name"] = "NewName2"      // Correct param for newName
+        });
+        _output.WriteLine($"Response: {json}");
+
+        // Assert — should fail because sheet_name (oldName) is null
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("success").GetBoolean(),
+            "Should fail when source_name is used instead of sheet_name");
+        Assert.True(root.TryGetProperty("errorMessage", out var errorMsg),
+            "Expected errorMessage in response");
+        Assert.Contains("oldName", errorMsg.GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Bug report attempt 3: sheet_name + source_sheet fails.
+    /// User guessed source_sheet (which is for cross-file move/copy).
+    /// Expected error: "newName is required" because target_name was not provided.
+    /// </summary>
+    [Fact]
+    public async Task Rename_WithSheetNameAndSourceSheet_FailsWithNewNameRequired()
+    {
+        // Arrange
+        await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "create",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "TestSheet3"
+        });
+
+        // Act — user's attempt 3 from bug report
+        var json = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "rename",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "TestSheet3",
+            ["source_sheet"] = "NewName3"     // Wrong param! source_sheet is for cross-file ops
+        });
+        _output.WriteLine($"Response: {json}");
+
+        // Assert — should fail because target_name (newName) is null
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("success").GetBoolean(),
+            "Should fail when source_sheet is used instead of target_name");
+        Assert.True(root.TryGetProperty("errorMessage", out var errorMsg),
+            "Expected errorMessage in response");
+        Assert.Contains("newName", errorMsg.GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verify that both old and new name missing produces a clear error.
+    /// Tests the case where a caller provides only the action and session_id.
+    /// </summary>
+    [Fact]
+    public async Task Rename_WithNoNameParameters_FailsWithOldNameRequired()
+    {
+        // Act — call rename with no name parameters at all
+        var json = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "rename",
+            ["session_id"] = _sessionId
+        });
+        _output.WriteLine($"Response: {json}");
+
+        // Assert — should fail with old name being the first validation error
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("success").GetBoolean(),
+            "Should fail when no name parameters are provided");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task<string> CallToolAsync(string toolName, Dictionary<string, object?> arguments)
+    {
+        var result = await _client!.CallToolAsync(toolName, arguments, cancellationToken: _cts.Token);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Content);
+        Assert.NotEmpty(result.Content);
+
+        var textBlock = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textBlock);
+
+        return textBlock.Text;
+    }
+
+    #endregion
+
+    #region Cleanup
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await CleanupAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await CleanupAsync();
+    }
+
+    private async Task CleanupAsync()
+    {
+        if (!string.IsNullOrEmpty(_sessionId) && _client != null)
+        {
+            try
+            {
+                await CallToolAsync("file", new Dictionary<string, object?>
+                {
+                    ["action"] = "close",
+                    ["session_id"] = _sessionId,
+                    ["save"] = false
+                });
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"Warning: Failed to close session: {ex.Message}");
+            }
+        }
+
+        if (_client != null)
+        {
+            await _client.DisposeAsync();
+        }
+
+        _clientToServerPipe.Writer.Complete();
+        _serverToClientPipe.Writer.Complete();
+
+        if (_serverTask != null)
+        {
+            var shutdownTimeout = Task.Delay(TimeSpan.FromSeconds(10));
+            var completed = await Task.WhenAny(_serverTask, shutdownTimeout);
+
+            if (completed == shutdownTimeout)
+            {
+                _output.WriteLine("Warning: Server did not shut down gracefully, forcing cancellation");
+                await _cts.CancelAsync();
+                try
+                {
+                    await _serverTask;
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected
+                }
+            }
+        }
+
+        Program.ResetTestTransport();
+        _cts.Dispose();
+
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    try
+                    {
+                        Directory.Delete(_tempDir, recursive: true);
+                        break;
+                    }
+                    catch (IOException) when (i < 2)
+                    {
+                        await Task.Delay(500);
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Fixes two bugs reported in the Excel MCP bug report (2026-02-23):

### Bug 1 & 3: Sheet name quoting in COM source data references (#512)

**Root cause:** ChartCommands.Lifecycle.cs and PivotTableCommands.Create.cs construct source data references as $\"{sourceSheet}!{sourceRange}\" without quoting the sheet name. Excel COM requires single quotes for sheet names with spaces or special characters: 'Sheet Name'!A1:D6.

**Fix:** Wrap sheet names in single quotes (safe for all names, even without spaces).

**Files changed:**
- src/ExcelMcp.Core/Commands/Chart/ChartCommands.Lifecycle.cs — quote sheet name in \CreateFromRange\
- src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.Create.cs — same fix for pivot cache source data

### Bug 2: Worksheet rename parameter discoverability (#513)

**Root cause:** \ExcelWorksheetTool.cs\ is manually written (not source-generated) and the \	arget_name\ parameter description only mentioned "copied" worksheet, not "renamed".

**Fix:** Updated XML doc to: "New name for the worksheet (required for: rename, copy)"

**File changed:**
- \src/ExcelMcp.McpServer/Tools/ExcelWorksheetTool.cs\

### Regression Tests (12 new)

| Test File | Tests | Coverage |
|-----------|-------|----------|
| \ChartCommandsTests.BugRegression.cs\ | 4 | Sheet names with spaces, data at non-first row |
| \PivotTableCommandsTests.BugRegression.cs\ | 3 | Source/dest with spaces, hyphen in name |
| \WorksheetRenameParameterTests.cs\ | 5 | MCP parameter contract tests |

All 12 tests pass. Pre-commit hooks pass (COM leak check, coverage audit, CLI workflow, MCP smoke test).

Closes #512, closes #513