### PR TITLE
Fix COM lifetime handling for PIA migration

### DIFF
--- a/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.ComInterop.Session;
@@ -214,8 +213,8 @@ public static class ExcelSession
 
                 ComUtilities.TryQuitExcel(excel);
 
-                if (workbook != null) { Marshal.ReleaseComObject(workbook); workbook = null; }
-                if (excel != null) { Marshal.ReleaseComObject(excel); excel = null; }
+                ComUtilities.Release(ref workbook);
+                ComUtilities.Release(ref excel);
 
                 try
                 {

--- a/src/ExcelMcp.Core/Commands/Chart/PivotChartStrategy.cs
+++ b/src/ExcelMcp.Core/Commands/Chart/PivotChartStrategy.cs
@@ -13,14 +13,19 @@ public class PivotChartStrategy : IChartStrategy
     public bool CanHandle(dynamic chart)
     {
         // PivotCharts: chart.PivotLayout exists
+        dynamic? pivotLayout = null;
         try
         {
-            var pivotLayout = chart.PivotLayout;
+            pivotLayout = chart.PivotLayout;
             return pivotLayout != null;
         }
         catch (COMException)
         {
             return false;
+        }
+        finally
+        {
+            ComUtilities.Release(ref pivotLayout);
         }
     }
 

--- a/src/ExcelMcp.Core/Commands/Chart/RegularChartStrategy.cs
+++ b/src/ExcelMcp.Core/Commands/Chart/RegularChartStrategy.cs
@@ -13,14 +13,19 @@ public class RegularChartStrategy : IChartStrategy
     public bool CanHandle(dynamic chart)
     {
         // Regular charts: chart.PivotLayout is null or doesn't exist
+        dynamic? pivotLayout = null;
         try
         {
-            var pivotLayout = chart.PivotLayout;
+            pivotLayout = chart.PivotLayout;
             return pivotLayout == null;
         }
         catch (COMException)
         {
             return true; // No PivotLayout property = Regular chart
+        }
+        finally
+        {
+            ComUtilities.Release(ref pivotLayout);
         }
     }
 

--- a/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.Core.PowerQuery;
+using Excel = Microsoft.Office.Interop.Excel;
 
 
 namespace Sbroenne.ExcelMcp.Core.Commands;
@@ -14,24 +15,47 @@ public partial class ConnectionCommands : IConnectionCommands
 {
     #region Helper Methods
 
-    /// <summary>
-    /// Returns the typed sub-connection (OLEDBConnection, ODBCConnection, TextConnection, or WebConnection)
-    /// based on the connection type. For types 3/4, tries TextConnection first then WebConnection
-    /// because Excel may report CSV files as either type.
-    /// </summary>
+    private static DateTime? GetRefreshDateSafe(object? refreshDate)
+    {
+        return refreshDate switch
+        {
+            null => null,
+            DateTime dateTime => dateTime,
+            double oaDate => DateTime.FromOADate(oaDate),
+            _ => null
+        };
+    }
+
     private static dynamic? GetTypedSubConnection(dynamic conn)
     {
         int connType = conn.Type;
 
-        if (connType == 1) return conn.OLEDBConnection;
-        if (connType == 2) return conn.ODBCConnection;
+        if (connType == 1)
+        {
+            return conn.OLEDBConnection;
+        }
+
+        if (connType == 2)
+        {
+            return conn.ODBCConnection;
+        }
+
         if (connType is 3 or 4)
         {
-            try { return conn.TextConnection; }
+            try
+            {
+                return conn.TextConnection;
+            }
             catch (COMException)
             {
-                try { return conn.WebConnection; }
-                catch (COMException) { return null; }
+                try
+                {
+                    return conn.WebConnection;
+                }
+                catch (COMException)
+                {
+                    return null;
+                }
             }
         }
 
@@ -40,38 +64,314 @@ public partial class ConnectionCommands : IConnectionCommands
 
     private static bool GetBackgroundQuerySetting(dynamic conn)
     {
-        try { return GetTypedSubConnection(conn)?.BackgroundQuery ?? false; }
-        catch (COMException) { return false; }
+        try
+        {
+            int connType = conn.Type;
+            if (connType == 1)
+            {
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
+                {
+                    oledbConnection = conn.OLEDBConnection;
+                    return oledbConnection?.BackgroundQuery ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
+                }
+            }
+
+            if (connType == 2)
+            {
+                Excel.ODBCConnection? odbcConnection = null;
+                try
+                {
+                    odbcConnection = conn.ODBCConnection;
+                    return odbcConnection?.BackgroundQuery ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
+                }
+            }
+
+            if (connType is 3 or 4)
+            {
+                dynamic? textConnection = null;
+                try
+                {
+                    textConnection = conn.TextConnection;
+                    return textConnection?.BackgroundQuery ?? false;
+                }
+                catch (COMException)
+                {
+                }
+                finally
+                {
+                    ComUtilities.Release(ref textConnection);
+                }
+
+                dynamic? webConnection = null;
+                try
+                {
+                    webConnection = conn.WebConnection;
+                    return webConnection?.BackgroundQuery ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref webConnection);
+                }
+            }
+        }
+        catch (COMException)
+        {
+        }
+
+        return false;
     }
 
     private static bool GetRefreshOnFileOpenSetting(dynamic conn)
     {
-        try { return GetTypedSubConnection(conn)?.RefreshOnFileOpen ?? false; }
-        catch (COMException) { return false; }
+        try
+        {
+            int connType = conn.Type;
+            if (connType == 1)
+            {
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
+                {
+                    oledbConnection = conn.OLEDBConnection;
+                    return oledbConnection?.RefreshOnFileOpen ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
+                }
+            }
+
+            if (connType == 2)
+            {
+                Excel.ODBCConnection? odbcConnection = null;
+                try
+                {
+                    odbcConnection = conn.ODBCConnection;
+                    return odbcConnection?.RefreshOnFileOpen ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
+                }
+            }
+
+            if (connType is 3 or 4)
+            {
+                dynamic? textConnection = null;
+                try
+                {
+                    textConnection = conn.TextConnection;
+                    return textConnection?.RefreshOnFileOpen ?? false;
+                }
+                catch (COMException)
+                {
+                }
+                finally
+                {
+                    ComUtilities.Release(ref textConnection);
+                }
+
+                dynamic? webConnection = null;
+                try
+                {
+                    webConnection = conn.WebConnection;
+                    return webConnection?.RefreshOnFileOpen ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref webConnection);
+                }
+            }
+        }
+        catch (COMException)
+        {
+        }
+
+        return false;
     }
 
     private static bool GetSavePasswordSetting(dynamic conn)
     {
-        try { return GetTypedSubConnection(conn)?.SavePassword ?? false; }
-        catch (COMException) { return false; }
+        try
+        {
+            int connType = conn.Type;
+            if (connType == 1)
+            {
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
+                {
+                    oledbConnection = conn.OLEDBConnection;
+                    return oledbConnection?.SavePassword ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
+                }
+            }
+
+            if (connType == 2)
+            {
+                Excel.ODBCConnection? odbcConnection = null;
+                try
+                {
+                    odbcConnection = conn.ODBCConnection;
+                    return odbcConnection?.SavePassword ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
+                }
+            }
+
+            if (connType is 3 or 4)
+            {
+                dynamic? textConnection = null;
+                try
+                {
+                    textConnection = conn.TextConnection;
+                    return textConnection?.SavePassword ?? false;
+                }
+                catch (COMException)
+                {
+                }
+                finally
+                {
+                    ComUtilities.Release(ref textConnection);
+                }
+
+                dynamic? webConnection = null;
+                try
+                {
+                    webConnection = conn.WebConnection;
+                    return webConnection?.SavePassword ?? false;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref webConnection);
+                }
+            }
+        }
+        catch (COMException)
+        {
+        }
+
+        return false;
     }
 
     private static int GetRefreshPeriod(dynamic conn)
     {
-        try { return GetTypedSubConnection(conn)?.RefreshPeriod ?? 0; }
-        catch (COMException) { return 0; }
+        try
+        {
+            int connType = conn.Type;
+            if (connType == 1)
+            {
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
+                {
+                    oledbConnection = conn.OLEDBConnection;
+                    return oledbConnection?.RefreshPeriod ?? 0;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
+                }
+            }
+
+            if (connType == 2)
+            {
+                Excel.ODBCConnection? odbcConnection = null;
+                try
+                {
+                    odbcConnection = conn.ODBCConnection;
+                    return odbcConnection?.RefreshPeriod ?? 0;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
+                }
+            }
+
+            if (connType is 3 or 4)
+            {
+                dynamic? textConnection = null;
+                try
+                {
+                    textConnection = conn.TextConnection;
+                    return textConnection?.RefreshPeriod ?? 0;
+                }
+                catch (COMException)
+                {
+                }
+                finally
+                {
+                    ComUtilities.Release(ref textConnection);
+                }
+
+                dynamic? webConnection = null;
+                try
+                {
+                    webConnection = conn.WebConnection;
+                    return webConnection?.RefreshPeriod ?? 0;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref webConnection);
+                }
+            }
+        }
+        catch (COMException)
+        {
+        }
+
+        return 0;
     }
 
     private static DateTime? GetLastRefreshDate(dynamic conn)
     {
         try
         {
-            // RefreshDate is only available on OLEDB and ODBC connections
             int connType = conn.Type;
-            if (connType is not (1 or 2)) return null;
-            return GetTypedSubConnection(conn)?.RefreshDate;
+            if (connType == 1)
+            {
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
+                {
+                    oledbConnection = conn.OLEDBConnection;
+                    return GetRefreshDateSafe(oledbConnection?.RefreshDate);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
+                }
+            }
+
+            if (connType == 2)
+            {
+                Excel.ODBCConnection? odbcConnection = null;
+                try
+                {
+                    odbcConnection = conn.ODBCConnection;
+                    return GetRefreshDateSafe(odbcConnection?.RefreshDate);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
+                }
+            }
         }
-        catch (COMException) { return null; }
+        catch (COMException)
+        {
+        }
+
+        return null;
     }
 
     private static string? GetConnectionString(dynamic conn)
@@ -81,28 +381,63 @@ public partial class ConnectionCommands : IConnectionCommands
             int connType = conn.Type;
             string? connectionString = null;
 
-            if (connType == 1) // OLEDB
+            if (connType == 1)
             {
-                connectionString = conn.OLEDBConnection?.Connection?.ToString();
-            }
-            else if (connType == 2) // ODBC
-            {
-                connectionString = conn.ODBCConnection?.Connection?.ToString();
-            }
-            else if (connType == 4) // TEXT (xlConnectionTypeTEXT)
-            {
-                dynamic textConn = conn.TextConnection;
-                if (textConn != null)
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
                 {
-                    connectionString = textConn.Connection?.ToString();
+                    oledbConnection = conn.OLEDBConnection;
+                    connectionString = oledbConnection?.Connection?.ToString();
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
                 }
             }
-            else if (connType == 5) // WEB (xlConnectionTypeWEB)
+            else if (connType == 2)
             {
-                dynamic webConn = conn.WebConnection;
-                if (webConn != null)
+                Excel.ODBCConnection? odbcConnection = null;
+                try
                 {
-                    connectionString = webConn.Connection?.ToString();
+                    odbcConnection = conn.ODBCConnection;
+                    connectionString = odbcConnection?.Connection?.ToString();
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
+                }
+            }
+            else if (connType is 3 or 4)
+            {
+                dynamic? textConnection = null;
+                try
+                {
+                    textConnection = conn.TextConnection;
+                    connectionString = textConnection?.Connection?.ToString();
+                }
+                catch (COMException)
+                {
+                }
+                finally
+                {
+                    ComUtilities.Release(ref textConnection);
+                }
+
+                if (string.IsNullOrWhiteSpace(connectionString))
+                {
+                    dynamic? webConnection = null;
+                    try
+                    {
+                        webConnection = conn.WebConnection;
+                        connectionString = webConnection?.Connection?.ToString();
+                    }
+                    catch (COMException)
+                    {
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref webConnection);
+                    }
                 }
             }
 
@@ -131,31 +466,133 @@ public partial class ConnectionCommands : IConnectionCommands
 
     private static string? GetCommandText(dynamic conn)
     {
-        try { return GetTypedSubConnection(conn)?.CommandText?.ToString(); }
-        catch (COMException) { return null; }
+        try
+        {
+            int connType = conn.Type;
+            if (connType == 1)
+            {
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
+                {
+                    oledbConnection = conn.OLEDBConnection;
+                    return oledbConnection?.CommandText?.ToString();
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
+                }
+            }
+
+            if (connType == 2)
+            {
+                Excel.ODBCConnection? odbcConnection = null;
+                try
+                {
+                    odbcConnection = conn.ODBCConnection;
+                    return odbcConnection?.CommandText?.ToString();
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
+                }
+            }
+
+            if (connType is 3 or 4)
+            {
+                dynamic? textConnection = null;
+                try
+                {
+                    textConnection = conn.TextConnection;
+                    return textConnection?.CommandText?.ToString();
+                }
+                catch (COMException)
+                {
+                }
+                finally
+                {
+                    ComUtilities.Release(ref textConnection);
+                }
+
+                dynamic? webConnection = null;
+                try
+                {
+                    webConnection = conn.WebConnection;
+                    return webConnection?.CommandText?.ToString();
+                }
+                finally
+                {
+                    ComUtilities.Release(ref webConnection);
+                }
+            }
+        }
+        catch (COMException)
+        {
+        }
+
+        return null;
     }
 
     private static string? GetCommandType(dynamic conn)
     {
+        int commandType;
         try
         {
-            // CommandType is only available on OLEDB and ODBC connections
             int connType = conn.Type;
-            if (connType is not (1 or 2)) return null;
-
-            int? cmdType = GetTypedSubConnection(conn)?.CommandType;
-            if (!cmdType.HasValue) return "Unknown(null)";
-            return cmdType.Value switch
+            if (connType == 1)
             {
-                1 => "Cube",
-                2 => "SQL",
-                3 => "Table",
-                4 => "Default",
-                5 => "List",
-                _ => $"Unknown({cmdType.Value.ToString(CultureInfo.InvariantCulture)})"
-            };
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
+                {
+                    oledbConnection = conn.OLEDBConnection;
+                    if (oledbConnection == null)
+                    {
+                        return null;
+                    }
+
+                    commandType = Convert.ToInt32(oledbConnection.CommandType, CultureInfo.InvariantCulture);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
+                }
+            }
+            else if (connType == 2)
+            {
+                Excel.ODBCConnection? odbcConnection = null;
+                try
+                {
+                    odbcConnection = conn.ODBCConnection;
+                    if (odbcConnection == null)
+                    {
+                        return null;
+                    }
+
+                    commandType = Convert.ToInt32(odbcConnection.CommandType, CultureInfo.InvariantCulture);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
+                }
+            }
+            else
+            {
+                return null;
+            }
         }
-        catch (COMException) { return null; }
+        catch (COMException)
+        {
+            return null;
+        }
+
+        return commandType switch
+        {
+            1 => "Cube",
+            2 => "SQL",
+            3 => "Table",
+            4 => "Default",
+            5 => "List",
+            _ => $"Unknown({commandType.ToString(CultureInfo.InvariantCulture)})"
+        };
     }
 
     private static object GetConnectionProperties(dynamic conn)
@@ -232,116 +669,174 @@ public partial class ConnectionCommands : IConnectionCommands
 
             if (connType == 1) // OLEDB
             {
-                var oledb = conn.OLEDBConnection;
-                if (oledb != null)
+                Excel.OLEDBConnection? oledbConnection = null;
+                try
                 {
-                    if (!string.IsNullOrWhiteSpace(definition.ConnectionString))
+                    oledbConnection = conn.OLEDBConnection;
+                    if (oledbConnection != null)
                     {
-                        oledb.Connection = definition.ConnectionString;
+                        if (!string.IsNullOrWhiteSpace(definition.ConnectionString))
+                        {
+                            oledbConnection.Connection = definition.ConnectionString;
+                        }
+                        if (!string.IsNullOrWhiteSpace(definition.CommandText))
+                        {
+                            oledbConnection.CommandText = definition.CommandText;
+                        }
+                        if (definition.BackgroundQuery.HasValue)
+                        {
+                            oledbConnection.BackgroundQuery = definition.BackgroundQuery.Value;
+                        }
+                        if (definition.RefreshOnFileOpen.HasValue)
+                        {
+                            oledbConnection.RefreshOnFileOpen = definition.RefreshOnFileOpen.Value;
+                        }
+                        if (definition.SavePassword.HasValue)
+                        {
+                            oledbConnection.SavePassword = definition.SavePassword.Value;
+                        }
+                        if (definition.RefreshPeriod.HasValue)
+                        {
+                            oledbConnection.RefreshPeriod = definition.RefreshPeriod.Value;
+                        }
                     }
-                    if (!string.IsNullOrWhiteSpace(definition.CommandText))
-                    {
-                        oledb.CommandText = definition.CommandText;
-                    }
-                    if (definition.BackgroundQuery.HasValue)
-                    {
-                        oledb.BackgroundQuery = definition.BackgroundQuery.Value;
-                    }
-                    if (definition.RefreshOnFileOpen.HasValue)
-                    {
-                        oledb.RefreshOnFileOpen = definition.RefreshOnFileOpen.Value;
-                    }
-                    if (definition.SavePassword.HasValue)
-                    {
-                        oledb.SavePassword = definition.SavePassword.Value;
-                    }
-                    if (definition.RefreshPeriod.HasValue)
-                    {
-                        oledb.RefreshPeriod = definition.RefreshPeriod.Value;
-                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref oledbConnection);
                 }
             }
             else if (connType == 2) // ODBC
             {
-                var odbc = conn.ODBCConnection;
-                if (odbc != null)
+                Excel.ODBCConnection? odbcConnection = null;
+                try
                 {
-                    if (!string.IsNullOrWhiteSpace(definition.ConnectionString))
+                    odbcConnection = conn.ODBCConnection;
+                    if (odbcConnection != null)
                     {
-                        odbc.Connection = definition.ConnectionString;
+                        if (!string.IsNullOrWhiteSpace(definition.ConnectionString))
+                        {
+                            odbcConnection.Connection = definition.ConnectionString;
+                        }
+                        if (!string.IsNullOrWhiteSpace(definition.CommandText))
+                        {
+                            odbcConnection.CommandText = definition.CommandText;
+                        }
+                        if (definition.BackgroundQuery.HasValue)
+                        {
+                            odbcConnection.BackgroundQuery = definition.BackgroundQuery.Value;
+                        }
+                        if (definition.RefreshOnFileOpen.HasValue)
+                        {
+                            odbcConnection.RefreshOnFileOpen = definition.RefreshOnFileOpen.Value;
+                        }
+                        if (definition.SavePassword.HasValue)
+                        {
+                            odbcConnection.SavePassword = definition.SavePassword.Value;
+                        }
+                        if (definition.RefreshPeriod.HasValue)
+                        {
+                            odbcConnection.RefreshPeriod = definition.RefreshPeriod.Value;
+                        }
                     }
-                    if (!string.IsNullOrWhiteSpace(definition.CommandText))
-                    {
-                        odbc.CommandText = definition.CommandText;
-                    }
-                    if (definition.BackgroundQuery.HasValue)
-                    {
-                        odbc.BackgroundQuery = definition.BackgroundQuery.Value;
-                    }
-                    if (definition.RefreshOnFileOpen.HasValue)
-                    {
-                        odbc.RefreshOnFileOpen = definition.RefreshOnFileOpen.Value;
-                    }
-                    if (definition.SavePassword.HasValue)
-                    {
-                        odbc.SavePassword = definition.SavePassword.Value;
-                    }
-                    if (definition.RefreshPeriod.HasValue)
-                    {
-                        odbc.RefreshPeriod = definition.RefreshPeriod.Value;
-                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbcConnection);
                 }
             }
             else if (connType is 3 or 4) // TEXT (type 3) or WEB (type 4) - Excel may report CSV files as either
             {
                 // Excel has type 3/4 confusion: CSV files created with "TEXT;filepath" may be reported as type 4 (WEB)
                 // Try TextConnection first (correct for type 3), fall back to WebConnection if that fails
-                dynamic? textOrWeb = null!;
+                dynamic? textConnection = null;
                 try
                 {
-                    textOrWeb = conn.TextConnection; // Try TEXT first
+                    textConnection = conn.TextConnection; // Try TEXT first
                 }
-                catch (System.Runtime.InteropServices.COMException)
+                catch (COMException)
+                {
+                }
+
+                if (textConnection != null)
                 {
                     try
                     {
-                        textOrWeb = conn.WebConnection; // Fall back to WEB
+                        if (!string.IsNullOrWhiteSpace(definition.ConnectionString))
+                        {
+                            textConnection.Connection = definition.ConnectionString;
+                        }
+                        if (!string.IsNullOrWhiteSpace(definition.CommandText))
+                        {
+                            textConnection.CommandText = definition.CommandText;
+                        }
+                        if (definition.BackgroundQuery.HasValue)
+                        {
+                            textConnection.BackgroundQuery = definition.BackgroundQuery.Value;
+                        }
+                        if (definition.RefreshOnFileOpen.HasValue)
+                        {
+                            textConnection.RefreshOnFileOpen = definition.RefreshOnFileOpen.Value;
+                        }
+                        if (definition.SavePassword.HasValue)
+                        {
+                            textConnection.SavePassword = definition.SavePassword.Value;
+                        }
+                        if (definition.RefreshPeriod.HasValue)
+                        {
+                            textConnection.RefreshPeriod = definition.RefreshPeriod.Value;
+                        }
                     }
-                    catch (System.Runtime.InteropServices.COMException)
+                    finally
                     {
-                        // Neither works - skip property updates
+                        ComUtilities.Release(ref textConnection);
                     }
+
+                    return;
                 }
 
-                if (textOrWeb != null)
+                dynamic? webConnection = null;
+                try
                 {
-                    if (!string.IsNullOrWhiteSpace(definition.ConnectionString))
+                    webConnection = conn.WebConnection; // Fall back to WEB
+                    if (webConnection != null)
                     {
-                        textOrWeb.Connection = definition.ConnectionString;
-                    }
-                    if (!string.IsNullOrWhiteSpace(definition.CommandText))
-                    {
-                        textOrWeb.CommandText = definition.CommandText;
-                    }
-                    if (definition.BackgroundQuery.HasValue)
-                    {
-                        textOrWeb.BackgroundQuery = definition.BackgroundQuery.Value;
-                    }
-                    if (definition.RefreshOnFileOpen.HasValue)
-                    {
-                        textOrWeb.RefreshOnFileOpen = definition.RefreshOnFileOpen.Value;
-                    }
-                    if (definition.SavePassword.HasValue)
-                    {
-                        textOrWeb.SavePassword = definition.SavePassword.Value;
-                    }
-                    if (definition.RefreshPeriod.HasValue)
-                    {
-                        textOrWeb.RefreshPeriod = definition.RefreshPeriod.Value;
+                        if (!string.IsNullOrWhiteSpace(definition.ConnectionString))
+                        {
+                            webConnection.Connection = definition.ConnectionString;
+                        }
+                        if (!string.IsNullOrWhiteSpace(definition.CommandText))
+                        {
+                            webConnection.CommandText = definition.CommandText;
+                        }
+                        if (definition.BackgroundQuery.HasValue)
+                        {
+                            webConnection.BackgroundQuery = definition.BackgroundQuery.Value;
+                        }
+                        if (definition.RefreshOnFileOpen.HasValue)
+                        {
+                            webConnection.RefreshOnFileOpen = definition.RefreshOnFileOpen.Value;
+                        }
+                        if (definition.SavePassword.HasValue)
+                        {
+                            webConnection.SavePassword = definition.SavePassword.Value;
+                        }
+                        if (definition.RefreshPeriod.HasValue)
+                        {
+                            webConnection.RefreshPeriod = definition.RefreshPeriod.Value;
+                        }
                     }
                 }
+                catch (COMException)
+                {
+                    // Neither works - skip property updates
+                }
+                finally
+                {
+                    ComUtilities.Release(ref webConnection);
+                }
             }
-            else if (connType == 5) // XMLMAP (moved from 4 due to type 3/4 merge)
+            else if (connType == 5) // XMLMAP
             {
                 // XMLMAP connection properties - future implementation
                 // For now, just update basic properties like description (already done above)
@@ -408,9 +903,10 @@ public partial class ConnectionCommands : IConnectionCommands
     {
         if (!value.HasValue) return;
 
+        dynamic? subConn = null;
         try
         {
-            dynamic? subConn = GetTypedSubConnection(conn);
+            subConn = GetTypedSubConnection(conn);
             if (subConn != null)
             {
                 SetProperty(subConn, propertyName, value.Value);
@@ -419,6 +915,10 @@ public partial class ConnectionCommands : IConnectionCommands
         catch (COMException)
         {
             // Property not available for this connection type
+        }
+        finally
+        {
+            ComUtilities.Release(ref subConn);
         }
     }
 

--- a/src/ExcelMcp.Core/Commands/PivotTable/RegularPivotTableFieldStrategy.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/RegularPivotTableFieldStrategy.cs
@@ -16,15 +16,19 @@ public class RegularPivotTableFieldStrategy : IPivotTableFieldStrategy
         // Regular PivotTables are NOT OLAP and have PivotFields
         if (PivotTableHelpers.IsOlapPivotTable(pivot))
             return false; // This is OLAP, not regular
-
+        dynamic? pivotFields = null;
         try
         {
-            dynamic pivotFields = pivot.PivotFields;
+            pivotFields = pivot.PivotFields;
             return pivotFields != null;
         }
         catch (System.Runtime.InteropServices.COMException)
         {
             return false;
+        }
+        finally
+        {
+            ComUtilities.Release(ref pivotFields);
         }
     }
 

--- a/tests/ExcelMcp.Core.Tests/Helpers/ConnectionTestHelper.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/ConnectionTestHelper.cs
@@ -1,3 +1,4 @@
+using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
@@ -32,14 +33,17 @@ public static class ConnectionTestHelper
         using var batch = ExcelSession.BeginBatch(filePath);
         batch.Execute((ctx, ct) =>
         {
+            dynamic? connections = null;
+            dynamic? newConnection = null;
+            dynamic? oledb = null;
             try
             {
                 // Get connections collection
-                dynamic connections = ctx.Book.Connections;
+                connections = ctx.Book.Connections;
 
                 // Create OLEDB connection using Add2() (current method, Add() is deprecated)
                 // Per instructions: Must use Connections.Add2() for OLEDB/ODBC connections
-                dynamic newConnection = connections.Add2(
+                newConnection = connections.Add2(
                     Name: connectionName,
                     Description: $"Test OLEDB connection created by {nameof(CreateOleDbConnection)}",
                     ConnectionString: connectionString,
@@ -52,7 +56,7 @@ public static class ConnectionTestHelper
                 // Configure OLEDB connection properties
                 if (newConnection.Type == 1) // OLEDB
                 {
-                    dynamic oledb = newConnection.OLEDBConnection;
+                    oledb = newConnection.OLEDBConnection;
                     if (oledb != null)
                     {
                         oledb.BackgroundQuery = true;
@@ -68,6 +72,12 @@ public static class ConnectionTestHelper
             {
                 throw new InvalidOperationException($"Failed to create OLEDB connection '{connectionName}': {ex.Message}", ex);
             }
+            finally
+            {
+                ComUtilities.Release(ref oledb);
+                ComUtilities.Release(ref newConnection);
+                ComUtilities.Release(ref connections);
+            }
         });
     }
 
@@ -79,9 +89,10 @@ public static class ConnectionTestHelper
         using var batch = ExcelSession.BeginBatch(filePath);
         batch.Execute((ctx, ct) =>
         {
+            dynamic? connections = null;
             try
             {
-                dynamic connections = ctx.Book.Connections;
+                connections = ctx.Book.Connections;
 
                 // Create ODBC connection using NAMED parameters (Excel COM requires this)
                 connections.Add(
@@ -97,6 +108,10 @@ public static class ConnectionTestHelper
             catch (Exception ex)
             {
                 throw new InvalidOperationException($"Failed to create ODBC connection '{connectionName}': {ex.Message}", ex);
+            }
+            finally
+            {
+                ComUtilities.Release(ref connections);
             }
         });
     }


### PR DESCRIPTION
## Summary
- release probed COM objects deterministically in chart and pivot strategies
- refactor connection sub-connection access to use explicit COM lifetimes
- replace manual release calls in `ExcelSession` with `ComUtilities.Release`
- tighten connection test helper cleanup

## Validation
- `dotnet build Sbroenne.ExcelMcp.sln -c Debug --nologo --no-restore`
- `dotnet test tests\ExcelMcp.ComInterop.Tests\ExcelMcp.ComInterop.Tests.csproj --filter "RunType=OnDemand"`
- `dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName~ConnectionCommandsTests"`
- focused chart and pivot-field validation for the touched strategy paths