### PR TITLE
fix: publish excel-cli plugin without bundled binary

### DIFF
--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -19,18 +19,19 @@ copilot plugin marketplace add sbroenne/mcp-server-excel-plugins
 copilot plugin install excel-cli@mcp-server-excel-plugins
 ```
 
-### Step 2: Wire the Bundled CLI onto PATH
+### Step 2: Install `excelcli`
 
-The plugin now ships the actual `excelcli.exe` binary in `bin\`. Run the helper once to expose it as the `excelcli` command from any terminal:
+Install the CLI separately, then keep using the plugin for guidance:
 
+**Option A: Standalone ZIP**
+1. Download `ExcelMcp-CLI-{version}-windows.zip` from [Releases](https://github.com/sbroenne/mcp-server-excel/releases/latest)
+2. Extract `excelcli.exe` to a permanent folder
+3. Add that folder to your PATH
+
+**Option B: .NET Tool**
 ```powershell
-pwsh -ExecutionPolicy Bypass -File "$env:USERPROFILE\.copilot\installed-plugins\mcp-server-excel-plugins\excel-cli\bin\install-global.ps1"
+dotnet tool install --global Sbroenne.ExcelMcp.CLI
 ```
-
-The helper:
-- creates `~/.copilot/bin` if needed
-- writes `excelcli.cmd` and `excelcli.ps1` shims that point at the plugin-bundled binary
-- adds `~/.copilot/bin` to your user PATH if missing
 
 ### Step 3: Verify
 
@@ -41,14 +42,11 @@ excelcli --help
 
 ## What's Included
 
-- **Bundled `excelcli.exe`** — self-contained Windows CLI, no separate download
 - **`excel-cli` skill** — token-efficient Excel automation guidance for coding agents
-- **Install helper** — one-time PATH wiring for the bundled CLI
 
 ## Notes
 
-- If you reinstall the plugin or test a locally built plugin path, re-run `install-global.ps1` so the shim points at the current plugin directory.
-- The standalone ZIP and NuGet tool remain available for non-plugin installs, but they are no longer required for the Copilot plugin path.
+- The plugin is skill-only; install `excelcli` separately via the standalone ZIP or NuGet tool.
 
 ## Support
 

--- a/.github/plugins/marketplace-repo/README.md
+++ b/.github/plugins/marketplace-repo/README.md
@@ -7,7 +7,7 @@ This repository is the publish target for plugin artifacts from [`sbroenne/mcp-s
 ## Plugins
 
 - **excel-mcp** — MCP server plugin for conversational Excel automation
-- **excel-cli** — CLI skill plugin with bundled `excelcli.exe` for scripting and coding-agent workflows
+- **excel-cli** — CLI skill plugin for scripting and coding-agent workflows
 
 ## Repository Layout
 
@@ -31,17 +31,13 @@ copilot plugin install excel-mcp@mcp-server-excel-plugins
 copilot plugin install excel-cli@mcp-server-excel-plugins
 ```
 
-After installing `excel-cli`, run the bundled helper once to wire the plugin-shipped CLI onto PATH:
-
-```powershell
-pwsh -ExecutionPolicy Bypass -File "$env:USERPROFILE\.copilot\installed-plugins\mcp-server-excel-plugins\excel-cli\bin\install-global.ps1"
-```
+The `excel-cli` plugin is skill-only. Install `excelcli` separately from the main release ZIP or NuGet tool if you want the command on PATH.
 
 ## Notes
 
 - **Windows only** — ExcelMcp depends on Microsoft Excel COM automation.
 - **excel-mcp** includes MCP configuration plus helper scripts for the ExcelMcp MCP server.
-- **excel-cli** bundles the actual self-contained `excelcli.exe` binary inside `plugins/excel-cli/bin/`.
+- **excel-cli** provides the skill package only; install `excelcli` separately from the source repo releases if needed.
 
 ## Source and Support
 

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -261,24 +261,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Publish self-contained CLI for plugin bundling
-        run: |
-          $VERSION = "${{ needs.get-version.outputs.version }}"
-          dotnet publish source\src\ExcelMcp.CLI\ExcelMcp.CLI.csproj `
-            --configuration Release `
-            --runtime win-x64 `
-            --self-contained true `
-            -p:PublishSingleFile=true `
-            -p:IncludeNativeLibrariesForSelfExtract=true `
-            -p:PublishTrimmed=false `
-            -p:PublishReadyToRun=false `
-            -p:Version=$VERSION `
-            -p:AssemblyVersion=$VERSION.0 `
-            -p:FileVersion=$VERSION.0 `
-            -p:NuGetAudit=false `
-            --output source\plugin-cli-publish
-        shell: pwsh
-
       - name: Build plugins from validated templates
         run: |
           $VERSION = "${{ needs.get-version.outputs.version }}"
@@ -287,7 +269,7 @@ jobs:
           # Build script copies from ../mcp-server-excel-plugins/plugins/
           # We checked out published repo at ./published, so adjust path
           cd source
-          & .\scripts\Build-Plugins.ps1 -Version $VERSION -PluginTemplateDir "..\published\plugins" -CliPublishDir ".\plugin-cli-publish"
+          & .\scripts\Build-Plugins.ps1 -Version $VERSION -PluginTemplateDir "..\published\plugins"
         shell: pwsh
 
       - name: Upload excel-mcp plugin artifact

--- a/.squad/agents/cheritto/history.md
+++ b/.squad/agents/cheritto/history.md
@@ -9,6 +9,7 @@
 ## Learnings
 
 <!-- Append learnings below -->
+- 2026-04-25: The published Copilot marketplace repo cannot accept the self-contained `excelcli.exe` bundle once it crosses GitHub's file-size limit (observed at ~175 MB, rejected with `GH001`). The durable fix is to keep `excel-cli` as a skill-only plugin and leave CLI binary distribution to the main GitHub release ZIP / NuGet channels.
 - 2026-04-25: In GitHub Actions PowerShell steps, handling an expected native exit code is a two-part fix: capture the code with `PSNativeCommandUseErrorActionPreference = $false`, then clear `$LASTEXITCODE` before the step ends if that non-zero code was expected. Otherwise the step can still fail even after your script branches correctly.
 - 2026-04-25: In GitHub Actions PowerShell steps, `git diff --quiet` is not safe as a bare `if (...)` condition when a diff is expected. Treat exit code `1` as data, not failure: temporarily disable `PSNativeCommandUseErrorActionPreference`, capture `$LASTEXITCODE`, then branch on `0` (no changes) vs `1` (changes present).
 - 2026-04-25: A failed Dependabot security update on `vscode-extension` can be a real repo issue without a usable upstream patch path. In this case `@vscode/vsce` 3.x pulled `@azure/msal-node -> uuid@^8.3.0`, so the practical fix was to validate Dependabot's suggested `@vscode/vsce` 2.25.0 downgrade, then confirm `npm audit` and the exact `npm run package` release path still pass before merging.

--- a/.squad/skills/plugin-overlay-bundling/SKILL.md
+++ b/.squad/skills/plugin-overlay-bundling/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "plugin-overlay-bundling"
-description: "Pattern for keeping published plugin templates stable while layering source-owned helper files and bundled binaries."
+description: "Pattern for keeping published plugin templates stable while layering source-owned helper files and skill content."
 ---
 
 ## Context
 
-Use this when plugin artifacts are built by copying validated templates from a published/distribution repo, but the source repo still needs to own release-coupled helper files or bundled executables.
+Use this when plugin artifacts are built by copying validated templates from a published/distribution repo, but the source repo still needs to own release-coupled helper files or skill content.
 
 ## Pattern
 
@@ -15,18 +15,18 @@ Use this when plugin artifacts are built by copying validated templates from a p
    - install helpers
    - wrapper scripts
 3. In the build script, apply the overlay after copying the template, then inject version metadata.
-4. If the plugin must ship a binary, stage the real publish output first and copy it into the plugin bundle (for example `plugins/<plugin-name>/bin/`).
+4. Prefer keeping published plugins lightweight; ship binaries through the main release artifacts unless the marketplace repo can safely host them.
 5. Update the release workflow and source-side sync gate to watch both the build script and the overlay directory.
 6. If the published marketplace repo is mid-migration, make the automation prefer the canonical marketplace manifest path/schema (`.github/plugin/marketplace.json`, `metadata.version`) but tolerate the legacy path/schema (`marketplace.json`, `version`) until the published repo is updated.
 
 ## Why
 
 - Preserves the “copy validated templates” discipline without forcing the published repo to be the only authoring surface.
-- Lets release-time packaging reuse the exact publish output that other distributions already trust.
+- Avoids pushing oversized release binaries into the published marketplace repo.
 - Keeps plugin-specific helper scripts versioned in the source repo, where product/release changes are made.
 - Lets source automation become more spec-compliant without forcing an all-at-once published-repo migration.
 
 ## Example
 
-- `scripts/Build-Plugins.ps1` copies `../mcp-server-excel-plugins/plugins/excel-cli`, applies `.github/plugins/excel-cli/`, and bundles `plugin-cli-publish/excelcli.exe` into `plugins/excel-cli/bin/`.
-- `publish-plugins.yml` stages the self-contained CLI with `dotnet publish ... --output source\plugin-cli-publish` before invoking `Build-Plugins.ps1`.
+- `scripts/Build-Plugins.ps1` copies `../mcp-server-excel-plugins/plugins/excel-cli`, applies `.github/plugins/excel-cli/`, and refreshes the skill content without adding release binaries.
+- `publish-plugins.yml` can publish the plugin bundle directly after `Build-Plugins.ps1` because the standalone CLI remains distributed through GitHub Releases and NuGet.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This package provides both **CLI** and **MCP Server** interfaces. Choose based o
 | **MCP Server** | Conversational AI (Claude Desktop, VS Code Chat) | Rich tool discovery, persistent connection. Better for interactive, exploratory workflows. |
 
 **Installation:**
-- **CLI via Copilot plugin** (Recommended for Copilot CLI): Install the `excel-cli` plugin — bundles `excelcli.exe` and the `excel-cli` skill together
+- **CLI via Copilot plugin** (Recommended for Copilot CLI): Install the `excel-cli` plugin for skill guidance, then install `excelcli` separately
 - **CLI Standalone**: Download ZIP from [releases](https://github.com/sbroenne/mcp-server-excel/releases/latest) or install via NuGet
 - **Skill only**: Install the `excel-cli` skill separately when your agent already has `excelcli` available on PATH
 - **MCP Server**: Download from releases or install VS Code Extension
@@ -135,11 +135,11 @@ copilot plugin marketplace add sbroenne/mcp-server-excel-plugins
 
 # Install one or both plugins with Copilot CLI
 copilot plugin install excel-mcp@mcp-server-excel-plugins   # For conversational AI
-copilot plugin install excel-cli@mcp-server-excel-plugins   # For scripting / coding agents (bundles excelcli.exe)
+copilot plugin install excel-cli@mcp-server-excel-plugins   # For scripting / coding agents
 ```
 
 - **`excel-mcp`** — MCP-server-centric workflows
-- **`excel-cli`** — token-efficient CLI workflows with bundled self-contained `excelcli.exe` (no .NET runtime required)
+- **`excel-cli`** — token-efficient CLI workflow guidance; install `excelcli` separately from the release ZIP or NuGet tool
 - Install **either plugin or both**, depending on your agent surface and workflow
 
 The published repo [`sbroenne/mcp-server-excel-plugins`](https://github.com/sbroenne/mcp-server-excel-plugins) is the actual Copilot CLI marketplace. This source repo is **not** itself a marketplace; `.github/plugins/` only contains source-owned overlay files that the publish workflow copies into the published plugin directories.
@@ -148,11 +148,7 @@ These are **GitHub Copilot marketplace packages**, not a generic cross-tool inst
 
 These plugins are republished automatically after each successful ExcelMcp release by a follow-on workflow that uses a stored cross-repo token scoped to the published marketplace repo. That publish path is sync-gated (no downstream republish when plugin-facing install artifacts did not change), keeps downgrade/tag mismatches blocked, and still exposes a manual maintainer re-sync path for repair/replay scenarios.
 
-After installing `excel-cli`, run the bundled one-time helper to expose the plugin-shipped CLI on PATH:
-
-```powershell
-pwsh -ExecutionPolicy Bypass -File "$env:USERPROFILE\.copilot\installed-plugins\mcp-server-excel-plugins\excel-cli\bin\install-global.ps1"
-```
+The `excel-cli` plugin is skill-only. Install `excelcli` separately from the standalone ZIP or NuGet tool when you need the command on PATH.
 
 **📖 [Plugin Installation Guide →](docs/INSTALLATION.md#github-copilot-plugins-alternative-installation)** | **[Published Marketplace Repo →](https://github.com/sbroenne/mcp-server-excel-plugins)** | **[VS Code Agent Plugins →](https://code.visualstudio.com/docs/copilot/customization/agent-plugins)** | **[Claude Plugins Reference →](https://code.claude.com/docs/en/plugins-reference)**
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -33,7 +33,7 @@ Use this order to avoid setup confusion:
    - **GitHub Copilot Plugins** (Copilot CLI users) — marketplace installation
    - **Manual MCP setup** (other MCP clients like Cursor, Windsurf)
 2. **Validate MCP setup** (run the quick test prompt in Step 4 of manual setup, or test in your client after extension/MCPB/plugin install)
-3. **Optional:** install CLI (`excelcli`) for scripting/RPA (auto-included with Copilot CLI plugins)
+3. **Optional:** install CLI (`excelcli`) for scripting/RPA
 4. **Optional:** install agent skills separately for non-extension environments
 
 ### GitHub Copilot Plugins (Easiest for Copilot CLI Users)
@@ -48,11 +48,12 @@ copilot plugin marketplace add sbroenne/mcp-server-excel-plugins
 copilot plugin install excel-mcp@sbroenne/mcp-server-excel-plugins
 ```
 
-**Excel CLI** (Skill + bundled CLI for coding agents):
+**Excel CLI** (Skill for coding agents):
 ```powershell
 copilot plugin install excel-cli@sbroenne/mcp-server-excel-plugins
-pwsh -File "$env:USERPROFILE\.copilot\installed-plugins\mcp-server-excel-plugins\excel-cli\bin\install-global.ps1"
 ```
+
+Install `excelcli` separately from the standalone ZIP or NuGet tool if you want the command on PATH.
 
 Both plugins are maintained in [`sbroenne/mcp-server-excel-plugins`](https://github.com/sbroenne/mcp-server-excel-plugins) and auto-updated after each release.
 
@@ -349,10 +350,10 @@ copilot plugin install excel-cli@mcp-server-excel-plugins
 ### One-time post-install steps
 
 - **`excel-mcp`** — follow the plugin README if you want to merge the bundled MCP config into your user-level Copilot config.
-- **`excel-cli`** — the plugin now ships a self-contained `excelcli.exe` deliverable (no .NET runtime required). Run the bundled helper once to expose it on PATH:
+- **`excel-cli`** — the plugin is skill-only. Install `excelcli` separately from the standalone ZIP or NuGet tool if you want the command on PATH:
 
 ```powershell
-pwsh -ExecutionPolicy Bypass -File "$env:USERPROFILE\.copilot\installed-plugins\mcp-server-excel-plugins\excel-cli\bin\install-global.ps1"
+dotnet tool install --global Sbroenne.ExcelMcp.CLI
 excelcli --version
 ```
 
@@ -365,7 +366,7 @@ excelcli --version
 
 > **Source-layout note:** This source repo is not itself a Copilot CLI marketplace. The `.github/plugins/` folders are source-owned overlays that the publish workflow copies into the published marketplace repo.
 
-The plugins are republished automatically after every successful ExcelMcp release by a follow-up workflow that uses a stored cross-repo PAT scoped to the published marketplace repo. That publish path is sync-gated (so unchanged plugin-facing releases do not force a republish), keeps downgrade/tag mismatch guards in place, stages the self-contained `excelcli.exe` publish output into the `excel-cli` plugin, and retains a manual maintainer re-sync path for repair/replay scenarios. If a fresh GitHub release is visible but the plugin marketplace is still catching up, wait for the follow-up **Publish Plugins** workflow to finish.
+The plugins are republished automatically after every successful ExcelMcp release by a follow-up workflow that uses a stored cross-repo PAT scoped to the published marketplace repo. That publish path is sync-gated (so unchanged plugin-facing releases do not force a republish), keeps downgrade/tag mismatch guards in place, and retains a manual maintainer re-sync path for repair/replay scenarios. If a fresh GitHub release is visible but the plugin marketplace is still catching up, wait for the follow-up **Publish Plugins** workflow to finish.
 
 ---
 

--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -12,7 +12,7 @@ All ExcelMcp components are released together with a single version tag:
 | **CLI** | Standalone exe ZIP | NuGet (.NET tool) | `excelcli.exe` — no .NET runtime required |
 | **VS Code Extension** | VSIX + Marketplace | — | Self-contained — bundles MCP Server + CLI + skills |
 | **MCPB** | Claude Desktop bundle | — | Self-contained one-click installation |
-| **GitHub Copilot Plugins** | Published plugin marketplace | — | `excel-mcp` and `excel-cli` plugins with bundled binary and skills |
+| **GitHub Copilot Plugins** | Published plugin marketplace | — | `excel-mcp` and `excel-cli` plugins with MCP config and skills |
 | **Agent Skills** | GitHub Release ZIP | Direct skill extraction | Reusable skill packages for AI coding assistants (`npx skills add`) |
 
 ## Unified Release Workflow
@@ -27,7 +27,6 @@ When you run the release workflow, all components are released together:
 1. **CLI** → Standalone self-contained exe (`excelcli.exe`) shipped as:
    - ZIP file (primary distribution)
    - NuGet package (secondary distribution)
-   - **Bundled inside the `excel-cli` GitHub Copilot plugin** (published by `publish-plugins.yml`)
 2. **MCP Server** → Standalone self-contained exe (`mcp-excel.exe`) + ZIP [primary] + NuGet pack [secondary]
 3. **VS Code Extension** → Self-contained VSIX (bundles both exes + skills) → VS Code Marketplace
 4. **MCPB** → Claude Desktop bundle (`.mcpb` file)
@@ -103,7 +102,7 @@ The main release workflow runs automatically (10 jobs), then the plugin publish 
 7. **publish-mcp-registry** (10-30 min) → Waits for NuGet propagation, updates MCP Registry
 8. **publish** → Publishes to NuGet.org and VS Code Marketplace
 9. **create-release** → Creates GitHub Release with all artifacts, then creates auto-PR to update CHANGELOG
-10. **publish-plugins.yml** (follow-on workflow) → Sync-gated republish of `excel-mcp` and `excel-cli` to `sbroenne/mcp-server-excel-plugins`, including the bundled self-contained `excelcli.exe` inside the `excel-cli` plugin when plugin-facing install artifacts changed
+10. **publish-plugins.yml** (follow-on workflow) → Sync-gated republish of `excel-mcp` and `excel-cli` to `sbroenne/mcp-server-excel-plugins` when plugin-facing install artifacts changed
 
 ### 4. Verify Release
 
@@ -130,7 +129,7 @@ The `publish-plugins.yml` workflow automatically publishes updated plugins when 
     - Copies validated plugin structure from the published marketplace repo
     - Applies source-owned plugin overlays from `.github/plugins/` (overlay content only; not standalone plugin roots)
     - Updates version in plugin.json and version.txt
-    - Bundles the self-contained CLI publish output into `plugins/excel-cli/bin/`
+    - Keeps `excel-cli` as a skill-only plugin; standalone CLI distribution remains the release ZIP/NuGet tool
     - Refreshes skill content (always uses latest source)
 4. **Checks published-repo guards** before mutation, reading the current published plugin version from the canonical marketplace manifest when present (or the legacy root manifest before migration):
     - Rejects explicit tag/version mismatches

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -168,20 +168,16 @@ copilot plugin marketplace add sbroenne/mcp-server-excel-plugins
 
 # Install one or both plugins with Copilot CLI
 copilot plugin install excel-mcp@mcp-server-excel-plugins
-copilot plugin install excel-cli@mcp-server-excel-plugins   # Bundles excelcli.exe
+copilot plugin install excel-cli@mcp-server-excel-plugins
 ```
 
 - **`excel-mcp`** — Best for conversational Excel workflows through the MCP server
-- **`excel-cli`** — Best for token-efficient scripting and coding-agent workflows with bundled self-contained `excelcli.exe`
+- **`excel-cli`** — Best for token-efficient scripting and coding-agent workflows; install `excelcli` separately from the release ZIP or NuGet tool
 - Install **either one or both** depending on how you work
 
 These are **GitHub Copilot marketplace packages**. The commands above are the documented Copilot CLI install path. VS Code also supports agent plugins in preview, and Claude has its own plugin system, but those surfaces use their own enablement and installation flows. The published marketplace repo is refreshed automatically after each ExcelMcp release by a follow-on workflow that uses a stored cross-repo PAT scoped to that repo. That publish path is sync-gated, blocks downgrade/tag mismatches, and still keeps a manual maintainer re-sync path for repair/replay scenarios. The published repo is the marketplace; this source repo only owns the release inputs and overlay files used to build those published plugin directories.
 
-After installing `excel-cli`, run the bundled one-time helper to expose the plugin-shipped CLI on PATH:
-
-```powershell
-pwsh -ExecutionPolicy Bypass -File "$env:USERPROFILE\.copilot\installed-plugins\mcp-server-excel-plugins\excel-cli\bin\install-global.ps1"
-```
+The `excel-cli` plugin is skill-only. Install `excelcli` separately from the standalone ZIP or NuGet tool when you need the command on PATH.
 
 **Manual Installation:**
 ```powershell

--- a/scripts/Build-Plugins.ps1
+++ b/scripts/Build-Plugins.ps1
@@ -11,7 +11,6 @@
     3. Apply source-owned plugin overlays from .github/plugins/ (overlay content only, not standalone plugin roots)
     4. Refresh skills content from source repo
     5. Refresh shared references from source repo
-    6. Bundle the released/self-contained excelcli publish output into the excel-cli plugin
 
     WHY COPY NOT GENERATE:
     - Phase 1/2 created validated bin scripts, READMEs, configs
@@ -32,9 +31,6 @@
 .PARAMETER PluginTemplateDir
     Validated plugin templates source. Default: ../mcp-server-excel-plugins/plugins/ in the published marketplace repo.
 
-.PARAMETER CliPublishDir
-    Directory containing the self-contained CLI publish output (must contain excelcli.exe).
-
 .EXAMPLE
     ./Build-Plugins.ps1
 
@@ -44,8 +40,7 @@
 param(
     [string]$Version = $null,
     [string]$OutputDir = "plugins",
-    [string]$PluginTemplateDir = $null,
-    [string]$CliPublishDir = $null
+    [string]$PluginTemplateDir = $null
 )
 
 $ErrorActionPreference = "Stop"
@@ -117,49 +112,6 @@ function Apply-PluginOverlay {
 
     Write-Host "  Applying source-owned plugin overlay..." -ForegroundColor Cyan
     Copy-DirectoryFiles -SourceDir $overlaySource -DestinationDir $DestinationDir
-}
-
-function Resolve-CliPublishDir {
-    param(
-        [string]$RequestedPath
-    )
-
-    $candidates = @()
-
-    if ($RequestedPath) {
-        $candidates += $RequestedPath
-    }
-
-    $candidates += @(
-        (Join-Path $RepoRoot "plugin-cli-publish"),
-        (Join-Path $RepoRoot "cli-publish"),
-        (Join-Path $RepoRoot "artifacts\pre-commit\cli-publish"),
-        (Join-Path $RepoRoot "src\ExcelMcp.CLI\bin\Release\net10.0-windows")
-    )
-
-    foreach ($candidate in $candidates | Select-Object -Unique) {
-        if ($candidate -and (Test-Path (Join-Path $candidate "excelcli.exe"))) {
-            return (Resolve-Path $candidate).Path
-        }
-    }
-
-    Write-Error @"
-❌ CLI publish output not found.
-
-Build-Plugins.ps1 now bundles the actual excelcli deliverable into the excel-cli plugin.
-Provide -CliPublishDir pointing at a self-contained publish directory, or build one first:
-
-  dotnet publish src\ExcelMcp.CLI\ExcelMcp.CLI.csproj `
-    --configuration Release `
-    --runtime win-x64 `
-    --self-contained true `
-    -p:PublishSingleFile=true `
-    -p:IncludeNativeLibrariesForSelfExtract=true `
-    -p:PublishTrimmed=false `
-    -p:PublishReadyToRun=false `
-    --output .\plugin-cli-publish
-"@
-    exit 1
 }
 
 Write-Host "`n=== Building Copilot CLI Plugins v$Version ===" -ForegroundColor Green
@@ -248,14 +200,6 @@ $pluginJson | ConvertTo-Json -Depth 10 | Set-Content $PluginJsonPath -Encoding U
 Write-Host "  Updating version.txt to $Version..." -ForegroundColor Cyan
 Set-Content -Path (Join-Path $OutputCli "version.txt") -Value $Version -Encoding UTF8 -NoNewline
 
-Write-Host "  Bundling excelcli deliverable..." -ForegroundColor Cyan
-$ResolvedCliPublishDir = Resolve-CliPublishDir -RequestedPath $CliPublishDir
-$CliBinDir = Join-Path $OutputCli "bin"
-if (-not (Test-Path $CliBinDir)) {
-    New-Item -ItemType Directory -Path $CliBinDir -Force | Out-Null
-}
-Copy-Item -Path (Join-Path $ResolvedCliPublishDir "*") -Destination $CliBinDir -Recurse -Force
-
 Write-Host "  Refreshing excel-cli skill content..." -ForegroundColor Cyan
 $SourceSkillCli = Join-Path $SkillsDir "excel-cli\SKILL.md"
 $DestSkillCli = Join-Path $OutputCli "skills\excel-cli\SKILL.md"
@@ -284,7 +228,7 @@ Write-Host "Output:  $OutputDir"
 Write-Host ""
 Write-Host "Plugins:" -ForegroundColor Cyan
 Write-Host "  ✓ excel-mcp (MCP Server + Skill)" -ForegroundColor Green
-Write-Host "  ✓ excel-cli (CLI Skill + bundled excelcli.exe)" -ForegroundColor Green
+Write-Host "  ✓ excel-cli (CLI Skill only; install excelcli separately)" -ForegroundColor Green
 Write-Host ""
 Write-Host "Test locally:" -ForegroundColor Yellow
 Write-Host "  copilot plugin install $OutputDir\excel-mcp"

--- a/skills/excel-cli/README.md
+++ b/skills/excel-cli/README.md
@@ -86,21 +86,19 @@ excel-cli/
 
 ## CLI Tool Installation
 
-The **GitHub Copilot `excel-cli` plugin** now bundles the self-contained `excelcli.exe` deliverable (no .NET runtime required for that install path).
+The **GitHub Copilot `excel-cli` plugin** installs the skill package only.
 
 ### Via GitHub Copilot Plugin
 
-If you install `excel-cli` through the GitHub Copilot plugin marketplace, the plugin ships the actual CLI in its `bin\` folder. Run the bundled helper once to expose it on PATH:
+If you install `excel-cli` through the GitHub Copilot plugin marketplace, install `excelcli` separately and keep using the plugin for workflow guidance:
 
 ```powershell
-pwsh -ExecutionPolicy Bypass -File "$env:USERPROFILE\.copilot\installed-plugins\mcp-server-excel-plugins\excel-cli\bin\install-global.ps1"
+dotnet tool install --global Sbroenne.ExcelMcp.CLI
 ```
 
 ### Via Skill Package
 
 Plain skill-only installs still need `excelcli` available separately on PATH (for example via the standalone ZIP or the NuGet tool below).
-
-If you reinstall the plugin to a different location, re-run `install-global.ps1` so the shim points at the current bundled binary.
 
 ### Manual Download (Standalone)
 


### PR DESCRIPTION
## Summary
- keep the published \\xcel-cli\\ plugin skill-only instead of copying the self-contained CLI binary into the marketplace repo
- remove the extra CLI publish/bundling step from \\publish-plugins.yml\\ and update \\Build-Plugins.ps1\\
- update plugin/install/release docs to point users at the standalone CLI ZIP or NuGet tool for \\xcelcli\\

## Validation
- ran \\scripts/Build-Plugins.ps1 -Version 1.8.46 -PluginTemplateDir D:\\\\source\\\\mcp-server-excel\\\\plugins-repo-inspect\\\\plugins -OutputDir .\\\\plugins-test\\ successfully
- verified the built \\plugins-test/excel-cli\\ bundle does not contain \\xcelcli.exe\\
- verified the built \\xcel-cli\\ plugin footprint is small (~168 KB total) instead of a 175 MB binary payload
- ran \\git diff --check\\
- parsed \\scripts/Build-Plugins.ps1\\ successfully with PowerShell AST

## Why
The replayed \\publish-plugins\\ workflow now gets past the earlier PowerShell exit-code bug, but the push still fails because GitHub rejects the 175 MB \\plugins/excel-cli/bin/excelcli.exe\\ payload (GH001). Keeping the Copilot plugin skill-only restores a publishable marketplace repo while preserving standalone CLI distribution through existing release artifacts.