### PR TITLE
fix: CLI and MCP Server version always reported as 1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,25 +130,14 @@ jobs:
         echo "VERSION=$version" >> $env:GITHUB_ENV
       shell: pwsh
 
-    - name: Update CLI Version
-      run: |
-        $version = $env:VERSION
-        $csprojPath = "src/ExcelMcp.CLI/ExcelMcp.CLI.csproj"
-        $content = Get-Content $csprojPath -Raw
-        $content = $content -replace '<Version>[\d\.]+</Version>', "<Version>$version</Version>"
-        $content = $content -replace '<AssemblyVersion>[\d\.]+\.[\d\.]+</AssemblyVersion>', "<AssemblyVersion>$version.0</AssemblyVersion>"
-        $content = $content -replace '<FileVersion>[\d\.]+\.[\d\.]+</FileVersion>', "<FileVersion>$version.0</FileVersion>"
-        Set-Content $csprojPath $content
-      shell: pwsh
-
     - name: Restore
       run: dotnet restore src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
 
     - name: Build CLI
-      run: dotnet build src/ExcelMcp.CLI/ExcelMcp.CLI.csproj --configuration Release --no-restore
+      run: dotnet build src/ExcelMcp.CLI/ExcelMcp.CLI.csproj --configuration Release --no-restore -p:Version=${{ env.VERSION }} -p:AssemblyVersion=${{ env.VERSION }}.0 -p:FileVersion=${{ env.VERSION }}.0
 
     - name: Pack CLI NuGet
-      run: dotnet pack src/ExcelMcp.CLI/ExcelMcp.CLI.csproj --configuration Release --no-build --output ./cli-nupkg
+      run: dotnet pack src/ExcelMcp.CLI/ExcelMcp.CLI.csproj --configuration Release --no-build --output ./cli-nupkg -p:Version=${{ env.VERSION }}
 
     - name: Upload CLI Build Output
       uses: actions/upload-artifact@v4
@@ -198,22 +187,6 @@ jobs:
       run: |
         $version = $env:VERSION
 
-        # Update CLI version (for bundling)
-        $cliPath = "src/ExcelMcp.CLI/ExcelMcp.CLI.csproj"
-        $content = Get-Content $cliPath -Raw
-        $content = $content -replace '<Version>[\d\.]+</Version>', "<Version>$version</Version>"
-        $content = $content -replace '<AssemblyVersion>[\d\.]+\.[\d\.]+</AssemblyVersion>', "<AssemblyVersion>$version.0</AssemblyVersion>"
-        $content = $content -replace '<FileVersion>[\d\.]+\.[\d\.]+</FileVersion>', "<FileVersion>$version.0</FileVersion>"
-        Set-Content $cliPath $content
-
-        # Update MCP Server version
-        $csprojPath = "src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj"
-        $content = Get-Content $csprojPath -Raw
-        $content = $content -replace '<Version>[\d\.]+</Version>', "<Version>$version</Version>"
-        $content = $content -replace '<AssemblyVersion>[\d\.]+\.[\d\.]+</AssemblyVersion>', "<AssemblyVersion>$version.0</AssemblyVersion>"
-        $content = $content -replace '<FileVersion>[\d\.]+\.[\d\.]+</FileVersion>', "<FileVersion>$version.0</FileVersion>"
-        Set-Content $csprojPath $content
-
         # Update MCP Registry server.json
         $serverJsonPath = "src/ExcelMcp.McpServer/.mcp/server.json"
         $serverContent = Get-Content $serverJsonPath -Raw
@@ -226,12 +199,12 @@ jobs:
       run: dotnet restore src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
 
     - name: Build
-      run: dotnet build src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj --configuration Release --no-restore
+      run: dotnet build src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj --configuration Release --no-restore -p:Version=${{ env.VERSION }} -p:AssemblyVersion=${{ env.VERSION }}.0 -p:FileVersion=${{ env.VERSION }}.0
       env:
         APPINSIGHTS_CONNECTION_STRING: ${{ secrets.APPINSIGHTS_CONNECTION_STRING }}
 
     - name: Pack NuGet
-      run: dotnet pack src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj --configuration Release --no-build --output ./nupkg
+      run: dotnet pack src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj --configuration Release --no-build --output ./nupkg -p:Version=${{ env.VERSION }}
 
     - name: Create Release Package
       run: |
@@ -288,21 +261,13 @@ jobs:
       run: |
         $version = $env:VERSION
 
-        # Update MCP Server version
-        $csprojPath = "src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj"
-        $content = Get-Content $csprojPath -Raw
+        # Update Directory.Build.props (single source of truth for all project versions)
+        $propsPath = "Directory.Build.props"
+        $content = Get-Content $propsPath -Raw
         $content = $content -replace '<Version>[\d\.]+</Version>', "<Version>$version</Version>"
         $content = $content -replace '<AssemblyVersion>[\d\.]+\.[\d\.]+</AssemblyVersion>', "<AssemblyVersion>$version.0</AssemblyVersion>"
         $content = $content -replace '<FileVersion>[\d\.]+\.[\d\.]+</FileVersion>', "<FileVersion>$version.0</FileVersion>"
-        Set-Content $csprojPath $content
-
-        # Update CLI version (bundled in VS Code extension)
-        $cliPath = "src/ExcelMcp.CLI/ExcelMcp.CLI.csproj"
-        $content = Get-Content $cliPath -Raw
-        $content = $content -replace '<Version>[\d\.]+</Version>', "<Version>$version</Version>"
-        $content = $content -replace '<AssemblyVersion>[\d\.]+\.[\d\.]+</AssemblyVersion>', "<AssemblyVersion>$version.0</AssemblyVersion>"
-        $content = $content -replace '<FileVersion>[\d\.]+\.[\d\.]+</FileVersion>', "<FileVersion>$version.0</FileVersion>"
-        Set-Content $cliPath $content
+        Set-Content $propsPath $content
       shell: pwsh
 
     - name: Update Extension Version

--- a/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+++ b/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
@@ -19,10 +19,7 @@
     <!-- CLI doesn't need XML documentation warnings - command usage is shown in console output -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
-    <!-- Version Information -->
-    <Version>1.0.0</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <!-- Version inherited from Directory.Build.props; overridden by CI via -p:Version -->
 
     <!-- Package-specific properties -->
     <PackageId>Sbroenne.ExcelMcp.CLI</PackageId>

--- a/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
+++ b/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
@@ -20,10 +20,7 @@
     <!-- Allow test project to access internal members (e.g., SetTelemetryClient) -->
     <InternalsVisibleTo>Sbroenne.ExcelMcp.McpServer.Tests</InternalsVisibleTo>
 
-    <!-- Version Information -->
-    <Version>1.0.0</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <!-- Version inherited from Directory.Build.props; overridden by CI via -p:Version -->
 
     <!-- NuGet MCP Server Configuration -->
     <PackageId>Sbroenne.ExcelMcp.McpServer</PackageId>


### PR DESCRIPTION
## Bug Fix: Version Reporting

### Problem
The CLI update check and About dialog always reported version \1.0.0\, even on published releases. The \--version\ flag worked correctly because the release workflow patched \.csproj\ files in CI, but that fix was never committed back.

### Root Cause
Both \ExcelMcp.CLI.csproj\ and \ExcelMcp.McpServer.csproj\ hardcoded \<Version>1.0.0</Version>\, overriding \Directory.Build.props\ (which has \1.7.0\). The release workflow used text replacement to patch these in CI before building, but the changes were ephemeral — local builds and daemons started from local builds always got \1.0.0\.

### Solution
- **Removed** hardcoded \Version\/\AssemblyVersion\/\FileVersion\ from both \.csproj\ files — they now inherit from \Directory.Build.props\
- **Updated** release workflow to use \-p:Version\ MSBuild property on \dotnet build\/\pack\ commands instead of \.csproj\ text replacement
- VS Code extension job patches \Directory.Build.props\ directly (since it builds via npm)

### Files Changed
- \src/ExcelMcp.CLI/ExcelMcp.CLI.csproj\ — removed hardcoded version
- \src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj\ — removed hardcoded version
- \.github/workflows/release.yml\ — replaced text replacement with \-p:Version\

### Verification
- Local build now reports \1.7.0\ (from \Directory.Build.props\) instead of \1.0.0\
- All pre-commit checks passed (COM leaks, coverage, smoke tests)