### PR TITLE
Fix IRM-protected workbook startup handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,6 +146,19 @@ public void TestMethod()
 
 **Test Fixture Anti-Pattern:** NEVER use both `IClassFixture<T>` and `[Collection("...")]` with a collection fixture on the same test class. Dual fixtures create concurrent Excel sessions that deadlock during initialization with `maxParallelThreads: 1`. Use ONLY the collection fixture.
 
+**Golden Rule (Diagnose Before Coding):** No changes without a failing test first. Write a test that proves the bug exists, watch it fail, then fix it, then watch it pass. Diagnose root cause before writing any code — spent a full session implementing the wrong fix once (issue was daemon dying, but coded a UI fix + 4 tests, all reverted).
+
+**COM Fix Patterns (2026):**
+- `OleMessageFilter.MessagePending` must return `WAITDEFPROCESS` (1), not `WAITNOPROCESS` (2) — causes STA deadlock on re-entrant COM callbacks (e.g. conditional formatting on formula cells).
+- `OleMessageFilter.RetryRejectedCall` must retry `SERVERCALL_REJECTED` (dwRejectType=1) for 120s — enterprise auth dialogs cause repeated rejections.
+- `ExcelBatch` starts Excel visible during open so auth/sign-in dialogs are interactable, hides after success. Tests suppress via `ExcelBatch.SuppressVisibleDuringOpen = true` in `[ModuleInitializer]`.
+- VBA `App.Run()` must use late-bound `Type.InvokeMember("Run", BindingFlags.InvokeMethod, ...)` — early-bound PIA `Run()` triggers `FileNotFoundException` for `Microsoft.Vbe.Interop.dll` when VBE isn't installed.
+- Startup leak fix: use locals (`startupExcel`, `startupPrimaryWorkbook`, `startupWorkbooks`) for COM cleanup during `ExcelBatch` open — don't rely on session fields that may not be set if open fails mid-way.
+- `ComDiagnostics.Collect()` utility gathers COM environment info (CLSID, PIA GUID, bitness, Office install type) for enriching `InvalidCastException` messages.
+- `WithSessionAsync` must catch `OperationCanceledException` and force-close session; `ExcelBatch.Execute` must fail fast if `_operationTimedOut` is set.
+
+**GitHub Issue Comments:** ALWAYS verify @mention usernames match the actual issue/PR author before posting. Read the issue/PR to confirm the author's handle — wrong @mentions are embarrassing and unprofessional.
+
 ---
 
 ## 📚 How Path-Specific Instructions Work

--- a/.github/instructions/development-workflow.instructions.md
+++ b/.github/instructions/development-workflow.instructions.md
@@ -102,6 +102,20 @@ Quick reference:
 
 Workflow calculates version → builds all components → creates git tag → GitHub release with all artifacts
 
+**Quick release from terminal:**
+```powershell
+gh workflow run release.yml -f bump=patch   # or minor/major
+```
+
+## GitHub Issue Comment Protocol
+
+**ALWAYS verify @mention usernames before posting comments on issues or PRs.**
+
+1. Read the issue/PR to confirm the actual author's GitHub handle
+2. Use the correct handle in @mentions — never guess from display names
+3. Wrong @mentions are embarrassing and may notify the wrong person
+4. When posting on multiple issues in sequence, re-verify each author (they differ!)
+
 ## Key Principles
 
 1. Feature branches mandatory

--- a/src/ExcelMcp.CLI/Commands/SessionCommands.cs
+++ b/src/ExcelMcp.CLI/Commands/SessionCommands.cs
@@ -25,7 +25,12 @@ internal sealed class SessionCreateCommand : AsyncCommand<SessionCreateCommand.S
         var response = await client.SendAsync(new ServiceRequest
         {
             Command = "session.create",
-            Args = JsonSerializer.Serialize(new { filePath = settings.FilePath, timeoutSeconds = settings.TimeoutSeconds }, ServiceProtocol.JsonOptions)
+            Args = JsonSerializer.Serialize(new
+            {
+                filePath = settings.FilePath,
+                show = settings.Show,
+                timeoutSeconds = settings.TimeoutSeconds
+            }, ServiceProtocol.JsonOptions)
         }, cancellationToken);
 
         if (response.Success)
@@ -48,6 +53,10 @@ internal sealed class SessionCreateCommand : AsyncCommand<SessionCreateCommand.S
         [CommandOption("--timeout <SECONDS>")]
         [Description("Session timeout in seconds")]
         public int? TimeoutSeconds { get; init; }
+
+        [CommandOption("--show")]
+        [Description("Show the Excel window for IRM/auth prompts instead of running hidden")]
+        public bool Show { get; init; }
     }
 }
 
@@ -65,7 +74,12 @@ internal sealed class SessionOpenCommand : AsyncCommand<SessionOpenCommand.Setti
         var response = await client.SendAsync(new ServiceRequest
         {
             Command = "session.open",
-            Args = JsonSerializer.Serialize(new { filePath = settings.FilePath, timeoutSeconds = settings.TimeoutSeconds }, ServiceProtocol.JsonOptions)
+            Args = JsonSerializer.Serialize(new
+            {
+                filePath = settings.FilePath,
+                show = settings.Show,
+                timeoutSeconds = settings.TimeoutSeconds
+            }, ServiceProtocol.JsonOptions)
         }, cancellationToken);
 
         if (response.Success)
@@ -88,6 +102,10 @@ internal sealed class SessionOpenCommand : AsyncCommand<SessionOpenCommand.Setti
         [CommandOption("--timeout <SECONDS>")]
         [Description("Session timeout in seconds")]
         public int? TimeoutSeconds { get; init; }
+
+        [CommandOption("--show")]
+        [Description("Show the Excel window for IRM/auth prompts instead of running hidden")]
+        public bool Show { get; init; }
     }
 }
 

--- a/src/ExcelMcp.CLI/Program.cs
+++ b/src/ExcelMcp.CLI/Program.cs
@@ -93,11 +93,11 @@ internal sealed class Program
             // Session commands
             config.AddBranch("session", branch =>
             {
-                branch.SetDescription("Session management. WORKFLOW: open -> use sessionId -> close (--save to persist).");
+                branch.SetDescription("Session management. WORKFLOW: open -> use sessionId -> close (--save to persist). Use --show for IRM/auth prompts.");
                 branch.AddCommand<SessionCreateCommand>("create")
-                    .WithDescription("Create a new Excel file, open it, and create a session.");
+                    .WithDescription("Create a new Excel file, open it, and create a session. Add --show for visible Excel.");
                 branch.AddCommand<SessionOpenCommand>("open")
-                    .WithDescription("Open an Excel file and create a session.");
+                    .WithDescription("Open an Excel file and create a session. Add --show for visible Excel.");
                 branch.AddCommand<SessionCloseCommand>("close")
                     .WithDescription("Close a session. Use --save to persist changes.");
                 branch.AddCommand<SessionListCommand>("list")

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -39,7 +39,7 @@ excelcli --version
 excelcli --help
 ```
 
-> 🔁 **Session Workflow:** Always start with `excelcli session open <file>` (captures the session id), pass `--session <id>` to other commands, then `excelcli session close <id> --save` when finished. The CLI reuses the same Excel instance through that lifecycle.
+> 🔁 **Session Workflow:** Always start with `excelcli session open <file>` (captures the session id), pass `--session <id>` to other commands, then `excelcli session close --session <id> --save` when finished. Add `--show` when Excel must stay visible for IRM/AIP sign-in or other authentication prompts.
 
 ### Secondary Installation: .NET Global Tool
 
@@ -78,6 +78,9 @@ For scripting and coding agents, use `-q`/`--quiet` to suppress banner and outpu
 excelcli -q session open data.xlsx
 excelcli -q range get-values --session 1 --sheet Sheet1 --range A1:B2
 excelcli -q session close --session 1 --save
+
+# IRM/AIP-protected workbook
+excelcli -q session open protected.xlsx --show --timeout 15
 ```
 
 Banner auto-suppresses when stdout is piped or redirected.
@@ -155,6 +158,9 @@ The CLI uses an explicit session-based workflow where you open a file, perform o
 excelcli session open data.xlsx
 # Output: Session ID: 550e8400-e29b-41d4-a716-446655440000
 
+# IRM/AIP or auth prompt workflow
+excelcli session open protected.xlsx --show
+
 # 2. List active sessions anytime
 excelcli session list
 
@@ -163,10 +169,10 @@ excelcli sheet create --session 550e8400-e29b-41d4-a716-446655440000 --sheet "Ne
 excelcli powerquery list --session 550e8400-e29b-41d4-a716-446655440000
 
 # 4. Close and save changes
-excelcli session close 550e8400-e29b-41d4-a716-446655440000 --save
+excelcli session close --session 550e8400-e29b-41d4-a716-446655440000 --save
 
 # OR: Close and discard changes (no --save flag)
-excelcli session close 550e8400-e29b-41d4-a716-446655440000
+excelcli session close --session 550e8400-e29b-41d4-a716-446655440000
 ```
 
 ### Session Lifecycle Benefits
@@ -220,6 +226,13 @@ excelcli -q session open report.xlsx           # Returns session ID
 excelcli -q sheet create --session 1 --sheet "Summary"
 excelcli -q range set-values --session 1 --sheet Summary --range A1 --values '[["Hello"]]'
 excelcli -q session close --session 1 --save   # Persist changes
+```
+
+**Visible Excel for IRM/auth workflows:**
+```powershell
+excelcli -q session open "D:\Docs\Protected.xlsx" --show --timeout 120
+excelcli -q session list                        # session shows isExcelVisible=true
+excelcli -q session close --session <id>
 ```
 
 **Power Query ETL:**
@@ -320,6 +333,15 @@ where.exe excelcli
 # Run PowerShell/CMD as Administrator if you encounter permission errors
 # excelcli.exe is a standalone exe - no installation needed
 ```
+
+### IRM / AIP Protected Workbooks
+
+```powershell
+# Keep Excel visible so authentication or policy prompts can surface
+excelcli session open "D:\Docs\Protected.xlsx" --show --timeout 120
+```
+
+Use `--show` whenever hidden automation would block on a sign-in, consent, or information-protection prompt.
 
 ---
 

--- a/src/ExcelMcp.ComInterop/FileAccessValidator.cs
+++ b/src/ExcelMcp.ComInterop/FileAccessValidator.cs
@@ -13,19 +13,32 @@ public static class FileAccessValidator
 
     /// <summary>
     /// Detects if the file is IRM/AIP-protected by checking for the OLE2 compound document
-    /// signature. IRM-protected files must be opened as read-only with Excel visible so the
-    /// user can authenticate through the Information Rights Management credential prompt.
+    /// signature on files whose format should be ZIP-based (OOXML). Legacy .xls files are
+    /// always OLE2 by design and are excluded from this check to avoid false positives.
+    /// IRM-protected files must be opened as read-only with Excel visible so the user can
+    /// authenticate through the Information Rights Management credential prompt.
     /// </summary>
     /// <param name="filePath">The file path to inspect.</param>
     /// <returns>
-    /// <c>true</c> if the file has the OLE2 Compound Document header, indicating IRM/AIP
-    /// encryption; <c>false</c> for standard ZIP-based .xlsx/.xlsm files or if the file
-    /// cannot be read.
+    /// <c>true</c> if the file has the OLE2 Compound Document header AND uses a modern
+    /// OOXML extension (.xlsx, .xlsm, .xlsb), indicating IRM/AIP encryption;
+    /// <c>false</c> for legacy .xls files (always OLE2), standard ZIP-based files, or
+    /// if the file cannot be read.
     /// </returns>
     public static bool IsIrmProtected(string filePath)
     {
         if (!File.Exists(filePath))
             return false;
+
+        // Legacy .xls/.xlt files are always OLE2 compound documents by design.
+        // They are NOT IRM-protected just because they have an OLE2 header.
+        var ext = Path.GetExtension(filePath);
+        if (ext.Equals(".xls", StringComparison.OrdinalIgnoreCase) ||
+            ext.Equals(".xlt", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
         try
         {
             Span<byte> header = stackalloc byte[8];

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -40,6 +40,7 @@ internal sealed class ExcelBatch : IExcelBatch
     private int _disposed; // 0 = not disposed, 1 = disposed (using int for Interlocked.CompareExchange)
     private int? _excelProcessId; // Excel.exe process ID for force-kill if needed
     private bool _operationTimedOut; // Track if an operation timed out for aggressive cleanup
+    private bool _startupDetectedIrmProtectedWorkbook;
 
     /// <summary>
     /// When true, suppresses the "start visible during open" behavior.
@@ -47,6 +48,12 @@ internal sealed class ExcelBatch : IExcelBatch
     /// Production code should never set this.
     /// </summary>
     internal static bool SuppressVisibleDuringOpen { get; set; }
+
+    /// <summary>
+    /// Test-only seam for simulating a blocked workbook open path during startup.
+    /// Production code must leave this null.
+    /// </summary>
+    internal static Action<string, CancellationToken>? BeforeWorkbookOpenHook { get; set; }
 
     // COM state (STA thread only)
     private Excel.Application? _excel;
@@ -245,6 +252,12 @@ internal sealed class ExcelBatch : IExcelBatch
 
                         if (isIrm)
                         {
+                            _startupDetectedIrmProtectedWorkbook = true;
+                            if (!_showExcel)
+                            {
+                                throw new InvalidOperationException(CreateIrmRequiresVisibleSessionMessage(normalizedPath));
+                            }
+
                             // IRM/AIP-protected files are OLE2 containers that cannot be opened
                             // exclusively. Open read-only so the IRM credential prompt works.
                             _logger.LogDebug(
@@ -260,6 +273,8 @@ internal sealed class ExcelBatch : IExcelBatch
                         // Open workbook with Excel COM
                         try
                         {
+                            BeforeWorkbookOpenHook?.Invoke(normalizedPath, _shutdownCts.Token);
+                            _shutdownCts.Token.ThrowIfCancellationRequested();
                             wb = isIrm
                                 // ReadOnly=true prevents "exclusive access required" errors on IRM-encrypted files
                                 ? (Excel.Workbook)tempExcel.Workbooks.Open(normalizedPath, ReadOnly: true)
@@ -464,6 +479,28 @@ internal sealed class ExcelBatch : IExcelBatch
         // a lingering hidden Excel.exe from the failed startup attempt.
         try
         {
+            bool completedInTime;
+            try
+            {
+                completedInTime = started.Task.Wait(_operationTimeout);
+            }
+            catch (AggregateException)
+            {
+                // Task.Wait() wraps faulted-task exceptions in AggregateException.
+                // Fall through to GetAwaiter().GetResult() which unwraps to the
+                // original exception type (e.g. InvalidOperationException for IRM).
+                completedInTime = true;
+            }
+
+            if (!completedInTime)
+            {
+                _operationTimedOut = true;
+                _workQueue.Writer.TryComplete();
+                _shutdownCts.Cancel();
+
+                throw new TimeoutException(CreateStartupTimeoutMessage());
+            }
+
             started.Task.GetAwaiter().GetResult();
         }
         catch
@@ -496,6 +533,24 @@ internal sealed class ExcelBatch : IExcelBatch
 
             throw;
         }
+    }
+
+    private string CreateStartupTimeoutMessage()
+    {
+        var protectedWorkbookHint = _startupDetectedIrmProtectedWorkbook
+            ? $" {CreateIrmRequiresVisibleSessionMessage(_workbookPath)}"
+            : string.Empty;
+
+        return
+            $"Excel startup timed out after {_operationTimeout.TotalSeconds} seconds while opening '{Path.GetFileName(_workbookPath)}'. " +
+            $"Excel may be blocked on an interactive dialog or unresponsive workbook open.{protectedWorkbookHint}";
+    }
+
+    private static string CreateIrmRequiresVisibleSessionMessage(string workbookPath)
+    {
+        return
+            $"IRM/AIP-protected workbook '{Path.GetFileName(workbookPath)}' requires an interactive Excel session. " +
+            "Retry with show=true so Excel stays visible for rights-management or enterprise-auth prompts, or open the workbook interactively first.";
     }
 
     public string WorkbookPath => _workbookPath;

--- a/src/ExcelMcp.McpServer/ServiceBridge/ServiceBridge.cs
+++ b/src/ExcelMcp.McpServer/ServiceBridge/ServiceBridge.cs
@@ -30,6 +30,7 @@ public static class ServiceBridge
 
     private static IServiceBridgeBackend? _service;
     private static Func<IServiceBridgeBackend> _serviceFactory = DefaultServiceFactory;
+    private static Exception? _lastStartupException;
 
     /// <summary>
     /// JSON serializer options for deserializing service responses.
@@ -56,10 +57,12 @@ public static class ServiceBridge
             }
 
             _service = _serviceFactory();
+            _lastStartupException = null;
             return true;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            _lastStartupException = ex;
             return false;
         }
         finally
@@ -83,7 +86,7 @@ public static class ServiceBridge
             return new ServiceResponse
             {
                 Success = false,
-                ErrorMessage = "Failed to start ExcelMCP Service in-process."
+                ErrorMessage = BuildServiceStartupErrorMessage(_lastStartupException)
             };
         }
 
@@ -260,6 +263,7 @@ public static class ServiceBridge
     {
         var service = Interlocked.Exchange(ref _service, null);
         service?.Dispose();
+        _lastStartupException = null;
     }
 
     internal static void SetServiceFactoryForTests(Func<IServiceBridgeBackend> serviceFactory)
@@ -272,5 +276,15 @@ public static class ServiceBridge
     {
         Dispose();
         _serviceFactory = DefaultServiceFactory;
+    }
+
+    private static string BuildServiceStartupErrorMessage(Exception? exception)
+    {
+        if (exception == null)
+        {
+            return "Failed to start ExcelMCP Service in-process.";
+        }
+
+        return $"Failed to start ExcelMCP Service in-process: {exception.GetType().Name}: {exception.Message}";
     }
 }

--- a/tests/ExcelMcp.CLI.Tests/Integration/IrmProtectedWorkbookRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/IrmProtectedWorkbookRegressionTests.cs
@@ -1,0 +1,159 @@
+using System.Diagnostics;
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Sbroenne.ExcelMcp.ComInterop;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+/// <summary>
+/// CLI regressions for IRM/AIP-protected workbook handling.
+/// Uses a deterministic fake-signature file for fail-fast guidance coverage and
+/// an opt-in real protected workbook via TEST_IRM_FILE for local startup validation.
+/// </summary>
+[Collection("Service")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "CLI")]
+[Trait("Layer", "CLI")]
+[Trait("RequiresExcel", "true")]
+public sealed class IrmProtectedWorkbookRegressionTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _fakeIrmFile;
+
+    public IrmProtectedWorkbookRegressionTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _fakeIrmFile = Path.Combine(Path.GetTempPath(), $"CliFakeIrm_{Guid.NewGuid():N}.xlsx");
+        File.WriteAllBytes(_fakeIrmFile, [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+    }
+
+    private static string? GetConfiguredIrmTestFilePath()
+    {
+        var irmTestFile = Environment.GetEnvironmentVariable("TEST_IRM_FILE");
+        return !string.IsNullOrWhiteSpace(irmTestFile) && File.Exists(irmTestFile)
+            ? Path.GetFullPath(irmTestFile)
+            : null;
+    }
+
+    [Fact]
+    public async Task SessionOpenHelp_ListsShowOption_ForProtectedWorkbooks()
+    {
+        var result = await CliProcessHelper.RunAsync(
+            ["session", "open", "--help"],
+            timeoutMs: 10000,
+            diagnosticLabel: "irm-session-open-help");
+
+        _output.WriteLine($"[irm-session-open-help] Stdout: {result.Stdout}");
+        _output.WriteLine($"[irm-session-open-help] Stderr: {result.Stderr}");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("--show", result.Stdout, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("IRM", result.Stdout, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    public async Task SessionOpen_IrmSignatureFile_WithoutShow_FailsFastWithInteractiveGuidance()
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        var (result, json) = await CliProcessHelper.RunJsonAsync(
+            ["session", "open", _fakeIrmFile, "--timeout", "15"],
+            timeoutMs: 20000,
+            diagnosticLabel: "irm-session-open-headless");
+
+        stopwatch.Stop();
+
+        _output.WriteLine($"[irm-session-open-headless] Stdout: {result.Stdout}");
+        _output.WriteLine($"[irm-session-open-headless] Stderr: {result.Stderr}");
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+
+        var error = json.RootElement.GetProperty("error").GetString();
+        Assert.NotNull(error);
+        Assert.Contains("IRM/AIP-protected workbook", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("show=true", error, StringComparison.OrdinalIgnoreCase);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(20),
+            "CLI session open must fail fast for protected workbooks when --show is omitted.");
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    public async Task SessionOpen_RealIrmWorkbook_WithShow_CompletesWithinTimeoutBudget_WhenConfigured()
+    {
+        var irmTestFile = GetConfiguredIrmTestFilePath();
+        if (irmTestFile == null)
+        {
+            return;
+        }
+
+        Assert.True(FileAccessValidator.IsIrmProtected(irmTestFile),
+            "TEST_IRM_FILE must point to a real IRM/AIP-protected workbook for this regression.");
+
+        var stopwatch = Stopwatch.StartNew();
+        string? sessionId = null;
+
+        try
+        {
+            var (result, json) = await CliProcessHelper.RunJsonAsync(
+                ["session", "open", irmTestFile, "--show", "--timeout", "15"],
+                timeoutMs: 20000,
+                diagnosticLabel: "irm-session-open-visible");
+
+            stopwatch.Stop();
+
+            _output.WriteLine($"[irm-session-open-visible] Stdout: {result.Stdout}");
+            _output.WriteLine($"[irm-session-open-visible] Stderr: {result.Stderr}");
+
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(20),
+                "CLI session open must return within the requested timeout budget for protected workbooks.");
+
+            if (result.ExitCode == 0)
+            {
+                Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+                sessionId = json.RootElement.GetProperty("sessionId").GetString();
+                Assert.False(string.IsNullOrWhiteSpace(sessionId));
+            }
+            else
+            {
+                Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+                var error = json.RootElement.GetProperty("error").GetString();
+                Assert.False(string.IsNullOrWhiteSpace(error));
+                Assert.DoesNotContain("show=true", error, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(sessionId))
+            {
+                var closeResult = await CliProcessHelper.RunAsync(
+                    ["session", "close", "--session", sessionId],
+                    timeoutMs: 30000,
+                    diagnosticLabel: "irm-session-close-visible");
+
+                _output.WriteLine($"[irm-session-close-visible] Stdout: {closeResult.Stdout}");
+                _output.WriteLine($"[irm-session-close-visible] Stderr: {closeResult.Stderr}");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_fakeIrmFile))
+        {
+#pragma warning disable CA1031
+            try
+            {
+                File.Delete(_fakeIrmFile);
+            }
+            catch
+            {
+            }
+#pragma warning restore CA1031
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/ExcelMcp.CLI.Tests/Integration/SessionVisibilityRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/SessionVisibilityRegressionTests.cs
@@ -1,0 +1,307 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+/// <summary>
+/// Regressions for CLI session visibility wiring. These tests prove the CLI forwards
+/// --show to the daemon/service layer and that session list exposes the effective flag.
+/// </summary>
+[Collection("Service")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "CLI")]
+[Trait("Layer", "CLI")]
+[Trait("RequiresExcel", "true")]
+public sealed class SessionVisibilityRegressionTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly List<string> _filesToDelete = [];
+
+    public SessionVisibilityRegressionTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task SessionOpen_WithoutShow_ReportsHiddenSession()
+    {
+        var workbookPath = CreateExistingWorkbookPath("session-open-hidden");
+        string? sessionId = null;
+
+        try
+        {
+            var (openResult, openJsonDocument) = await CliProcessHelper.RunJsonAsync(
+                ["session", "open", workbookPath],
+                timeoutMs: 30000,
+                diagnosticLabel: "session-open-hidden");
+            using var openJson = openJsonDocument;
+
+            _output.WriteLine($"[session-open-hidden] Stdout: {openResult.Stdout}");
+            _output.WriteLine($"[session-open-hidden] Stderr: {openResult.Stderr}");
+
+            Assert.Equal(0, openResult.ExitCode);
+            Assert.True(openJson.RootElement.GetProperty("success").GetBoolean());
+
+            sessionId = openJson.RootElement.GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(sessionId));
+
+            await AssertSessionVisibilityAsync(sessionId!, expectedVisible: false, "session-open-hidden-list");
+        }
+        finally
+        {
+            await CloseSessionIfNeededAsync(sessionId, "session-open-hidden-close");
+        }
+    }
+
+    [Fact]
+    public async Task SessionOpen_WithShow_ReportsVisibleSession()
+    {
+        var workbookPath = CreateExistingWorkbookPath("session-open-visible");
+        string? sessionId = null;
+
+        try
+        {
+            var (openResult, openJsonDocument) = await CliProcessHelper.RunJsonAsync(
+                ["session", "open", workbookPath, "--show"],
+                timeoutMs: 30000,
+                diagnosticLabel: "session-open-visible");
+            using var openJson = openJsonDocument;
+
+            _output.WriteLine($"[session-open-visible] Stdout: {openResult.Stdout}");
+            _output.WriteLine($"[session-open-visible] Stderr: {openResult.Stderr}");
+
+            Assert.Equal(0, openResult.ExitCode);
+            Assert.True(openJson.RootElement.GetProperty("success").GetBoolean());
+
+            sessionId = openJson.RootElement.GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(sessionId));
+
+            await AssertSessionVisibilityAsync(sessionId!, expectedVisible: true, "session-open-visible-list");
+        }
+        finally
+        {
+            await CloseSessionIfNeededAsync(sessionId, "session-open-visible-close");
+        }
+    }
+
+    [Fact]
+    public async Task SessionCreate_WithoutShow_ReportsHiddenSession()
+    {
+        var workbookPath = CreateNewWorkbookPath("session-create-hidden");
+        string? sessionId = null;
+
+        try
+        {
+            var (createResult, createJsonDocument) = await CliProcessHelper.RunJsonAsync(
+                ["session", "create", workbookPath],
+                timeoutMs: 30000,
+                diagnosticLabel: "session-create-hidden");
+            using var createJson = createJsonDocument;
+
+            _output.WriteLine($"[session-create-hidden] Stdout: {createResult.Stdout}");
+            _output.WriteLine($"[session-create-hidden] Stderr: {createResult.Stderr}");
+
+            Assert.Equal(0, createResult.ExitCode);
+            Assert.True(createJson.RootElement.GetProperty("success").GetBoolean());
+
+            sessionId = createJson.RootElement.GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(sessionId));
+            Assert.True(File.Exists(workbookPath));
+
+            await AssertSessionVisibilityAsync(sessionId!, expectedVisible: false, "session-create-hidden-list");
+        }
+        finally
+        {
+            await CloseSessionIfNeededAsync(sessionId, "session-create-hidden-close");
+        }
+    }
+
+    [Fact]
+    public async Task SessionCreate_WithShow_ReportsVisibleSession()
+    {
+        var workbookPath = CreateNewWorkbookPath("session-create-visible");
+        string? sessionId = null;
+
+        try
+        {
+            var (createResult, createJsonDocument) = await CliProcessHelper.RunJsonAsync(
+                ["session", "create", workbookPath, "--show"],
+                timeoutMs: 30000,
+                diagnosticLabel: "session-create-visible");
+            using var createJson = createJsonDocument;
+
+            _output.WriteLine($"[session-create-visible] Stdout: {createResult.Stdout}");
+            _output.WriteLine($"[session-create-visible] Stderr: {createResult.Stderr}");
+
+            Assert.Equal(0, createResult.ExitCode);
+            Assert.True(createJson.RootElement.GetProperty("success").GetBoolean());
+
+            sessionId = createJson.RootElement.GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(sessionId));
+            Assert.True(File.Exists(workbookPath));
+
+            await AssertSessionVisibilityAsync(sessionId!, expectedVisible: true, "session-create-visible-list");
+        }
+        finally
+        {
+            await CloseSessionIfNeededAsync(sessionId, "session-create-visible-close");
+        }
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    public async Task SessionOpen_RealIrmWorkbookWithShow_ReturnsWithinTimeoutBudget_WhenConfigured()
+    {
+        var irmTestFile = GetConfiguredIrmTestFilePath();
+        if (irmTestFile == null)
+        {
+            return;
+        }
+
+        string? sessionId = null;
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var (openResult, openJsonDocument) = await CliProcessHelper.RunJsonAsync(
+                ["session", "open", irmTestFile, "--show", "--timeout", "15"],
+                timeoutMs: 20000,
+                diagnosticLabel: "session-open-irm-show");
+            stopwatch.Stop();
+            using var openJson = openJsonDocument;
+
+            _output.WriteLine($"[session-open-irm-show] Elapsed: {stopwatch.Elapsed.TotalSeconds:F1}s");
+            _output.WriteLine($"[session-open-irm-show] Stdout: {openResult.Stdout}");
+            _output.WriteLine($"[session-open-irm-show] Stderr: {openResult.Stderr}");
+
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(20),
+                "CLI session open must return within the requested timeout budget for protected workbooks.");
+            Assert.True(openJson.RootElement.TryGetProperty("success", out var successProp));
+
+            if (successProp.GetBoolean())
+            {
+                sessionId = openJson.RootElement.GetProperty("sessionId").GetString();
+                Assert.False(string.IsNullOrWhiteSpace(sessionId));
+                await AssertSessionVisibilityAsync(sessionId!, expectedVisible: true, "session-open-irm-show-list");
+            }
+            else
+            {
+                var error = openJson.RootElement.GetProperty("error").GetString();
+                Assert.False(string.IsNullOrWhiteSpace(error));
+            }
+
+            var (listResult, listJsonDocument) = await CliProcessHelper.RunJsonAsync(
+                ["session", "list"],
+                timeoutMs: 10000,
+                diagnosticLabel: "session-open-irm-show-list-all");
+            using var listJson = listJsonDocument;
+
+            Assert.Equal(0, listResult.ExitCode);
+            Assert.True(listJson.RootElement.GetProperty("success").GetBoolean());
+        }
+        finally
+        {
+            await CloseSessionIfNeededAsync(sessionId, "session-open-irm-show-close");
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var file in _filesToDelete)
+        {
+            if (!File.Exists(file))
+            {
+                continue;
+            }
+
+#pragma warning disable CA1031
+            try
+            {
+                File.Delete(file);
+            }
+            catch
+            {
+            }
+#pragma warning restore CA1031
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task AssertSessionVisibilityAsync(string sessionId, bool expectedVisible, string diagnosticLabel)
+    {
+        var (listResult, listJsonDocument) = await CliProcessHelper.RunJsonAsync(
+            ["session", "list"],
+            timeoutMs: 10000,
+            diagnosticLabel: diagnosticLabel);
+        using var listJson = listJsonDocument;
+
+        _output.WriteLine($"[{diagnosticLabel}] Stdout: {listResult.Stdout}");
+        _output.WriteLine($"[{diagnosticLabel}] Stderr: {listResult.Stderr}");
+
+        Assert.Equal(0, listResult.ExitCode);
+        Assert.True(listJson.RootElement.GetProperty("success").GetBoolean());
+
+        var session = listJson.RootElement
+            .GetProperty("sessions")
+            .EnumerateArray()
+            .FirstOrDefault(item => string.Equals(
+                item.GetProperty("sessionId").GetString(),
+                sessionId,
+                StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal(JsonValueKind.Object, session.ValueKind);
+        Assert.Equal(expectedVisible, session.GetProperty("isExcelVisible").GetBoolean());
+    }
+
+    private async Task CloseSessionIfNeededAsync(string? sessionId, string diagnosticLabel)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return;
+        }
+
+        var closeResult = await CliProcessHelper.RunAsync(
+            ["session", "close", "--session", sessionId],
+            timeoutMs: 30000,
+            diagnosticLabel: diagnosticLabel);
+
+        _output.WriteLine($"[{diagnosticLabel}] Stdout: {closeResult.Stdout}");
+        _output.WriteLine($"[{diagnosticLabel}] Stderr: {closeResult.Stderr}");
+    }
+
+    private string CreateExistingWorkbookPath(string prefix)
+    {
+        var workbookPath = Path.Combine(Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}.xlsx");
+        var sourceWorkbookPath = Path.Combine(
+            GetRepositoryRoot(),
+            "tests",
+            "ExcelMcp.ComInterop.Tests",
+            "Integration",
+            "Session",
+            "TestFiles",
+            "batch-test-static.xlsx");
+        Assert.True(File.Exists(sourceWorkbookPath), $"Static workbook fixture missing: {sourceWorkbookPath}");
+
+        File.Copy(sourceWorkbookPath, workbookPath, overwrite: true);
+        _filesToDelete.Add(workbookPath);
+        return workbookPath;
+    }
+
+    private string CreateNewWorkbookPath(string prefix)
+    {
+        var workbookPath = Path.Combine(Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}.xlsx");
+        _filesToDelete.Add(workbookPath);
+        return workbookPath;
+    }
+
+    private static string? GetConfiguredIrmTestFilePath()
+    {
+        var irmTestFile = Environment.GetEnvironmentVariable("TEST_IRM_FILE");
+        return !string.IsNullOrWhiteSpace(irmTestFile) && File.Exists(irmTestFile)
+            ? Path.GetFullPath(irmTestFile)
+            : null;
+    }
+
+    private static string GetRepositoryRoot() =>
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+}

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTests.cs
@@ -32,6 +32,14 @@ public class ExcelBatchTests : IAsyncLifetime
     private static string? _staticTestFile;
     private string? _testFileCopy;
 
+    private static string? GetConfiguredIrmTestFilePath()
+    {
+        var irmTestFile = Environment.GetEnvironmentVariable("TEST_IRM_FILE");
+        return !string.IsNullOrWhiteSpace(irmTestFile) && File.Exists(irmTestFile)
+            ? Path.GetFullPath(irmTestFile)
+            : null;
+    }
+
     public ExcelBatchTests(ITestOutputHelper output)
     {
         _output = output;
@@ -398,6 +406,104 @@ public class ExcelBatchTests : IAsyncLifetime
 #pragma warning disable CA1031 // Intentional: best-effort test cleanup
                 try { File.Delete(testFile); } catch (Exception) { /* Best effort cleanup */ }
 #pragma warning restore CA1031
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    public void BeginBatch_IrmWorkbook_ShowFalse_FailsFastBeforeOpen()
+    {
+        string fakeIrmFile = Path.Join(Path.GetTempPath(), $"batch-irm-headless-{Guid.NewGuid():N}.xlsx");
+        File.WriteAllBytes(fakeIrmFile, [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+
+        bool openAttempted = false;
+        ExcelBatch.BeforeWorkbookOpenHook = (_, _) => openAttempted = true;
+
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                ExcelSession.BeginBatch(show: false, operationTimeout: TimeSpan.FromSeconds(15), fakeIrmFile));
+
+            Assert.False(openAttempted);
+            Assert.Contains("IRM/AIP-protected workbook", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("show=true", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            ExcelBatch.BeforeWorkbookOpenHook = null;
+
+#pragma warning disable CA1031 // Intentional: best-effort test cleanup
+            try { File.Delete(fakeIrmFile); } catch (Exception) { }
+#pragma warning restore CA1031
+        }
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    public async Task BeginBatch_RealIrmWorkbook_CompletesStartupWithinBudget_WhenConfigured()
+    {
+        // Real IRM startup depends on interactive auth/enterprise policy and cannot run in CI.
+        var irmTestFile = GetConfiguredIrmTestFilePath();
+        if (irmTestFile == null)
+        {
+            return;
+        }
+
+        var startingExcelPids = Process.GetProcessesByName("EXCEL")
+            .Select(process => process.Id)
+            .ToHashSet();
+
+        var stopwatch = Stopwatch.StartNew();
+        IExcelBatch? batch = null;
+
+        try
+        {
+            var openTask = Task.Run(() => ExcelSession.BeginBatch(show: true, operationTimeout: TimeSpan.FromSeconds(15), irmTestFile));
+
+            try
+            {
+                batch = await openTask.WaitAsync(TimeSpan.FromSeconds(20));
+            }
+            catch (TimeoutException)
+            {
+                KillUnexpectedExcelProcesses(startingExcelPids);
+                Assert.Fail(
+                    "Opening the configured IRM workbook did not complete within 20 seconds. " +
+                    "This is the hang regression surface for protected-workbook startup.");
+            }
+            _output.WriteLine($"Opened IRM workbook in {stopwatch.Elapsed.TotalSeconds:F1}s");
+        }
+        finally
+        {
+            batch?.Dispose();
+        }
+    }
+
+    private static void KillUnexpectedExcelProcesses(HashSet<int> startingExcelPids)
+    {
+        foreach (var process in Process.GetProcessesByName("EXCEL"))
+        {
+            if (startingExcelPids.Contains(process.Id))
+            {
+                process.Dispose();
+                continue;
+            }
+
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: false);
+                    process.WaitForExit(5000);
+                }
+            }
+            catch
+            {
+            }
+            finally
+            {
+                process.Dispose();
             }
         }
     }

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTimeoutTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTimeoutTests.cs
@@ -68,6 +68,73 @@ public class ExcelBatchTimeoutTests : IAsyncLifetime
         return Task.CompletedTask;
     }
 
+    [Fact]
+    public void BeginBatch_StartupOpenBlocks_ThrowsTimeoutExceptionInsteadOfHanging()
+    {
+        using var startupBlocked = new ManualResetEventSlim(false);
+        ExcelBatch.BeforeWorkbookOpenHook = (_, cancellationToken) =>
+        {
+            startupBlocked.Set();
+            cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(30));
+        };
+
+        try
+        {
+            var sw = Stopwatch.StartNew();
+
+            var ex = Assert.Throws<TimeoutException>(() =>
+                ExcelSession.BeginBatch(
+                    show: false,
+                    operationTimeout: TimeSpan.FromSeconds(8),
+                    _testFileCopy!));
+
+            sw.Stop();
+
+            Assert.True(startupBlocked.Wait(TimeSpan.FromSeconds(10)),
+                "Startup hook was not reached before the timeout assertion.");
+            Assert.Contains("startup timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(Path.GetFileName(_testFileCopy!), ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(30),
+                $"Startup timeout regression: BeginBatch took {sw.Elapsed.TotalSeconds:F1}s. Expected a bounded timeout, not a hang.");
+        }
+        finally
+        {
+            ExcelBatch.BeforeWorkbookOpenHook = null;
+        }
+    }
+
+    [Fact]
+    public void BeginBatch_IrmStartupOpenBlocks_TimeoutMessageIncludesInteractiveGuidance()
+    {
+        string fakeIrmFile = Path.Join(Path.GetTempPath(), $"batch-timeout-irm-{Guid.NewGuid():N}.xlsx");
+        File.WriteAllBytes(fakeIrmFile, [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+
+        ExcelBatch.BeforeWorkbookOpenHook = (_, cancellationToken) =>
+        {
+            cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(30));
+        };
+
+        try
+        {
+            var ex = Assert.Throws<TimeoutException>(() =>
+                ExcelSession.BeginBatch(
+                    show: true,
+                    operationTimeout: TimeSpan.FromSeconds(8),
+                    fakeIrmFile));
+
+            Assert.Contains("IRM/AIP-protected", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("show=true", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            ExcelBatch.BeforeWorkbookOpenHook = null;
+
+#pragma warning disable CA1031 // Intentional: best-effort test cleanup
+            try { File.Delete(fakeIrmFile); } catch (Exception) { }
+#pragma warning restore CA1031
+        }
+    }
+
     /// <summary>
     /// REGRESSION TEST: Execute() must throw TimeoutException when operation exceeds the configured timeout.
     /// Before Bug 8 fix, timeout existed but had no recovery — the caller got the exception but

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.IrmDetection.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.IrmDetection.cs
@@ -11,6 +11,19 @@ public partial class FileCommandsTests
 {
     // === IMPROVEMENT #5: IRM DETECTION TESTS ===
 
+    private static readonly byte[] Ole2Signature =
+    [
+        0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1
+    ];
+
+    private static string? GetConfiguredIrmTestFilePath()
+    {
+        var irmTestFile = Environment.GetEnvironmentVariable("TEST_IRM_FILE");
+        return !string.IsNullOrWhiteSpace(irmTestFile) && System.IO.File.Exists(irmTestFile)
+            ? Path.GetFullPath(irmTestFile)
+            : null;
+    }
+
     [Fact]
     public void Test_NormalFile_NoIrmProtection()
     {
@@ -28,14 +41,48 @@ public partial class FileCommandsTests
     }
 
     [Fact]
-    public void Test_IrmProtectedFile_DetectsProtection()
+    public void Test_IrmSignatureFile_DetectsProtection()
     {
-        // Arrange - Skip if no IRM protected test file available
-        // For now, simulate or use a real IRM-protected file if available
-        string? irmTestFile = Environment.GetEnvironmentVariable("TEST_IRM_FILE");
-        if (string.IsNullOrEmpty(irmTestFile) || !System.IO.File.Exists(irmTestFile))
+        // Arrange - deterministic OLE2 header seam for IRM detection logic
+        var testFile = Path.Join(_fixture.TempDir, $"FakeIrm_{Guid.NewGuid():N}.xlsx");
+        System.IO.File.WriteAllBytes(testFile, Ole2Signature);
+
+        // Act
+        var info = _fileCommands.Test(testFile);
+
+        // Assert
+        Assert.True(info.Exists);
+        Assert.True(info.IsValid);
+        Assert.True(info.IsIrmProtected);
+        Assert.Null(info.Message);
+    }
+
+    [Fact]
+    public void Test_LegacyXlsFile_NotFlaggedAsIrm()
+    {
+        // Regression: .xls files are always OLE2 compound documents by design.
+        // They must NOT be misclassified as IRM-protected.
+        var testFile = Path.Join(_fixture.TempDir, $"LegacyBiff_{Guid.NewGuid():N}.xls");
+        System.IO.File.WriteAllBytes(testFile, Ole2Signature);
+
+        // Act
+        var info = _fileCommands.Test(testFile);
+
+        // Assert
+        Assert.True(info.Exists);
+        // Note: .xls is not in the Test() valid-extension list (.xlsx/.xlsm only),
+        // so IsValid is false. The key assertion is IRM detection.
+        Assert.False(info.IsIrmProtected, "Legacy .xls (OLE2) must not be flagged as IRM-protected");
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    public void Test_RealIrmProtectedFile_DetectsProtection_WhenConfigured()
+    {
+        // Real protected workbooks require local credentials and cannot run safely in CI.
+        var irmTestFile = GetConfiguredIrmTestFilePath();
+        if (irmTestFile == null)
         {
-            // Skip this test - requires actual IRM-protected file
             return;
         }
 

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolProtocolRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolProtocolRegressionTests.cs
@@ -41,6 +41,14 @@ public sealed class ExcelFileToolProtocolRegressionTests : IAsyncLifetime
         _output.WriteLine($"Test directory: {_tempDir}");
     }
 
+    private static string? GetConfiguredIrmTestFilePath()
+    {
+        var irmTestFile = Environment.GetEnvironmentVariable("TEST_IRM_FILE");
+        return !string.IsNullOrWhiteSpace(irmTestFile) && File.Exists(irmTestFile)
+            ? Path.GetFullPath(irmTestFile)
+            : null;
+    }
+
     public async Task InitializeAsync()
     {
         Program.ConfigureTestTransport(_clientToServerPipe, _serverToClientPipe);
@@ -119,6 +127,78 @@ public sealed class ExcelFileToolProtocolRegressionTests : IAsyncLifetime
             ["session_id"] = sessionId,
             ["save"] = false
         });
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    public async Task FileOpen_RealIrmWorkbook_ReturnsWithinTimeoutBudget_WhenConfigured()
+    {
+        // Real IRM/AIP workbooks require local auth state and are intentionally opt-in only.
+        var irmTestFile = GetConfiguredIrmTestFilePath();
+        if (irmTestFile == null)
+        {
+            return;
+        }
+
+        var testResult = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "test",
+            ["path"] = irmTestFile
+        });
+
+        using (var testJson = JsonDocument.Parse(testResult))
+        {
+            Assert.True(testJson.RootElement.GetProperty("success").GetBoolean());
+            Assert.True(testJson.RootElement.GetProperty("isIrmProtected").GetBoolean());
+        }
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var openResult = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "open",
+            ["path"] = irmTestFile,
+            ["timeout_seconds"] = 15
+        }).WaitAsync(TimeSpan.FromSeconds(20));
+        stopwatch.Stop();
+
+        _output.WriteLine($"IRM open result after {stopwatch.Elapsed.TotalSeconds:F1}s: {openResult}");
+
+        using var openJson = JsonDocument.Parse(openResult);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(20),
+            "MCP file.open must return within the requested timeout budget for protected workbooks.");
+        Assert.True(openJson.RootElement.TryGetProperty("success", out var successProp));
+
+        string? sessionId = null;
+        if (successProp.GetBoolean())
+        {
+            sessionId = openJson.RootElement.GetProperty("session_id").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(sessionId));
+        }
+        else
+        {
+            var errorMessage = openJson.RootElement.GetProperty("errorMessage").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(errorMessage));
+        }
+
+        var listResult = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "list"
+        });
+
+        using (var listJson = JsonDocument.Parse(listResult))
+        {
+            Assert.True(listJson.RootElement.GetProperty("success").GetBoolean());
+        }
+
+        if (!string.IsNullOrWhiteSpace(sessionId))
+        {
+            await CallToolAsync("file", new Dictionary<string, object?>
+            {
+                ["action"] = "close",
+                ["session_id"] = sessionId,
+                ["save"] = false
+            });
+        }
     }
 
     private async Task DisposeAsyncCore()

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolTests.cs
@@ -19,6 +19,11 @@ namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
 [Trait("Feature", "File")]
 public class ExcelFileToolTests(ITestOutputHelper output)
 {
+    private static readonly byte[] Ole2Signature =
+    [
+        0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1
+    ];
+
     [Fact]
     public void Create_ProtectedSystemPath_ReturnsJsonError()
     {
@@ -173,6 +178,44 @@ public class ExcelFileToolTests(ITestOutputHelper output)
         var json = JsonDocument.Parse(result).RootElement;
         Assert.False(json.GetProperty("success").GetBoolean());
         Assert.False(json.GetProperty("exists").GetBoolean());
+    }
+
+    [Fact]
+    public void Test_IrmSignatureFile_ReturnsIrmMetadata()
+    {
+        // Arrange
+        var tempPath = Path.Join(Path.GetTempPath(), $"ExcelFileTool_Irm_{Guid.NewGuid():N}.xlsx");
+
+        try
+        {
+            File.WriteAllBytes(tempPath, Ole2Signature);
+
+            // Act
+            var result = ExcelFileTool.ExcelFile(
+                FileAction.Test,
+                path: tempPath,
+                session_id: null,
+                save: false,
+                show: false,
+                timeout_seconds: 300);
+
+            output.WriteLine($"Result: {result}");
+
+            // Assert
+            var json = JsonDocument.Parse(result).RootElement;
+            Assert.True(json.GetProperty("success").GetBoolean());
+            Assert.True(json.GetProperty("exists").GetBoolean());
+            Assert.True(json.GetProperty("isValid").GetBoolean());
+            Assert.True(json.GetProperty("isIrmProtected").GetBoolean());
+            Assert.False(json.TryGetProperty("isError", out _));
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
     }
 }
 

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ServiceBridgeCancellationTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ServiceBridgeCancellationTests.cs
@@ -70,6 +70,19 @@ public sealed class ServiceBridgeCancellationTests : IDisposable
         Assert.Contains("session-ambient", backend.ClosedSessions);
     }
 
+    [Fact]
+    public async Task SendAsync_WhenServiceFactoryThrows_IncludesStartupFailureDetails()
+    {
+        Bridge.SetServiceFactoryForTests(static () => throw new FileNotFoundException("office runtime missing"));
+
+        var response = await Bridge.SendAsync("session.open");
+
+        Assert.False(response.Success);
+        Assert.Contains("Failed to start ExcelMCP Service in-process", response.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("FileNotFoundException", response.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("office runtime missing", response.ErrorMessage, StringComparison.Ordinal);
+    }
+
     private sealed class BlockingBackend : IServiceBridgeBackend
     {
         private readonly TaskCompletionSource<ServiceResponse> _response =


### PR DESCRIPTION
## Problem
Opening certain IRM/AIP-protected workbooks could stall hidden Excel startup, which looked like the MCP server was hanging. A second issue made diagnosis harder because startup/bootstrap failures were being collapsed into a generic in-process service start error.

## Root cause
- IRM-protected workbooks can require interactive Excel visibility during open/auth flows.
- Hidden startup paths were not failing fast with actionable guidance.
- ServiceBridge masked the underlying startup exception details.
- CLI needed parity for visible session open/create workflows.

## Fix
- Fail fast for IRM-protected workbook opens when Excel is not visible, with explicit guidance.
- Keep startup/open behavior bounded and surface timeout guidance for interactive cases.
- Preserve the underlying startup/bootstrap exception details through `ServiceBridge`.
- Add CLI `--show` parity for session open/create.
- Add focused IRM regression coverage across CLI, Core, MCP, and ComInterop.

## Validation
- CLI IRM regressions: 8 passed
- Core IRM regressions: 6 passed
- MCP IRM regressions: 3 passed
- ComInterop IRM regressions: 4 passed
- Pre-commit checks passed, including CLI workflow smoke test and MCP smoke test

## Real protected workbook used for local validation
`D:\source\cp_toolkit\CPLAN Standardization - Excel Workstream - FY26.xlsx`