### PR TITLE
chore: switch npm publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ name: Release All Components
 # Required GitHub Secrets:
 # - NUGET_USER: Your NuGet.org username (profile name, NOT email)
 # - VSCE_TOKEN: VS Code Marketplace PAT
-# - NPM_TOKEN: npmjs.org automation token (for skill packages)
 # - APPINSIGHTS_CONNECTION_STRING: Application Insights connection string
+#
+# npm publishing uses Trusted Publishing (OIDC) — no token needed.
+# Configure at npmjs.com → Package Settings → Trusted Publisher.
 
 on:
   workflow_dispatch:
@@ -716,22 +718,21 @@ jobs:
       continue-on-error: true
 
     - name: Setup npm registry
-      run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        registry-url: https://registry.npmjs.org
 
     - name: Publish excel-mcp-skill to npm
       run: |
         cd npm-packages/excel-mcp-skill
         npm publish --provenance --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       continue-on-error: true
 
     - name: Publish excel-cli-skill to npm
       run: |
         cd npm-packages/excel-cli-skill
         npm publish --provenance --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       continue-on-error: true
 
   # =============================================================================


### PR DESCRIPTION
Remove NPM_TOKEN dependency for npm publishing. Use OIDC-based Trusted Publishing instead — no token needed, npm authenticates via GitHub Actions OIDC provider.

Trusted Publishing is already configured on npmjs.com for both `excel-mcp-skill` and `excel-cli-skill`.