### PR TITLE
Fix daemon timeout regressions

### DIFF
--- a/src/ExcelMcp.CLI/Commands/ServiceCommands.cs
+++ b/src/ExcelMcp.CLI/Commands/ServiceCommands.cs
@@ -37,12 +37,14 @@ internal sealed class ServiceStartCommand : AsyncCommand
 /// </summary>
 internal sealed class ServiceStopCommand : AsyncCommand
 {
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(2);
+
     public override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
         var pipeName = DaemonAutoStart.GetPipeName();
         try
         {
-            using var client = new ServiceClient(pipeName, connectTimeout: TimeSpan.FromSeconds(2));
+            using var client = new ServiceClient(pipeName, connectTimeout: CommandTimeout, requestTimeout: CommandTimeout);
             var response = await client.SendAsync(new ServiceRequest { Command = "service.shutdown" }, cancellationToken);
             if (response.Success)
             {
@@ -70,12 +72,14 @@ internal sealed class ServiceStopCommand : AsyncCommand
 /// </summary>
 internal sealed class ServiceStatusCommand : AsyncCommand
 {
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(2);
+
     public override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
         var pipeName = DaemonAutoStart.GetPipeName();
         try
         {
-            using var client = new ServiceClient(pipeName, connectTimeout: TimeSpan.FromSeconds(2));
+            using var client = new ServiceClient(pipeName, connectTimeout: CommandTimeout, requestTimeout: CommandTimeout);
             var response = await client.SendAsync(new ServiceRequest { Command = "service.status" }, cancellationToken);
             if (response.Success && response.Result != null)
             {

--- a/src/ExcelMcp.CLI/Commands/SessionCommands.cs
+++ b/src/ExcelMcp.CLI/Commands/SessionCommands.cs
@@ -137,10 +137,12 @@ internal sealed class SessionCloseCommand : AsyncCommand<SessionCloseCommand.Set
 
 internal sealed class SessionListCommand : AsyncCommand
 {
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(2);
+
     public override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
         var pipeName = DaemonAutoStart.GetPipeName();
-        using var client = new ServiceClient(pipeName, connectTimeout: TimeSpan.FromSeconds(2));
+        using var client = new ServiceClient(pipeName, connectTimeout: CommandTimeout, requestTimeout: CommandTimeout);
 
         try
         {

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -422,6 +422,8 @@ internal sealed class ExcelBatch : IExcelBatch
 
     public TimeSpan OperationTimeout => _operationTimeout;
 
+    public bool HasTimedOutOperation => _operationTimedOut;
+
     public bool IsExcelProcessAlive()
     {
         if (_disposed != 0) return false;

--- a/src/ExcelMcp.ComInterop/Session/IExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/IExcelBatch.cs
@@ -127,6 +127,12 @@ public interface IExcelBatch : IDisposable
     bool IsExcelProcessAlive();
 
     /// <summary>
+    /// Gets whether a previous operation timed out or was cancelled while Excel was unresponsive.
+    /// When true, the session is poisoned and callers must fail fast instead of queueing more work.
+    /// </summary>
+    bool HasTimedOutOperation { get; }
+
+    /// <summary>
     /// Gets the Excel process ID, if captured.
     /// </summary>
     /// <returns>Process ID, or null if not captured during startup.</returns>

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -402,24 +402,13 @@ public sealed class ExcelMcpService : IDisposable
             return new ServiceResponse { Success = false, ErrorMessage = "sessionId is required" };
         }
 
-        var batch = _sessionManager.GetSession(request.SessionId);
-        if (batch == null)
+        var sessionError = TryGetUsableSession(request.SessionId, out var batch);
+        if (sessionError != null)
         {
-            return new ServiceResponse { Success = false, ErrorMessage = $"Session '{request.SessionId}' not found" };
+            return sessionError;
         }
 
-        // Check if Excel process is still alive before attempting save
-        if (!batch.IsExcelProcessAlive())
-        {
-            _sessionManager.CloseSession(request.SessionId, save: false, force: true);
-            return new ServiceResponse
-            {
-                Success = false,
-                ErrorMessage = $"Excel process for session '{request.SessionId}' has died. Session has been closed. Please create a new session."
-            };
-        }
-
-        batch.Save();
+        batch!.Save();
         return new ServiceResponse { Success = true };
     }
 
@@ -653,34 +642,15 @@ public sealed class ExcelMcpService : IDisposable
             return Task.FromResult(new ServiceResponse { Success = false, ErrorMessage = "sessionId is required" });
         }
 
-        var batch = _sessionManager.GetSession(sessionId);
-        if (batch == null)
+        var sessionError = TryGetUsableSession(sessionId, out var batch);
+        if (sessionError != null)
         {
-            return Task.FromResult(new ServiceResponse { Success = false, ErrorMessage = $"Session '{sessionId}' not found" });
-        }
-
-        // Check if Excel process is still alive before attempting operation
-        if (!batch.IsExcelProcessAlive())
-        {
-            // Excel died - clean up the dead session
-            try
-            {
-                _sessionManager.CloseSession(sessionId, save: false, force: true);
-            }
-            catch (Exception cleanupEx)
-            {
-                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
-            }
-            return Task.FromResult(new ServiceResponse
-            {
-                Success = false,
-                ErrorMessage = $"Excel process for session '{sessionId}' has died. Session has been closed. Please create a new session."
-            });
+            return Task.FromResult(sessionError);
         }
 
         try
         {
-            var response = action(batch);
+            var response = action(batch!);
             return Task.FromResult(response);
         }
         catch (TimeoutException ex)
@@ -783,6 +753,45 @@ public sealed class ExcelMcpService : IDisposable
 
             return Task.FromResult(new ServiceResponse { Success = false, ErrorMessage = $"{ex.GetType().Name}: {ex.Message}" });
         }
+    }
+
+    private ServiceResponse? TryGetUsableSession(string sessionId, out IExcelBatch? batch)
+    {
+        batch = _sessionManager.GetSession(sessionId);
+        if (batch == null)
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = $"Session '{sessionId}' not found" };
+        }
+
+        if (batch.HasTimedOutOperation)
+        {
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorMessage = $"A previous operation on session '{sessionId}' timed out or was cancelled. " +
+                               "Please close the session and reopen the workbook before retrying."
+            };
+        }
+
+        if (!batch.IsExcelProcessAlive())
+        {
+            try
+            {
+                _sessionManager.CloseSession(sessionId, save: false, force: true);
+            }
+            catch (Exception cleanupEx)
+            {
+                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+            }
+
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorMessage = $"Excel process for session '{sessionId}' has died. Session has been closed. Please create a new session."
+            };
+        }
+
+        return null;
     }
 
     public void Dispose()

--- a/src/ExcelMcp.Service/ServiceClient.cs
+++ b/src/ExcelMcp.Service/ServiceClient.cs
@@ -32,18 +32,20 @@ public sealed class ServiceClient : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         using var pipe = ServiceSecurity.CreateClient(_pipeName);
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutCts.CancelAfter(_requestTimeout);
+        using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        connectCts.CancelAfter(_connectTimeout);
 
         try
         {
-            await pipe.ConnectAsync((int)_connectTimeout.TotalMilliseconds, timeoutCts.Token);
+            await pipe.ConnectAsync((int)_connectTimeout.TotalMilliseconds, connectCts.Token);
 
             // Use StreamJsonRpc typed proxy for the RPC call
             var proxy = JsonRpc.Attach<IExcelDaemonRpc>(pipe);
             try
             {
-                return await proxy.ProcessCommandAsync(request);
+                using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                requestCts.CancelAfter(_requestTimeout);
+                return await proxy.ProcessCommandAsync(request).WaitAsync(requestCts.Token);
             }
             finally
             {
@@ -55,7 +57,11 @@ public sealed class ServiceClient : IDisposable
         {
             return new ServiceResponse { Success = false, ErrorMessage = "Service connection timed out" };
         }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (connectCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "Service connection timed out" };
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
             return new ServiceResponse { Success = false, ErrorMessage = "Service request timed out" };
         }

--- a/tests/ExcelMcp.CLI.Tests/Integration/CliDaemonTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/CliDaemonTests.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
+using System.IO.Pipes;
 using System.Text.Json;
 using Sbroenne.ExcelMcp.CLI.Infrastructure;
 using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Sbroenne.ExcelMcp.Service;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -77,27 +79,81 @@ public sealed class CliDaemonTests : IAsyncLifetime
     [Fact]
     public async Task ServiceStart_WhenDaemonMutexHeldButUnresponsive_ReturnsActionableError()
     {
-        using var daemonMutex = new Mutex(initiallyOwned: true, DaemonAutoStart.GetDaemonMutexName(_testPipeName), out bool createdNew);
-        Assert.True(createdNew, "Test should acquire a unique daemon mutex");
-        try
-        {
-            var result = await CliProcessHelper.RunAsync("service start", timeoutMs: 20000, environmentVariables: TestEnv);
-            _output.WriteLine($"Start response: {result.Stdout}");
-            _output.WriteLine($"Start stderr: {result.Stderr}");
+        await using var heldMutex = await HeldMutex.AcquireAsync(DaemonAutoStart.GetDaemonMutexName(_testPipeName));
 
-            using var json = JsonDocument.Parse(result.Stdout);
-            Assert.Equal(1, result.ExitCode);
-            Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        var result = await CliProcessHelper.RunAsync("service start", timeoutMs: 20000, environmentVariables: TestEnv);
+        _output.WriteLine($"Start response: {result.Stdout}");
+        _output.WriteLine($"Start stderr: {result.Stderr}");
 
-            var error = json.RootElement.GetProperty("error").GetString();
-            Assert.NotNull(error);
-            Assert.Contains("not responding", error, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("service stop", error, StringComparison.OrdinalIgnoreCase);
-        }
-        finally
-        {
-            daemonMutex.ReleaseMutex();
-        }
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+
+        var error = json.RootElement.GetProperty("error").GetString();
+        Assert.NotNull(error);
+        Assert.Contains("not responding", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("service stop", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ServiceStart_WhenDaemonAcceptsConnectionButNeverReplies_ReturnsActionableError()
+    {
+        await using var heldMutex = await HeldMutex.AcquireAsync(DaemonAutoStart.GetDaemonMutexName(_testPipeName));
+
+        await using var stalledDaemon = new StalledPipeServer(_testPipeName, _output);
+        await stalledDaemon.StartAsync();
+
+        var result = await CliProcessHelper.RunAsync("service start", timeoutMs: 20000, environmentVariables: TestEnv);
+        _output.WriteLine($"Start response: {result.Stdout}");
+        _output.WriteLine($"Start stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+
+        var error = json.RootElement.GetProperty("error").GetString();
+        Assert.NotNull(error);
+        Assert.Contains("not responding", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("service stop", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ServiceStatus_WhenDaemonAcceptsConnectionButNeverReplies_FailsQuicklyWithTimeoutError()
+    {
+        await using var stalledDaemon = new StalledPipeServer(_testPipeName, _output);
+        await stalledDaemon.StartAsync();
+
+        var result = await CliProcessHelper.RunAsync("service status", timeoutMs: 10000, environmentVariables: TestEnv);
+        _output.WriteLine($"Status response: {result.Stdout}");
+        _output.WriteLine($"Status stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.False(json.RootElement.GetProperty("running").GetBoolean());
+
+        var error = json.RootElement.GetProperty("error").GetString();
+        Assert.NotNull(error);
+        Assert.Contains("timed out", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SessionList_WhenDaemonAcceptsConnectionButNeverReplies_FailsQuicklyWithTimeoutError()
+    {
+        await using var stalledDaemon = new StalledPipeServer(_testPipeName, _output);
+        await stalledDaemon.StartAsync();
+
+        var result = await CliProcessHelper.RunAsync("session list", timeoutMs: 10000, environmentVariables: TestEnv);
+        _output.WriteLine($"Session list response: {result.Stdout}");
+        _output.WriteLine($"Session list stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+
+        var error = json.RootElement.GetProperty("error").GetString();
+        Assert.NotNull(error);
+        Assert.Contains("timed out", error, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -288,6 +344,147 @@ public sealed class CliDaemonTests : IAsyncLifetime
         finally
         {
             _daemonProcess.Dispose();
+        }
+    }
+
+    private sealed class StalledPipeServer : IAsyncDisposable
+    {
+        private readonly string _pipeName;
+        private readonly ITestOutputHelper _output;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly TaskCompletionSource _listeningTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly Task _serverTask;
+        private NamedPipeServerStream? _server;
+
+        public StalledPipeServer(string pipeName, ITestOutputHelper output)
+        {
+            _pipeName = pipeName;
+            _output = output;
+            _serverTask = RunAsync();
+        }
+
+        public Task StartAsync() => _listeningTcs.Task;
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+
+            if (_server != null)
+            {
+                try
+                {
+                    await _server.DisposeAsync();
+                }
+                catch
+                {
+                }
+            }
+
+            try
+            {
+                await _serverTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            _cts.Dispose();
+        }
+
+        private async Task RunAsync()
+        {
+            try
+            {
+                _server = ServiceSecurity.CreateSecureServer(_pipeName);
+                _listeningTcs.TrySetResult();
+                _output.WriteLine($"Stalled pipe server listening on {_pipeName}");
+
+                await _server.WaitForConnectionAsync(_cts.Token);
+                _output.WriteLine("Stalled pipe server accepted a connection");
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, _cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                if (_server != null)
+                {
+                    try
+                    {
+                        if (_server.IsConnected)
+                        {
+                            _server.Disconnect();
+                        }
+                    }
+                    catch
+                    {
+                    }
+
+                    await _server.DisposeAsync();
+                    _server = null;
+                }
+            }
+        }
+    }
+
+    private sealed class HeldMutex : IAsyncDisposable
+    {
+        private readonly string _mutexName;
+        private readonly TaskCompletionSource _acquiredTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ManualResetEventSlim _releaseSignal = new(false);
+        private readonly Thread _thread;
+        private Mutex? _mutex;
+
+        private HeldMutex(string mutexName)
+        {
+            _mutexName = mutexName;
+            _thread = new Thread(ThreadMain)
+            {
+                IsBackground = true,
+                Name = $"HeldMutex-{mutexName}"
+            };
+            _thread.Start();
+        }
+
+        public static async Task<HeldMutex> AcquireAsync(string mutexName)
+        {
+            var heldMutex = new HeldMutex(mutexName);
+            await heldMutex._acquiredTcs.Task;
+            return heldMutex;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _releaseSignal.Set();
+            _thread.Join(TimeSpan.FromSeconds(5));
+            _releaseSignal.Dispose();
+            return ValueTask.CompletedTask;
+        }
+
+        private void ThreadMain()
+        {
+            try
+            {
+                _mutex = new Mutex(initiallyOwned: true, _mutexName, out bool createdNew);
+                if (!createdNew)
+                {
+                    throw new InvalidOperationException($"Failed to acquire unique test mutex '{_mutexName}'.");
+                }
+
+                _acquiredTcs.TrySetResult();
+                _releaseSignal.Wait();
+                _mutex.ReleaseMutex();
+            }
+            catch (Exception ex)
+            {
+                _acquiredTcs.TrySetException(ex);
+            }
+            finally
+            {
+                _mutex?.Dispose();
+            }
         }
     }
 }

--- a/tests/ExcelMcp.CLI.Tests/Unit/ExcelMcpServiceErrorTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/ExcelMcpServiceErrorTests.cs
@@ -1,5 +1,10 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Service;
 using Xunit;
+using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.CLI.Tests.Unit;
 
@@ -96,5 +101,132 @@ public sealed class ExcelMcpServiceErrorTests
         Assert.False(response.Success);
         Assert.NotNull(response.ErrorMessage);
         Assert.NotEmpty(response.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SessionCommandOnTimedOutSession_FailsFastBeforeExecutingBatch()
+    {
+        using var service = new ExcelMcpService();
+        var batch = new FakeBatch { HasTimedOutOperation = true };
+        const string sessionId = "timed-out-sheet-list";
+
+        RegisterSession(service, sessionId, batch);
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "sheet.list",
+            SessionId = sessionId
+        });
+
+        Assert.False(response.Success);
+        Assert.NotNull(response.ErrorMessage);
+        Assert.Contains("timed out or was cancelled", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("reopen", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, batch.ExecuteCalls);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SessionSaveOnTimedOutSession_FailsFastBeforeSaving()
+    {
+        using var service = new ExcelMcpService();
+        var batch = new FakeBatch { HasTimedOutOperation = true };
+        const string sessionId = "timed-out-save";
+
+        RegisterSession(service, sessionId, batch);
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.save",
+            SessionId = sessionId
+        });
+
+        Assert.False(response.Success);
+        Assert.NotNull(response.ErrorMessage);
+        Assert.Contains("timed out or was cancelled", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, batch.SaveCalls);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SessionSaveOnHealthySession_StillSavesNormally()
+    {
+        using var service = new ExcelMcpService();
+        var batch = new FakeBatch();
+        const string sessionId = "healthy-save";
+
+        RegisterSession(service, sessionId, batch);
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.save",
+            SessionId = sessionId
+        });
+
+        Assert.True(response.Success);
+        Assert.Equal(1, batch.SaveCalls);
+    }
+
+    private static void RegisterSession(ExcelMcpService service, string sessionId, FakeBatch batch)
+    {
+        var sessionManager = GetPrivateField<SessionManager>(service, "_sessionManager");
+        var activeSessions = GetPrivateField<ConcurrentDictionary<string, IExcelBatch>>(sessionManager, "_activeSessions");
+        var activeFilePaths = GetPrivateField<ConcurrentDictionary<string, string>>(sessionManager, "_activeFilePaths");
+        var sessionFilePaths = GetPrivateField<ConcurrentDictionary<string, string>>(sessionManager, "_sessionFilePaths");
+        var activeOperationCounts = GetPrivateField<ConcurrentDictionary<string, int>>(sessionManager, "_activeOperationCounts");
+        var showExcelFlags = GetPrivateField<ConcurrentDictionary<string, bool>>(sessionManager, "_showExcelFlags");
+        var sessionOrigins = GetPrivateField<ConcurrentDictionary<string, SessionOrigin>>(sessionManager, "_sessionOrigins");
+        var sessionCreatedAt = GetPrivateField<ConcurrentDictionary<string, DateTime>>(sessionManager, "_sessionCreatedAt");
+
+        var normalizedPath = Path.GetFullPath(batch.WorkbookPath);
+        activeSessions[sessionId] = batch;
+        activeFilePaths[normalizedPath] = sessionId;
+        sessionFilePaths[sessionId] = normalizedPath;
+        activeOperationCounts[sessionId] = 0;
+        showExcelFlags[sessionId] = false;
+        sessionOrigins[sessionId] = SessionOrigin.CLI;
+        sessionCreatedAt[sessionId] = DateTime.UtcNow;
+    }
+
+    private static T GetPrivateField<T>(object instance, string fieldName)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (T)field!.GetValue(instance)!;
+    }
+
+    private sealed class FakeBatch : IExcelBatch
+    {
+        public string WorkbookPath { get; init; } = Path.Combine(Path.GetTempPath(), $"fake-batch-{Guid.NewGuid():N}.xlsx");
+        public Microsoft.Extensions.Logging.ILogger Logger { get; } = NullLogger.Instance;
+        public IReadOnlyDictionary<string, Excel.Workbook> Workbooks { get; } = new Dictionary<string, Excel.Workbook>();
+        public bool HasTimedOutOperation { get; init; }
+        public int ExecuteCalls { get; private set; }
+        public int SaveCalls { get; private set; }
+        public int? ExcelProcessId => 1234;
+        public TimeSpan OperationTimeout => TimeSpan.FromSeconds(5);
+
+        public Excel.Workbook GetWorkbook(string filePath) => throw new NotSupportedException();
+
+        public void Execute(Action<ExcelContext, CancellationToken> operation, CancellationToken cancellationToken = default)
+        {
+            ExecuteCalls++;
+            throw new InvalidOperationException("Execute should not be called for a poisoned fake batch.");
+        }
+
+        public T Execute<T>(Func<ExcelContext, CancellationToken, T> operation, CancellationToken cancellationToken = default)
+        {
+            ExecuteCalls++;
+            throw new InvalidOperationException("Execute should not be called for a poisoned fake batch.");
+        }
+
+        public void Save(CancellationToken cancellationToken = default)
+        {
+            SaveCalls++;
+        }
+
+        public bool IsExcelProcessAlive() => true;
+
+        public void Dispose()
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary
- split daemon connect timeout handling from request timeout handling so stalled replies fail fast
- add bounded request timeouts to lightweight CLI daemon probe commands
- reject poisoned timed-out sessions before routing more session work
- add regression coverage for stalled-daemon and poisoned-session paths

## Validation
- dotnet test tests/ExcelMcp.CLI.Tests --filter "FullyQualifiedName~ExcelMcpServiceErrorTests|FullyQualifiedName~CliDaemonTests" --no-restore
- dotnet test slice for `PowerQuerySerialWorkflowRegressionTests` (passed 1/1)
- pre-commit checks including CLI workflow smoke and MCP Server smoke