### PR TITLE
fix: name worksheet ListObject after query in LoadToTable

### DIFF
--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.LoadTo.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.LoadTo.cs
@@ -325,6 +325,12 @@ public partial class PowerQueryCommands
                 OleMessageFilter.ExitLongOperation();
             }
 
+            // Name the table after the query for predictable M-code referencing.
+            // Without this, Excel auto-assigns a generic name ("Table1", "Table2", etc.)
+            // which makes Excel.CurrentWorkbook(){[Name=queryName]}[Content] lookups unreliable.
+            try { listObject.Name = queryName; }
+            catch { /* Non-critical — if rename fails (e.g. name conflict), load still succeeded. */ }
+
             // Capture results - use ListObject Range for total rows, subtract header
             dynamic? listObjectRange = listObject.Range;
             int totalRows = listObjectRange != null ? Convert.ToInt32(listObjectRange.Rows.Count) : 0;


### PR DESCRIPTION
## Problem

When loading a Power Query to a worksheet table (\load-to\ with destination \worksheet\), Excel auto-assigns a generic table name like \Table1\ or \Table_ExternalData_1\. This breaks M-code lookups of the form:

\\\m
Excel.CurrentWorkbook(){[Name = queryName]}[Content]
\\\

which is the standard pattern for referencing staged tables in self-contained M code.

## Fix

Call \listObject.Name = queryName\ after \OleMessageFilter.ExitLongOperation()\ in \LoadQueryToWorksheet()\. Wrapped in try/catch since the rename is non-critical — if it fails (e.g. name conflict), the load still succeeded.

## Tests

Added two regression tests in \PowerQueryWorksheetCleanupTests\:

- \Create_LoadToTable_WorksheetTableNamedAfterQuery\ — verifies a query loaded directly to worksheet gets a table named after itself, not \Table1\
- \LoadTo_ConnectionOnlyToTable_WorksheetTableNamedAfterQuery\ — verifies the same when switching from \connection-only\ to \worksheet\ and refreshing

Both tests pass. Build clean (0 errors, 0 warnings). Pre-commit hook passed all 10 checks.