### PR TITLE
fix: table append JsonElement COM marshalling + --values stdin sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,340 +2,556 @@
 
 All notable changes to ExcelMcp will be documented in this file.
 
+This changelog covers all components:
+- **MCP Server** - Model Context Protocol server for AI assistants
+- **CLI** - Command-line interface for scripting and coding agents
+- **VS Code Extension** - One-click installation with bundled MCP Server
+- **MCPB** - Claude Desktop bundle for one-click installation
+
 ## [Unreleased]
 
-### Added
-- **IRM/AIP-protected file support** in `file(action='open')`: Files protected with Azure Information Protection (AIP/IRM) are automatically detected via OLE2 Compound Document header signature (`D0 CF 11 E0 A1 B1 1A E1`). They are opened read-only with Excel forced visible so the Windows IRM credential prompt can appear — no extra parameters needed.
-- **`isIrmProtected` field in `file(action='test')` response**: Reports whether a file uses the OLE2/IRM format before attempting to open it, enabling agents to pre-flight check and set expectations (IRM files are always read-only).
+### Fixed
+
+- **`table append` JsonElement COM marshalling** (#519): Row values containing booleans or strings were passed as raw `System.Text.Json.JsonElement` to `cell.Value2`, which COM interop cannot marshal to a Variant. Fixed by calling `RangeHelpers.ConvertToCellValue()` (the same fix already present in `range set-values`) to unwrap `JsonElement` to native types before assignment.
+
+- **`--values`/`--rows` inline JSON: PowerShell quote-stripping + stdin sentinel** (#521): Windows `CreateProcess` strips inner double-quotes when PowerShell passes arguments to native executables, so `--values '[["ACD Full Term",0.26]]'` arrives as `[[ACD Full Term,0.26]]` (invalid JSON). The generated `DeserializeNestedCollection<T>` now: (1) emits a clear error message that mentions `--values-file` and `--values -` as workarounds, and (2) supports a stdin sentinel — passing `--values -` (or `--rows -`) reads the JSON from `Console.In`, avoiding shell quoting entirely.
+
+- **Table `add-to-data-model` bracket column names block DAX formulas**: Excel table columns with literal bracket characters in their names (e.g., from OLEDB import sources) cannot be referenced in DAX formulas after being added to the Data Model. Added new `stripBracketColumnNames` parameter (default: `false`). When `false`, bracket column names are reported in `bracketColumnsFound` so users are aware of the issue. When `true`, the source table column headers are renamed (brackets removed) before adding to the Data Model, enabling full DAX access. The `add-to-data-model` result now includes `bracketColumnsFound` and `bracketColumnsRenamed` fields.
+
+- **PowerQuery `load-to data-model` silently succeeded without loading data**: `powerquery load-to` with `data-model` destination returned `success: true` but the table never appeared in the Power Pivot Data Model. The connection was registered via `Connections.Add2()` but `connection.Refresh()` was never called, so data was not actually loaded. Fixed by calling `connection.Refresh()` after creating the connection, consistent with how `load-to worksheet` works.
+
+- **`chartconfig set-data-labels` threw raw COMException on Line charts with bar-only position**: Setting `labelPosition` to `InsideEnd`, `InsideBase`, or `OutsideEnd` on a Line chart threw a raw COM exception with no user-friendly explanation. These positions are only valid for bar, column, and area chart types. Fixed by catching the COMException and throwing an `InvalidOperationException` with a descriptive message explaining which chart types support each position, consistent with how `ShowPercentage` handles unsupported chart types.
+
+- **`rangeformat format-range` parameter documentation listed wrong valid values for `borderStyle`**: The `borderStyle` parameter help incorrectly listed `thin`, `medium`, `thick`, `dashed`, and `dotted` as valid values — those are `borderWeight` values. The valid `borderStyle` values are `continuous`, `dash`, `dot`, `dashdot`, `dashdotdot`, `double`, `slantdashdot`, and `none`. Documentation corrected.
+
+- **`rangeformat format-range` rejected `middle` as a vertical alignment value**: The `verticalAlignment` parameter only accepted `center` but not the common alias `middle`. Both now accepted and produce identical center-vertical alignment.
 
 ### Changed
-- **MCP SDK upgraded** from `ModelContextProtocol` 0.8.0-preview.1 to 0.9.0-preview.2
-  - Updated `ImageContentBlock.Data` from `string` to `ReadOnlyMemory<byte>` (binary data API change)
-- CLI daemon IPC migrated from custom protocol to StreamJsonRpc — improved reliability and error handling
-- Enhanced daemon security with SID validation and `CurrentUserOnly` pipe access
+
+- **`screenshot` CLI `--output` flag documentation clarified**: The `--output <path>` flag saves the screenshot directly to a PNG or JPEG file instead of printing base64 JSON to stdout. This was already functional but was documented as "For CLI: saved to file" without explaining that `--output` is required to save to a file.
+
+- **office.dll not found when opening workbooks with connections/data model** (#487 follow-up): The `AssemblyResolve` handler only searched `AppContext.BaseDirectory` for `office.dll`. In NuGet-installed tool deployments, `office.dll` is never copied there (it is only present in local dev builds via `Directory.Build.targets`). Opening workbooks with external connections, Power Query, or a Data Model triggered code paths that caused the CLR to load `Microsoft.Office.Interop.Excel.dll`, which in turn requested `office.dll v16`. The handler returned `null` → `FileNotFoundException`. Fixed by adding fallback search order: (1) `AppContext.BaseDirectory`, (2) .NET Framework GAC v16, (3) GAC v15 (accepted by CLR as substitute), (4) Office 365 click-to-run installation directories. `Directory.Build.targets` also updated to prefer v16 GAC when available.
+
+### Changed
+
+- **Migrated Excel COM interop to strongly-typed Microsoft Office PIA**: Replaced dynamic late-binding throughout the codebase with strongly-typed `Microsoft.Office.Interop.Excel` types for improved reliability and compile-time error detection. Power Query APIs (`Workbook.Queries`) and VBA project access remain as dynamic calls where PIA coverage is unavailable.
 
 ### Fixed
-- **Chart `create-from-range`** (#512): sheet names with spaces or special characters now quoted in source data reference — fixes COM error when source sheet name contains spaces
-- **PivotTable `create-from-range`** (#512): same quoting fix for pivot cache source data reference
-- **Worksheet `rename`** (#513): `target_name` parameter description now mentions rename action, improving LLM discoverability
-- Standardized all data operation timeouts to 30 minutes via `ComInteropConstants.DataOperationTimeout`
-  - Power Query `load-to` increased from 5 min to 30 min
-  - Connection `refresh` and `load-to` increased from 5 min to 30 min
-  - Power Query `refresh`/`refresh-all` now use the same constant (was inline 30 min)
-  - `ExcelBatch.Execute()` no longer double-caps timeout when caller provides a cancellation token
-- Corrected stale documentation claiming 60-600 second range restriction on refresh timeout (no such validation exists)
 
-## [1.8.12] - 2026-02-22
+- **All Excel sessions crashed with FileNotFoundException for office.dll** (#487): After PIA migration, `ExcelBatch` STA thread declared `tempExcel` as typed `Excel.Application`. Casting a typed COM interop object to `(dynamic)` retains PIA type metadata; the DLR then resolved `MsoAutomationSecurity` from `office.dll` (Microsoft.Office.Core v16.0.0.0) at runtime, which is not bundled with the deployed .NET tool. Every session (create and open) crashed before opening any workbook. Fixed by casting to `(object)` first before `(dynamic)` to force pure IDispatch binding. Also removed a broken `<Reference>` to office.dll with a wrong v15.0.0.0 hint path (runtime required v16.0.0.0).
 
-### Fixed
-- Power Query `refresh` and `refresh-all` no longer crash when very large timeout values are provided
+- **STA Deadlock on Conditional Formatting and Other Re-entrant COM Operations**: `OleMessageFilter.MessagePending` was returning `2` (`PENDINGMSG_WAITNOPROCESS`) instead of `1` (`PENDINGMSG_WAITDEFPROCESS`). When Excel fires a re-entrant callback (e.g. `Calculate`/`SheetChange` event) during a `FormatConditions.Add()` call, `WAITNOPROCESS` blocked COM from delivering the callback — Excel waited for the callback while the STA thread waited for Excel, causing a permanent deadlock. Any operation that triggers Excel's internal event loop (conditional formatting on formula cells, PivotTable refresh, Power Query refresh) was affected. Fixed by returning `1` so COM delivers pending inbound calls during the outgoing `IDispatch.Invoke`.
+- **Hung Session After Tool Call Cancellation**: When a user cancelled a tool call while the STA thread was stuck in `IDispatch.Invoke`, `WithSessionAsync` had no `catch (OperationCanceledException)` handler — the session remained alive with a permanently blocked STA thread, causing all subsequent operations to hang. Fixed by adding `catch (OperationCanceledException)` that force-closes the session (same pattern as the existing `TimeoutException` handler).
+- **Slow Fail on Successive Calls After Timeout/Cancellation**: After a timeout or cancellation, `Execute<T>` would queue new work on a permanently stuck STA thread, forcing each subsequent caller to wait for its own full timeout before failing. Fixed by adding a fail-fast pre-check: if `_operationTimedOut` is set, throw `TimeoutException` immediately.
 
-## [1.8.11] - 2026-02-22
+- **COM Apartment Boundary in SaveWorkbook** (#482): Removed `Task.Run(() => workbook.Save())` in `ExcelShutdownService` — this marshalled the COM call from the STA thread to an MTA thread-pool thread, which is incorrect and fragile in .NET 8+. Save is now called directly on the STA thread, which is always the case inside `ExcelBatch.Execute()`.
+- **Wrong-Process Force-Kill from Fallback PID** (#482): Removed the "newest EXCEL.EXE process" fallback PID detection in `ExcelBatch`. When the `Hwnd` path fails, force-kill is now disabled with a warning rather than risking killing an unrelated Excel workbook the user has open.
+- **Redundant `Thread.Sleep` in Dispose** (#482): Removed 100 ms `Thread.Sleep` from `ExcelBatch.Dispose()`. The preceding `_shutdownCts.Cancel()` call immediately wakes the STA thread from `WaitToReadAsync`, making the sleep redundant and adding unnecessary latency.
+- **Exception Type Lost in Service Error Responses** (#482): `ExcelMcpService` top-level `catch` blocks now return `"{ExType}: {ex.Message}"` instead of just `ex.Message`, making unexpected failures distinguishable without a full stack trace.
+- **COM Timeout Hang** — ExcelBatch now force-kills Excel process on timeout instead of hanging indefinitely on `WaitForSingleObject`; ExcelMcpService catches `TimeoutException` to prevent unhandled exceptions
+- **FileSystemWatcher CPU Spin** — Disabled `IConfiguration` reload-on-change in MCP Server to prevent 85%+ CPU usage from `FileSystemWatcher` polling
+- **Process Handle Leak** — Fixed `Process` object not being disposed in `ExcelBatch.ForceKillExcelProcess()`
+- **Configuration Sources Cleared** — Re-add environment variables and command-line args after clearing config sources (were accidentally removed)
+- **Source Generator Type Aggregation** — Fixed nullable type upgrade logic in `ServiceInfoExtractor` that could lose type information across partial interfaces
+- **Chart Trendline Parameter Name** — Renamed `type` → `trendlineType` in `IChartConfigCommands` to avoid COM parameter ambiguity
+- **Chart Style Error Message** — Improved `SetStyle` error message to show valid range when `styleId` is out of bounds
+- **Chart InvalidOperationException** — Added catch for `InvalidOperationException` in chart appearance commands
 
-### Fixed
-- `--timeout` parameter on `powerquery refresh-all` now works end-to-end (was silently ignored)
-- CLI pipe timeout no longer races with operation timeout on long-running refreshes
+### Changed
 
-## [1.8.10] - 2026-02-22
-
-### Fixed
-- CLI daemon no longer spawns duplicate instances during long-running operations (e.g. `powerquery refresh-all`)
-
-## [1.8.9] - 2026-02-22
-
-### Fixed
-- `powerquery load-to` now correctly transitions between all load destinations (e.g. worksheet → connection-only, data-model → worksheet)
-- `powerquery get-load-config` no longer crashes on connection-only queries
-- CLI banner no longer pollutes JSON output when piped (e.g. `excelcli ... | ConvertFrom-Json`)
-
-## [1.8.8] - 2026-02-22
-
-### Fixed
-- `powerquery refresh` no longer crashes when `--timeout` is omitted (uses 5-minute default)
-
-## [1.8.7] - 2026-02-21
-
-### Fixed
-- `table add-to-data-model` now handles column names containing brackets — new `stripBracketColumnNames` parameter
-- `powerquery load-to data-model` now actually loads data into the Data Model (was silently no-op)
-- `chartconfig set-data-labels` gives clear error when using bar-only label positions on Line charts
-- `rangeformat format-range` — corrected `borderStyle` valid values in documentation
-- `rangeformat format-range` now accepts `middle` as alias for `center` vertical alignment
-
-## [1.8.6] - 2026-02-21
-
-### Fixed
-- Workbooks with connections, Power Query, or Data Model no longer crash on open in NuGet tool installs
-
-## [1.8.3] - 2026-02-19
-
-### Fixed
-- Operations that trigger Excel recalculation (conditional formatting on formula cells, PivotTable refresh, Power Query refresh) no longer hang
-- Session no longer becomes permanently stuck after cancelling a tool call
-- After a timeout, subsequent operations now fail immediately instead of waiting for another full timeout
-
-## [1.8.2] - 2026-02-19
-
-### Fixed
-- Excel process no longer hangs on timeout — forcefully recovered instead
-- Fixed 85%+ CPU usage caused by configuration file watcher
-- Session save on workbook close now works reliably
-- Improved error messages with exception type information
-- Fixed errors when saving workbooks during shutdown
-
-## [1.8.0] - 2026-02-17
+- **Chart Test Performance** — Refactored 80 chart tests to share a single pre-populated fixture file via `File.Copy()` instead of creating individual files via COM, eliminating ~74 redundant Excel sessions
 
 ### Added
-- **Screenshot quality parameter** — `High`/`Medium`/`Low` quality settings (default: `Medium`)
-- **Window Management** — new `window` tool with 9 operations: show/hide Excel, arrange windows, set status bar text
-- **CLI `--output` flag** — save command output directly to a file
-- **CLI Batch Mode** — execute multiple CLI commands from a JSON file in a single launch
+
+- **Screenshot quality parameter**: New `quality` parameter on screenshot tool (`High`/`Medium`/`Low`). Default is `Medium` (JPEG at 75% scale, ~4–8x smaller than original PNG). Use `High` (PNG, full scale) when fine text needs careful inspection, `Low` (JPEG at 50% scale) for layout overviews.
+- **Window Management Tool** (#470): New `window` tool with 9 operations to control Excel window visibility, position, state, and status bar — enabling "Agent Mode" where users watch AI work in Excel
+  - `show` / `hide` — Toggle Excel visibility (syncs with session metadata)
+  - `bring-to-front` — Bring Excel to foreground
+  - `get-info` — Query window state (visibility, position, size, foreground status)
+  - `set-state` — Set normal / minimized / maximized
+  - `set-position` — Set window left, top, width, height
+  - `arrange` — Preset layouts: left-half, right-half, top-half, bottom-half, center, full-screen
+  - `set-status-bar` — Display live operation status text in Excel's status bar
+  - `clear-status-bar` — Restore default status bar text
+  - MCP Server proactively asks users about showing Excel for visual tasks (charts, dashboards)
+  - Agent Mode, Presentation Mode, and Debug Mode workflow guidance
+- **CLI `--output` flag** for all commands: Save command output directly to a file. Screenshot commands automatically save decoded PNG images instead of base64 JSON
+- **CLI Batch Mode** (#463): New `excelcli batch` command executes multiple CLI commands from a JSON file in a single process launch
+  - Session auto-capture from `session.open`/`session.create`, auto-clear on `session.close`
+  - NDJSON output for machine-readable results
+  - `--stop-on-error` flag to halt on first failure (default: continue all)
 
 ### Fixed
-- Screenshots now work reliably regardless of Excel visibility
-- Worksheet `copy-to-file` and `move-to-file` no longer require a session parameter
-- CLI `--help` no longer crashes on commands with bracket characters in descriptions
-- Sessions auto-save when MCP server exits or client disconnects
 
-## [1.7.7] - 2026-02-17
-
-### Added
-- Chart collision detection and auto-positioning with `targetRange` parameter
-
-## [1.7.6] - 2026-02-16
-
-### Added
-- **CLI Batch Mode** — `excelcli batch` executes multiple commands from a JSON file
-
-## [1.7.5] - 2026-02-16
-
-### Fixed
-- Fixed 100% CPU usage in background message pump loop
-
-## [1.7.4] - 2026-02-16
-
-### Fixed
-- Fixed crash when accessing non-OLEDB connection types
+- **Screenshot reliability**: Screenshots now work reliably regardless of whether Excel is visible or hidden. Added automatic retry for transient capture failures
+- **CLI `--help` crash** (#463): Fixed Spectre.Console markup crash when parameter descriptions contain `[`/`]` characters (e.g., `[A1 notation]`)
+- **Source generator tool filtering**: Fixed `mcpTool ?? "unknown"` fallback; added `HasMcpToolAttribute` to correctly filter MCP-only tools
+- **Skills docs parameter names**: Fixed wrong CLI parameter names in `conditionalformat.md` and `slicer.md` reference files
+- **Auto-save on shutdown**: Sessions are now auto-saved before closing when MCP server exits or client disconnects, preventing silent data loss from session timeouts
+- **Session creation resilience**: Added retry logic (Polly) for transient COM failures (`CO_E_SERVER_EXEC_FAILURE`, `RPC_E_CALL_FAILED`) during Excel process startup under resource constraints
 
 ## [1.7.2] - 2026-02-15
 
 ### Added
-- **In-process service architecture** — MCP Server and CLI each host the service internally, eliminating service discovery failures
-- **CLI NuGet package** — CLI now published as `Sbroenne.ExcelMcp.CLI`
 
-## [1.7.1] - 2026-02-15
+- **In-Process Service Architecture** (#454): MCP Server and CLI each host ExcelMCP Service in-process instead of sharing a separate service process
+  - Eliminates service discovery failures (especially NuGet tool installs) and cross-process coordination
+
+- **Separate CLI NuGet Package** (#452): CLI published as `Sbroenne.ExcelMcp.CLI` alongside MCP Server
+  - Service version negotiation: client validates exact version match with running service on connect
 
 ### Fixed
-- Release workflow no longer publishes partial releases on build failures
 
-## [1.6.10] - 2026-02-15
+- **Build Workflow Path** (#455): Fixed target framework path (`net10.0` → `net10.0-windows`) and formatting errors in build workflow
+
+## [1.7.1] - 2026-02-09
+
+### Fixed
+
+- **Release Workflow** (#451): Moved all external publishing steps after builds succeed to prevent partial releases
+
+## [1.6.10] - 2026-02-06
 
 ### ⚠️ BREAKING CHANGES
 
-**See [BREAKING-CHANGES.md](docs/BREAKING-CHANGES.md) for migration guide.**
+**See [BREAKING-CHANGES.md](docs/BREAKING-CHANGES.md) for complete migration guide.**
+LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CLI).
 
-- Tool names simplified: removed `excel_` prefix (e.g. `excel_range` → `range`)
+- **Tool Names Simplified**: Removed `excel_` prefix from all 23 MCP tool names (e.g., `excel_range` → `range`, `excel_file` → `file`). Titles also shortened (e.g., `"Chart Operations"`). VS Code extension server name → `excel-mcp`.
 
 ### Added
-- **Calculation Mode Control** — new `calculation_mode` tool (automatic, manual, semi-automatic)
-- CLI commands now auto-generated from Core — guaranteed 1:1 MCP/CLI parity
-- Added `npx add-mcp` installation method
+
+- **CLI Code Generation** (#433): CLI commands auto-generated from Core via Roslyn source generators — guarantees 1:1 MCP/CLI parity
+- **Calculation Mode Control** (#430): New `calculation_mode` tool/CLI command (automatic, manual, semi-automatic modes; workbook/sheet/range scopes)
+- **Installation via npx** (#449): Added `npx add-mcp` as primary installation method in docs
+
+### Changed
+
+- **MCP Prompt Reduction** (#442): Reduced prompts from 7 to 4 with ~76% content reduction; removed `excel_` prefix from prompt names
+- **VS Code Extension**: Self-contained publishing (no .NET runtime needed), CLI removed from extension, skills use `chatSkills` contribution point
+- **LLM Tests** (#446): Migrated to pytest-aitest v0.3.x from PyPI with unified MCP/CLI test suite
+- **Release Workflow** (#443): Switched to workflow_dispatch with version bump UI; added stale issue workflow
+- **Terminology**: "Daemon" → "ExcelMCP Service" throughout docs
+- **MCP SKILL template** (#448): Added Workflow Checklist table for quick reference (open → create → write → format → save)
+- **CLI SKILL template** (#448): Added "List Parameters Use JSON Arrays" to Common Pitfalls section
+- **Slicer reference doc**: Added CLI JSON Array Quoting section with PowerShell escaping examples
+- **MCPB**: Removed agent skills from Claude Desktop bundle
+
+### Fixed
+
+- **MCP Server Release Path** (#450): Corrected package path to `net10.0-windows`
+- **Broken Emoji Characters**: Fixed corrupted emoji in README files
 
 ### Removed
-- Docker/Glama.ai deployment support
+
+- **Glama.ai Support**: Removed Docker-based deployment (`Dockerfile`, `glama.json`, `.dockerignore`, docs)
 
 ## [1.6.9] - 2026-02-04
 
 ### Added
-- CLI tray icon: "Update CLI" menu option, save prompts when closing sessions
+
+- **CLI Daemon Improvements**: Enhanced tray icon experience with better update management and save prompts
+  - Added "Update CLI" menu option when updates are available (detects global vs local .NET tool install)
+  - Added save dialog (Yes/No/Cancel) when closing individual sessions from tray
+  - Added save dialog (Yes/No/Cancel) when stopping daemon with active sessions
+  - Removed redundant disabled "Excel CLI Daemon" status menu entry
+  - Toast notifications now mention the Update CLI menu option for easier access
+  - Update command shows in confirmation dialog before execution
+  - Auto-restart daemon after successful update
 
 ### Fixed
-- PivotTable field operations no longer cause "RPC server is unavailable" errors on Data Model PivotTables
+
+- **PivotTable RPC Disconnection** (#426): Fixed "RPC server is unavailable (0x800706BA)" error during rapid OLAP PivotTable field operations
+  - ROOT CAUSE: `RefreshTable()` called after each field operation triggered synchronous Analysis Services queries
+  - FIX: Removed RefreshTable() from field manipulation methods (AddRowField, AddColumnField, AddFilterField, RemoveField, SetFieldFunction)
+  - Field changes now take effect immediately without blocking AS queries
+  - Call `pivottable(refresh)` explicitly to update visual display after configuring fields
+  - Applies to both OLAP (Data Model) and regular PivotTables for consistency
 
 ## [1.6.8] - 2026-02-03
 
+### Changed
+
+- **JSON Property Names Reverted** (#417): Removed short property name mappings for better readability
+  - JSON output now uses camelCase C# property names (e.g., `success`, `errorMessage`, `filePath`)
+  - Removed 433 `[JsonPropertyName]` attributes from model files
+  - LLMs and humans can now read JSON without consulting a mapping table
+
 ### Fixed
-- CLI commands no longer silently ignore user-provided parameter values for `connection`, `powerquery`, `chart`, `table`, and `vba` commands
-- JSON output uses readable property names (reverted short names)
+
+- **CLI Banner Cleanup**: Removed PowerShell warning from startup banner
+  - Guidance moved to skill documentation (Rule 2: Use File-Based Input)
+  - CLI output is now cleaner and less cluttered
+
+- **CLI Missing Parameter Mappings** (#423): Fixed CLI commands silently ignoring user-provided values
+  - ROOT CAUSE: Settings properties defined but not passed to daemon in args switch statements
+  - FIX: Added missing parameter mappings for affected commands:
+    - `connection set-properties`: Added `description`, `backgroundQuery`, `savePassword`, `refreshPeriod`
+    - `powerquery create/load-to`: Added `targetSheet`, `targetCellAddress`
+    - `chart create-*` and `move`: Added `left`, `top`, `width`, `height`
+    - `table append`: Fixed to parse CSV into proper `rows` format
+    - `vba run`: Added `timeoutSeconds`
+  - Added pre-commit check (`check-cli-settings-usage.ps1`) to prevent future occurrences
 
 ## [1.6.5] - 2026-02-03
 
-### Fixed
-- Dead Excel sessions are now auto-detected and cleaned up — no more confusing timeouts when Excel process dies
+- **Dead Session Detection** (#414): Auto-detect and cleanup sessions when Excel process dies
+  - ROOT CAUSE: `SessionManager` never checked if Excel process was alive, leaving dead sessions in dictionary
+  - FIX: `GetSession()`, `GetActiveSessions()`, and `IsSessionAlive()` now check process health and auto-cleanup
+  - `ExcelBatch.Execute()` validates Excel is alive before queueing operations
+  - Users now get clear error: "Excel process is no longer running" instead of confusing timeouts
+  - Dead sessions no longer block reopening the same file
+  - Affects both CLI and MCP Server (shared `SessionManager`)
 
 ## [1.6.4] - 2026-02-03
 
 ### Fixed
-- Setting formulas/values that trigger Data Model recalculation no longer times out
+
+- **COM Timeout with Data Model Dependencies** (#412): Fixed timeout when setting formulas/values that trigger Data Model recalculation
+  - ROOT CAUSE: Excel's automatic calculation blocks COM interface during DAX recalculation
+  - FIX: Temporarily disable calculation mode (xlCalculationManual) during write operations
+  - Affected methods: `SetFormulas`, `SetValues`, `Table.Append`, `NamedRange.Write`
+  - Formulas like `=INDEX(KPIs[Total_ACR],1)` now work without "The operation was canceled" error
 
 ## [1.6.3] - 2026-02-03
 
-### Fixed
-- Documentation improvements for Power Query M code and CLI command names
+### Documentation
+
+- **M Code Identifier Quoting** (#407): Added guidance for special characters in Power Query identifiers
+- **PowerQuery Eval-First Workflow** (#405): Updated documentation with eval-first pattern
+- **CLI Command Name Fix** (#403): Fixed CLI command name in agent skills installation docs
 
 ## [1.6.2] - 2026-02-02
 
+### Fixed
+
+- **Power Query Refresh Error Propagation** (#399): Fixed bug where `refresh` action returned `success: true` even when Power Query had formula errors
+  - ROOT CAUSE: `Connection.Refresh()` silently swallows errors for worksheet queries (InModel=false)
+  - FIX: Now uses `QueryTable.Refresh(false)` for worksheet queries which properly throws errors
+  - Data Model queries (InModel=true) continue using `Connection.Refresh()` which does throw errors
+  - Errors now surface clearly: `"[Expression.Error] The name 'Source' wasn't recognized..."`
+
+- **Table Create Auto-Expand from Single Cell**: Fixed issue where `table create --range A1` created single-cell table
+  - ROOT CAUSE: Excel's `ListObjects.Add()` doesn't auto-expand from a single cell
+  - FIX: Now uses `Range.CurrentRegion` when single cell provided, capturing all contiguous data
+  - Prevents Data Model issues where tables only contain header column
+
 ### Added
-- **Power Query `evaluate`** — execute M code directly and return results without creating a permanent query
-- **`mCodeFile` parameter** — read M code from file instead of inline string (avoids escaping issues)
-- **`vbaCodeFile` parameter** — read VBA code from file instead of inline string
+
+- **Power Query Evaluate** (#400): New `evaluate` action to execute M code directly and return results
+  - Execute arbitrary M code without creating a permanent query
+  - Returns tabular results (columns, rows) in JSON format
+  - Automatically cleans up temporary query and worksheet
+  - Errors propagate properly (e.g., invalid M syntax throws with error message)
+  - Example: `excelcli powerquery evaluate --file data.xlsx --mcode "let Source = #table({\"Name\",...})"`
+
+- **MCP Power Query mCodeFile Parameter**: Read M code from file instead of inline string
+  - New `mCodeFile` parameter on `powerquery` tool for `create`, `update`, `evaluate` actions
+  - Avoids JSON escaping issues with complex M code containing special characters
+  - File takes precedence if both `mCode` and `mCodeFile` provided
+
+- **MCP VBA vbaCodeFile Parameter**: Read VBA code from file instead of inline string
+  - New `vbaCodeFile` parameter on `vba` tool for `create-module`, `update-module` actions
+  - Handles VBA code with quotes and special characters cleanly
+  - File takes precedence if both `vbaCode` and `vbaCodeFile` provided
+
+## [1.6.1] - 2026-02-01
 
 ### Fixed
-- `powerquery refresh` now correctly reports errors instead of returning success on formula errors
-- `table create` from a single cell now auto-expands to the full contiguous data range
+
+- **CLI PackAsTool Workaround** (#396): Fixed CLI packaging issue with net10.0-windows target
+- **CI Duplicate Paths** (#394): Removed duplicate paths key in build workflow
 
 ## [1.6.0] - 2026-02-01
 
+### Fixed
+
+- **MCPB Skills Key** (#392): Removed unsupported 'skills' key from manifest
+- **Data Model MSOLAP Error** (#391): Better error message when MSOLAP provider is missing
+
+## [1.5.14] - 2025-02-01
+
 ### Added
-- **Complete CLI Rewrite** — 14 command categories with 210 operations matching MCP Server
-- **Quiet Mode** — `-q` flag for clean JSON-only output
-- **Session timeout** — configurable `timeoutSeconds` on `file(open)` and `file(create)`
-- **PowerQuery `unload`** — remove data from load destinations while keeping query definition
+
+#### CLI Redesign (Breaking Change)
+- **Complete CLI Rewrite** (#387): Redesigned CLI for coding agents and scripting - **NOT backwards compatible**
+  - 14 unified command categories with 210 operations matching MCP Server
+  - All commands now use `--session` parameter (was positional in some commands)
+  - Comprehensive `--help` descriptions on all commands synced with MCP tool descriptions
+  - All `--file` parameters support both new file creation and existing files
+  - New `excelcli list-actions` command to discover all available operations
+  - Exit code standardization (0=success, 1=error, 2=validation)
+
+- **Quiet Mode**: `-q`/`--quiet` flag suppresses banner for agent-friendly JSON-only output
+  - Auto-detects piped/redirected stdout and suppresses banner automatically
+
+- **Version Check**: `excelcli version --check` queries NuGet to show if update available
+
+- **Session Close --save**: Single `--save` flag for atomic save-and-close workflow
+  - Replaces separate save + close sequence for cleaner scripting
+
+- **CLI Action Coverage Pre-commit Check**: New `check-cli-action-coverage.ps1` script
+  - Ensures CLI switch statements cover ALL action strings from ActionExtensions.cs
+  - Prevents "action not handled" bugs from reaching production
+  - Validates 210 operations across 21 CLI commands
+
+#### MCP Server Enhancements  
+- **Session Operation Timeout** (#388): Configurable timeout prevents infinite hangs
+  - New `timeoutSeconds` parameter on `file(open)` and `file(create)` actions
+  - Default: 300 seconds (5 minutes), configurable range: 10-3600 seconds
+  - Applies to ALL operations within session; exceeding timeout throws `TimeoutException`
+
+- **Create Action** (#385): Renamed `create-and-open` to simpler `create` action
+  - Single-action file creation and session opening
+  - Performance: ~3.8 seconds (vs ~7-8 seconds with separate create+open)
+
+- **PowerQuery Unload Action**: New `unload` action removes data from all load destinations
+  - Keeps query definition intact while clearing worksheet/model data
+
+#### Testing & Quality
+- **LLM Integration Tests**: Comprehensive pytest-aitest test suite for CLI
+  - 9 test scenarios covering all major Excel operations
+  - Chart positioning, PivotTable layout, Power Query, slicers, tables, ranges
+  - Financial report automation workflow tests
+
+- **Agent Skills**: New structured skills documentation for AI assistants
+  - `skills/excel-cli/` - CLI-specific skill with commands reference
+  - `skills/excel-mcp/` - MCP Server skill with tools reference
+  - `skills/shared/` - Shared workflows, anti-patterns, behavioral rules
 
 ### Fixed
-- Better error message when MSOLAP provider is missing for Data Model operations
-
-## [1.5.13] - 2026-01-26
-
-### Added
-- **Chart Formatting** — data labels, axis scale, gridlines, series markers (8 new operations)
-- **Chart Trendlines** — add, list, delete, and configure trendlines (4 new operations)
-
-## [1.5.11] - 2026-01-22
-
-### Added
-- Agent Skills included in all artifacts
-- MCPB bundle now includes LICENSE and CHANGELOG.md
-
-## [1.5.8] - 2026-01-20
-
-### Added
-- Available as a Claude Desktop MCPB Extension
-
-## [1.5.6] - 2026-01-20
-
-### Added
-- **Slicers** — create, list, filter, and delete slicers for PivotTables and Tables (8 new operations)
-
-## [1.5.5] - 2026-01-19
-
-### Added
-- **DMV Queries** — query Data Model metadata via Dynamic Management Views
-
-## [1.5.4] - 2026-01-19
-
-### Added
-- **DAX Queries** — execute DAX EVALUATE queries against the Data Model
-- **DAX-backed Tables** — create worksheet tables populated by DAX queries
-
-## [1.5.0] - 2026-01-09
+- **Calculated Field Bug**: Fixed PivotTable calculated field creation error
+- **COM Diagnostics**: Improved error reporting for COM object lifecycle issues
 
 ### Changed
-- **Tool Reorganization** — split 12 tools into 21 focused tools (186 operations total)
-- **.NET 10 Upgrade** — requires .NET 10.0
+- CLI timeout option uses `--timeout <seconds>` (was `--timeout-seconds`)
+- All CLI commands now require explicit `--session` parameter
+
+## [1.5.13] - 2025-01-24
+
+### Added
+- **Chart Formatting** (#384): Enhanced chart formatting capabilities
+  - **Data Labels**: Configure label position and visibility (showValue, showCategory, showPercentage, etc.)
+  - **Axis Scale**: Get/set axis scale properties (min, max, units, auto-scale flags)
+  - **Gridlines**: Control major/minor gridlines visibility on chart axes
+  - **Series Markers**: Configure marker style, size, and colors for data series
+  - 8 new operations bringing total chart operations to 22
+
+- **Chart Trendlines** (#386): Statistical analysis and forecasting for chart series
+  - **Add Trendline**: Linear, Exponential, Logarithmic, Polynomial, Power, Moving Average
+  - **List Trendlines**: View all trendlines on a series
+  - **Delete Trendline**: Remove trendline by index
+  - **Configure Trendline**: Forward/backward forecasting, display equation and R² value
+  - 4 new operations bringing total chart operations to 26
+
+## [1.5.11] - 2025-01-22
+
+### Added
+- Added Agent Skill to all artifacts
+
+### Changed
+- **MCPB Submission Compliance**: Bundle now includes LICENSE and CHANGELOG.md per Anthropic requirements
+- **Documentation Updates**: All READMEs updated with LLM-tested example prompts and accurate tool counts (22 tools, 194 operations)
+
+## [1.5.8] - 2025-01-20
+
+### Added
+- Now available as a Claude Desktop MCPB Extension
+  
+## [1.5.6] - 2025-01-20
+
+### Added
+- **PivotTable & Table Slicers** (#363): New `slicer` tool for interactive filtering
+  - **PivotTable Slicers**: Create, list, filter, and delete slicers for PivotTable fields
+  - **Table Slicers**: Create, list, filter, and delete slicers for Excel Table columns
+  - 8 new operations for interactive data filtering
+
+## [1.5.5] - 2025-01-19
+
+### Added
+- **DMV Query Execution** (#353): Query Data Model metadata using Dynamic Management Views
+  - New `execute-dmv` action on `datamodel` tool
+  - Query TMSCHEMA_MEASURES, TMSCHEMA_RELATIONSHIPS, DISCOVER_CALC_DEPENDENCY, etc.
+
+## [1.5.4] - 2025-01-19
+
+### Added
+- **DAX EVALUATE Query Execution** (#356): Execute DAX queries against the Data Model
+  - New `evaluate` action on `datamodel` tool for ad-hoc DAX queries
+- **DAX-Backed Excel Tables** (#356): Create worksheet tables populated by DAX queries
+  - New `create-from-dax`, `update-dax`, `get-dax` actions
+
+## [1.5.0] - 2025-01-10
+
+### Changed
+- **Tool Reorganization** (#341): Split 12 monolithic tools into 21 focused tools
+  - 186 operations total, better organized for AI assistants
+  - Ranges: 4 tools (range, range_edit, range_format, range_link)
+  - PivotTables: 3 tools (pivottable, pivottable_field, pivottable_calc)
+  - Tables: 2 tools (table, table_column)
+  - Data Model: 2 tools (datamodel, datamodel_rel)
+  - Charts: 2 tools (chart, chart_config)
+  - Worksheets: 2 tools (worksheet, worksheet_style)
+
+### Added
+- **LLM Integration Testing** (#341): Real AI agent testing using [pytest-aitest](https://github.com/sbroenne/pytest-aitest)
+
+### Changed
+- **.NET 10 Upgrade**: Requires .NET 10.0 instead of .NET 8.0
 
 ## [1.4.42] - 2025-12-15
 
 ### Added
-- Power Query `rename` and Data Model `rename-table` actions
+- **Power Query Rename** (#326, #327): New `rename` action for Power Query queries
+- **Data Model Table Rename** (#326, #327): New `rename-table` action for Data Model tables
 
 ## [1.4.41] - 2025-12-14
 
 ### Fixed
-- Fixed error when updating Power Query in workbooks with Data Model
+- **Power Query Data Model Fix** (#324): Fixed "0x800A03EC" error when updating Power Query in workbooks with Data Model present
 
 ## [1.4.40] - 2025-12-14
 
 ### Changed
-- Upgraded MCP SDK to 0.5.0 with proper error signaling
+- **MCP SDK Upgrade** (#301): Upgraded ModelContextProtocol SDK from 0.4.1-preview.1 to 0.5.0-preview.1
+  - Proper `isError` signaling for tool execution failures
+  - Deterministic exit codes (0 = success, 1 = fatal error)
 
 ## [1.4.37] - 2025-12-06
 
+### Changed
+- **PivotTable Performance** (#286): Optimized `RefreshTable()` calls
+
 ### Added
-- Data Model table members support
-- PivotTable refresh performance improvements
+- **Data Model Members** (#288): Added support for Data Model table members
+
+## [1.4.36] - 2025-12-06
+
+### Changed
+- **Documentation Updates** (#290): Updated tool/operation counts
+
+### Fixed
+- **SEO Fix** (#292): Fixed robots.txt sitemap URL
 
 ## [1.4.35] - 2025-12-05
 
 ### Added
-- **Data Model Relationships** — create, update, and delete relationships
+- **Data Model Relationships** (#278): Full support for creating, updating, and deleting relationships
+- **Custom Domain** (#276): excelmcpserver.dev
 
 ## [1.4.34] - 2025-12-05
 
 ### Fixed
-- DAX formulas now work on European locales (comma as decimal separator)
+- **DAX Formula Locale Handling** (#281): DAX formulas now work on European locales
 
 ## [1.4.33] - 2025-12-04
 
-### Added
-- Cross-file worksheet operations: `copy-to-file` and `move-to-file`
+### Changed
+- **Atomic Cross-File Worksheet Operations** (#273): New `copy-to-file` and `move-to-file` actions
 
 ## [1.4.32] - 2025-12-04
 
 ### Fixed
-- Charts can now be created from Data Model PivotTables
+- **OLAP PivotChart Creation** (#267): `CreateFromPivotTable` now works with OLAP/Data Model PivotTables
+- **Power Query LoadToBoth Detection** (#271): Fixed incorrect detection
 
 ## [1.4.31] - 2025-12-04
 
 ### Fixed
-- Number and date formats now work correctly on non-US locales
+- **Locale-Independent Number Formatting** (#263): Number and date formats now work on non-US locales
 
 ## [1.4.30] - 2025-12-03
 
+### Fixed
+- **OLAP PivotTable AddValueField** (#261): Fixed errors when adding value fields to Data Model PivotTables
+
 ### Added
-- `showExcel: true` parameter to watch AI work in Excel in real time
+- **Show Excel Mode**: Open with `showExcel: true` to watch AI changes live
+
+## [1.4.28] - 2025-12-01
 
 ### Fixed
-- Fixed errors when adding value fields to Data Model PivotTables
+- **VS Code Extension Display Name** (#257): Corrected MCP server display name
 
 ## [1.4.25] - 2025-12-01
 
 ### Changed
-- VS Code extension is 89% smaller (framework-dependent deployment)
+- **89% Smaller Extension Size** (#250): Switched to framework-dependent deployment
 
 ## [1.4.24] - 2025-12-01
 
-### Added
-- PivotTable grand totals, date/numeric grouping, calculated fields, layout control (172 total operations)
-
 ### Fixed
-- MCP Server no longer stops due to network errors
+- **Session Stability** (#245): Fixed Excel MCP Server stopping due to network errors
+
+### Added
+- **PivotTable Grand Totals Control**: Show/hide row and column grand totals
+- **PivotTable Grouping**: Group dates by days/months/quarters/years
+- **PivotTable Calculated Fields**: Create calculated fields with formulas
+- **PivotTable Layout & Subtotals**: Configure layout form and subtotals visibility
+- Total operations: 172
 
 ## [1.4.0] - 2025-11-24
 
 ### Added
-- Table `get-data` action
+- **Excel Table Get Data** (#234): New `get-data` action returns table rows
 
 ### Fixed
-- Power Query no longer creates spurious "Error Query" entries
+- **Power Query Error Query Fix** (#236): Fixed spurious "Error Query" entries
 
 ## [1.3.0] - 2025-11-22
 
 ### Added
-- 15 chart operations
-- Connection `delete` action
-- OLAP PivotTable measures
+- **Chart Operations** (#229): 15 new chart actions
+- **Connection Delete** (#226): New `delete` action
+- **OLAP PivotTable Measures** (#217): Auto-create DAX measures
+
+### Changed
+- **PivotTable Enhancements** (#219, #220): Date/numeric grouping, calculated fields
 
 ## [1.2.0] - 2025-11-17
 
 ### Added
-- Worksheet `move` action for reordering sheets
+- **Worksheet Reordering** (#186): New `move` action
 
 ### Fixed
-- Fixed crashes with disconnected COM proxies
+- **MCP Server Crash Fix** (#192): Fixed crashes with disconnected COM proxies
+- **Connection Create Fix** (#190): Fixed COM dispatch error
 
 ## [1.1.0] - 2025-11-10
 
-### Added
-- PivotTables from Data Model, connection `create`, configurable timeouts, `querytable` tool, CLI batch mode
-
 ### Fixed
-- File lock errors, Power Query update overwriting, formula/value "out of memory" error, Data Model loading
+- **File Lock Fix** (#173): Fixed "file already open" errors
+- **LoadTo Silent Failure Fix** (#170): LoadTo now properly fails on duplicates
+- **Validation InputTitle/Message** (#167): Fixed empty values
+- **Power Query Update Fix** (#140): Fixed M code merging instead of replacing
+- **SetFormulas/SetValues Fix** (#199): Fixed "out of memory" error
+- **Data Model Loading Fix** (#64): Fixed `set-load-to-data-model` failures
+- **Power Query Persistence** (#42): Fixed load-to-data-model not persisting
+
+### Added
+- **PivotTable Discovery** (#155): Improved LLM discoverability
+- **CLI Batch Support** (#152): Batch mode for bulk operations
+- **Timeout Support** (#131): Configurable timeouts for all tools
+- **QueryTable Support** (#129): New `excel_querytable` tool
+- **Connection Create** (#127): New `create` action
+- **PivotTable from Data Model** (#109): Create PivotTables from Power Pivot
+
+### Changed
+- **Numeric Column Names** (#136): Column names can now be numeric
 
 ## [1.0.0] - 2025-10-29
 
 ### Added
-- Initial release — MCP Server with 11 tools and 100+ operations
+- Initial release of ExcelMcp
+- MCP Server with 11 tools and 100+ operations
 - CLI for command-line scripting
-- VS Code Extension
-- Power Query, Data Model, Tables, PivotTables, Ranges, Charts, Named Ranges, VBA, Worksheets
+- VS Code Extension for one-click installation
+- Power Query management
+- Data Model / Power Pivot support
+- Excel Tables and PivotTables
+- Range operations with formulas
+- Chart creation
+- Named ranges and parameters
+- VBA macro execution
+- Worksheet lifecycle management
+- Batch operations for performance

--- a/src/ExcelMcp.Core/Commands/Table/TableCommands.Data.cs
+++ b/src/ExcelMcp.Core/Commands/Table/TableCommands.Data.cs
@@ -2,6 +2,7 @@ using Excel = Microsoft.Office.Interop.Excel;
 using System.Globalization;
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
 using Sbroenne.ExcelMcp.Core.Models;
 using Sbroenne.ExcelMcp.Core.Utilities;
 
@@ -86,7 +87,7 @@ public partial class TableCommands
                         try
                         {
                             cell = sheet.Cells[currentRow + i, table.Range.Column + j];
-                            cell.Value2 = rowValues[j] ?? string.Empty;
+                            cell.Value2 = RangeHelpers.ConvertToCellValue(rowValues[j]);
                         }
                         finally
                         {

--- a/src/ExcelMcp.Core/ExcelMcp.Core.csproj
+++ b/src/ExcelMcp.Core/ExcelMcp.Core.csproj
@@ -54,6 +54,10 @@
   </Target>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Sbroenne.ExcelMcp.Core.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Include README and LICENSE in package -->
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Table/TableCommandsTests.BugRegression.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Table/TableCommandsTests.BugRegression.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Table;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Table;
+
+/// <summary>
+/// Bug regression tests for TableCommands.
+/// These tests reproduce known bugs and must fail before the fix and pass after.
+/// </summary>
+[Trait("Layer", "Core")]
+[Trait("Category", "Integration")]
+[Trait("RequiresExcel", "true")]
+[Trait("Feature", "Tables")]
+[Trait("Speed", "Medium")]
+public sealed class TableCommandsTests_BugRegression : IClassFixture<TempDirectoryFixture>
+{
+    private readonly TableCommands _tableCommands;
+    private readonly TempDirectoryFixture _fixture;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableCommandsTests_BugRegression"/> class.
+    /// </summary>
+    public TableCommandsTests_BugRegression(TempDirectoryFixture fixture)
+    {
+        _tableCommands = new TableCommands();
+        _fixture = fixture;
+    }
+
+    /// <summary>
+    /// Regression test for issue #519:
+    /// table append throws COM marshalling exception when row values are JsonElement
+    /// (as produced by CLI JSON deserialization of --rows parameter).
+    /// Before fix: throws NotSupportedException / InvalidCastException / COMException.
+    /// After fix: appends rows successfully.
+    /// </summary>
+    [Fact]
+    public void Append_WithJsonElementValues_DoesNotThrow()
+    {
+        // Arrange: create a workbook with a table that has string, bool, and number columns
+        var testFile = CoreTestHelper.CreateUniqueTestFile(
+            nameof(TableCommandsTests_BugRegression),
+            nameof(Append_WithJsonElementValues_DoesNotThrow),
+            _fixture.TempDir,
+            ".xlsx");
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        // Create data + table in the same batch (no save needed)
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic sheet = ctx.Book.Worksheets[1];
+            sheet.Name = "Data";
+            sheet.Range["A1"].Value2 = "Label";
+            sheet.Range["B1"].Value2 = "IsActive";
+            sheet.Range["C1"].Value2 = "Amount";
+            sheet.Range["A2"].Value2 = "Initial";
+            sheet.Range["B2"].Value2 = true;
+            sheet.Range["C2"].Value2 = 1.0;
+            return 0;
+        });
+        _tableCommands.Create(batch, "Data", "DataTable", "A1:C2", true, "TableStyleLight1");
+
+        // Act: deserialize rows the same way the CLI does — via JsonSerializer producing JsonElement
+        // This is key: the values must be JsonElement (boxed as object?), not raw C# types
+        var rowsJson = """[["NewRow", true, 99.5], ["AnotherRow", false, 0.0]]""";
+        var deserializedRows = JsonSerializer.Deserialize<List<List<object?>>>(rowsJson)!;
+
+        // Confirm the test is correctly structured: values must be JsonElements, not strings/bools
+        Assert.IsType<JsonElement>(deserializedRows[0][0]);
+        Assert.IsType<JsonElement>(deserializedRows[0][1]);
+        Assert.IsType<JsonElement>(deserializedRows[0][2]);
+
+        // Assert: should not throw — before the fix this throws a COM marshalling exception
+        _tableCommands.Append(batch, "DataTable", deserializedRows);
+
+        // Verify rows were appended
+        var info = _tableCommands.Read(batch, "DataTable");
+        Assert.True(info.Success, $"Read after append failed: {info.ErrorMessage}");
+        Assert.Equal(3, info.Table!.RowCount); // 1 original + 2 appended
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Unit/ServiceRegistryJsonParsingTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/ServiceRegistryJsonParsingTests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.Generated;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ServiceRegistry.DeserializeNestedCollection (generated helper).
+/// Covers bug regressions for issue #521:
+///   --values inline JSON loses string quotes in PowerShell (stdin sentinel + better error).
+/// These tests must FAIL before the fix and PASS after.
+/// </summary>
+[Trait("Layer", "Core")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "ServiceRegistry")]
+[Trait("Speed", "Fast")]
+[Trait("RequiresExcel", "false")]
+public sealed class ServiceRegistryJsonParsingTests
+{
+    private static readonly System.Type _registryType = typeof(ServiceRegistry);
+
+    private static List<List<object?>> Deserialize(string json)
+    {
+        var method = _registryType.GetMethod(
+            "DeserializeNestedCollection",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var genericMethod = method.MakeGenericMethod(typeof(List<List<object?>>));
+        try
+        {
+            return (List<List<object?>>)genericMethod.Invoke(null, [json])!;
+        }
+        catch (System.Reflection.TargetInvocationException ex)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
+            throw; // unreachable
+        }
+    }
+
+    /// <summary>
+    /// Regression test for issue #521 — error path:
+    /// When PowerShell strips double-quotes, `--values '[["ACD Full Term",0.26]]'`
+    /// arrives as `[[ACD Full Term,0.26]]` (invalid JSON).
+    /// The error message MUST mention `--values-file` or `--values -` to help users.
+    /// Before fix: error message says "Invalid JSON for nested collection. Expected 2D array..."
+    ///             with no mention of PowerShell or --values-file.
+    /// After fix: error message explicitly mentions the workaround options.
+    /// </summary>
+    [Fact]
+    public void DeserializeNestedCollection_MangledJsonFromPowerShell_ErrorMentionsValuesFile()
+    {
+        // This is what PowerShell hands to the native exe after stripping inner quotes:
+        var mangledJson = "[[ACD Full Term,0.26]]";
+
+        var ex = Assert.Throws<ArgumentException>(() => Deserialize(mangledJson));
+
+        // The error message must guide the user toward the correct fix
+        Assert.True(
+            ex.Message.Contains("values-file", StringComparison.OrdinalIgnoreCase) ||
+            ex.Message.Contains("--values -", StringComparison.OrdinalIgnoreCase),
+            $"Error message should mention '--values-file' or '--values -' but was: {ex.Message}");
+    }
+
+    /// <summary>
+    /// Regression test for issue #521 — stdin sentinel path:
+    /// When `json == "-"`, the method should read JSON from Console.In instead of
+    /// attempting to parse the literal string "-" as JSON.
+    /// Before fix: throws ArgumentException because "-" is not valid JSON.
+    /// After fix: reads from Console.In and deserializes correctly.
+    /// </summary>
+    [Fact]
+    public void DeserializeNestedCollection_StdinSentinel_ReadsFromConsoleIn()
+    {
+        var validJson = """[["ACD Full Term", 0.26], ["RI 3yr", 0.40]]""";
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader(validJson));
+        try
+        {
+            var result = Deserialize("-");
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(2, result[0].Count);
+            // Values come back as JsonElement when deserializing List<List<object?>>
+            var firstLabel = result[0][0] is JsonElement je ? je.GetString() : result[0][0]?.ToString();
+            Assert.Equal("ACD Full Term", firstLabel);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two bugs found during real-world usage of the 	able append and CLI --values/--rows parameter handling.

## Fixes

### #519 — 	able append JsonElement COM marshalling error
Row values passed to Append() were System.Text.Json.JsonElement boxed as object?. Assigning a JsonElement directly to cell.Value2 throws a COM marshalling exception because COM cannot convert JsonElement to a Variant. Fixed by using RangeHelpers.ConvertToCellValue() — the same helper already used correctly in \ange set-values\.

### #521 — \--values\ inline JSON: PowerShell quote-stripping + stdin sentinel
Windows \CreateProcess\ strips inner double-quotes from shell arguments, so inline JSON containing strings arrives mangled (e.g. \[[ACD Full Term,0.26]]\). The generated \DeserializeNestedCollection<T>\ now:
1. Emits a clear error message mentioning \--values-file\ and \--values -\ as workarounds
2. Supports a stdin sentinel: \--values -\ (or \--rows -\) reads JSON from \Console.In\, bypassing shell quoting entirely

## Tests
- **TableCommandsTests_BugRegression.Append_WithJsonElementValues_DoesNotThrow** — integration test that deserializes JSON (producing \JsonElement\ values) then appends to a table; confirmed failing before fix, passing after
- **\ServiceRegistryJsonParsingTests.DeserializeNestedCollection_StdinSentinel_ReadsFromConsoleIn\** — unit test for stdin sentinel
- **\ServiceRegistryJsonParsingTests.DeserializeNestedCollection_MangledJsonFromPowerShell_ErrorMentionsValuesFile\** — unit test verifying improved error message

## Checklist
- [x] Tests written and confirmed failing before fix
- [x] Tests passing after fix
- [x] Full solution build: 0 warnings, 0 errors
- [x] CHANGELOG updated