### PR TITLE
Upgrade Scriban to 7.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.103" />
     <!-- Template Engine for Skill Generation -->
-    <PackageVersion Include="Scriban" Version="6.6.0" />
+    <PackageVersion Include="Scriban" Version="7.0.0" />
     <!-- MSBuild Task Development -->
     <PackageVersion Include="Microsoft.Build.Framework" Version="18.3.3" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.3.3" />


### PR DESCRIPTION
## Summary
- upgrade Scriban from 6.6.0 to 7.0.0 in central package management
- fix the `build-cli` restore failure caused by the vulnerable Scriban package in `ExcelMcp.Build.Tasks`

## Validation
- `dotnet build src\\ExcelMcp.CLI\\ExcelMcp.CLI.csproj -c Release --nologo`
- `dotnet build Sbroenne.ExcelMcp.sln -c Debug --nologo`
- repository pre-commit checks passed during commit creation