### PR TITLE
fix: add cancellation and robust refresh to Connection and PowerQuery refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **Connection `refresh` and PowerQuery `refresh` / `refresh-all` could hang or miss cancellation on async data sources**: `WorkbookConnection.Refresh()` returns immediately when the provider runs asynchronously, leaving the STA thread without a way to detect completion or honour the operation timeout. Both Connection and PowerQuery refresh now set the sub-connection's `BackgroundQuery = true`, call `Refresh()`, then poll `.Refreshing` in a loop that responds to cancellation and calls `.CancelRefresh()` when the timeout fires. `powerquery refresh-all` was also updated to use the same robust `RefreshConnectionByQueryName` path (which includes `QueryTable.Refresh(false)` for worksheet queries) instead of a bare `connection.Refresh()`.
+
 - **CLI and MCP Server version always reported as 1.0.0** (#523): The update check and About dialog always showed version 1.0.0 instead of the actual installed version. Fixed by removing hardcoded version properties from project files so they inherit from the central version configuration.
 
 - **`table append` JsonElement COM marshalling** (#519): Row values containing booleans or strings were passed as raw `System.Text.Json.JsonElement` to `cell.Value2`, which COM interop cannot marshal to a Variant. Fixed by calling `RangeHelpers.ConvertToCellValue()` (the same fix already present in `range set-values`) to unwrap `JsonElement` to native types before assignment.

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.RefreshTimeout.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.RefreshTimeout.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Connection;
+
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Connection")]
+public partial class ConnectionCommandsTests
+{
+    [Fact]
+    public void RefreshWait_WhenCancellationRequested_InvokesCancelActionAndThrows()
+    {
+        MethodInfo waitMethod = GetRefreshWaitMethod();
+
+        bool cancelCalled = false;
+        using var cts = new CancellationTokenSource();
+
+        var cancellationThread = new Thread(() =>
+        {
+            Thread.Sleep(50);
+            cts.Cancel();
+        });
+        cancellationThread.Start();
+
+        try
+        {
+            var exception = Assert.Throws<TargetInvocationException>(() =>
+                waitMethod.Invoke(null,
+                [
+                    (Func<bool>)(() => true),
+                    (Action)(() => cancelCalled = true),
+                    cts.Token
+                ]));
+
+            Assert.IsType<OperationCanceledException>(exception.InnerException);
+            Assert.True(cancelCalled);
+        }
+        finally
+        {
+            cancellationThread.Join();
+        }
+    }
+
+    [Fact]
+    public void RefreshWait_WhenRefreshCompletes_DoesNotInvokeCancelAction()
+    {
+        MethodInfo waitMethod = GetRefreshWaitMethod();
+
+        int pollCount = 0;
+        bool cancelCalled = false;
+
+        waitMethod.Invoke(null,
+        [
+            (Func<bool>)(() => Interlocked.Increment(ref pollCount) == 1),
+            (Action)(() => cancelCalled = true),
+            CancellationToken.None
+        ]);
+
+        Assert.True(pollCount >= 2);
+        Assert.False(cancelCalled);
+    }
+
+    private static MethodInfo GetRefreshWaitMethod()
+    {
+        var waitMethod = typeof(ConnectionCommands).GetMethod(
+            "WaitForConnectionRefreshCompletion",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        return waitMethod ?? throw new InvalidOperationException(
+            "Expected private method WaitForConnectionRefreshCompletion was not found.");
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.RefreshWait.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.RefreshWait.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PowerQuery;
+
+public partial class PowerQueryCommandsTests
+{
+    [Fact]
+    public void RefreshWait_WhenCancellationRequested_InvokesCancelActionAndThrows()
+    {
+        MethodInfo waitMethod = GetRefreshWaitMethod();
+
+        bool cancelCalled = false;
+        using var cts = new CancellationTokenSource();
+
+        var cancellationThread = new Thread(() =>
+        {
+            Thread.Sleep(50);
+            cts.Cancel();
+        });
+        cancellationThread.Start();
+
+        try
+        {
+            var exception = Assert.Throws<TargetInvocationException>(() =>
+                waitMethod.Invoke(null,
+                [
+                    (Func<bool>)(() => true),
+                    (Action)(() => cancelCalled = true),
+                    cts.Token
+                ]));
+
+            Assert.IsType<OperationCanceledException>(exception.InnerException);
+            Assert.True(cancelCalled);
+        }
+        finally
+        {
+            cancellationThread.Join();
+        }
+    }
+
+    [Fact]
+    public void RefreshWait_WhenRefreshCompletes_DoesNotInvokeCancelAction()
+    {
+        MethodInfo waitMethod = GetRefreshWaitMethod();
+
+        int pollCount = 0;
+        bool cancelCalled = false;
+
+        waitMethod.Invoke(null,
+        [
+            (Func<bool>)(() => Interlocked.Increment(ref pollCount) == 1),
+            (Action)(() => cancelCalled = true),
+            CancellationToken.None
+        ]);
+
+        Assert.True(pollCount >= 2);
+        Assert.False(cancelCalled);
+    }
+
+    private static MethodInfo GetRefreshWaitMethod()
+    {
+        var waitMethod = typeof(PowerQueryCommands).GetMethod(
+            "WaitForRefreshCompletion",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        return waitMethod ?? throw new InvalidOperationException(
+            "Expected private method WaitForRefreshCompletion was not found.");
+    }
+}


### PR DESCRIPTION
## Problem

WorkbookConnection.Refresh() returns immediately when the provider uses async background refresh, leaving the STA thread with no way to detect completion or honour the operation timeout. Similarly, powerquery refresh-all used a simpler bare connection.Refresh() path that bypassed the QueryTable.Refresh(false) strategy needed for worksheet-loaded queries.

## Root Cause

Three separate call sites used unguarded Refresh() calls:
1. ConnectionCommands.Refresh — pure conn.Refresh() passthrough with no polling or cancellation
2. PowerQueryCommands.RefreshConnectionByQueryName (Data Model path) — bare 	argetConnection.Refresh() with no CancellationToken
3. PowerQueryCommands.RefreshAll — used FindConnectionForQuery + connection.Refresh() bypassing the QueryTable path

## Solution

**Files Changed:**
- src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.Lifecycle.cs — added RefreshWorkbookConnection() helper; wires cancellation token through to WaitForConnectionRefreshCompletion
- src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Helpers.cs — added RefreshWorkbookConnection() for the Data Model path; RefreshConnectionByQueryName now accepts CancellationToken
- src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Refresh.cs — passes 	imeoutCts.Token to RefreshConnectionByQueryName; RefreshAll now uses RefreshConnectionByQueryName (robust path) instead of FindConnectionForQuery + connection.Refresh()

**Refresh strategy (both Connection and PowerQuery Data Model):**
1. Set sub-connection BackgroundQuery = true so Refresh() returns immediately and the provider loads asynchronously
2. Call Refresh()
3. Probe .Refreshing — if the provider exposes it, enter poll loop
4. Poll every 200ms; on CancellationToken fire, call .CancelRefresh() and throw OperationCanceledException

## Test Coverage (4 tests, 2 scenarios)

**Core — Connection (2 tests):**
- RefreshWait_WhenCancellationRequested_InvokesCancelActionAndThrows
- RefreshWait_WhenRefreshCompletes_DoesNotInvokeCancelAction

**Core — PowerQuery (2 tests):**
- RefreshWait_WhenCancellationRequested_InvokesCancelActionAndThrows
- RefreshWait_WhenRefreshCompletes_DoesNotInvokeCancelAction

**Test files:**
- 	ests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.RefreshTimeout.cs
- 	ests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.RefreshWait.cs

All 27 ConnectionCommandsTests (including 2 new) and all 45 PowerQueryCommandsTests verified passing.

## Documentation Updated
1. CHANGELOG.md — added entry under [Unreleased] § Fixed

## Backwards Compatibility
✅ Fully backwards compatible — Refresh() and RefreshAll() signatures unchanged; cancellation is opt-in via existing timeout mechanism