### PR TITLE
docs(gh-pages): add Copilot CLI Plugin install button to hero grid

### DIFF
--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -39,6 +39,10 @@ canonical_url: "https://excelmcpserver.dev/"
     <a href="https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp" class="button-link">Install Extension</a>
   </div>
   <div style="text-align: center;">
+    <p><strong>Copilot CLI Plugin</strong></p>
+    <a href="/installation/#copilot-cli-install-path" class="button-link">Plugin Marketplace</a>
+  </div>
+  <div style="text-align: center;">
     <p><strong>Claude Desktop</strong></p>
     <a href="https://github.com/sbroenne/mcp-server-excel/releases/latest" class="button-link">One-Click Install</a>
   </div>


### PR DESCRIPTION
Adds the Copilot CLI Plugin tile to the hero quick-install grid on the landing page, alongside VS Code extension and Claude Desktop options.

This surfaces the plugin marketplace install path for CLI users at first glance.