### PR TITLE
Fix daemon shutdown and Power Query diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **Power Query privacy/firewall failures were flattened into generic service errors or hangs instead of surfacing a stable diagnostic**: Core now classifies recognized Power Query failures into structured categories such as `Privacy`, `Expression`, `Connectivity`, and `Authentication` via `PowerQueryCommandException`. The service, CLI, and MCP layers now preserve `errorCategory` in their responses, and refresh timeouts on firewall-prone query formulas are reported as likely privacy issues instead of leaving callers blind. Added a privacy-safe synthetic firewall repro in Core, a CLI regression for structured privacy output, and real verification against the CP Toolkit `ConfigData` scenario.
+
 - **Synchronous COM refresh follow-up stability** (#544): `powerquery update` still used a standalone synchronous refresh path while related Data Model and DAX-backed table refresh operations continued to rely on callback-sensitive COM patterns. Fixed by routing `powerquery update` through the shared COM-safe refresh helper, replacing `EnterLongOperation()` in Data Model refresh with pending-cancellation handling, and wrapping DAX table refresh calls with the same `OleMessageFilter.SetPendingCancellationToken(...)` pattern. Added both Core and MCP regression coverage for `powerquery update`, and the full Power Query feature slice now passes locally.
 
 ### Added

--- a/src/ExcelMcp.CLI/Commands/ServiceCommands.cs
+++ b/src/ExcelMcp.CLI/Commands/ServiceCommands.cs
@@ -38,6 +38,8 @@ internal sealed class ServiceStartCommand : AsyncCommand
 internal sealed class ServiceStopCommand : AsyncCommand
 {
     private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan ShutdownWaitTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ShutdownPollInterval = TimeSpan.FromMilliseconds(250);
 
     public override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
@@ -48,21 +50,119 @@ internal sealed class ServiceStopCommand : AsyncCommand
             var response = await client.SendAsync(new ServiceRequest { Command = "service.shutdown" }, cancellationToken);
             if (response.Success)
             {
-                Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped." }, ServiceProtocol.JsonOptions));
-                return 0;
-            }
-            else
-            {
-                Console.WriteLine(JsonSerializer.Serialize(new { success = false, error = response.ErrorMessage ?? "Failed to stop service." }, ServiceProtocol.JsonOptions));
+                if (await WaitForDaemonExitAsync(pipeName, cancellationToken))
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped." }, ServiceProtocol.JsonOptions));
+                    return 0;
+                }
+
+                if (await TryForceStopTrackedDaemonAsync(pipeName, cancellationToken))
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped.", forced = true }, ServiceProtocol.JsonOptions));
+                    return 0;
+                }
+
+                Console.WriteLine(JsonSerializer.Serialize(
+                    new { success = false, error = $"Service acknowledged shutdown but did not exit within {ShutdownWaitTimeout.TotalSeconds:0} seconds." },
+                    ServiceProtocol.JsonOptions));
                 return 1;
             }
+
+            if (!DaemonAutoStart.IsDaemonMutexHeld(pipeName))
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service not running." }, ServiceProtocol.JsonOptions));
+                return 0;
+            }
+
+            if (await TryForceStopTrackedDaemonAsync(pipeName, cancellationToken))
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped.", forced = true }, ServiceProtocol.JsonOptions));
+                return 0;
+            }
+
+            Console.WriteLine(JsonSerializer.Serialize(
+                new
+                {
+                    success = false,
+                    error = response.ErrorMessage ?? "Daemon is running but not responding, and the tracked daemon process could not be stopped."
+                },
+                ServiceProtocol.JsonOptions));
+            return 1;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Can't connect — daemon not running
-            Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service not running." }, ServiceProtocol.JsonOptions));
-            return 0;
+            if (!DaemonAutoStart.IsDaemonMutexHeld(pipeName))
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service not running." }, ServiceProtocol.JsonOptions));
+                return 0;
+            }
+
+            if (await TryForceStopTrackedDaemonAsync(pipeName, cancellationToken))
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped.", forced = true }, ServiceProtocol.JsonOptions));
+                return 0;
+            }
+
+            Console.WriteLine(JsonSerializer.Serialize(
+                new
+                {
+                    success = false,
+                    error = $"Daemon is running but not responding, and the tracked daemon process could not be stopped. {ex.GetType().Name}: {ex.Message}"
+                },
+                ServiceProtocol.JsonOptions));
+            return 1;
         }
+    }
+
+    private static async Task<bool> WaitForDaemonExitAsync(string pipeName, CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + ShutdownWaitTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!DaemonAutoStart.IsDaemonMutexHeld(pipeName))
+            {
+                DaemonProcessTracker.Clear(pipeName);
+                return true;
+            }
+
+            await Task.Delay(ShutdownPollInterval, cancellationToken);
+        }
+
+        return !DaemonAutoStart.IsDaemonMutexHeld(pipeName);
+    }
+
+    private static async Task<bool> TryForceStopTrackedDaemonAsync(string pipeName, CancellationToken cancellationToken)
+    {
+        if (!DaemonProcessTracker.TryGetTrackedProcess(pipeName, out var trackedProcess))
+        {
+            return false;
+        }
+
+        using var _ = trackedProcess;
+
+        try
+        {
+            trackedProcess.Kill(entireProcessTree: true);
+
+            using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            waitCts.CancelAfter(ShutdownWaitTimeout);
+            await trackedProcess.WaitForExitAsync(waitCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // Already exited between lookup and kill.
+        }
+        catch
+        {
+            return false;
+        }
+
+        DaemonProcessTracker.Clear(pipeName);
+        return await WaitForDaemonExitAsync(pipeName, cancellationToken);
     }
 }
 

--- a/src/ExcelMcp.CLI/Commands/SessionCommands.cs
+++ b/src/ExcelMcp.CLI/Commands/SessionCommands.cs
@@ -35,8 +35,7 @@ internal sealed class SessionCreateCommand : AsyncCommand<SessionCreateCommand.S
         }
         else
         {
-            Console.WriteLine(JsonSerializer.Serialize(new { success = false, error = response.ErrorMessage }, ServiceProtocol.JsonOptions));
-            return 1;
+            return CliErrorOutput.WriteServiceError(response);
         }
     }
 
@@ -76,8 +75,7 @@ internal sealed class SessionOpenCommand : AsyncCommand<SessionOpenCommand.Setti
         }
         else
         {
-            Console.WriteLine(JsonSerializer.Serialize(new { success = false, error = response.ErrorMessage }, ServiceProtocol.JsonOptions));
-            return 1;
+            return CliErrorOutput.WriteServiceError(response);
         }
     }
 
@@ -118,8 +116,7 @@ internal sealed class SessionCloseCommand : AsyncCommand<SessionCloseCommand.Set
         }
         else
         {
-            Console.WriteLine(JsonSerializer.Serialize(new { success = false, error = response.ErrorMessage }, ServiceProtocol.JsonOptions));
-            return 1;
+            return CliErrorOutput.WriteServiceError(response);
         }
     }
 
@@ -154,8 +151,7 @@ internal sealed class SessionListCommand : AsyncCommand
             }
             else
             {
-                Console.WriteLine(JsonSerializer.Serialize(new { success = false, error = response.ErrorMessage }, ServiceProtocol.JsonOptions));
-                return 1;
+                return CliErrorOutput.WriteServiceError(response);
             }
         }
         catch (Exception)
@@ -191,8 +187,7 @@ internal sealed class SessionSaveCommand : AsyncCommand<SessionSaveCommand.Setti
         }
         else
         {
-            Console.WriteLine(JsonSerializer.Serialize(new { success = false, error = response.ErrorMessage }, ServiceProtocol.JsonOptions));
-            return 1;
+            return CliErrorOutput.WriteServiceError(response);
         }
     }
 

--- a/src/ExcelMcp.CLI/Infrastructure/CliErrorOutput.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/CliErrorOutput.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sbroenne.ExcelMcp.Service;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+internal static class CliErrorOutput
+{
+    public static int WriteServiceError(ServiceResponse response)
+    {
+        Console.WriteLine(Serialize(response.ErrorMessage, response.ErrorCategory));
+        return 1;
+    }
+
+    public static int WriteError(string errorMessage, string? errorCategory = null)
+    {
+        Console.WriteLine(Serialize(errorMessage, errorCategory));
+        return 1;
+    }
+
+    private static string Serialize(string? errorMessage, string? errorCategory)
+    {
+        return JsonSerializer.Serialize(new ErrorEnvelope
+        {
+            Success = false,
+            Error = errorMessage ?? "Unknown error.",
+            ErrorCategory = errorCategory
+        }, ServiceProtocol.JsonOptions);
+    }
+
+    private sealed class ErrorEnvelope
+    {
+        public bool Success { get; init; }
+
+        public string Error { get; init; } = string.Empty;
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ErrorCategory { get; init; }
+    }
+}

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonAutoStart.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonAutoStart.cs
@@ -85,7 +85,7 @@ internal static class DaemonAutoStart
     /// Checks whether a daemon process currently holds the daemon mutex for the given pipe name.
     /// Returns true if a daemon is running (even if temporarily busy).
     /// </summary>
-    private static bool IsDaemonMutexHeld(string pipeName)
+    internal static bool IsDaemonMutexHeld(string pipeName)
     {
         try
         {

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonProcessTracker.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonProcessTracker.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Sbroenne.ExcelMcp.Service;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+/// <summary>
+/// Tracks the daemon process for a specific pipe so the CLI can distinguish
+/// "not running" from "running but unresponsive" during stop/recovery flows.
+/// </summary>
+internal static class DaemonProcessTracker
+{
+    private sealed class DaemonProcessRecord
+    {
+        public int ProcessId { get; set; }
+        public long StartedAtUtcFileTime { get; set; }
+    }
+
+    public static void RegisterCurrentProcess(string pipeName)
+    {
+        var current = Process.GetCurrentProcess();
+        RegisterProcess(pipeName, current.Id, current.StartTime.ToUniversalTime().ToFileTimeUtc());
+    }
+
+    internal static void RegisterProcess(string pipeName, int processId, long startedAtUtcFileTime)
+    {
+        Directory.CreateDirectory(GetTrackingDirectory());
+        var record = new DaemonProcessRecord
+        {
+            ProcessId = processId,
+            StartedAtUtcFileTime = startedAtUtcFileTime
+        };
+
+        File.WriteAllText(
+            GetTrackingFilePath(pipeName),
+            JsonSerializer.Serialize(record, ServiceProtocol.JsonOptions));
+    }
+
+    public static void Clear(string pipeName)
+    {
+        try
+        {
+            var trackingFile = GetTrackingFilePath(pipeName);
+            if (File.Exists(trackingFile))
+            {
+                File.Delete(trackingFile);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup only.
+        }
+    }
+
+    public static bool TryGetTrackedProcess(string pipeName, out Process? process)
+    {
+        process = null;
+        if (!TryReadRecord(pipeName, out var record))
+        {
+            return false;
+        }
+
+        try
+        {
+            var candidate = Process.GetProcessById(record.ProcessId);
+            if (candidate.HasExited)
+            {
+                candidate.Dispose();
+                Clear(pipeName);
+                return false;
+            }
+
+            var startedAtUtcFileTime = candidate.StartTime.ToUniversalTime().ToFileTimeUtc();
+            if (startedAtUtcFileTime != record.StartedAtUtcFileTime)
+            {
+                candidate.Dispose();
+                Clear(pipeName);
+                return false;
+            }
+
+            process = candidate;
+            return true;
+        }
+        catch
+        {
+            Clear(pipeName);
+            return false;
+        }
+    }
+
+    private static bool TryReadRecord(string pipeName, out DaemonProcessRecord record)
+    {
+        record = null!;
+
+        try
+        {
+            var trackingFile = GetTrackingFilePath(pipeName);
+            if (!File.Exists(trackingFile))
+            {
+                return false;
+            }
+
+            var json = File.ReadAllText(trackingFile);
+            var parsed = JsonSerializer.Deserialize<DaemonProcessRecord>(json, ServiceProtocol.JsonOptions);
+            if (parsed == null || parsed.ProcessId <= 0 || parsed.StartedAtUtcFileTime <= 0)
+            {
+                Clear(pipeName);
+                return false;
+            }
+
+            record = parsed;
+            return true;
+        }
+        catch
+        {
+            Clear(pipeName);
+            return false;
+        }
+    }
+
+    private static string GetTrackingDirectory() =>
+        Path.Combine(Path.GetTempPath(), "ExcelMcp", "cli-daemon");
+
+    internal static string GetTrackingFilePath(string pipeName)
+    {
+        var nameBytes = Encoding.UTF8.GetBytes(pipeName);
+        var safeName = Convert.ToHexString(SHA256.HashData(nameBytes));
+        return Path.Combine(GetTrackingDirectory(), $"{safeName}.json");
+    }
+}

--- a/src/ExcelMcp.CLI/Infrastructure/ServiceCommandBase.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/ServiceCommandBase.cs
@@ -79,10 +79,7 @@ internal abstract class ServiceCommandBase<TSettings> : AsyncCommand<TSettings>
         {
             // Parameter validation failed (e.g., required param missing)
             // Return clean JSON error with exit code 1 instead of unhandled crash
-            Console.WriteLine(JsonSerializer.Serialize(
-                new { success = false, error = ex.Message },
-                ServiceProtocol.JsonOptions));
-            return 1;
+            return CliErrorOutput.WriteError(ex.Message);
         }
 
         // Connect to CLI daemon service (auto-starts if not running)
@@ -114,11 +111,7 @@ internal abstract class ServiceCommandBase<TSettings> : AsyncCommand<TSettings>
         }
         else
         {
-            var errorJson = JsonSerializer.Serialize(
-                new { success = false, error = response.ErrorMessage },
-                ServiceProtocol.JsonOptions);
-            Console.WriteLine(errorJson);
-            return 1;
+            return CliErrorOutput.WriteServiceError(response);
         }
     }
 

--- a/src/ExcelMcp.CLI/Program.cs
+++ b/src/ExcelMcp.CLI/Program.cs
@@ -274,46 +274,55 @@ internal sealed class Program
             daemonMutex.Dispose();
             return 0;
         }
-        var service = new Service.ExcelMcpService();
+        DaemonProcessTracker.RegisterCurrentProcess(pipeName);
 
-        // Capture the UI synchronization context after Application starts
-        SynchronizationContext? uiContext = null;
-
-        // Start pipe server on background thread with 10-minute idle timeout
-        var serviceTask = Task.Run(() => service.RunAsync(pipeName, idleTimeout: TimeSpan.FromMinutes(10)));
-
-        // When service shuts down (idle timeout or remote shutdown), exit the WinForms loop
-        serviceTask.ContinueWith(_ =>
+        try
         {
-            if (uiContext != null)
+            var service = new Service.ExcelMcpService();
+
+            // Capture the UI synchronization context after Application starts
+            SynchronizationContext? uiContext = null;
+
+            // Start pipe server on background thread with 10-minute idle timeout
+            var serviceTask = Task.Run(() => service.RunAsync(pipeName, idleTimeout: TimeSpan.FromMinutes(10)));
+
+            // When service shuts down (idle timeout or remote shutdown), exit the WinForms loop
+            serviceTask.ContinueWith(_ =>
             {
-                uiContext.Post(_ => Application.ExitThread(), null);
-            }
-            else
+                if (uiContext != null)
+                {
+                    uiContext.Post(_ => Application.ExitThread(), null);
+                }
+                else
+                {
+                    Application.ExitThread();
+                }
+            }, TaskScheduler.Default);
+
+            // Run WinForms message loop with tray icon on main thread
+            using var tray = new CliServiceTray(service.SessionManager, () =>
             {
+                service.RequestShutdown();
                 Application.ExitThread();
-            }
-        }, TaskScheduler.Default);
+            });
 
-        // Run WinForms message loop with tray icon on main thread
-        using var tray = new CliServiceTray(service.SessionManager, () =>
+            uiContext = SynchronizationContext.Current;
+            Application.Run();
+
+            // Wait for service to finish
+            serviceTask.Wait(TimeSpan.FromSeconds(5));
+            service.Dispose();
+
+            return 0;
+        }
+        finally
         {
-            service.RequestShutdown();
-            Application.ExitThread();
-        });
+            DaemonProcessTracker.Clear(pipeName);
 
-        uiContext = SynchronizationContext.Current;
-        Application.Run();
-
-        // Wait for service to finish
-        serviceTask.Wait(TimeSpan.FromSeconds(5));
-        service.Dispose();
-
-        // Release the daemon mutex so a new daemon can start if needed
-        daemonMutex.ReleaseMutex();
-        daemonMutex.Dispose();
-
-        return 0;
+            // Release the daemon mutex so a new daemon can start if needed
+            daemonMutex.ReleaseMutex();
+            daemonMutex.Dispose();
+        }
     }
 }
 

--- a/src/ExcelMcp.ComInterop/ServiceClient/ServiceProtocol.cs
+++ b/src/ExcelMcp.ComInterop/ServiceClient/ServiceProtocol.cs
@@ -61,6 +61,9 @@ public sealed class ServiceResponse
     /// <summary>Error message if Success is false.</summary>
     public string? ErrorMessage { get; init; }
 
+    /// <summary>Structured error category if Success is false.</summary>
+    public string? ErrorCategory { get; init; }
+
     /// <summary>JSON-serialized result data.</summary>
     public string? Result { get; init; }
 }

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommandException.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommandException.cs
@@ -1,0 +1,24 @@
+namespace Sbroenne.ExcelMcp.Core.Commands;
+
+/// <summary>
+/// Exception for Power Query refresh failures with a structured category.
+/// </summary>
+public sealed class PowerQueryCommandException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PowerQueryCommandException"/> class.
+    /// </summary>
+    /// <param name="message">The Power Query error message.</param>
+    /// <param name="errorCategory">The classified Power Query error category.</param>
+    /// <param name="innerException">The underlying exception raised by Excel/COM.</param>
+    public PowerQueryCommandException(string message, string errorCategory, Exception innerException)
+        : base(message, innerException)
+    {
+        ErrorCategory = errorCategory;
+    }
+
+    /// <summary>
+    /// Gets the classified Power Query error category.
+    /// </summary>
+    public string ErrorCategory { get; }
+}

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Refresh.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Refresh.cs
@@ -38,44 +38,65 @@ public partial class PowerQueryCommands
         }
 
         using var timeoutCts = new CancellationTokenSource(timeout);
+        string? queryFormula = null;
 
-        return batch.Execute((ctx, ct) =>
+        try
         {
-            Excel.WorkbookQuery? query = null;
-            try
+            return batch.Execute((ctx, ct) =>
             {
-                query = ComUtilities.FindQuery(ctx.Book, queryName);
-                if (query == null)
+                Excel.WorkbookQuery? query = null;
+                try
                 {
-                    throw new InvalidOperationException($"Query '{queryName}' not found.");
+                    query = ComUtilities.FindQuery(ctx.Book, queryName);
+                    if (query == null)
+                    {
+                        throw new InvalidOperationException($"Query '{queryName}' not found.");
+                    }
+
+                    queryFormula = query.Formula?.ToString();
+
+                    // Refresh the query - exceptions propagate from both:
+                    // - QueryTable.Refresh() for worksheet queries
+                    // - Connection.Refresh() for Data Model queries
+                    progress?.Report(new ProgressInfo { Current = 0, Total = 1, Message = $"Refreshing '{queryName}'" });
+                    bool refreshed;
+                    try
+                    {
+                        refreshed = RefreshConnectionByQueryName(ctx.Book, queryName, timeoutCts.Token);
+                    }
+                    catch (Exception ex) when (TryWrapPowerQueryException(ex, out var pqEx))
+                    {
+                        throw pqEx!;
+                    }
+
+                    if (!refreshed)
+                    {
+                        throw new InvalidOperationException($"Could not find connection or table for query '{queryName}'.");
+                    }
+
+                    result.HasErrors = false;
+                    result.Success = true;
+                    result.LoadedToSheet = DetermineLoadedSheet(ctx.Book, queryName);
+
+                    bool isLoadedToDataModel = IsQueryLoadedToDataModel(ctx.Book, queryName);
+                    result.IsConnectionOnly = string.IsNullOrEmpty(result.LoadedToSheet) && !isLoadedToDataModel;
+
+                    progress?.Report(new ProgressInfo { Current = 1, Total = 1, Message = $"Refreshed '{queryName}'" });
+                    return result;
                 }
-
-                // Refresh the query - exceptions propagate from both:
-                // - QueryTable.Refresh() for worksheet queries
-                // - Connection.Refresh() for Data Model queries
-                progress?.Report(new ProgressInfo { Current = 0, Total = 1, Message = $"Refreshing '{queryName}'" });
-                bool refreshed = RefreshConnectionByQueryName(ctx.Book, queryName, timeoutCts.Token);
-
-                if (!refreshed)
+                finally
                 {
-                    throw new InvalidOperationException($"Could not find connection or table for query '{queryName}'.");
+                    ComUtilities.Release(ref query);
                 }
-
-                result.HasErrors = false;
-                result.Success = true;
-                result.LoadedToSheet = DetermineLoadedSheet(ctx.Book, queryName);
-
-                bool isLoadedToDataModel = IsQueryLoadedToDataModel(ctx.Book, queryName);
-                result.IsConnectionOnly = string.IsNullOrEmpty(result.LoadedToSheet) && !isLoadedToDataModel;
-
-                progress?.Report(new ProgressInfo { Current = 1, Total = 1, Message = $"Refreshed '{queryName}'" });
-                return result;
-            }
-            finally
-            {
-                ComUtilities.Release(ref query);
-            }
-        }, timeoutCts.Token);
+            }, timeoutCts.Token);
+        }
+        catch (TimeoutException ex) when (IsLikelyPrivacyFirewallRisk(queryFormula))
+        {
+            throw new PowerQueryCommandException(
+                $"Likely Formula.Firewall/privacy-blocked refresh for query '{queryName}'. The query combines Excel.CurrentWorkbook with an external data source and Excel may have shown a privacy/modal prompt instead of returning a normal refresh error.",
+                "Privacy",
+                ex);
+        }
     }
 
     /// <summary>
@@ -125,6 +146,11 @@ public partial class PowerQueryCommands
                         try
                         {
                             refreshed = RefreshConnectionByQueryName(ctx.Book, queryName, timeoutCts.Token);
+                        }
+                        catch (Exception ex) when (TryWrapPowerQueryException(ex, out var pqEx))
+                        {
+                            errors.Add($"{queryName} [{pqEx!.ErrorCategory}]: {pqEx.Message}");
+                            continue;
                         }
                         catch (COMException ex)
                         {

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.cs
@@ -45,28 +45,69 @@ public partial class PowerQueryCommands : IPowerQueryCommands
         return true;
     }
 
-    /// <summary>
-    /// Parse COM exception to extract user-friendly Power Query error message
-    /// </summary>
-    private static string ParsePowerQueryError(COMException comEx)
+    private static string? ClassifyPowerQueryError(string message)
     {
-        var message = comEx.Message;
+        if (message.Contains("Formula.Firewall", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("privacy level", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("combine data", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("may not directly access a data source", StringComparison.OrdinalIgnoreCase))
+            return "Privacy";
 
         if (message.Contains("authentication", StringComparison.OrdinalIgnoreCase))
-            return "Data source authentication failed. Check credentials and permissions.";
+            return "Authentication";
+
         if (message.Contains("could not reach", StringComparison.OrdinalIgnoreCase) ||
-            message.Contains("unable to connect", StringComparison.OrdinalIgnoreCase))
-            return "Cannot connect to data source. Check network connectivity.";
-        if (message.Contains("privacy level", StringComparison.OrdinalIgnoreCase) ||
-            message.Contains("combine data", StringComparison.OrdinalIgnoreCase))
-            return "Formula.Firewall error - privacy levels must be configured in Excel UI (cannot be automated)";
-        if (message.Contains("syntax", StringComparison.OrdinalIgnoreCase))
-            return "M code syntax error. Review query formula.";
+            message.Contains("unable to connect", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("DataSource.Error", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("Web.Contents", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("File.Contents", StringComparison.OrdinalIgnoreCase))
+            return "Connectivity";
+
+        if (message.Contains("syntax", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("token", StringComparison.OrdinalIgnoreCase))
+            return "Syntax";
+
         if (message.Contains("permission", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("access denied", StringComparison.OrdinalIgnoreCase))
-            return "Access denied. Check file or data source permissions.";
+            return "Permissions";
 
-        return message; // Return original if no pattern matches
+        if (message.Contains("Expression.Error", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("wasn't recognized", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("didn't find", StringComparison.OrdinalIgnoreCase))
+            return "Expression";
+
+        return null;
+    }
+
+    private static bool TryWrapPowerQueryException(Exception exception, out PowerQueryCommandException? powerQueryException)
+    {
+        var category = ClassifyPowerQueryError(exception.Message);
+        if (category != null)
+        {
+            powerQueryException = new PowerQueryCommandException(exception.Message, category, exception);
+            return true;
+        }
+
+        powerQueryException = null;
+        return false;
+    }
+
+    private static bool IsLikelyPrivacyFirewallRisk(string? mCode)
+    {
+        if (string.IsNullOrWhiteSpace(mCode))
+        {
+            return false;
+        }
+
+        bool usesWorkbookParameter = mCode.Contains("Excel.CurrentWorkbook", StringComparison.OrdinalIgnoreCase);
+        bool usesExternalSource =
+            mCode.Contains("File.Contents", StringComparison.OrdinalIgnoreCase) ||
+            mCode.Contains("Web.Contents", StringComparison.OrdinalIgnoreCase) ||
+            mCode.Contains("SharePoint.Contents", StringComparison.OrdinalIgnoreCase) ||
+            mCode.Contains("Sql.Database", StringComparison.OrdinalIgnoreCase) ||
+            mCode.Contains("OData.Feed", StringComparison.OrdinalIgnoreCase);
+
+        return usesWorkbookParameter && usesExternalSource;
     }
 
     /// <summary>

--- a/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
@@ -127,6 +127,7 @@ public static partial class ExcelFileTool
             {
                 success = false,
                 errorMessage = response.ErrorMessage ?? "Failed to open session",
+                errorCategory = response.ErrorCategory,
                 filePath = path,
                 isError = true
             }, ExcelToolsBase.JsonOptions);
@@ -192,6 +193,7 @@ public static partial class ExcelFileTool
                 success = false,
                 session_id = sessionId,
                 errorMessage = response.ErrorMessage ?? "Failed to close session",
+                errorCategory = response.ErrorCategory,
                 isError = true
             }, ExcelToolsBase.JsonOptions);
         }
@@ -245,6 +247,7 @@ public static partial class ExcelFileTool
             {
                 success = false,
                 errorMessage = response.ErrorMessage ?? "Failed to create session",
+                errorCategory = response.ErrorCategory,
                 filePath = path,
                 isError = true
             }, ExcelToolsBase.JsonOptions);
@@ -314,6 +317,7 @@ public static partial class ExcelFileTool
             {
                 success = false,
                 errorMessage = response.ErrorMessage ?? "Failed to list sessions",
+                errorCategory = response.ErrorCategory,
                 isError = true
             }, ExcelToolsBase.JsonOptions);
         }

--- a/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
@@ -111,6 +111,7 @@ public static class ExcelToolsBase
             {
                 success = false,
                 errorMessage = response.ErrorMessage ?? $"Command '{command}' failed",
+                errorCategory = response.ErrorCategory,
                 isError = true
             }, JsonOptions);
         }
@@ -143,6 +144,7 @@ public static class ExcelToolsBase
             {
                 success = false,
                 errorMessage = response.ErrorMessage ?? $"Command '{command}' failed",
+                errorCategory = response.ErrorCategory,
                 isError = true
             }, JsonOptions);
         }

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -254,7 +254,7 @@ public sealed class ExcelMcpService : IDisposable
         catch (Exception ex)
         {
             // Include type name so callers can distinguish exception kinds (GitHub #482, Bug 5)
-            return new ServiceResponse { Success = false, ErrorMessage = $"{ex.GetType().Name}: {ex.Message}" };
+            return CreateErrorResponse(ex);
         }
     }
 
@@ -350,7 +350,7 @@ public sealed class ExcelMcpService : IDisposable
         }
         catch (Exception ex)
         {
-            return new ServiceResponse { Success = false, ErrorMessage = $"{ex.GetType().Name}: {ex.Message}" };
+            return CreateErrorResponse(ex);
         }
     }
 
@@ -376,7 +376,7 @@ public sealed class ExcelMcpService : IDisposable
         }
         catch (Exception ex)
         {
-            return new ServiceResponse { Success = false, ErrorMessage = $"{ex.GetType().Name}: {ex.Message}" };
+            return CreateErrorResponse(ex);
         }
     }
 
@@ -669,6 +669,7 @@ public sealed class ExcelMcpService : IDisposable
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
+                ErrorCategory = "Timeout",
                 ErrorMessage = $"Excel operation timed out and the session has been closed: {ex.Message} " +
                                "Please reopen the file with a new session."
             });
@@ -691,6 +692,7 @@ public sealed class ExcelMcpService : IDisposable
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
+                ErrorCategory = "Cancelled",
                 ErrorMessage = $"Operation was cancelled and the session has been closed. " +
                                "The Excel COM thread may have been unresponsive. " +
                                "Please reopen the file with a new session."
@@ -712,6 +714,7 @@ public sealed class ExcelMcpService : IDisposable
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
+                ErrorCategory = "ExcelProcessDied",
                 ErrorMessage = $"Excel process for session '{sessionId}' has died (the application may have been closed or crashed). " +
                                "Session has been cleaned up. Please reopen the file with a new session."
             });
@@ -732,6 +735,7 @@ public sealed class ExcelMcpService : IDisposable
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
+                ErrorCategory = "ExcelProcessDied",
                 ErrorMessage = $"Excel process for session '{sessionId}' is no longer running. " +
                                "Session has been cleaned up. Please reopen the file with a new session."
             });
@@ -751,8 +755,26 @@ public sealed class ExcelMcpService : IDisposable
                 }
             }
 
-            return Task.FromResult(new ServiceResponse { Success = false, ErrorMessage = $"{ex.GetType().Name}: {ex.Message}" });
+            return Task.FromResult(CreateErrorResponse(ex));
         }
+    }
+
+    private static ServiceResponse CreateErrorResponse(Exception ex)
+    {
+        return ex switch
+        {
+            PowerQueryCommandException pqEx => new ServiceResponse
+            {
+                Success = false,
+                ErrorCategory = pqEx.ErrorCategory,
+                ErrorMessage = $"{pqEx.GetType().Name}: {pqEx.Message}"
+            },
+            _ => new ServiceResponse
+            {
+                Success = false,
+                ErrorMessage = $"{ex.GetType().Name}: {ex.Message}"
+            }
+        };
     }
 
     private ServiceResponse? TryGetUsableSession(string sessionId, out IExcelBatch? batch)

--- a/src/ExcelMcp.Service/ServiceProtocol.cs
+++ b/src/ExcelMcp.Service/ServiceProtocol.cs
@@ -63,6 +63,9 @@ public sealed class ServiceResponse
     /// <summary>Error message if Success is false.</summary>
     public string? ErrorMessage { get; init; }
 
+    /// <summary>Structured error category if Success is false.</summary>
+    public string? ErrorCategory { get; init; }
+
     /// <summary>JSON-serialized result data.</summary>
     public string? Result { get; init; }
 
@@ -73,6 +76,7 @@ public sealed class ServiceResponse
     {
         Success = shared.Success,
         ErrorMessage = shared.ErrorMessage,
+        ErrorCategory = shared.ErrorCategory,
         Result = shared.Result
     };
 }

--- a/tests/ExcelMcp.CLI.Tests/Integration/CliDaemonTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/CliDaemonTests.cs
@@ -220,6 +220,32 @@ public sealed class CliDaemonTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ServiceStop_WhenDaemonIsUnresponsiveButTracked_ForceStopsTrackedProcess()
+    {
+        var mutexName = DaemonAutoStart.GetDaemonMutexName(_testPipeName);
+        using var sleeper = StartMutexHoldingProcess(mutexName);
+        await WaitForMutexAsync(mutexName);
+
+        DaemonProcessTracker.RegisterProcess(
+            _testPipeName,
+            sleeper.Id,
+            sleeper.StartTime.ToUniversalTime().ToFileTimeUtc());
+
+        var result = await CliProcessHelper.RunAsync("service stop", timeoutMs: 15000, environmentVariables: TestEnv);
+        _output.WriteLine($"Forced stop response: {result.Stdout}");
+        _output.WriteLine($"Forced stop stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(json.RootElement.GetProperty("forced").GetBoolean());
+
+        var exited = sleeper.WaitForExit(5000);
+        Assert.True(exited, "Tracked daemon process should be force-stopped when shutdown RPC cannot get through");
+        Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(_testPipeName)));
+    }
+
+    [Fact]
     public async Task ServiceRun_SecondInstance_ExitsImmediatelyWithoutDuplicate()
     {
         // Start first daemon and wait until it is ready
@@ -301,6 +327,43 @@ public sealed class CliDaemonTests : IAsyncLifetime
         var process = new Process { StartInfo = startInfo };
         process.Start();
         return process;
+    }
+
+    private static Process StartMutexHoldingProcess(string mutexName)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "powershell",
+                Arguments = $"-NoLogo -NoProfile -NonInteractive -Command \"$created = $false; $m = New-Object System.Threading.Mutex($true, '{mutexName}', [ref]$created); if (-not $created) {{ exit 99 }}; try {{ Start-Sleep -Seconds 60 }} finally {{ $m.ReleaseMutex(); $m.Dispose() }}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            }
+        };
+
+        process.Start();
+        return process;
+    }
+
+    private static async Task WaitForMutexAsync(string mutexName, int maxRetries = 20, int delayMs = 250)
+    {
+        for (var i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                using var mutex = Mutex.OpenExisting(mutexName);
+                return;
+            }
+            catch (WaitHandleCannotBeOpenedException)
+            {
+                await Task.Delay(delayMs);
+            }
+        }
+
+        throw new TimeoutException($"Mutex '{mutexName}' was not acquired within {maxRetries * delayMs}ms");
     }
 
     private async Task WaitForDaemonReadyAsync(int maxRetries = 20, int delayMs = 500)

--- a/tests/ExcelMcp.CLI.Tests/Integration/PowerQueryErrorReportingTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/PowerQueryErrorReportingTests.cs
@@ -1,0 +1,108 @@
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Collection("Service")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "PowerQuery")]
+[Trait("Layer", "CLI")]
+[Trait("RequiresExcel", "true")]
+public sealed class PowerQueryErrorReportingTests : IDisposable
+{
+    private readonly string _testFile = Path.Combine(Path.GetTempPath(), $"PqErrorReporting_{Guid.NewGuid():N}.xlsx");
+    private string? _sessionId;
+
+    [Fact]
+    public async Task Refresh_SyntheticFirewallError_ReturnsStructuredPrivacyCategory()
+    {
+        var queryName = "SyntheticFirewallQuery";
+        var validMCode = """
+            let
+                Source = #table({"X"}, {{1}})
+            in
+                Source
+            """;
+        var firewallMCode = """
+            let
+                Root = error Error.Record(
+                    "Formula.Firewall",
+                    "Query 'ConfigData' (step 'Root') references other queries or steps, so it may not directly access a data source.",
+                    null)
+            in
+                Root
+            """;
+
+        var (sessionResult, sessionJson) = await CliProcessHelper.RunJsonAsync(
+            ["session", "create", _testFile],
+            timeoutMs: 60000,
+            diagnosticLabel: "pq-error-reporting-session-create");
+
+        Assert.Equal(0, sessionResult.ExitCode);
+        _sessionId = sessionJson.RootElement.GetProperty("sessionId").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(_sessionId));
+
+        try
+        {
+            var (createResult, createJson) = await CliProcessHelper.RunJsonAsync(
+                ["powerquery", "create", "--session", _sessionId!, "--query-name", queryName, "--m-code", validMCode],
+                timeoutMs: 120000,
+                diagnosticLabel: "pq-error-reporting-create");
+
+            Assert.Equal(0, createResult.ExitCode);
+            Assert.True(createJson.RootElement.GetProperty("success").GetBoolean());
+
+            var (updateResult, updateJson) = await CliProcessHelper.RunJsonAsync(
+                ["powerquery", "update", "--session", _sessionId!, "--query-name", queryName, "--m-code", firewallMCode, "--refresh", "false"],
+                timeoutMs: 120000,
+                diagnosticLabel: "pq-error-reporting-update");
+
+            Assert.Equal(0, updateResult.ExitCode);
+            Assert.True(updateJson.RootElement.GetProperty("success").GetBoolean());
+
+            var (refreshResult, refreshJson) = await CliProcessHelper.RunJsonAsync(
+                ["powerquery", "refresh", "--session", _sessionId!, "--query-name", queryName, "--timeout", "60"],
+                timeoutMs: 120000,
+                diagnosticLabel: "pq-error-reporting-refresh");
+
+            Assert.NotEqual(0, refreshResult.ExitCode);
+            Assert.False(refreshJson.RootElement.GetProperty("success").GetBoolean());
+            Assert.Equal("Privacy", refreshJson.RootElement.GetProperty("errorCategory").GetString());
+            Assert.Contains("Formula.Firewall", refreshJson.RootElement.GetProperty("error").GetString(), StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(_sessionId))
+            {
+#pragma warning disable CA1031
+                try
+                {
+                    await CliProcessHelper.RunAsync(
+                        ["session", "close", "--session", _sessionId!, "--save", "false"],
+                        timeoutMs: 60000,
+                        diagnosticLabel: "pq-error-reporting-close");
+                }
+                catch
+                {
+                }
+#pragma warning restore CA1031
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFile))
+        {
+            try
+            {
+                File.Delete(_testFile);
+            }
+            catch
+            {
+            }
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.RefreshErrors.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.RefreshErrors.cs
@@ -121,6 +121,41 @@ in
             $"Expected Power Query error but got: {exception.Message}");
     }
 
+    [Fact]
+    public void Refresh_QueryWithSyntheticFirewallError_ThrowsCategorizedPowerQueryException()
+    {
+        var testExcelFile = _fixture.CreateTestFile();
+        var queryName = "SyntheticFirewallQuery";
+
+        var validMCode = @"let
+    Source = #table({""X""}, {{1}})
+in
+    Source";
+
+        var firewallMCode = @"let
+    Root = error Error.Record(
+        ""Formula.Firewall"",
+        ""Query 'ConfigData' (step 'Root') references other queries or steps, so it may not directly access a data source."",
+        null)
+in
+    Root";
+
+        using var batch = ExcelSession.BeginBatch(testExcelFile);
+
+        _powerQueryCommands.Create(batch, queryName, validMCode, PowerQueryLoadMode.LoadToTable);
+        batch.Save();
+
+        _powerQueryCommands.Update(batch, queryName, firewallMCode, refresh: false);
+        batch.Save();
+
+        var exception = Assert.Throws<PowerQueryCommandException>(() =>
+            _powerQueryCommands.Refresh(batch, queryName, TimeSpan.FromMinutes(1)));
+
+        Assert.Equal("Privacy", exception.ErrorCategory);
+        Assert.Contains("Formula.Firewall", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("may not directly access a data source", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// Regression test: Valid worksheet query should refresh successfully (no false positives).
     /// </summary>


### PR DESCRIPTION
## Summary
- fix daemon shutdown handling for unresponsive tracked service processes
- classify Power Query refresh failures in Core and preserve rrorCategory through service, CLI, and MCP responses
- add regressions for daemon recovery and structured PQ privacy reporting, plus changelog notes

## Validation
- dotnet test tests\\ExcelMcp.CLI.Tests\\ExcelMcp.CLI.Tests.csproj --no-restore --filter "FullyQualifiedName~CliDaemonTests|FullyQualifiedName=Sbroenne.ExcelMcp.CLI.Tests.Integration.PowerQueryErrorReportingTests.Refresh_SyntheticFirewallError_ReturnsStructuredPrivacyCategory"
- dotnet test tests\\ExcelMcp.Core.Tests\\ExcelMcp.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~PowerQueryCommandsTests.RefreshErrors"
- real workbook verification with xcelcli powerquery refresh --session <id> --query-name ConfigData --timeout 60 against D:\source\cp_toolkit\consumption_plan\Consumption Plan.xlsx, which now returns rrorCategory: \"Privacy\"

## Notes
- this closes the reporting gap for the reproduced ConfigData privacy/firewall scenario
- release can follow the normal unified workflow once this PR is accepted