### PR TITLE
feat: add npm skill packages for excel-mcp and excel-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ name: Release All Components
 # Required GitHub Secrets:
 # - NUGET_USER: Your NuGet.org username (profile name, NOT email)
 # - VSCE_TOKEN: VS Code Marketplace PAT
+# - NPM_TOKEN: npmjs.org automation token (for skill packages)
 # - APPINSIGHTS_CONNECTION_STRING: Application Insights connection string
 
 on:
@@ -498,6 +499,38 @@ jobs:
         name: agent-skills
         path: artifacts/skills/excel-skills-*.zip
 
+    - name: Populate npm Skill Packages
+      run: |
+        $version = $env:VERSION
+
+        # Populate excel-mcp-skill
+        $mcpTarget = "packages/excel-mcp-skill/skills/excel-mcp"
+        Get-ChildItem $mcpTarget -Exclude ".gitkeep" -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
+        Copy-Item "skills/excel-mcp/SKILL.md" $mcpTarget
+        Copy-Item "skills/excel-mcp/references" "$mcpTarget/references" -Recurse -ErrorAction SilentlyContinue
+
+        # Populate excel-cli-skill
+        $cliTarget = "packages/excel-cli-skill/skills/excel-cli"
+        Get-ChildItem $cliTarget -Exclude ".gitkeep" -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
+        Copy-Item "skills/excel-cli/SKILL.md" $cliTarget
+        Copy-Item "skills/excel-cli/references" "$cliTarget/references" -Recurse -ErrorAction SilentlyContinue
+
+        # Update versions in package.json files
+        foreach ($pkg in @("packages/excel-mcp-skill/package.json", "packages/excel-cli-skill/package.json")) {
+          $content = Get-Content $pkg -Raw
+          $content = $content -replace '"version":\s*"[\d\.]+"', "`"version`": `"$version`""
+          Set-Content $pkg $content
+        }
+
+        Write-Host "Populated npm skill packages at v$version"
+      shell: pwsh
+
+    - name: Upload npm Skill Packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: npm-skill-packages
+        path: packages/
+
   # =============================================================================
   # Job 6: Wait for NuGet Propagation + MCP Registry
   # =============================================================================
@@ -646,6 +679,12 @@ jobs:
         name: vscode-vsix
         path: vscode-vsix
 
+    - name: Download npm Skill Packages
+      uses: actions/download-artifact@v4
+      with:
+        name: npm-skill-packages
+        path: npm-packages
+
     - name: NuGet Login (OIDC)
       uses: NuGet/login@v1
       id: nuget-login
@@ -674,6 +713,25 @@ jobs:
         pat: ${{ secrets.VSCE_TOKEN }}
         registryUrl: https://marketplace.visualstudio.com
         extensionFile: vscode-vsix/excelmcp-${{ env.VERSION }}.vsix
+      continue-on-error: true
+
+    - name: Setup npm registry
+      run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+    - name: Publish excel-mcp-skill to npm
+      run: |
+        cd npm-packages/excel-mcp-skill
+        npm publish --provenance --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      continue-on-error: true
+
+    - name: Publish excel-cli-skill to npm
+      run: |
+        cd npm-packages/excel-cli-skill
+        npm publish --provenance --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       continue-on-error: true
 
   # =============================================================================
@@ -759,7 +817,8 @@ jobs:
 
         **Agent Skills** (for AI coding assistants)
         - VS Code Extension includes both skills automatically (excel-mcp + excel-cli)
-        - For other agents: download `excel-skills-v${{ env.VERSION }}.zip` or install via `npx skills add sbroenne/mcp-server-excel`
+        - Install via npm: `npx skillpm install excel-mcp-skill` or `npx skillpm install excel-cli-skill`
+        - Or download `excel-skills-v${{ env.VERSION }}.zip` or install via `npx skills add sbroenne/mcp-server-excel`
 
         ### Requirements
         - Windows OS

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ _ReSharper*/
 *.snupkg
 **/[Pp]ackages/*
 !**/[Pp]ackages/build/
+!/packages/
+!/packages/**
 *.nuget.props
 *.nuget.targets
 
@@ -240,3 +242,7 @@ Directory.Build.props.user
 # All tracked because `npx skills add` pulls from the repo tree.
 vscode-extension/skills/*
 llm-tests/aitest-reports/
+
+# npm skill packages - build output (populated by Build-AgentSkills.ps1)
+packages/*/skills/*/SKILL.md
+packages/*/skills/*/references/

--- a/packages/excel-cli-skill/README.md
+++ b/packages/excel-cli-skill/README.md
@@ -1,0 +1,36 @@
+# excel-cli-skill
+
+An [Agent Skill](https://agentskills.io) for automating Microsoft Excel via the [excelcli](https://excelmcpserver.dev) command-line tool.
+
+## What this skill does
+
+When loaded by an AI agent (Claude, Codex, Cursor, Gemini CLI, etc.), this skill teaches the agent how to automate Excel from scripts and CI/CD pipelines:
+
+- **Workbook management** — open, create, save, close
+- **Range operations** — read/write values, formatting, formulas
+- **Tables & PivotTables** — create, modify, refresh
+- **Charts** — create and configure chart types
+- **Power Query (M code)** — create and edit queries
+- **Data Model (DAX)** — add measures and calculated columns
+- **VBA macros, conditional formatting**, and more
+
+## Requirements
+
+- Windows with Microsoft Excel 2016+ installed
+- Install the CLI: `dotnet tool install --global Sbroenne.ExcelMcp.CLI`
+
+## Install
+
+```bash
+npx skillpm install excel-cli-skill
+```
+
+Or with npm directly:
+
+```bash
+npm install excel-cli-skill
+```
+
+## License
+
+MIT

--- a/packages/excel-cli-skill/package.json
+++ b/packages/excel-cli-skill/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "excel-cli-skill",
+  "version": "1.7.0",
+  "description": "Agent Skill for automating Microsoft Excel via CLI — Power Query, DAX, PivotTables, Charts, VBA, and more from scripts and coding agents",
+  "keywords": [
+    "agent-skill",
+    "excel",
+    "cli",
+    "spreadsheet",
+    "power-query",
+    "dax",
+    "pivottable",
+    "automation"
+  ],
+  "homepage": "https://excelmcpserver.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sbroenne/mcp-server-excel.git",
+    "directory": "packages/excel-cli-skill"
+  },
+  "bugs": {
+    "url": "https://github.com/sbroenne/mcp-server-excel/issues"
+  },
+  "author": "sbroenne",
+  "license": "MIT",
+  "files": [
+    "skills",
+    "README.md",
+    "LICENSE"
+  ],
+  "dependencies": {}
+}

--- a/packages/excel-cli-skill/skills/excel-cli/.gitkeep
+++ b/packages/excel-cli-skill/skills/excel-cli/.gitkeep
@@ -1,0 +1,3 @@
+# Build output — populated by Build-AgentSkills.ps1
+# SKILL.md and references/ are copied here during build.
+# Do not edit manually.

--- a/packages/excel-mcp-skill/README.md
+++ b/packages/excel-mcp-skill/README.md
@@ -1,0 +1,36 @@
+# excel-mcp-skill
+
+An [Agent Skill](https://agentskills.io) for automating Microsoft Excel via the [Excel MCP Server](https://excelmcpserver.dev).
+
+## What this skill does
+
+When loaded by an AI agent (Claude, Codex, Cursor, Gemini CLI, etc.), this skill teaches the agent how to automate Excel through 225 MCP operations:
+
+- **Workbook management** — open, create, save, close
+- **Range operations** — read/write values, formatting, formulas
+- **Tables & PivotTables** — create, modify, refresh
+- **Charts** — create and configure chart types
+- **Power Query (M code)** — create and edit queries
+- **Data Model (DAX)** — add measures and calculated columns
+- **Conditional formatting, slicers, VBA macros**, and more
+
+## Requirements
+
+- Windows with Microsoft Excel 2016+ installed
+- [Excel MCP Server](https://github.com/sbroenne/mcp-server-excel) running
+
+## Install
+
+```bash
+npx skillpm install excel-mcp-skill
+```
+
+Or with npm directly:
+
+```bash
+npm install excel-mcp-skill
+```
+
+## License
+
+MIT

--- a/packages/excel-mcp-skill/package.json
+++ b/packages/excel-mcp-skill/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "excel-mcp-skill",
+  "version": "1.7.0",
+  "description": "Agent Skill for automating Microsoft Excel via MCP Server — 225 operations including Power Query, DAX, PivotTables, Charts, and more",
+  "keywords": [
+    "agent-skill",
+    "excel",
+    "mcp",
+    "mcp-server",
+    "spreadsheet",
+    "power-query",
+    "dax",
+    "pivottable"
+  ],
+  "homepage": "https://excelmcpserver.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sbroenne/mcp-server-excel.git",
+    "directory": "packages/excel-mcp-skill"
+  },
+  "bugs": {
+    "url": "https://github.com/sbroenne/mcp-server-excel/issues"
+  },
+  "author": "sbroenne",
+  "license": "MIT",
+  "files": [
+    "skills",
+    "README.md",
+    "LICENSE"
+  ],
+  "dependencies": {},
+  "skillpm": {
+    "mcpServers": [
+      "sbroenne/mcp-server-excel"
+    ]
+  }
+}

--- a/packages/excel-mcp-skill/skills/excel-mcp/.gitkeep
+++ b/packages/excel-mcp-skill/skills/excel-mcp/.gitkeep
@@ -1,0 +1,3 @@
+# Build output — populated by Build-AgentSkills.ps1
+# SKILL.md and references/ are copied here during build.
+# Do not edit manually.

--- a/scripts/Build-AgentSkills.ps1
+++ b/scripts/Build-AgentSkills.ps1
@@ -3,8 +3,10 @@
     Builds the Excel MCP Agent Skills package for distribution.
 
 .DESCRIPTION
-    Creates a single distributable artifact for Agent Skills:
+    Creates distributable artifacts for Agent Skills:
     - excel-skills-v{version}.zip: Combined skill package with both excel-mcp and excel-cli
+    - packages/excel-mcp-skill/: npm package for excel-mcp skill (publish with npm publish)
+    - packages/excel-cli-skill/: npm package for excel-cli skill (publish with npm publish)
     - CLAUDE.md: Claude Code project instructions
     - .cursorrules: Cursor project rules
 
@@ -12,7 +14,7 @@
     to both excel-mcp/references/ and excel-cli/references/ during packaging.
 
     Users install with: npx skills add sbroenne/mcp-server-excel
-    Then select which skill(s) they want: excel-cli, excel-mcp, or both.
+    Or via npm: npx skillpm install excel-mcp-skill
 
 .PARAMETER OutputDir
     Output directory for artifacts. Default: artifacts/skills
@@ -309,6 +311,32 @@ try {
     if (Test-Path $StagingDir) {
         Remove-Item $StagingDir -Recurse -Force
     }
+}
+
+Write-Host ""
+Write-Host "Building npm skill packages..." -ForegroundColor Yellow
+
+# Populate excel-mcp-skill npm package
+$NpmMcpDir = Join-Path $RepoRoot "packages/excel-mcp-skill/skills/excel-mcp"
+if (Test-Path $NpmMcpDir) {
+    # Clean previous build output (keep .gitkeep)
+    Get-ChildItem $NpmMcpDir -Exclude ".gitkeep" -Recurse | Remove-Item -Recurse -Force
+    # Copy SKILL.md
+    Copy-Item -Path (Join-Path $SkillsDir "excel-mcp/SKILL.md") -Destination $NpmMcpDir
+    Copy-SharedReferences -SkillPath $NpmMcpDir -SkillName "excel-mcp"
+    Write-Host "  Populated: packages/excel-mcp-skill/" -ForegroundColor Green
+}
+
+# Populate excel-cli-skill npm package
+$NpmCliDir = Join-Path $RepoRoot "packages/excel-cli-skill/skills/excel-cli"
+if (Test-Path $NpmCliDir) {
+    # Clean previous build output (keep .gitkeep)
+    Get-ChildItem $NpmCliDir -Exclude ".gitkeep" -Recurse | Remove-Item -Recurse -Force
+    # Copy SKILL.md
+    Copy-Item -Path (Join-Path $SkillsDir "excel-cli/SKILL.md") -Destination $NpmCliDir
+    Copy-SharedReferences -SkillPath $NpmCliDir -SkillName "excel-cli"
+    Generate-CliReference -SkillPath $NpmCliDir
+    Write-Host "  Populated: packages/excel-cli-skill/" -ForegroundColor Green
 }
 
 # Copy CLAUDE.md and .cursorrules


### PR DESCRIPTION
Adds two npm-publishable Agent Skill packages:

- **excel-mcp-skill** — Excel MCP Server skill (225 operations)
- **excel-cli-skill** — Excel CLI skill (excelcli automation)

### Changes
- `packages/excel-mcp-skill/` and `packages/excel-cli-skill/` with `package.json` + `README.md`
- `Build-AgentSkills.ps1` extended to populate npm package dirs during build
- Release workflow publishes both to npm alongside NuGet/VSIX/MCPB
- `.gitignore` updated: static files tracked, build artifacts (SKILL.md, references/) ignored

### How it works
1. `Build-AgentSkills.ps1` copies SKILL.md + references into `packages/*/skills/*/`
2. Release workflow updates `package.json` versions, then `npm publish`
3. Users install via `npx skillpm install excel-mcp-skill`

### Dry-run verified
Both packages pass `npm publish --dry-run` ✅