### PR TITLE
Revert excelcli daemon startup retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **Reverted CLI daemon auto-start retry behavior** (#627): Removed the retry loop and wrapped cancellation/error-message changes from the previous `excelcli` daemon startup update, restoring the single-start behavior while preserving the existing daemon readiness checks.
+
 - **Data Model MSOLAP class-registration diagnostics now identify the provider Excel uses** (#624): `datamodel.evaluate` and `datamodel.execute-dmv` previously mapped every `0x80040154` from Excel's Data Model ADO connection to a generic "MSOLAP is not installed" message. The error now reports the specific provider parsed from `ModelConnection.ADOConnection.ConnectionString`, redacts connection-string credentials, and explains that Excel's COM provider selection is not affected by copying ADOMD/MSOLAP DLLs beside the server executable.
 
 - **CLI skill guidance now matches the actual CLI surface**: Removed MCP-style shared reference files from the `excel-cli` skill package so agents no longer see examples like `range_format(action: ...)` or underscore tool names when they should use `excelcli -q <command> <action> --kebab-case-flags`. The CLI skill now promotes `references/cli-commands.md` as the command/action/parameter source of truth, documents the real command-group naming convention, and packaging scripts no longer copy MCP shared references into the CLI skill. Added skill-generation regressions to keep the CLI references CLI-specific.

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonAutoStart.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonAutoStart.cs
@@ -16,8 +16,6 @@ internal static class DaemonAutoStart
     internal static readonly TimeSpan StartupReadyConnectTimeout = TimeSpan.FromSeconds(1);
     internal static readonly TimeSpan StartupReadyRetryInterval = TimeSpan.FromMilliseconds(250);
     internal static readonly TimeSpan StartupReadyTimeout = TimeSpan.FromSeconds(10);
-    internal static readonly int StartupMaxAttempts = 2; // one retry after the first attempt
-    internal static readonly TimeSpan StartupRetryDelay = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// Gets the pipe name for the CLI daemon (supports env var override for testing).
@@ -76,43 +74,11 @@ internal static class DaemonAutoStart
             // Daemon exited while we waited — start a replacement.
         }
 
-        // No daemon running — start it.
-        // Retry on fast-exit failures (daemon exited before becoming ready), which
-        // handles transient issues such as security software scanning the binary on first
-        // launch.  TimeoutException (daemon started but took too long to become responsive)
-        // is not retried — that reflects a persistent condition and should surface immediately.
-        for (var attempt = 0; attempt < StartupMaxAttempts; attempt++)
-        {
-            if (attempt > 0)
-                await Task.Delay(StartupRetryDelay, cancellationToken);
+        // No daemon running — start it
+        await StartDaemonAsync(pipeName, cancellationToken);
 
-            var isLastAttempt = attempt == StartupMaxAttempts - 1;
-            try
-            {
-                await StartDaemonAsync(pipeName, cancellationToken);
-
-                // Return new client connected to the now-running daemon
-                return new ServiceClient(pipeName);
-            }
-            catch (TimeoutException)
-            {
-                throw; // Timeout is not transient — surface immediately without retry
-            }
-            catch (InvalidOperationException ex) when (isLastAttempt)
-            {
-                throw new InvalidOperationException(
-                    $"{ex.Message} (daemon startup failed after {StartupMaxAttempts} attempt(s); " +
-                    "run 'excelcli service stop' to clear any stale state, then retry)",
-                    ex);
-            }
-            catch (InvalidOperationException)
-            {
-                // Transient fast-exit on a non-final attempt — wait StartupRetryDelay then retry
-            }
-        }
-
-        // Unreachable: the last-attempt catch always rethrows.
-        throw new System.Diagnostics.UnreachableException();
+        // Return new client connected to the now-running daemon
+        return new ServiceClient(pipeName);
     }
 
     /// <summary>
@@ -185,10 +151,6 @@ internal static class DaemonAutoStart
                     return;
                 }
             }
-        }
-        catch (OperationCanceledException)
-        {
-            throw; // Don't wrap cancellation — let it propagate to the caller
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Reverts PR #627's excelcli daemon auto-start retry behavior
- Restores the previous single-start daemon startup path
- Adds a changelog entry for the patch release notes

## Validation
- dotnet build src\ExcelMcp.CLI\ExcelMcp.CLI.csproj -c Release --no-restore
- dotnet test tests\ExcelMcp.CLI.Tests\ExcelMcp.CLI.Tests.csproj --filter "Feature=ServiceDaemon" --no-restore
- pre-commit hook gates passed, including release build and smoke tests