### PR TITLE
Fix publish-plugins staged-change detection

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -478,12 +478,27 @@ jobs:
 
           git -C published-repo add -A
 
-          if (git -C published-repo diff --staged --quiet) {
+          $previousNativeCommandPreference = $PSNativeCommandUseErrorActionPreference
+          $stagedDiffExitCode = 0
+
+          try {
+            $PSNativeCommandUseErrorActionPreference = $false
+            git -C published-repo diff --staged --quiet
+            $stagedDiffExitCode = $LASTEXITCODE
+          }
+          finally {
+            $PSNativeCommandUseErrorActionPreference = $previousNativeCommandPreference
+          }
+
+          if ($stagedDiffExitCode -eq 0) {
             Write-Host "No changes to commit (plugins already up to date)"
             "has_changes=false" >> $env:GITHUB_OUTPUT
           }
-          else {
+          elseif ($stagedDiffExitCode -eq 1) {
             "has_changes=true" >> $env:GITHUB_OUTPUT
+          }
+          else {
+            throw "git diff --staged --quiet failed with exit code $stagedDiffExitCode"
           }
 
       - name: Commit and push changes

--- a/.squad/agents/cheritto/history.md
+++ b/.squad/agents/cheritto/history.md
@@ -9,6 +9,7 @@
 ## Learnings
 
 <!-- Append learnings below -->
+- 2026-04-25: In GitHub Actions PowerShell steps, `git diff --quiet` is not safe as a bare `if (...)` condition when a diff is expected. Treat exit code `1` as data, not failure: temporarily disable `PSNativeCommandUseErrorActionPreference`, capture `$LASTEXITCODE`, then branch on `0` (no changes) vs `1` (changes present).
 - 2026-04-25: A failed Dependabot security update on `vscode-extension` can be a real repo issue without a usable upstream patch path. In this case `@vscode/vsce` 3.x pulled `@azure/msal-node -> uuid@^8.3.0`, so the practical fix was to validate Dependabot's suggested `@vscode/vsce` 2.25.0 downgrade, then confirm `npm audit` and the exact `npm run package` release path still pass before merging.
 - 2026-04-25: `publish-plugins.yml` must resolve source release tags from a fetched git checkout (`git tag --points-at workflow_run.head_sha`), not from the REST `matching-refs` payload. Release tags here are annotated, so `.object.sha` is the tag object SHA, not the released commit SHA; the old lookup caused the follow-on publish workflow to fail immediately after a successful release.
 - 2026-04-25: The retired Azure runner workflow files were safe to delete once the docs stopped telling people to rename `.disabled` files back into service. Minimal cleanup was enough: remove the two disabled workflow files, update the workflow instructions, and reframe the Azure runner guide as historical infrastructure reference.


### PR DESCRIPTION
## Summary
- stop treating git diff --staged --quiet exit code 1 as a workflow failure in the publish sync step
- capture the native git exit code explicitly so normal staged plugin updates set has_changes=true
- keep the hotfix surgical to the publish workflow and the recorded Cheritto learning

## Validation
- exercised the new exit-code handling locally for both no-staged-change (0) and staged-change (1) cases
- pre-commit hook passed, including release build, CLI smoke test, MCP smoke test, release deliverables, VS Code package validation, MCPB bundle, and agent skills packaging
- reproduced the failed workflow on release v1.8.46, then fixed the exact step that aborted after a successful sync