### PR TITLE
fix: use late-bound COM dispatch for vba.run (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **vba(action: 'run') fails on Office 365 Click-to-Run** (#550): `vba.run` used early-bound PIA call `Application.Run()` which triggered assembly resolution of `Microsoft.Vbe.Interop.dll` — a DLL not available on Click-to-Run Office installations without the Visual Studio Office workload. Switched to late-bound COM dispatch via `Type.InvokeMember`, matching the pattern used by all other VBA operations. Also fixed parameter spreading — multiple macro arguments are now passed as individual COM parameters instead of a single array.
+
 - **Session startup "Specified cast is not valid" now includes COM diagnostic info** (#559): When `Activator.CreateInstance` succeeds but PIA interface cast fails (typically due to COM registration mismatches on certain Office Click-to-Run configurations), the error message now includes the resolved CLSID, PIA interface GUID, process bitness, and Office install path. This helps diagnose machine-specific COM registration issues without requiring remote debugging.
 
 - **Enterprise-managed devices: auth/sign-in pop-ups could freeze session startup**: On enterprise-managed Windows devices, Excel sometimes shows modal authentication or sign-in dialogs during startup. Because ExcelMcp started Excel hidden, these dialogs were invisible and blocked COM calls indefinitely (SERVERCALL_REJECTED). Fixed with two changes: (1) `OleMessageFilter.RetryRejectedCall` now retries `SERVERCALL_REJECTED` responses for up to 120 seconds instead of cancelling immediately, giving users time to interact with auth dialogs. (2) `ExcelBatch` now starts Excel visible during session open so auth dialogs are interactable, then hides it after all workbooks are loaded if `show=false` was requested.

--- a/src/ExcelMcp.Core/Commands/Vba/VbaCommands.Operations.cs
+++ b/src/ExcelMcp.Core/Commands/Vba/VbaCommands.Operations.cs
@@ -29,15 +29,24 @@ public partial class VbaCommands
         {
             try
             {
-                if (parameters.Length == 0)
+                // Use late-bound COM dispatch via Type.InvokeMember to avoid dependency on
+                // Microsoft.Vbe.Interop.dll, which is not available on Click-to-Run Office
+                // installations. The early-bound PIA call ctx.App.Run() triggers assembly
+                // resolution of VBE types through the embedded Application interface metadata.
+                var args = new object[1 + parameters.Length];
+                args[0] = procedureName;
+                for (int i = 0; i < parameters.Length; i++)
                 {
-                    ctx.App.Run(procedureName);
+                    args[i + 1] = parameters[i];
                 }
-                else
-                {
-                    object[] paramObjects = parameters.Cast<object>().ToArray();
-                    ctx.App.Run(procedureName, paramObjects);
-                }
+
+                ctx.App.GetType().InvokeMember(
+                    "Run",
+                    System.Reflection.BindingFlags.InvokeMethod,
+                    null,
+                    ctx.App,
+                    args,
+                    System.Globalization.CultureInfo.InvariantCulture);
 
                 return new OperationResult { Success = true, FilePath = batch.WorkbookPath };
             }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Vba/VbaCommandsTests.Trust.ScriptCommands.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Vba/VbaCommandsTests.Trust.ScriptCommands.cs
@@ -1,4 +1,5 @@
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
 using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
@@ -144,6 +145,60 @@ End Sub";
         Assert.Contains("UpdatedCode", viewResult.Code);
         Assert.Contains("Updated", viewResult.Code);
         Assert.DoesNotContain("OriginalCode", viewResult.Code);
+    }
+
+    [Fact]
+    public void ScriptCommands_Run_WithParameters_PassesArgumentsCorrectly()
+    {
+        // Arrange
+        var testFile = _fixture.CreateTestFile();
+
+        // Import a macro that writes a parameter to a cell for verification
+        string vbaCode = @"Sub TestWithParam(value As String)
+    ThisWorkbook.Sheets(1).Range(""A1"").Value = value
+End Sub";
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _scriptCommands.Import(batch, "ParamTest", vbaCode);
+
+        // Act - Run with parameter
+        _scriptCommands.Run(batch, "ParamTest.TestWithParam", null, "HelloWorld");
+
+        // Assert - Verify the macro wrote the value
+        var rangeCommands = new RangeCommands();
+        var result = rangeCommands.GetValues(batch, "Sheet1", "A1");
+        Assert.True(result.Success, $"GetValues should succeed. Error: {result.ErrorMessage}");
+        Assert.NotNull(result.Values);
+        Assert.Single(result.Values);
+        Assert.Equal("HelloWorld", result.Values[0][0]?.ToString());
+    }
+
+    [Fact]
+    public void ScriptCommands_Run_WithMultipleParameters_PassesAllArguments()
+    {
+        // Arrange
+        var testFile = _fixture.CreateTestFile();
+
+        // Import a macro that writes two parameters to separate cells
+        string vbaCode = @"Sub TestMultiParam(val1 As String, val2 As String)
+    ThisWorkbook.Sheets(1).Range(""A1"").Value = val1
+    ThisWorkbook.Sheets(1).Range(""B1"").Value = val2
+End Sub";
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _scriptCommands.Import(batch, "MultiParamTest", vbaCode);
+
+        // Act - Run with two parameters
+        _scriptCommands.Run(batch, "MultiParamTest.TestMultiParam", null, "First", "Second");
+
+        // Assert - Verify both parameters were passed correctly
+        var rangeCommands = new RangeCommands();
+        var result = rangeCommands.GetValues(batch, "Sheet1", "A1:B1");
+        Assert.True(result.Success, $"GetValues should succeed. Error: {result.ErrorMessage}");
+        Assert.NotNull(result.Values);
+        Assert.Single(result.Values); // one row
+        Assert.Equal("First", result.Values[0][0]?.ToString());
+        Assert.Equal("Second", result.Values[0][1]?.ToString());
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #550 — `vba(action: 'run')` fails on Office 365 Click-to-Run installations with `FileNotFoundException: Microsoft.Vbe.Interop.dll`.

## Root Cause

The `Run` method used early-bound PIA call `ctx.App.Run()` through the typed `Excel.Application` interface. On Click-to-Run Office installations without the Visual Studio Office workload, this triggered assembly resolution of `Microsoft.Vbe.Interop.dll` — a DLL that is not bundled, not in the GAC, and not available via NuGet for .NET 5+.

All other VBA operations (list, view, import, update, delete) already used late-bound COM via `dynamic` and worked fine.

## Fix

Replaced the early-bound `ctx.App.Run()` call with `Type.InvokeMember("Run", ...)` for late-bound COM dispatch. This:
1. Eliminates the `Microsoft.Vbe.Interop.dll` dependency entirely
2. Matches the late-bound COM pattern used by all other VBA operations
3. Fixes parameter spreading — multiple macro arguments are now passed as individual COM parameters instead of a single array

## Changes

| File | Change |
|------|--------|
| `VbaCommands.Operations.cs` | Late-bound COM dispatch via `Type.InvokeMember` |
| `VbaCommandsTests.Trust.ScriptCommands.cs` | 2 new integration tests for parameter passing |
| `CHANGELOG.md` | Added fix entry |

## Testing

- [x] All 9 VBA integration tests pass (including 2 new parameter tests)
- [x] Build: 0 errors, 0 warnings
- [x] Pre-commit: 10/10 checks pass (COM leaks, coverage, CLI workflow, MCP smoke test)

Also closes #558 (duplicate).
