### PR TITLE
Handle auth/sign-in repeated pop-ups on enterprise-managed devices 

### DIFF
--- a/src/ExcelMcp.ComInterop/OleMessageFilter.cs
+++ b/src/ExcelMcp.ComInterop/OleMessageFilter.cs
@@ -196,6 +196,8 @@ public sealed partial class OleMessageFilter : IOleMessageFilter
     /// <summary>
     /// Handles rejected COM calls from Excel.
     /// Implements automatic retry logic with exponential backoff for busy/unavailable conditions.
+    /// Also retries SERVERCALL_REJECTED (modal dialogs like auth popups) with a longer window
+    /// so the user has time to dismiss the dialog before the call is cancelled.
     /// </summary>
     /// <param name="htaskCallee">Handle to the task that rejected the call</param>
     /// <param name="dwTickCount">Number of milliseconds since rejection occurred</param>
@@ -209,33 +211,54 @@ public sealed partial class OleMessageFilter : IOleMessageFilter
     {
         // dwRejectType values:
         // SERVERCALL_RETRYLATER (2) = Server is busy, try again later
-        // SERVERCALL_REJECTED (1) = Server rejected the call
+        // SERVERCALL_REJECTED (1) = Server rejected the call (typically modal dialog showing)
 
+        const int SERVERCALL_REJECTED = 1;
         const int SERVERCALL_RETRYLATER = 2;
         const int RETRY_TIMEOUT_MS = 30000;
+        const int REJECTED_RETRY_TIMEOUT_MS = 120000; // 2 minutes for modal dialogs (auth popups, etc.)
 
-        if (dwRejectType != SERVERCALL_RETRYLATER)
+        if (dwRejectType == SERVERCALL_RETRYLATER)
         {
-            return -1; // Cancel immediately for non-retry scenarios
+            if (dwTickCount >= RETRY_TIMEOUT_MS)
+            {
+                return -1; // Cancel the call if timeout exceeded
+            }
+
+            // Exponential backoff based on elapsed time:
+            // 0-1s:   100ms delays (quick retries for brief busy states)
+            // 1-5s:   200ms delays
+            // 5-15s:  500ms delays
+            // 15-30s: 1000ms delays (Excel is seriously stuck)
+            return dwTickCount switch
+            {
+                < 1000 => 100,
+                < 5000 => 200,
+                < 15000 => 500,
+                _ => 1000
+            };
         }
 
-        if (dwTickCount >= RETRY_TIMEOUT_MS)
+        if (dwRejectType == SERVERCALL_REJECTED)
         {
-            return -1; // Cancel the call if timeout exceeded
+            // Modal dialog scenario (auth popups, privacy level dialogs, etc.)
+            // Retry with longer backoff to give the user time to dismiss the dialog.
+            // Without this, COM calls fail immediately when Excel shows any modal UI.
+            if (dwTickCount >= REJECTED_RETRY_TIMEOUT_MS)
+            {
+                return -1; // Give up after 2 minutes — dialog was not dismissed
+            }
+
+            // Slower backoff since we're waiting for human interaction
+            return dwTickCount switch
+            {
+                < 2000 => 500,
+                < 10000 => 1000,
+                _ => 2000
+            };
         }
 
-        // Exponential backoff based on elapsed time:
-        // 0-1s:   100ms delays (quick retries for brief busy states)
-        // 1-5s:   200ms delays
-        // 5-15s:  500ms delays
-        // 15-30s: 1000ms delays (Excel is seriously stuck)
-        return dwTickCount switch
-        {
-            < 1000 => 100,
-            < 5000 => 200,
-            < 15000 => 500,
-            _ => 1000
-        };
+        return -1; // Cancel immediately for unknown rejection types
     }
 
     /// <summary>

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -27,6 +27,11 @@ internal sealed class ExcelBatch : IExcelBatch
     [DllImport("user32.dll")]
     private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
 
+    // P/Invoke for connecting to a running COM object (replaces Marshal.GetActiveObject in .NET 5+)
+    // Internal so ExcelSession can also use it for CreateWorkbookOnStaThread
+    [DllImport("oleaut32.dll", PreserveSig = false)]
+    internal static extern void GetActiveObject([MarshalAs(UnmanagedType.LPStruct)] Guid rclsid, IntPtr pvReserved, [MarshalAs(UnmanagedType.IUnknown)] out object ppunk);
+
     private readonly string _workbookPath; // Primary workbook path
     private readonly string[] _allWorkbookPaths; // All workbook paths (includes primary)
     private readonly bool _showExcel; // Whether to show Excel window
@@ -40,6 +45,7 @@ internal sealed class ExcelBatch : IExcelBatch
     private int _disposed; // 0 = not disposed, 1 = disposed (using int for Interlocked.CompareExchange)
     private int? _excelProcessId; // Excel.exe process ID for force-kill if needed
     private bool _operationTimedOut; // Track if an operation timed out for aggressive cleanup
+    private bool _attachedToExisting; // True if we connected to an already-running Excel (don't quit on dispose)
 
     // COM state (STA thread only)
     private Excel.Application? _excel;
@@ -110,14 +116,38 @@ internal sealed class ExcelBatch : IExcelBatch
                 OleMessageFilter.Register();
 
                 // Create Excel and workbook ON THIS STA THREAD
+                // Try to connect to an already-running Excel instance first.
+                // This avoids auth/sign-in popups that fire during new COM activation
+                // on corporate/managed machines where the popup can't be suppressed.
                 Type? excelType = Type.GetTypeFromProgID("Excel.Application");
                 if (excelType == null)
                 {
                     throw new InvalidOperationException("Microsoft Excel is not installed on this system.");
                 }
 
-                Excel.Application tempExcel = (Excel.Application)Activator.CreateInstance(excelType)!;
-                tempExcel.Visible = _showExcel;
+                Excel.Application tempExcel;
+                bool attachedToExisting = false;
+
+                try
+                {
+                    // Attempt to connect to an existing Excel.Application via the Running Object Table.
+                    // If the user already has Excel open (and authenticated), we piggyback on that instance.
+                    Guid excelClsid = excelType.GUID;
+                    GetActiveObject(excelClsid, IntPtr.Zero, out object existingObj);
+                    tempExcel = (Excel.Application)existingObj;
+                    attachedToExisting = true;
+                    _logger.LogDebug("Attached to existing Excel instance (avoiding new COM activation auth popups)");
+                }
+                catch (COMException)
+                {
+                    // No running Excel — create a new instance.
+                    // Start visible so any auth dialogs can be interacted with.
+                    tempExcel = (Excel.Application)Activator.CreateInstance(excelType)!;
+                    tempExcel.Visible = true;
+                    _logger.LogDebug("Created new Excel instance (no existing instance found)");
+                }
+
+                _attachedToExisting = attachedToExisting;
                 tempExcel.DisplayAlerts = false;
 
                 // Capture Excel process ID for force-kill scenarios (hung Excel, dead RPC connection)
@@ -254,6 +284,13 @@ internal sealed class ExcelBatch : IExcelBatch
                 _workbooks = tempWorkbooks;
                 _context = new ExcelContext(_workbookPath, _excel, _workbook!);
 
+                // Now that workbooks are open and any auth dialogs have been handled,
+                // set the requested visibility. If user didn't ask to show Excel, hide it.
+                if (!_showExcel)
+                {
+                    tempExcel.Visible = false;
+                }
+
                 started.SetResult();
 
                 // Message pump - process work queue until completion or cancellation.
@@ -357,6 +394,9 @@ internal sealed class ExcelBatch : IExcelBatch
                 // Previously multi-workbook batches used bare COM calls without resilience,
                 // while single-workbook batches used ExcelShutdownService. Now both paths
                 // get the same exponential backoff retry for COM busy conditions.
+                //
+                // If we attached to an existing Excel instance (_attachedToExisting), we only
+                // close our workbooks — we do NOT quit Excel since it belongs to the user.
                 if (_workbooks != null && _workbooks.Count > 1)
                 {
                     _logger.LogDebug("Closing {Count} workbooks via ExcelShutdownService", _workbooks.Count);
@@ -374,13 +414,15 @@ internal sealed class ExcelBatch : IExcelBatch
                     }
                     _workbooks.Clear();
 
-                    // Close primary workbook AND quit Excel (with resilient retry)
-                    ExcelShutdownService.CloseAndQuit(_workbook, _excel, false, _workbookPath, _logger);
+                    // Close primary workbook — only quit Excel if we created it
+                    var excelToQuit = _attachedToExisting ? null : _excel;
+                    ExcelShutdownService.CloseAndQuit(_workbook, excelToQuit, false, _workbookPath, _logger);
                 }
                 else
                 {
-                    // Single workbook: same ExcelShutdownService path
-                    ExcelShutdownService.CloseAndQuit(_workbook, _excel, false, _workbookPath, _logger);
+                    // Single workbook — only quit Excel if we created it
+                    var excelToQuit = _attachedToExisting ? null : _excel;
+                    ExcelShutdownService.CloseAndQuit(_workbook, excelToQuit, false, _workbookPath, _logger);
                 }
 
                 _workbook = null;

--- a/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.ComInterop.Session;
@@ -167,21 +168,37 @@ public static class ExcelSession
             Excel.Application? excel = null;
             Excel.Workbook? workbook = null;
 
+            bool attachedToExisting = false;
+
             try
             {
                 OleMessageFilter.Register();
 
-                var excelType = Type.GetTypeFromProgID("Excel.Application");
-                if (excelType == null)
+                // Try connecting to an already-running Excel first (avoids auth popups on managed machines)
+                try
                 {
-                    throw new InvalidOperationException("Excel is not installed or not properly registered.");
+                    var excelClsid = new Guid("00024500-0000-0000-C000-000000000046");
+                    ExcelBatch.GetActiveObject(excelClsid, IntPtr.Zero, out object existingExcel);
+                    excel = (Excel.Application)existingExcel;
+                    attachedToExisting = true;
                 }
+                catch (COMException)
+                {
+                    // No running Excel — fall back to creating a new instance
+                    var excelType = Type.GetTypeFromProgID("Excel.Application");
+                    if (excelType == null)
+                    {
+                        throw new InvalidOperationException("Excel is not installed or not properly registered.");
+                    }
 
 #pragma warning disable IL2072
-                excel = (Excel.Application)Activator.CreateInstance(excelType)!;
+                    excel = (Excel.Application)Activator.CreateInstance(excelType)!;
 #pragma warning restore IL2072
 
-                excel.Visible = false;
+                    // Start visible so auth dialogs are interactable on managed machines
+                    excel.Visible = true;
+                }
+
                 excel.DisplayAlerts = false;
 
                 workbook = (Excel.Workbook)excel.Workbooks.Add();
@@ -211,7 +228,11 @@ public static class ExcelSession
                 }
                 catch { }
 
-                ComUtilities.TryQuitExcel(excel);
+                // Only quit Excel if we created it (don't kill user's existing instance)
+                if (!attachedToExisting)
+                {
+                    ComUtilities.TryQuitExcel(excel);
+                }
 
                 ComUtilities.Release(ref workbook);
                 ComUtilities.Release(ref excel);


### PR DESCRIPTION
## Summary
On corporate/managed Windows machines (or at least where I work), Excel COM activation triggers repeated Windows sign-in popups. making the MCP unusable/unable to attach to a workbook. This hopefully aims to improve/provide some useful suggestions on how you all amazing folks can handle this 🙌  Thank you!!!

## Type of Change
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (dependency updates, code cleanup, etc.)

## Related Issues
Closes #[issue number]
Relates to #[issue number]

## Changes Made
 - ExcelBatch.cs: STA init tries GetActiveObject() via P/Invoke (oleaut32.dll) to connect to a running Excel instance before falling back to Activator.CreateInstance. 
Added _attachedToExisting flag so Dispose() closes workbooks but doesn't quit the user's Excel. Changed GetActiveObject P/Invoke from private to internal for reuse.
 - ExcelSession.cs: Applied same GetActiveObject pattern to CreateWorkbookOnStaThread — a second code path that was creating fresh Excel instances and triggering auth 
popups. Added using System.Runtime.InteropServices for COMException.
 - OleMessageFilter.cs: RetryRejectedCall now retries on SERVERCALL_REJECTED (modal dialog showing) with 2-minute backoff, not just SERVERCALL_RETRYLATER. Previously 
returned -1 (cancel immediately) which killed the operation instead of waiting for the user to dismiss the dialog.

Context

The PowerPoint MCP (trsdn/mcp-server-ppt) doesn't have this issue because PowerPoint.Application throws an error if you set Visible = false — so it's always visible and
auth dialogs are always interactable. Excel defaults to hidden mode, making the popups invisible/unclickable. The GetActiveObject approach avoids creating new processes
entirely on managed machines.

## Testing Performed
- [X] Tested manually with various Excel files
- [X] Verified Excel process cleanup (no excel.exe remains after 5 seconds)
- [ ] Tested error conditions (missing files, invalid arguments, etc.)
- [X] All existing commands still work
- [ ] VBA script execution tested (if applicable)
- [ ] XLSM file format validation tested (if applicable)
- [ ] VBA trust setup tested (if applicable)
- [ ] Build produces zero warnings

## Test Commands
```powershell
# Commands used for testing
ExcelMcp command1 "test.xlsx"
ExcelMcp command2 "test.xlsx" "param"
```

## Screenshots (if applicable)
[Add screenshots showing the new functionality]

## Core Commands Coverage Checklist ⚠️

**Does this PR add or modify Core Commands methods?** [ ] Yes [X] No

If YES, verify all steps completed:

- [ ] Added method to Core Commands interface (e.g., `IPowerQueryCommands.NewMethodAsync()`)
- [ ] Implemented method in Core Commands class (e.g., `PowerQueryCommands.NewMethodAsync()`)
- [ ] Added enum value to `ToolActions.cs` (e.g., `PowerQueryAction.NewMethod`)
- [ ] Added `ToActionString` mapping to `ActionExtensions.cs` (e.g., `PowerQueryAction.NewMethod => "new-method"`)
- [ ] Added switch case to appropriate MCP Tool (e.g., `ExcelPowerQueryTool.cs`)
- [ ] Implemented MCP method that calls Core method
- [ ] Build succeeds with 0 warnings (CS8524 compiler enforcement verified)
- [ ] Updated `CORE-COMMANDS-AUDIT.md` (if significant addition)
- [ ] Added integration tests for new action
- [ ] Updated MCP Server prompts documentation
- [ ] Updated CLI commands documentation (if applicable)

**Coverage Impact**: +___ methods, ___% → ___% coverage

## Checklist
- [X ] Code follows project style guidelines
- [ X] Self-review of code completed
- [ X] Code builds with zero warnings
- [ X] Appropriate error handling added
- [ ] Updated help text (if adding new commands)
- [ ] Updated README.md (if needed)
- [X] Follows Excel COM best practices from copilot-instructions.md
- [ X] Uses batch API with proper disposal (`using var batch` or `await using var batch`)
- [ ] Properly handles 1-based Excel indexing
- [ ] Escapes user input with `.EscapeMarkup()`
- [ ] Returns consistent exit codes (0 = success, 1+ = error)

## Additional Notes
Any additional information that reviewers should know.
