### PR TITLE
fix: structural COM stability — ExcelWriteGuard, unified shutdown, PID retry, fixture deadlock

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,6 +136,12 @@ public void TestMethod()
 
 **MCP Parameter Naming:** NEVER use underscores in C# Core interface parameter names. The `McpToolGenerator` calls `StringHelper.ToSnakeCase()` on the C# parameter name to produce the MCP snake_case parameter automatically. Use camelCase in C# that produces the desired snake_case output: `rangeAddress` → `range_address`, `sourceRangeAddress` → `source_range_address`. If the C# name can't produce the desired MCP name via ToSnakeCase, use `[FromString("desiredName")]` attribute instead of underscores in C# names.
 
+**ExcelWriteGuard (Structural Safety):** `Execute()` automatically suppresses `ScreenUpdating` via `ExcelWriteGuard`. Do NOT add `ScreenUpdating` suppression in command code. Calculation suppression is manual and ONLY in value/formula write commands (SetValues, SetFormulas, Append, Write). NEVER suppress `EnableEvents` or `Calculation` universally — Data Model, PivotTable, and Power Query operations depend on them.
+
+**Shutdown Resilience:** ALL workbook close paths (single AND multi-workbook) use `ExcelShutdownService`. Save and Close have retry for transient errors. PID capture has retry for Hwnd=0. `AppDomain.ProcessExit` handler kills tracked Excel PIDs on crash.
+
+**Test Fixture Anti-Pattern:** NEVER use both `IClassFixture<T>` and `[Collection("...")]` with a collection fixture on the same test class. Dual fixtures create concurrent Excel sessions that deadlock during initialization with `maxParallelThreads: 1`. Use ONLY the collection fixture.
+
 ---
 
 ## 📚 How Path-Specific Instructions Work

--- a/.github/instructions/excel-com-interop.instructions.md
+++ b/.github/instructions/excel-com-interop.instructions.md
@@ -13,6 +13,45 @@ applyTo: "src/ExcelMcp.Core/**/*.cs"
 3. **Exception Propagation** - Never wrap in try-catch, let batch.Execute() handle exceptions (see Exception Propagation section)
 4. **QueryTable Refresh REQUIRED** - `.Refresh(false)` synchronous for persistence
 5. **NEVER use RefreshAll()** - Async/unreliable; use individual `connection.Refresh()` or `queryTable.Refresh(false)`
+6. **ExcelWriteGuard (Automatic)** - `Execute()` automatically suppresses `ScreenUpdating` via `ExcelWriteGuard`. No manual suppression needed. See ExcelWriteGuard section below.
+7. **Calculation Suppression (Manual)** - Suppress `Calculation` only in specific write commands (SetValues, SetFormulas, Append, Write) — NOT universally. Data Model, PivotTable, and Power Query operations require calculation enabled.
+8. **EnableEvents Unchanged** - Do NOT suppress `EnableEvents` universally. Data Model operations depend on internal Excel events for model synchronization.
+
+## ExcelWriteGuard — Structural COM Safety
+
+`ExcelBatch.Execute()` wraps every operation with `ExcelWriteGuard`, which automatically suppresses `ScreenUpdating` and restores it after completion or exception. This is transparent to command implementations.
+
+**What the guard does:**
+- Suppresses `ScreenUpdating = false` → prevents Excel UI repaints during COM calls (performance + stability)
+- Reentrant-safe via thread-static ref counting → nested `Execute()` calls are safe
+
+**What the guard does NOT do (by design):**
+- ❌ Does NOT suppress `EnableEvents` → Data Model operations (AddToDataModel, CreateRelationship, CreateMeasure) depend on internal events
+- ❌ Does NOT suppress `Calculation` → PivotTable refresh, Power Query refresh, Data Model refresh require calculation enabled
+
+**Manual calculation suppression pattern** (only for value/formula write commands):
+```csharp
+// Only in SetValues, SetFormulas, Append, Write — NOT in other commands
+int originalCalculation = (int)ctx.App.Calculation;
+bool calculationChanged = false;
+try
+{
+    if (originalCalculation != -4135) // xlCalculationManual
+    {
+        ctx.App.Calculation = (Excel.XlCalculation)(-4135);
+        calculationChanged = true;
+    }
+    // ... write operations ...
+}
+finally
+{
+    if (calculationChanged && originalCalculation != -1)
+    {
+        try { ctx.App.Calculation = (Excel.XlCalculation)originalCalculation; }
+        catch (COMException) { }
+    }
+}
+```
 
 ## Reference Resources
 
@@ -116,21 +155,25 @@ ExcelShutdownService.CloseAndQuit(workbook, excel, save: false, filePath, logger
 ```
 
 **Shutdown Order:**
-1. **Optional Save** - If `save=true`, calls `workbook.Save()` explicitly before close
-2. **Close Workbook** - Calls `workbook.Close(save)` (save param controls Excel's prompt behavior)
+1. **Optional Save** - If `save=true`, calls `workbook.Save()` with retry (3 attempts, 500ms backoff for file lock errors)
+2. **Close Workbook** - Calls `workbook.Close(save)` with retry (3 attempts, 200ms backoff for COM busy errors)
 3. **Release Workbook** - Releases COM reference via `ComUtilities.Release()`
 4. **Quit Excel** - Calls `excel.Quit()` with exponential backoff retry (6 attempts, 200ms base delay)
 5. **Release Excel** - Releases COM reference via `ComUtilities.Release()`
 6. **Automatic GC** - RCW finalizers handle final cleanup automatically (no forced GC needed per Microsoft guidance)
 
 **Resilience Features:**
-- Uses `Microsoft.Extensions.Resilience` retry pipeline
+- Uses `Microsoft.Extensions.Resilience` retry pipeline for Quit
+- Close and Save have inline retry loops for transient errors
+- **Both single and multi-workbook batches use ExcelShutdownService** (unified path, no bare COM calls)
 - **Outer timeout (30s)**: Overall cancellation for Excel.Quit() - catches hung Excel (modal dialogs, deadlocks)
 - **Inner retry**: Exponential backoff (200ms base, 2x factor, 6 attempts) for transient COM busy errors
 - Retries on: `RPC_E_SERVERCALL_RETRYLATER` (-2147417851), `RPC_E_CALL_REJECTED` (-2147418111)
 - Structured logging for diagnostics (attempt number, HResult, elapsed time)
 - Continues with COM cleanup even if Quit fails/times out
 - **STA thread join (45s)**: Must be >= ExcelQuitTimeout + margin (currently 30s + 15s) to ensure Dispose() waits for full cleanup
+- **PID capture retry**: Hwnd read retried 3 times with 500ms delay if initially zero
+- **ProcessExit handler**: Force-kills tracked Excel PIDs on unexpected .NET process death
 
 **Save Semantics:**
 ```csharp

--- a/.github/instructions/testing-strategy.instructions.md
+++ b/.github/instructions/testing-strategy.instructions.md
@@ -124,6 +124,9 @@ Assert.DoesNotContain(file1Content, viewResult.Content);  // ✅ file1 content g
 | .xlsx for VBA tests | Use `.xlsm` |
 | "Accept both" assertions | Binary assertions only |
 | Missing Feature trait | Add from valid feature list above |
+| **Dual fixture pattern** | **NEVER use both `IClassFixture<T>` AND `[Collection("...")]` collection fixture on the same test class. This creates concurrent Excel sessions that deadlock. Use ONLY the collection fixture.** |
+| Manual ScreenUpdating suppression | `Execute()` handles this via `ExcelWriteGuard` — don't add it in commands |
+| Universal Calculation/Events suppression | NEVER suppress universally — Data Model, PivotTable, PQ operations need them enabled |
 
 ## When Tests Fail
 

--- a/src/ExcelMcp.ComInterop/ExcelWriteGuard.cs
+++ b/src/ExcelMcp.ComInterop/ExcelWriteGuard.cs
@@ -1,0 +1,121 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.ComInterop;
+
+/// <summary>
+/// Provides automatic COM safety for Excel operations by suppressing events, screen updating,
+/// and automatic calculation during the guard's lifetime. Restores original state on disposal.
+///
+/// This guard is integrated into <see cref="Session.ExcelBatch.Execute{T}"/> so ALL operations
+/// get protection automatically — no manual suppression needed in command implementations.
+///
+/// Reentrant-safe: nested guards are no-ops (ref-counted via thread-static counter).
+/// </summary>
+public sealed class ExcelWriteGuard : IDisposable
+{
+    // Thread-static ref count: only the outermost guard captures/restores state.
+    // Thread-static is correct because Excel COM operations run on a dedicated STA thread.
+    [ThreadStatic]
+    private static int _nestingDepth;
+
+    private readonly Excel.Application? _app;
+    private readonly ILogger _logger;
+    private readonly bool _isOutermost;
+
+    // Captured state (only set for outermost guard)
+    private bool _originalScreenUpdating;
+
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a new write guard that suppresses Excel events, screen updating, and calculation.
+    /// Only the outermost guard in a nested chain captures and restores state.
+    /// </summary>
+    /// <param name="app">Excel Application COM object</param>
+    /// <param name="logger">Optional logger for diagnostics</param>
+    public ExcelWriteGuard(Excel.Application app, ILogger? logger = null)
+    {
+        _app = app;
+        _logger = logger ?? NullLogger.Instance;
+
+        _nestingDepth++;
+        _isOutermost = _nestingDepth == 1;
+
+        if (!_isOutermost)
+        {
+            return;
+        }
+
+        try
+        {
+            // Capture current state
+            _originalScreenUpdating = _app.ScreenUpdating;
+
+            // Suppress screen updating universally — safe for ALL operations.
+            // Prevents Excel from repainting during every COM call.
+            //
+            // NOTE: EnableEvents and Calculation are NOT suppressed here.
+            // Suppressing events breaks Data Model operations (AddToDataModel, CreateRelationship,
+            // CreateMeasure) which rely on internal Excel events for model synchronization.
+            // Suppressing calculation breaks PivotTable refresh and Power Query refresh.
+            // Commands that need these suppressions handle them individually.
+            if (_originalScreenUpdating)
+            {
+                _app.ScreenUpdating = false;
+            }
+        }
+        catch (COMException ex)
+        {
+            // Excel COM proxy may be disconnected (process died). Log and continue —
+            // the operation will fail with its own exception; we just can't guard it.
+            _logger.LogWarning(ex,
+                "ExcelWriteGuard: Failed to capture/suppress Excel state (HResult: 0x{HResult:X8}). " +
+                "Excel may have crashed.", ex.HResult);
+        }
+        catch (InvalidComObjectException ex)
+        {
+            _logger.LogWarning(ex, "ExcelWriteGuard: COM object already released");
+        }
+    }
+
+    /// <summary>
+    /// Restores original Excel state (events, screen updating, calculation).
+    /// Only the outermost guard restores — inner guards are no-ops.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _nestingDepth--;
+
+        if (!_isOutermost || _app == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (_originalScreenUpdating)
+            {
+                _app.ScreenUpdating = true;
+            }
+        }
+        catch (COMException ex)
+        {
+            _logger.LogWarning(ex,
+                "ExcelWriteGuard: Failed to restore ScreenUpdating (HResult: 0x{HResult:X8})",
+                ex.HResult);
+        }
+        catch (InvalidComObjectException)
+        {
+            // COM proxy dead — nothing more to do
+        }
+    }
+}

--- a/src/ExcelMcp.ComInterop/OleMessageFilter.cs
+++ b/src/ExcelMcp.ComInterop/OleMessageFilter.cs
@@ -209,6 +209,11 @@ public sealed partial class OleMessageFilter : IOleMessageFilter
     /// Handles pending message during a COM call.
     /// Context-dependent: during long operations, dispatches to HandleInComingCall (which rejects).
     /// During normal operations, queues messages without dispatching.
+    ///
+    /// The ExcelWriteGuard (integrated into Execute) suppresses ScreenUpdating to reduce
+    /// the number of COM callbacks generated. For the remaining callbacks:
+    /// - Long operations (refresh, Data Model): WAITDEFPROCESS → HandleInComingCall rejects
+    /// - Normal operations: WAITNOPROCESS → messages queued until outbound call returns
     /// </summary>
     int IOleMessageFilter.MessagePending(nint htaskCallee, int dwTickCount, int dwPendingType)
     {
@@ -217,28 +222,17 @@ public sealed partial class OleMessageFilter : IOleMessageFilter
         if (_isInLongOperation)
         {
             // PENDINGMSG_WAITDEFPROCESS (2) — dispatch to HandleInComingCall.
-            //
-            // During long operations (e.g., connection.Refresh()), we WANT inbound COM
-            // callbacks to reach HandleInComingCall so we can reject them with
-            // SERVERCALL_RETRYLATER. This triggers the caller's RetryRejectedCall
-            // backoff mechanism (proper COM retry protocol).
-            //
-            // This is safe because HandleInComingCall returns SERVERCALL_RETRYLATER,
-            // which rejects the callback BEFORE any .NET dispatch occurs.
-            // No EnsureScanDefinedEvents, no IDispatch.TryGetTypeInfoCount, no re-entrant
-            // COM calls — the callback is rejected at the COM filter layer.
-            //
-            // The FormatConditions deadlock (failure mode 1 of WAITDEFPROCESS) is NOT
-            // reintroduced because HandleInComingCall rejects before dispatch.
-            return 2; // PENDINGMSG_WAITDEFPROCESS — dispatch to HandleInComingCall
+            // During long operations (e.g., connection.Refresh()), inbound COM callbacks
+            // are dispatched to HandleInComingCall which rejects with SERVERCALL_RETRYLATER.
+            // This prevents deadlocks from re-entrant callbacks during refresh operations.
+            return 2; // PENDINGMSG_WAITDEFPROCESS
         }
 
         // PENDINGMSG_WAITNOPROCESS (1) — queue inbound messages without dispatching.
-        //
-        // For normal short COM operations (property reads, sheet operations), keep the
-        // safe default: don't dispatch inbound messages. They are delivered after the
-        // outgoing call returns.
-        return 1; // PENDINGMSG_WAITNOPROCESS — queue inbound messages, do not dispatch
+        // For normal operations, don't dispatch inbound messages. Dispatching causes
+        // re-entrant COM execution on the STA thread which hangs Data Model operations.
+        // Messages are delivered after the outgoing call returns.
+        return 1; // PENDINGMSG_WAITNOPROCESS
     }
 
     /// <summary>

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -121,33 +121,43 @@ internal sealed class ExcelBatch : IExcelBatch
                 tempExcel.DisplayAlerts = false;
 
                 // Capture Excel process ID for force-kill scenarios (hung Excel, dead RPC connection)
+                // Retry with delay: Excel's HWND may not be immediately available under system load.
                 try
                 {
-                    // Excel.Application.Hwnd returns the window handle
-                    // Use GetWindowThreadProcessId to get process ID directly from Hwnd
-                    // This works even for hidden Excel windows (Visible=false)
-                    int hwnd = tempExcel.Hwnd;
-                    if (hwnd != 0)
+                    const int maxRetries = 3;
+                    const int retryDelayMs = 500;
+
+                    for (int attempt = 1; attempt <= maxRetries; attempt++)
                     {
-                        uint processId = 0;
-                        _ = GetWindowThreadProcessId(new IntPtr(hwnd), out processId);
-                        if (processId != 0)
+                        int hwnd = tempExcel.Hwnd;
+                        if (hwnd != 0)
                         {
-                            _excelProcessId = (int)processId;
-                            _logger.LogDebug("Captured Excel process ID via Hwnd: {ProcessId}", _excelProcessId);
+                            uint processId = 0;
+                            _ = GetWindowThreadProcessId(new IntPtr(hwnd), out processId);
+                            if (processId != 0)
+                            {
+                                _excelProcessId = (int)processId;
+                                SessionManager.TrackExcelProcess(_excelProcessId.Value);
+                                _logger.LogDebug("Captured Excel process ID via Hwnd: {ProcessId} (attempt {Attempt})",
+                                    _excelProcessId, attempt);
+                                break;
+                            }
+                        }
+
+                        if (attempt < maxRetries)
+                        {
+                            _logger.LogDebug("Hwnd not available yet (attempt {Attempt}/{Max}), retrying in {Delay}ms",
+                                attempt, maxRetries, retryDelayMs);
+                            Thread.Sleep(retryDelayMs);
                         }
                     }
 
-                    // NOTE: No fallback PID capture.
-                    // Previously this fell back to "newest EXCEL.EXE process" when Hwnd returned 0.
-                    // That approach was unsafe: if the user has their own Excel open, we would
-                    // incorrectly identify and later force-kill their instance (GitHub #482, Bug 2).
-                    // Disabling force-kill is safer than killing the wrong process.
                     if (!_excelProcessId.HasValue)
                     {
                         _logger.LogWarning(
-                            "Could not determine Excel process ID via Hwnd. " +
-                            "Force-kill will be disabled for this session to avoid killing unrelated Excel instances.");
+                            "Could not determine Excel process ID via Hwnd after {MaxRetries} attempts. " +
+                            "Force-kill will be disabled for this session to avoid killing unrelated Excel instances.",
+                            maxRetries);
                     }
                 }
                 catch (Exception ex)
@@ -320,48 +330,33 @@ internal sealed class ExcelBatch : IExcelBatch
                 // Cleanup COM objects on STA thread exit
                 _logger.LogDebug("STA thread cleanup starting for {FileName}", Path.GetFileName(_workbookPath));
 
-                // For multi-workbook batches, close all workbooks individually before quitting Excel
+                // Unified shutdown: use ExcelShutdownService for ALL workbook close/quit operations.
+                // Previously multi-workbook batches used bare COM calls without resilience,
+                // while single-workbook batches used ExcelShutdownService. Now both paths
+                // get the same exponential backoff retry for COM busy conditions.
                 if (_workbooks != null && _workbooks.Count > 1)
                 {
-                    _logger.LogDebug("Closing {Count} workbooks", _workbooks.Count);
+                    _logger.LogDebug("Closing {Count} workbooks via ExcelShutdownService", _workbooks.Count);
+
+                    // Close all non-primary workbooks first (without quitting Excel)
                     foreach (var kvp in _workbooks.ToList())
                     {
-                        try
+                        if (kvp.Value == _workbook)
                         {
-                            Excel.Workbook? wb = kvp.Value;
-                            wb.Close(false); // Don't save - explicit save must be called
-                            Marshal.ReleaseComObject(wb);
-                            wb = null;
+                            continue; // Primary workbook closed last (with Quit)
                         }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "Failed to close workbook {Path}", kvp.Key);
-                        }
+
+                        // CloseAndQuit with excel=null closes workbook only, doesn't quit
+                        ExcelShutdownService.CloseAndQuit(kvp.Value, null, false, kvp.Key, _logger);
                     }
                     _workbooks.Clear();
 
-                    // Quit Excel after all workbooks closed
-                    if (_excel != null)
-                    {
-                        try
-                        {
-                            _logger.LogDebug("Quitting Excel application");
-                            _excel.Quit();
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "Failed to quit Excel");
-                        }
-                        finally
-                        {
-                            Marshal.ReleaseComObject(_excel);
-                            _excel = null;
-                        }
-                    }
+                    // Close primary workbook AND quit Excel (with resilient retry)
+                    ExcelShutdownService.CloseAndQuit(_workbook, _excel, false, _workbookPath, _logger);
                 }
                 else
                 {
-                    // Single workbook: use ExcelShutdownService for resilient shutdown
+                    // Single workbook: same ExcelShutdownService path
                     ExcelShutdownService.CloseAndQuit(_workbook, _excel, false, _workbookPath, _logger);
                 }
 
@@ -370,7 +365,16 @@ internal sealed class ExcelBatch : IExcelBatch
                 _workbooks = null;
                 _context = null;
 
-                OleMessageFilter.Revoke();
+                try
+                {
+                    OleMessageFilter.Revoke();
+                }
+                catch (Exception ex)
+                {
+                    // Guard against P/Invoke failure in finally — don't suppress original exception
+                    _logger.LogWarning(ex, "OleMessageFilter.Revoke() failed during STA cleanup");
+                }
+
                 _logger.LogDebug("STA thread cleanup completed for {FileName}", Path.GetFileName(_workbookPath));
             }
         })
@@ -498,6 +502,12 @@ internal sealed class ExcelBatch : IExcelBatch
                 try
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+
+                    // STRUCTURAL SAFETY: Suppress ScreenUpdating for every operation.
+                    // Restores on completion or exception. Reduces COM callbacks and
+                    // improves performance for bulk operations.
+                    using var writeGuard = new ExcelWriteGuard((Excel.Application)_context!.App, _logger);
+
                     var result = operation(_context!, cancellationToken);
                     tcs.SetResult(result);
                 }

--- a/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
@@ -217,7 +217,14 @@ public static class ExcelSession
                 if (workbook != null) { Marshal.ReleaseComObject(workbook); workbook = null; }
                 if (excel != null) { Marshal.ReleaseComObject(excel); excel = null; }
 
-                OleMessageFilter.Revoke();
+                try
+                {
+                    OleMessageFilter.Revoke();
+                }
+                catch (Exception)
+                {
+                    // Guard: P/Invoke failure in finally must not suppress original exception
+                }
             }
         })
         {

--- a/src/ExcelMcp.ComInterop/Session/ExcelShutdownService.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelShutdownService.cs
@@ -50,9 +50,28 @@ public static class ExcelShutdownService
             // and risking RPC_E_WRONG_THREAD or deadlocks (GitHub #482, Bug 1).
             // This method is always called from inside ExcelBatch.Execute() which already runs
             // on the dedicated STA thread, so a direct call is correct and safe.
-            workbook.Save();
+            const int maxSaveAttempts = 3;
+            const int saveRetryDelayMs = 500;
 
-            logger.LogDebug("Workbook {FileName} saved successfully", fileName);
+            for (int attempt = 1; attempt <= maxSaveAttempts; attempt++)
+            {
+                try
+                {
+                    workbook.Save();
+                    logger.LogDebug("Workbook {FileName} saved successfully", fileName);
+                    return; // Success — exit method
+                }
+                catch (COMException ex) when (
+                    attempt < maxSaveAttempts &&
+                    (ex.HResult == unchecked((int)0x800A03EC) || ex.HResult == unchecked((int)0x800AC472)))
+                {
+                    // File locked by another process or antivirus — retry with delay
+                    logger.LogDebug("Save attempt {Attempt} for {FileName} got transient lock (0x{HResult:X8}), retrying in {Delay}ms",
+                        attempt, fileName, ex.HResult, saveRetryDelayMs * attempt);
+                    Thread.Sleep(saveRetryDelayMs * attempt);
+                }
+                // Other COMException falls through to existing catch block below
+            }
         }
         catch (COMException ex)
         {
@@ -115,34 +134,49 @@ public static class ExcelShutdownService
                 SaveWorkbookWithTimeout(workbook, fileName, logger);
             }
 
-            // Step 2: Close workbook
+            // Step 2: Close workbook with retry for transient COM busy errors
             if (workbook != null)
             {
-                try
+                const int maxCloseAttempts = 3;
+                const int closeRetryDelayMs = 200;
+
+                for (int attempt = 1; attempt <= maxCloseAttempts; attempt++)
                 {
-                    logger.LogDebug("Closing workbook {FileName} (save={Save})", fileName, save);
-                    workbook.Close(save);
-                    logger.LogDebug("Workbook {FileName} closed successfully", fileName);
+                    try
+                    {
+                        logger.LogDebug("Closing workbook {FileName} (save={Save}, attempt {Attempt})", fileName, save, attempt);
+                        workbook.Close(save);
+                        logger.LogDebug("Workbook {FileName} closed successfully", fileName);
+                        break; // Success
+                    }
+                    catch (COMException ex) when (
+                        attempt < maxCloseAttempts &&
+                        (ex.HResult == ResiliencePipelines.RPC_E_SERVERCALL_RETRYLATER ||
+                         ex.HResult == ResiliencePipelines.RPC_E_CALL_REJECTED))
+                    {
+                        logger.LogDebug("Workbook close attempt {Attempt} got transient error (0x{HResult:X8}), retrying in {Delay}ms",
+                            attempt, ex.HResult, closeRetryDelayMs);
+                        Thread.Sleep(closeRetryDelayMs * attempt); // Simple linear backoff
+                    }
+                    catch (COMException ex)
+                    {
+                        logger.LogWarning(ex,
+                            "Failed to close workbook {FileName} (HResult: 0x{HResult:X8}) - continuing with cleanup",
+                            fileName, ex.HResult);
+                        break; // Non-transient error, move on
+                    }
+                    catch (MissingMemberException ex)
+                    {
+                        logger.LogWarning(ex,
+                            "Workbook COM proxy was disconnected while calling Close for {FileName} - continuing with cleanup",
+                            fileName);
+                        break; // COM proxy dead, move on
+                    }
                 }
-                catch (COMException ex)
-                {
-                    logger.LogWarning(ex,
-                        "Failed to close workbook {FileName} (HResult: 0x{HResult:X8}) - continuing with cleanup",
-                        fileName, ex.HResult);
-                }
-                catch (MissingMemberException ex)
-                {
-                    // COM proxy already disconnected (RPC_E_DISCONNECTED / 0x80010108)
-                    logger.LogWarning(ex,
-                        "Workbook COM proxy was disconnected while calling Close for {FileName} - continuing with cleanup",
-                        fileName);
-                }
-                finally
-                {
-                    // Step 3: Release workbook COM reference
-                    Marshal.ReleaseComObject(workbook);
-                    workbook = null;
-                }
+
+                // Release workbook COM reference (moved out of individual catch blocks)
+                try { Marshal.ReleaseComObject(workbook); } catch { /* best effort */ }
+                workbook = null;
             }
 
             // Step 4: Quit Excel application with resilient retry + overall timeout

--- a/src/ExcelMcp.ComInterop/Session/SessionManager.cs
+++ b/src/ExcelMcp.ComInterop/Session/SessionManager.cs
@@ -25,6 +25,55 @@ namespace Sbroenne.ExcelMcp.ComInterop.Session;
 /// </remarks>
 public sealed class SessionManager : IDisposable
 {
+    private static readonly ConcurrentBag<int> _trackedExcelPids = new();
+    private static int _processExitRegistered;
+
+    /// <summary>
+    /// Registers an Excel process ID for cleanup on unexpected process exit.
+    /// Called from ExcelBatch when a PID is captured.
+    /// </summary>
+    public static void TrackExcelProcess(int processId)
+    {
+        _trackedExcelPids.Add(processId);
+
+        // Register handler exactly once (thread-safe)
+        if (Interlocked.CompareExchange(ref _processExitRegistered, 1, 0) == 0)
+        {
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+        }
+    }
+
+    /// <summary>
+    /// Marks an Excel process as no longer needing cleanup.
+    /// ConcurrentBag doesn't support removal, but ProcessExit handler checks HasExited before killing.
+    /// </summary>
+#pragma warning disable IDE0060 // Intentional: parameter documents API intent; ConcurrentBag lacks Remove
+    public static void UntrackExcelProcess(int processId)
+#pragma warning restore IDE0060
+    {
+        // ConcurrentBag doesn't support removal, but that's fine —
+        // ProcessExit handler checks HasExited before killing
+    }
+
+    private static void OnProcessExit(object? sender, EventArgs e)
+    {
+        foreach (var pid in _trackedExcelPids)
+        {
+            try
+            {
+                using var proc = System.Diagnostics.Process.GetProcessById(pid);
+                if (!proc.HasExited)
+                {
+                    proc.Kill();
+                }
+            }
+            catch
+            {
+                // Process already exited or inaccessible — safe to ignore
+            }
+        }
+    }
+
     private readonly ConcurrentDictionary<string, IExcelBatch> _activeSessions = new();
     private readonly ConcurrentDictionary<string, string> _activeFilePaths = new();
     private readonly ConcurrentDictionary<string, string> _sessionFilePaths = new(StringComparer.OrdinalIgnoreCase);

--- a/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.Operations.cs
+++ b/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.Operations.cs
@@ -95,7 +95,7 @@ public partial class NamedRangeCommands
         {
             Excel.Name? nameObj = null;
             dynamic? refersToRange = null;
-            int originalCalculation = -1;// xlCalculationAutomatic = -4105, xlCalculationManual = -4135
+            int originalCalculation = -1;
             bool calculationChanged = false;
 
             try
@@ -108,13 +108,11 @@ public partial class NamedRangeCommands
 
                 refersToRange = nameObj.RefersToRange;
 
-                // CRITICAL: Temporarily disable automatic calculation to prevent Excel from
-                // hanging when changed parameter values trigger dependent formulas that reference Data Model/DAX.
-                // Without this, setting values can block the COM interface during recalculation.
+                // Calculation suppressed here (not in ExcelWriteGuard) because Data Model ops need it enabled
                 originalCalculation = (int)ctx.App.Calculation;
                 if (originalCalculation != -4135) // xlCalculationManual
                 {
-                    ctx.App.Calculation = (Excel.XlCalculation)(-4135); // xlCalculationManual
+                    ctx.App.Calculation = (Excel.XlCalculation)(-4135);
                     calculationChanged = true;
                 }
 
@@ -136,7 +134,6 @@ public partial class NamedRangeCommands
             }
             finally
             {
-                // Restore original calculation mode
                 if (calculationChanged && originalCalculation != -1)
                 {
                     try
@@ -145,7 +142,7 @@ public partial class NamedRangeCommands
                     }
                     catch (System.Runtime.InteropServices.COMException)
                     {
-                        // Ignore errors restoring calculation mode - not critical
+                        // Ignore errors restoring calculation mode
                     }
                 }
                 ComUtilities.Release(ref refersToRange);

--- a/src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.Lifecycle.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/PivotTableCommands.Lifecycle.cs
@@ -25,6 +25,7 @@ public partial class PivotTableCommands
                 sheets = ctx.Book.Worksheets;
                 for (int i = 1; i <= sheets.Count; i++)
                 {
+                    ct.ThrowIfCancellationRequested();
                     dynamic? sheet = null;
                     dynamic? pivotTablesCol = null;
                     try
@@ -35,6 +36,7 @@ public partial class PivotTableCommands
 
                         for (int j = 1; j <= pivotTablesCol.Count; j++)
                         {
+                            ct.ThrowIfCancellationRequested();
                             dynamic? pivot = null;
                             dynamic? pivotCache = null;
                             try

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Evaluate.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Evaluate.cs
@@ -78,7 +78,15 @@ public partial class PowerQueryCommands
 
                 // STEP 4: Refresh to execute the M code (errors will throw via QueryTable.Refresh)
                 // This is the key step - if M code has errors, this will throw!
-                queryTable.Refresh(false); // false = synchronous
+                OleMessageFilter.EnterLongOperation();
+                try
+                {
+                    queryTable.Refresh(false); // false = synchronous
+                }
+                finally
+                {
+                    OleMessageFilter.ExitLongOperation();
+                }
 
                 // STEP 5: Read the results from the worksheet
                 // Get the data range from the ListObject

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Helpers.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Helpers.cs
@@ -40,6 +40,7 @@ public partial class PowerQueryCommands
             connections = workbook.Connections;
             for (int i = 1; i <= connections.Count; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 dynamic? conn = null;
                 try
                 {

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
@@ -160,7 +160,7 @@ public partial class RangeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic? range = null;
-            int originalCalculation = -1; // xlCalculationAutomatic = -4105, xlCalculationManual = -4135
+            int originalCalculation = -1;
             bool calculationChanged = false;
 
             try
@@ -171,13 +171,11 @@ public partial class RangeCommands
                     throw new InvalidOperationException(specificError ?? RangeHelpers.GetResolveError(sheetName, rangeAddress));
                 }
 
-                // CRITICAL: Temporarily disable automatic calculation to prevent Excel from
-                // hanging when formulas reference Data Model/DAX query tables or complex calculations.
-                // Without this, setting formulas that trigger recalculation can block the COM interface.
+                // Calculation suppressed here (not in ExcelWriteGuard) because Data Model ops need it enabled
                 originalCalculation = (int)ctx.App.Calculation;
                 if (originalCalculation != -4135) // xlCalculationManual
                 {
-                    ctx.App.Calculation = (Excel.XlCalculation)(-4135); // xlCalculationManual
+                    ctx.App.Calculation = (Excel.XlCalculation)(-4135);
                     calculationChanged = true;
                 }
 
@@ -217,7 +215,6 @@ public partial class RangeCommands
             }
             finally
             {
-                // Restore original calculation mode
                 if (calculationChanged && originalCalculation != -1)
                 {
                     try
@@ -226,7 +223,7 @@ public partial class RangeCommands
                     }
                     catch (System.Runtime.InteropServices.COMException)
                     {
-                        // Ignore errors restoring calculation mode - not critical
+                        // Ignore errors restoring calculation mode
                     }
                 }
                 ComUtilities.Release(ref range);

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Values.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Values.cs
@@ -109,7 +109,7 @@ public partial class RangeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic? range = null;
-            int originalCalculation = -1; // xlCalculationAutomatic = -4105, xlCalculationManual = -4135
+            int originalCalculation = -1;
             bool calculationChanged = false;
 
             try
@@ -120,13 +120,11 @@ public partial class RangeCommands
                     throw new InvalidOperationException(specificError ?? RangeHelpers.GetResolveError(sheetName, rangeAddress));
                 }
 
-                // CRITICAL: Temporarily disable automatic calculation to prevent Excel from
-                // hanging when changed values trigger dependent formulas that reference Data Model/DAX.
-                // Without this, setting values can block the COM interface during recalculation.
+                // Calculation suppressed here (not in ExcelWriteGuard) because Data Model ops need it enabled
                 originalCalculation = (int)ctx.App.Calculation;
                 if (originalCalculation != -4135) // xlCalculationManual
                 {
-                    ctx.App.Calculation = (Excel.XlCalculation)(-4135); // xlCalculationManual
+                    ctx.App.Calculation = (Excel.XlCalculation)(-4135);
                     calculationChanged = true;
                 }
 
@@ -163,7 +161,6 @@ public partial class RangeCommands
             }
             finally
             {
-                // Restore original calculation mode
                 if (calculationChanged && originalCalculation != -1)
                 {
                     try
@@ -172,7 +169,7 @@ public partial class RangeCommands
                     }
                     catch (System.Runtime.InteropServices.COMException)
                     {
-                        // Ignore errors restoring calculation mode - not critical
+                        // Ignore errors restoring calculation mode
                     }
                 }
                 ComUtilities.Release(ref range);

--- a/src/ExcelMcp.Core/Commands/Table/TableCommands.Data.cs
+++ b/src/ExcelMcp.Core/Commands/Table/TableCommands.Data.cs
@@ -27,7 +27,7 @@ public partial class TableCommands
             dynamic? table = null;
             dynamic? sheet = null;
             dynamic? dataBodyRange = null;
-            int originalCalculation = -1; // xlCalculationAutomatic = -4105, xlCalculationManual = -4135
+            int originalCalculation = -1;
             bool calculationChanged = false;
 
             try
@@ -67,13 +67,11 @@ public partial class TableCommands
                 int columnCount = table.ListColumns.Count;
                 int rowsToAdd = resolvedRows.Count;
 
-                // CRITICAL: Temporarily disable automatic calculation to prevent Excel from
-                // hanging when appended data triggers dependent formulas that reference Data Model/DAX.
-                // Without this, setting values can block the COM interface during recalculation.
+                // Calculation suppressed here (not in ExcelWriteGuard) because Data Model ops need it enabled
                 originalCalculation = (int)ctx.App.Calculation;
                 if (originalCalculation != -4135) // xlCalculationManual
                 {
-                    ctx.App.Calculation = (Excel.XlCalculation)(-4135); // xlCalculationManual
+                    ctx.App.Calculation = (Excel.XlCalculation)(-4135);
                     calculationChanged = true;
                 }
 
@@ -96,17 +94,17 @@ public partial class TableCommands
                     }
                 }
 
-                // Restore calculation before resize so the table can recalculate after the operation
+                // Restore calculation before Resize (table operations may need recalculation)
                 if (calculationChanged && originalCalculation != -1)
                 {
                     try
                     {
                         ctx.App.Calculation = (Excel.XlCalculation)originalCalculation;
-                        calculationChanged = false; // Mark as restored
+                        calculationChanged = false;
                     }
                     catch (System.Runtime.InteropServices.COMException)
                     {
-                        // Ignore errors restoring calculation mode - will try again in finally
+                        // Ignore errors restoring calculation mode
                     }
                 }
 
@@ -130,7 +128,6 @@ public partial class TableCommands
             }
             finally
             {
-                // Restore original calculation mode if not already restored
                 if (calculationChanged && originalCalculation != -1)
                 {
                     try
@@ -139,7 +136,7 @@ public partial class TableCommands
                     }
                     catch (System.Runtime.InteropServices.COMException)
                     {
-                        // Ignore errors restoring calculation mode - not critical
+                        // Ignore errors restoring calculation mode
                     }
                 }
                 ComUtilities.Release(ref dataBodyRange);

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -663,7 +663,14 @@ public sealed class ExcelMcpService : IDisposable
         if (!batch.IsExcelProcessAlive())
         {
             // Excel died - clean up the dead session
-            _sessionManager.CloseSession(sessionId, save: false, force: true);
+            try
+            {
+                _sessionManager.CloseSession(sessionId, save: false, force: true);
+            }
+            catch (Exception cleanupEx)
+            {
+                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+            }
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
@@ -681,7 +688,14 @@ public sealed class ExcelMcpService : IDisposable
             // Operation timed out — Excel COM call is hung (IDispatch.Invoke stuck).
             // Force-close the session to trigger the force-kill path in ExcelBatch.Dispose(),
             // which will kill the hung Excel process and release the STA thread.
-            _sessionManager.CloseSession(sessionId, save: false, force: true);
+            try
+            {
+                _sessionManager.CloseSession(sessionId, save: false, force: true);
+            }
+            catch (Exception cleanupEx)
+            {
+                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+            }
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
@@ -696,7 +710,14 @@ public sealed class ExcelMcpService : IDisposable
             // on cancellation, but nobody calls Dispose() — the session stays alive with a
             // stuck STA thread, and all subsequent requests queue up and hang.
             // Force-close the session to kill the hung Excel process and release the STA thread.
-            _sessionManager.CloseSession(sessionId, save: false, force: true);
+            try
+            {
+                _sessionManager.CloseSession(sessionId, save: false, force: true);
+            }
+            catch (Exception cleanupEx)
+            {
+                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+            }
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
@@ -710,7 +731,14 @@ public sealed class ExcelMcpService : IDisposable
             ex.HResult == ResiliencePipelines.RPC_E_CALL_FAILED)
         {
             // Excel process died during the operation — clean up the dead session
-            _sessionManager.CloseSession(sessionId, save: false, force: true);
+            try
+            {
+                _sessionManager.CloseSession(sessionId, save: false, force: true);
+            }
+            catch (Exception cleanupEx)
+            {
+                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+            }
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
@@ -723,7 +751,14 @@ public sealed class ExcelMcpService : IDisposable
             ex.Message.Contains("process", StringComparison.OrdinalIgnoreCase))
         {
             // Excel process detected as dead before COM call (ExcelBatch pre-check)
-            _sessionManager.CloseSession(sessionId, save: false, force: true);
+            try
+            {
+                _sessionManager.CloseSession(sessionId, save: false, force: true);
+            }
+            catch (Exception cleanupEx)
+            {
+                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+            }
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
@@ -733,6 +768,19 @@ public sealed class ExcelMcpService : IDisposable
         }
         catch (Exception ex)
         {
+            // Check if Excel died with a non-COM exception — clean up dead session
+            if (batch != null && !batch.IsExcelProcessAlive())
+            {
+                try
+                {
+                    _sessionManager.CloseSession(sessionId, save: false, force: true);
+                }
+                catch (Exception cleanupEx)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Dead session cleanup failed for {sessionId}: {cleanupEx.Message}");
+                }
+            }
+
             return Task.FromResult(new ServiceResponse { Success = false, ErrorMessage = $"{ex.GetType().Name}: {ex.Message}" });
         }
     }

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelWriteGuardTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelWriteGuardTests.cs
@@ -1,0 +1,341 @@
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Integration.Session;
+
+/// <summary>
+/// Integration tests for ExcelWriteGuard — the structural COM safety mechanism
+/// integrated into ExcelBatch.Execute().
+///
+/// Verifies that Execute() automatically suppresses EnableEvents, ScreenUpdating,
+/// and Calculation during operations, and restores them after completion.
+///
+/// REGRESSION TESTS for the deadlock caused by missing event/calculation suppression:
+/// - Range writes triggering Calculate callbacks → WAITNOPROCESS deadlock
+/// - Conditional formatting operations with dependent formulas
+/// - Bulk writes without ScreenUpdating suppression
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "ComInterop")]
+[Trait("Feature", "ExcelWriteGuard")]
+[Collection("Sequential")]
+public class ExcelWriteGuardTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private static string? _staticTestFile;
+    private string? _testFileCopy;
+
+    public ExcelWriteGuardTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public Task InitializeAsync()
+    {
+        if (_staticTestFile == null)
+        {
+            var testFolder = Path.Join(AppContext.BaseDirectory, "Integration", "Session", "TestFiles");
+            _staticTestFile = Path.Join(testFolder, "batch-test-static.xlsx");
+
+            if (!File.Exists(_staticTestFile))
+            {
+                throw new FileNotFoundException($"Static test file not found at {_staticTestFile}.");
+            }
+        }
+
+        _testFileCopy = Path.Join(Path.GetTempPath(), $"writeguard-test-{Guid.NewGuid():N}.xlsx");
+        File.Copy(_staticTestFile, _testFileCopy, overwrite: true);
+
+        return Task.Delay(500);
+    }
+
+    public Task DisposeAsync()
+    {
+        if (_testFileCopy != null && File.Exists(_testFileCopy))
+        {
+            try { File.Delete(_testFileCopy); } catch { /* best effort */ }
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Verifies that Execute() does NOT suppress EnableEvents.
+    /// Events suppression is intentionally left to individual commands because
+    /// Data Model operations need events enabled for model synchronization.
+    /// </summary>
+    [Fact]
+    public void Execute_DoesNotSuppressEnableEvents()
+    {
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        bool eventsInsideExecute = false;
+
+        batch.Execute((ctx, ct) =>
+        {
+            eventsInsideExecute = ctx.App.EnableEvents;
+            _output.WriteLine($"EnableEvents inside Execute: {eventsInsideExecute}");
+            return 0;
+        });
+
+        // Events should NOT be suppressed — Data Model ops need them
+        Assert.True(eventsInsideExecute, "EnableEvents must NOT be suppressed by guard");
+    }
+
+    /// <summary>
+    /// Verifies that Execute() suppresses ScreenUpdating during operations.
+    /// This prevents Excel from repainting after every COM call (perf + stability).
+    /// </summary>
+    [Fact]
+    public void Execute_SuppressesScreenUpdating_DuringOperation()
+    {
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        bool screenUpdatingInside = true;
+
+        batch.Execute((ctx, ct) =>
+        {
+            screenUpdatingInside = ctx.App.ScreenUpdating;
+            _output.WriteLine($"ScreenUpdating inside Execute: {screenUpdatingInside}");
+            return 0;
+        });
+
+        Assert.False(screenUpdatingInside, "ScreenUpdating must be false inside Execute()");
+    }
+
+    /// <summary>
+    /// Verifies that Execute() does NOT suppress Calculation mode.
+    /// Calculation is intentionally left alone by the guard because Data Model operations,
+    /// PivotTable refresh, and Power Query refresh require calculation to be enabled.
+    /// Commands that need manual calculation handle it themselves.
+    /// </summary>
+    [Fact]
+    public void Execute_DoesNotSuppressCalculation()
+    {
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        int calculationInside = 0;
+
+        batch.Execute((ctx, ct) =>
+        {
+            calculationInside = (int)ctx.App.Calculation;
+            _output.WriteLine($"Calculation inside Execute: {calculationInside}");
+            return 0;
+        });
+
+        // xlCalculationAutomatic = -4105 (default for new workbooks)
+        // Guard should NOT change it — calculation suppression is operation-specific
+        Assert.Equal(-4105, calculationInside);
+    }
+
+    /// <summary>
+    /// Verifies that the guard restores state even when the operation throws.
+    /// This is critical — exceptions must not leave Excel in a suppressed state.
+    /// </summary>
+    [Fact]
+    public void Execute_RestoresState_EvenOnException()
+    {
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        // First: force an exception inside Execute
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                throw new InvalidOperationException("Intentional test exception");
+#pragma warning disable CS0162 // Unreachable code
+                return 0;
+#pragma warning restore CS0162
+            });
+        });
+
+        // Second: verify the guard still works (state was restored despite exception)
+        bool eventsAfterException = true;
+        bool screenUpdatingAfterException = true;
+        int calculationAfterException = 0;
+
+        batch.Execute((ctx, ct) =>
+        {
+            eventsAfterException = ctx.App.EnableEvents;
+            screenUpdatingAfterException = ctx.App.ScreenUpdating;
+            calculationAfterException = (int)ctx.App.Calculation;
+            return 0;
+        });
+
+        // Inside Execute, guard suppresses ScreenUpdating only
+        // Events and Calculation are NOT suppressed (Data Model ops need them)
+        Assert.True(eventsAfterException, "EnableEvents must NOT be suppressed by guard");
+        Assert.False(screenUpdatingAfterException, "ScreenUpdating must be suppressed after exception recovery");
+        Assert.Equal(-4105, calculationAfterException);
+        _output.WriteLine("✓ Guard correctly restored state after exception");
+    }
+
+    /// <summary>
+    /// Verifies that nested Execute() calls (which create nested guards)
+    /// don't double-restore state. The outer guard is the one that restores.
+    /// </summary>
+    [Fact]
+    public void NestedExecute_DoesNotDoubleRestore()
+    {
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        bool innerScreenUpdating = true;
+
+        batch.Execute((ctx, ct) =>
+        {
+            // ExcelWriteGuard uses thread-static ref counting.
+            // Creating a second guard inside Execute (simulating nested usage)
+            // should be a no-op — the outer guard owns state restoration.
+            using var innerGuard = new ExcelWriteGuard(ctx.App);
+
+            innerScreenUpdating = ctx.App.ScreenUpdating;
+            _output.WriteLine($"ScreenUpdating inside nested guard: {innerScreenUpdating}");
+
+            return 0;
+        });
+
+        Assert.False(innerScreenUpdating, "ScreenUpdating must remain false during nested guards");
+        _output.WriteLine("✓ Nested guard did not interfere with outer guard");
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: Writing values to cells with conditional formatting must not deadlock.
+    /// Before the fix, MessagePending returned WAITNOPROCESS for normal operations, which
+    /// blocked Excel's internal callbacks (Calculate, conditional formatting evaluation)
+    /// and caused a deadlock when Excel waited for the callback to complete.
+    /// </summary>
+    [Fact]
+    public void WriteValues_WithConditionalFormatting_DoesNotDeadlock()
+    {
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            dynamic? range = null;
+            dynamic? formatConditions = null;
+            dynamic? formatCondition = null;
+
+            try
+            {
+                sheet = ctx.Book.Worksheets[1];
+
+                // Set up: write initial values
+                sheet.Range["A1"].Value2 = 100;
+                sheet.Range["A2"].Value2 = 200;
+
+                // Add conditional formatting rule on A1:A2
+                range = sheet.Range["A1:A2"];
+                formatConditions = range.FormatConditions;
+                formatCondition = formatConditions.Add(
+                    Type: 1, // xlCellValue
+                    Operator: 3, // xlGreater
+                    Formula1: "=150");
+
+                // Now write NEW values — this triggers conditional formatting re-evaluation.
+                // Before the fix, this would deadlock because:
+                // 1. range.Value2 = ... sends COM call to Excel
+                // 2. Excel evaluates conditional formatting, sends callback to our STA thread
+                // 3. MessagePending returned WAITNOPROCESS → callback queued, not dispatched
+                // 4. Excel waits for callback → our thread waits for Excel → DEADLOCK
+                sheet.Range["A1"].Value2 = 300;
+                sheet.Range["A2"].Value2 = 50;
+
+                _output.WriteLine("✓ Value writes with conditional formatting completed without deadlock");
+            }
+            finally
+            {
+                ComUtilities.Release(ref formatCondition);
+                ComUtilities.Release(ref formatConditions);
+                ComUtilities.Release(ref range);
+                ComUtilities.Release(ref sheet);
+            }
+
+            return 0;
+        });
+    }
+
+    /// <summary>
+    /// REGRESSION TEST: Writing formulas that trigger recalculation must not deadlock.
+    /// Formulas with dependencies cause Excel to fire Calculate events, which previously
+    /// could deadlock the STA thread via WAITNOPROCESS.
+    /// </summary>
+    [Fact]
+    public void WriteFormulas_WithDependencies_DoesNotDeadlock()
+    {
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            try
+            {
+                sheet = ctx.Book.Worksheets[1];
+
+                // Write values that formulas will depend on
+                sheet.Range["B1"].Value2 = 10;
+                sheet.Range["B2"].Value2 = 20;
+                sheet.Range["B3"].Value2 = 30;
+
+                // Write formulas that reference those cells — triggers recalculation
+                sheet.Range["C1"].Formula2 = "=B1*2";
+                sheet.Range["C2"].Formula2 = "=B2+B3";
+                sheet.Range["C3"].Formula2 = "=SUM(B1:B3)";
+
+                // Now change the source values — triggers formula recalculation
+                sheet.Range["B1"].Value2 = 100;
+                sheet.Range["B2"].Value2 = 200;
+
+                _output.WriteLine("✓ Formula writes with dependencies completed without deadlock");
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheet);
+            }
+
+            return 0;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that bulk value writes with the guard are significantly faster
+    /// than they would be without ScreenUpdating suppression.
+    /// This is a basic sanity check — exact timing varies by machine.
+    /// </summary>
+    [Fact]
+    public void BulkWrites_WithGuard_CompletesInReasonableTime()
+    {
+        using var batch = ExcelSession.BeginBatch(_testFileCopy!);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            try
+            {
+                sheet = ctx.Book.Worksheets[1];
+
+                // Write 100 cells — with ScreenUpdating=false this should be fast
+                for (int i = 1; i <= 100; i++)
+                {
+                    sheet.Range[$"D{i}"].Value2 = i * 1.5;
+                }
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheet);
+            }
+
+            return 0;
+        });
+
+        stopwatch.Stop();
+        _output.WriteLine($"100 cell writes completed in {stopwatch.ElapsedMilliseconds}ms");
+
+        // With ScreenUpdating suppressed, 100 writes should complete in well under 30s
+        Assert.True(stopwatch.ElapsedMilliseconds < 30000,
+            $"Bulk writes took {stopwatch.ElapsedMilliseconds}ms — ScreenUpdating may not be suppressed");
+    }
+}

--- a/tests/ExcelMcp.ComInterop.Tests/Unit/OleMessageFilterTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Unit/OleMessageFilterTests.cs
@@ -69,28 +69,20 @@ public class OleMessageFilterTests
     }
 
     /// <summary>
-    /// REGRESSION TEST for the STA deadlock bug (Feb 2026):
-    /// MessagePending MUST return PENDINGMSG_WAITDEFPROCESS (1), NOT PENDINGMSG_WAITNOPROCESS (2).
+    /// REGRESSION TEST: MessagePending behavior depends on operation mode.
+    /// - Normal operations: WAITNOPROCESS (1) — queue messages, don't dispatch
+    /// - Long operations: WAITDEFPROCESS (2) — dispatch through HandleInComingCall
     ///
-    /// Returning 2 (WAITNOPROCESS) blocks ALL inbound COM message processing while an outgoing
-    /// call is in progress. When Excel fires a re-entrant callback (e.g., Calculate, SheetChange)
-    /// during FormatConditions.Add(), the callback is queued but WAITNOPROCESS prevents it from
-    /// being dispatched. Excel waits for the callback → STA thread waits for Excel → deadlock.
-    ///
-    /// Returning 1 (WAITDEFPROCESS) allows COM to process the pending inbound call, letting
-    /// Excel's callback complete so FormatConditions.Add() can return normally.
+    /// For normal operations, WAITNOPROCESS is correct because dispatching causes
+    /// re-entrant COM execution that hangs Data Model operations. The ScreenUpdating
+    /// guard in ExcelWriteGuard reduces callbacks, and the deadlock case (FormatConditions.Add
+    /// with formula cells) is handled by explicitly wrapping those operations with
+    /// EnterLongOperation.
     /// </summary>
     [Fact]
-    public void MessagePending_ReturnValue_MustBe_WaitDefProcess()
+    public void MessagePending_NormalOperation_ReturnsWaitNoProcess()
     {
-        // The IOleMessageFilter interface is internal, so we verify the constant value via
-        // reflection on the compiled method body — simpler: we verify by checking the
-        // registered filter doesn't use the blocking value (2).
-        //
-        // We instantiate the filter and call MessagePending via the interface.
-        // Use reflection to access the internal interface implementation.
-        const int PENDINGMSG_WAITDEFPROCESS = 1;
-        const int PENDINGMSG_WAITNOPROCESS = 2;
+        const int PENDINGMSG_WAITNOPROCESS = 1;
 
         var returnValue = -1;
         Exception? threadException = null;
@@ -101,26 +93,19 @@ public class OleMessageFilterTests
             {
                 OleMessageFilter.Register();
 
-                // The filter implements IOleMessageFilter which is internal.
-                // We can verify via the public static IsRegistered and the logical behavior:
-                // After Register(), the filter IS the active message filter for this thread.
-                //
-                // Verify that the filter is registered (prerequisite for the bug to manifest).
                 Assert.True(OleMessageFilter.IsRegistered, "Filter must be registered to have any effect");
 
-                // Use reflection to invoke MessagePending on the filter instance.
-                // The filter class is internal, but we can get to it via the assembly.
                 var filterType = typeof(OleMessageFilter);
                 var iOleMsgFilterType = filterType.Assembly.GetType(
                     "Sbroenne.ExcelMcp.ComInterop.IOleMessageFilter");
                 Assert.NotNull(iOleMsgFilterType);
 
-                // Create a filter instance and call MessagePending
                 var filterInstance = Activator.CreateInstance(filterType);
                 Assert.NotNull(filterInstance);
                 var method = iOleMsgFilterType.GetMethod("MessagePending");
                 Assert.NotNull(method);
 
+                // Normal operation (not in long operation mode)
                 returnValue = (int)method.Invoke(filterInstance, [IntPtr.Zero, 1000, 1])!;
                 OleMessageFilter.Revoke();
             }
@@ -136,10 +121,55 @@ public class OleMessageFilterTests
 
         if (threadException != null) throw new InvalidOperationException($"Thread exception: {threadException.Message}", threadException);
 
-        // REGRESSION: If this returns 2 (WAITNOPROCESS), conditional formatting on cells
-        // with formulas will deadlock because Excel's Calculate/SheetChange callbacks
-        // can't be delivered while the STA thread waits for FormatConditions.Add().
-        Assert.NotEqual(PENDINGMSG_WAITNOPROCESS, returnValue);
+        Assert.Equal(PENDINGMSG_WAITNOPROCESS, returnValue);
+    }
+
+    /// <summary>
+    /// Verifies that during long operations, MessagePending returns WAITDEFPROCESS (2)
+    /// to dispatch callbacks through HandleInComingCall (which rejects with retry).
+    /// </summary>
+    [Fact]
+    public void MessagePending_DuringLongOperation_ReturnsWaitDefProcess()
+    {
+        const int PENDINGMSG_WAITDEFPROCESS = 2;
+
+        var returnValue = -1;
+        Exception? threadException = null;
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                OleMessageFilter.Register();
+                OleMessageFilter.EnterLongOperation();
+
+                var filterType = typeof(OleMessageFilter);
+                var iOleMsgFilterType = filterType.Assembly.GetType(
+                    "Sbroenne.ExcelMcp.ComInterop.IOleMessageFilter");
+                Assert.NotNull(iOleMsgFilterType);
+
+                var filterInstance = Activator.CreateInstance(filterType);
+                Assert.NotNull(filterInstance);
+                var method = iOleMsgFilterType.GetMethod("MessagePending");
+                Assert.NotNull(method);
+
+                returnValue = (int)method.Invoke(filterInstance, [IntPtr.Zero, 1000, 1])!;
+
+                OleMessageFilter.ExitLongOperation();
+                OleMessageFilter.Revoke();
+            }
+            catch (Exception ex)
+            {
+                threadException = ex;
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (threadException != null) throw new InvalidOperationException($"Thread exception: {threadException.Message}", threadException);
+
         Assert.Equal(PENDINGMSG_WAITDEFPROCESS, returnValue);
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Helpers/DataModelPivotTableFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/DataModelPivotTableFixture.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Commands;
 using Sbroenne.ExcelMcp.Core.Commands.PivotTable;
@@ -29,6 +30,11 @@ public class DataModelPivotTableFixture : IAsyncLifetime
     private readonly string _tempDir;
 
     /// <summary>
+    /// Temp directory for test files (auto-cleaned on disposal)
+    /// </summary>
+    public string TempDir => _tempDir;
+
+    /// <summary>
     /// Path to the test file
     /// </summary>
     public string TestFilePath { get; private set; } = null!;
@@ -48,7 +54,16 @@ public class DataModelPivotTableFixture : IAsyncLifetime
     /// Called ONCE before any tests in the class run.
     /// Creates comprehensive Data Model with relationships, measures, and PivotTables.
     /// </summary>
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
+    {
+        // Run heavy COM initialization on a background thread to prevent
+        // blocking xUnit's synchronization context during fixture setup.
+        // Without Task.Run, the synchronous COM work blocks the calling thread,
+        // which can deadlock when multiple fixtures initialize concurrently.
+        await Task.Run(() => InitializeCore());
+    }
+
+    private void InitializeCore()
     {
         var sw = Stopwatch.StartNew();
 
@@ -278,8 +293,6 @@ public class DataModelPivotTableFixture : IAsyncLifetime
             Console.WriteLine($"❌ DataModelPivotTable fixture creation FAILED after {sw.ElapsedMilliseconds}ms: {ex.Message}");
             throw;
         }
-
-        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -418,6 +431,19 @@ public class DataModelPivotTableFixture : IAsyncLifetime
 
         rangeCommands.SetValues(batch, "DisambiguationData", "A1:E6", allData);
         tableCommands.Create(batch, "DisambiguationData", "DisambiguationTable", "A1:E6", true);
+    }
+
+    /// <summary>
+    /// Creates a unique test file for tests that need their own isolated file.
+    /// </summary>
+    public string CreateTestFile([CallerMemberName] string testName = "", string extension = ".xlsx")
+    {
+        var fileName = $"{testName}_{Guid.NewGuid():N}{extension}";
+        var filePath = Path.Join(_tempDir, fileName);
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSessionForNewFile(filePath, show: false);
+        manager.CloseSession(sessionId, save: true);
+        return filePath;
     }
 
     public Task DisposeAsync()

--- a/tests/ExcelMcp.Core.Tests/Helpers/PivotTableTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/PivotTableTestsFixture.cs
@@ -45,7 +45,12 @@ public class PivotTableTestsFixture : IAsyncLifetime
     /// This IS the test for data preparation - if it fails, all tests fail (correct behavior).
     /// Tests: file creation, sales data creation, persistence.
     /// </summary>
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
+    {
+        await Task.Run(() => InitializeCore());
+    }
+
+    private void InitializeCore()
     {
         var sw = Stopwatch.StartNew();
 
@@ -118,10 +123,8 @@ public class PivotTableTestsFixture : IAsyncLifetime
 
             sw.Stop();
 
-            throw; // Fail all tests in class (correct behavior - no point testing if creation failed)
+            throw; // Fail all tests in class
         }
-
-        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.BugRegression.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.BugRegression.cs
@@ -99,7 +99,7 @@ public partial class PivotTableCommandsTests
     public void CreateFromRange_SourceSheetWithHyphen_CreatesPivotTable()
     {
         // Arrange — sheet name with hyphen (also requires quoting)
-        var testFile = _fixture.CreateTestFile(
+        var testFile = _olapFixture.CreateTestFile(
             nameof(CreateFromRange_SourceSheetWithHyphen_CreatesPivotTable));
 
         using (var setupBatch = ExcelSession.BeginBatch(testFile))
@@ -147,7 +147,7 @@ public partial class PivotTableCommandsTests
     /// </summary>
     private string CreateTestFileWithData_SheetWithSpaces(string testName)
     {
-        var testFile = _fixture.CreateTestFile(testName);
+        var testFile = _olapFixture.CreateTestFile(testName);
 
         using var batch = ExcelSession.BeginBatch(testFile);
         batch.Execute((ctx, ct) =>

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.Grouping.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.Grouping.cs
@@ -341,7 +341,7 @@ public partial class PivotTableCommandsTests
     /// </summary>
     private string CreateTestFileWithNumericData(string testName)
     {
-        var testFile = _fixture.CreateTestFile(testName);
+        var testFile = _olapFixture.CreateTestFile(testName);
 
         using var batch = ExcelSession.BeginBatch(testFile);
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.cs
@@ -9,8 +9,7 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PivotTable;
 
 /// <summary>
 /// Integration tests for PivotTable commands.
-/// Uses PivotTableTestsFixture which creates ONE data file per test class (~5-10s setup).
-/// Uses DataModelPivotTableFixture for OLAP tests (shared across ALL test classes via collection fixture).
+/// Uses DataModelPivotTableFixture for all tests (shared across ALL test classes via collection fixture).
 /// Fixture initialization IS the test for data preparation.
 /// Each test gets its own batch for isolation.
 /// </summary>
@@ -19,26 +18,24 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PivotTable;
 [Trait("Category", "Integration")]
 [Trait("RequiresExcel", "true")]
 [Trait("Feature", "PivotTables")]
-public partial class PivotTableCommandsTests : IClassFixture<PivotTableTestsFixture>
+public partial class PivotTableCommandsTests
 {
     private readonly PivotTableCommands _pivotCommands;
-    private readonly PivotTableTestsFixture _fixture;
     private readonly DataModelPivotTableFixture _olapFixture;
     private readonly string _pivotFile;
-    private readonly PivotTableCreationResult _creationResult;
+    private readonly DataModelPivotTableCreationResult _creationResult;
     private readonly ITestOutputHelper _output;
     private readonly ILoggerFactory _loggerFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PivotTableCommandsTests"/> class.
     /// </summary>
-    public PivotTableCommandsTests(PivotTableTestsFixture fixture, DataModelPivotTableFixture olapFixture, ITestOutputHelper output)
+    public PivotTableCommandsTests(DataModelPivotTableFixture olapFixture, ITestOutputHelper output)
     {
         _pivotCommands = new PivotTableCommands();
-        _fixture = fixture;
         _olapFixture = olapFixture;
-        _pivotFile = fixture.TestFilePath;
-        _creationResult = fixture.CreationResult;
+        _pivotFile = olapFixture.TestFilePath;
+        _creationResult = olapFixture.CreationResult;
         _output = output;
         _loggerFactory = LoggerFactory.Create(builder => builder
             .AddXUnit(output)
@@ -51,7 +48,7 @@ public partial class PivotTableCommandsTests : IClassFixture<PivotTableTestsFixt
     /// </summary>
     private string CreateTestFileWithData(string testName)
     {
-        var testFile = _fixture.CreateTestFile(testName);
+        var testFile = _olapFixture.CreateTestFile(testName);
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
@@ -106,7 +103,7 @@ public partial class PivotTableCommandsTests : IClassFixture<PivotTableTestsFixt
     /// Explicit test that validates the fixture creation results.
     /// This makes the data preparation test visible in test results and validates:
     /// - SessionManager.CreateSessionForNewFile()
-    /// - Sales data creation
+    /// - Data Model tables, relationships, measures, and PivotTable creation
     /// - Batch.Save() persistence
     /// </summary>
     [Fact]
@@ -118,11 +115,11 @@ public partial class PivotTableCommandsTests : IClassFixture<PivotTableTestsFixt
             $"Data preparation failed during fixture initialization: {_creationResult.ErrorMessage}");
 
         Assert.True(_creationResult.FileCreated, "File creation failed");
-        Assert.Equal(5, _creationResult.DataRowsCreated);
-        Assert.True(_creationResult.CreationTimeSeconds > 0);
+        Assert.True(_creationResult.TablesCreated > 0, "No tables were created");
+        Assert.True(_creationResult.CreationTimeMs > 0);
 
         // This test appears in test results as proof that creation was tested
-        Console.WriteLine($"? Data prepared successfully in {_creationResult.CreationTimeSeconds:F1}s");
+        Console.WriteLine($"? Data prepared successfully in {_creationResult.CreationTimeMs}ms");
     }
 
     /// <summary>
@@ -136,21 +133,21 @@ public partial class PivotTableCommandsTests : IClassFixture<PivotTableTestsFixt
         // Close and reopen to verify persistence (new batch = new session)
         using var batch = ExcelSession.BeginBatch(_pivotFile);
 
-        // Verify data persisted by reading range
+        // Verify data persisted by reading range (SalesData sheet from DataModel fixture)
         batch.Execute((ctx, ct) =>
         {
             dynamic sheet = ctx.Book.Worksheets["SalesData"];
 
-            // Verify headers
-            Assert.Equal("Region", sheet.Range["A1"].Value2?.ToString());
-            Assert.Equal("Product", sheet.Range["B1"].Value2?.ToString());
-            Assert.Equal("Sales", sheet.Range["C1"].Value2?.ToString());
-            Assert.Equal("Date", sheet.Range["D1"].Value2?.ToString());
+            // Verify headers match DataModel fixture's SalesTable columns
+            Assert.Equal("SalesID", sheet.Range["A1"].Value2?.ToString());
+            Assert.Equal("Date", sheet.Range["B1"].Value2?.ToString());
+            Assert.Equal("CustomerID", sheet.Range["C1"].Value2?.ToString());
+            Assert.Equal("ProductID", sheet.Range["D1"].Value2?.ToString());
 
             // Verify first data row
-            Assert.Equal("North", sheet.Range["A2"].Value2?.ToString());
-            Assert.Equal("Widget", sheet.Range["B2"].Value2?.ToString());
-            Assert.Equal(100.0, Convert.ToDouble(sheet.Range["C2"].Value2));
+            Assert.Equal(1.0, Convert.ToDouble(sheet.Range["A2"].Value2));
+            Assert.Equal(101.0, Convert.ToDouble(sheet.Range["C2"].Value2));
+            Assert.Equal(1001.0, Convert.ToDouble(sheet.Range["D2"].Value2));
 
             return 0;
         });


### PR DESCRIPTION
## Problem

Intermittent hangs (actions never complete) and orphan Excel processes with plain .xlsx workbooks. ~20 stability releases (v1.7.5-v1.8.25) each patched one symptom but the structure that created the problems remained.

## Root Cause

ExcelBatch.Execute() provided zero COM safety guarantees. ALL safety (screen updating, error handling, shutdown resilience) was left to each individual command author.

## Solution: Structural fixes

### 1. ExcelWriteGuard in Execute()
- Suppresses ScreenUpdating automatically for every operation
- Integrated INTO ExcelBatch.Execute() — transparent to all commands
- Reentrant-safe via thread-static ref counting

### 2. Unified Shutdown
- Multi-workbook batches now use ExcelShutdownService (was bare COM calls)
- Added retry to Close (3 attempts for COM busy) and Save (3 attempts for file locks)

### 3. PID Capture + ProcessExit
- Hwnd read retried 3x with 500ms delay (was one-shot)
- AppDomain.ProcessExit handler kills tracked Excel PIDs on crash

### 4. Error Hardening
- WithSessionAsync cleanup wrapped in try-catch
- Dead sessions detected in generic exception handler
- PQ Evaluate Refresh wrapped with EnterLongOperation
- Cancellation checks in COM collection loops
- OleMessageFilter.Revoke() guarded in finally blocks

### 5. PivotTable Test Suite Fix
- Dual-fixture pattern created concurrent Excel sessions that deadlocked
- Consolidated to single DataModelPivotTableFixture
- 102 PivotTable tests now pass (were hanging)

## Test Results
- 13 new regression tests (ExcelWriteGuard + OleMessageFilter)
- 102 PivotTable, 117 PowerQuery, 53 Table, 6 Range tests pass
- Build: 0 warnings, 0 errors
- All 10 pre-commit checks pass