### PR TITLE
Require opt-in for remote formula formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **Remote DAX and M formatting is now explicit opt-in** (#601): `powerquery create/update` and `datamodel create-measure/update-measure` no longer send formulas to remote formatter services by default. M code and DAX formulas are preserved as provided (with Excel locale separator translation for DAX), and callers must set `formatMCode=true` or `formatDax=true` to opt in to remote formatting via powerqueryformatter.com or daxformatter.com.
+
 - **CLI daemon startup stability**: Hardened `excelcli` daemon startup against stale named mutex handles and simultaneous `service start` calls. Startup is now serialized with a process-wide semaphore, daemon liveness checks ignore unowned/abandoned mutexes, and the daemon can take over stale mutex handles instead of exiting as a duplicate instance. Added ServiceDaemon regressions for stale mutex recovery and concurrent start requests, plus a parallel multi-file CLI E2E workflow that exercises independent workbook sessions through the same daemon.
 
 - **Reverted CLI daemon auto-start retry behavior** (#627): Removed the retry loop and wrapped cancellation/error-message changes from the previous `excelcli` daemon startup update, restoring the single-start behavior while preserving the existing daemon readiness checks.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -28,8 +28,8 @@
 **Atomic Operations** - Single-call workflows:
 - **List:** List all Power Query queries in workbook
 - **View:** View the M code of a Power Query
-- **Create:** Import + load in one operation (atomic workflow) with automatic formatting
-- **Update:** Update M code with automatic formatting and auto-refresh
+- **Create:** Import + load in one operation (atomic workflow), preserving M code by default
+- **Update:** Update M code, preserving M code by default, with optional auto-refresh
 - **Rename:** Rename a Power Query (trim + case-insensitive uniqueness check)
 - **Refresh:** Refresh a Power Query with timeout detection
 - **Refresh All:** Batch refresh all queries in workbook
@@ -39,7 +39,7 @@
 - **Delete:** Remove Power Query from workbook
 - **Evaluate:** Execute M code directly and return results (without creating a permanent query)
 
-**Automatic M-Code Formatting:** M code is automatically formatted on write operations (Create, Update) using the powerqueryformatter.com API (by mogularGmbH, MIT License). Read operations return M code as stored in Excel. Formatting adds ~100-500ms network latency but dramatically improves readability with proper indentation, spacing, and line breaks. Graceful fallback returns original M code if formatting fails.
+**M-Code Formatting:** M code is preserved exactly by default. Create and Update can opt in to remote formatting with `formatMCode=true`, which sends M code to powerqueryformatter.com and adds network latency. If remote formatting fails, the original M code is saved unchanged.
 
 ---
 
@@ -51,8 +51,8 @@
 - **List Columns:** List columns for a table
 - **List Measures:** List all DAX measures with formula previews
 - **Read Info:** Get comprehensive model information
-- **Create Measure:** Create new DAX measure with automatic formatting (format types: Currency, Percentage, Decimal, General)
-- **Update Measure:** Modify existing measure with automatic formatting
+- **Create Measure:** Create new DAX measure, preserving DAX by default (format types: Currency, Percentage, Decimal, General)
+- **Update Measure:** Modify existing measure, preserving DAX by default
 - **Delete Measure:** Remove measure from model
 - **Delete Table:** Remove table from Data Model
 - **List Relationships:** View all table relationships
@@ -65,7 +65,7 @@
 - **Evaluate:** Execute DAX EVALUATE queries and return tabular results (for ad-hoc analysis)
 - **Execute DMV:** Execute SQL-like DMV (Dynamic Management View) queries for metadata discovery
 
-**Automatic DAX Formatting:** DAX formulas are automatically formatted on write operations (CreateMeasure, UpdateMeasure) using the official Dax.Formatter library (SQLBI). Read operations return raw DAX as stored in Excel. Formatting adds ~100-500ms network latency but dramatically improves readability. Graceful fallback returns original DAX if formatting fails.
+**DAX Formatting:** DAX formulas are preserved exactly by default, subject to Excel locale separator translation. CreateMeasure and UpdateMeasure can opt in to remote formatting with `formatDax=true`, which sends DAX to daxformatter.com and adds network latency. If remote formatting fails, the original DAX is saved unchanged.
 
 **Note:** DAX calculated columns not supported - use Excel UI for calculated columns
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 **25 specialized tools with 230 operations:**
 
 - 🔄 **Power Query** (1 tool, 12 ops) - Atomic workflows, M code management, load destinations
-- 📊 **Data Model/DAX** (2 tools, 19 ops) - Measures with auto-formatted DAX, relationships, model structure
+- 📊 **Data Model/DAX** (2 tools, 19 ops) - Measures, relationships, model structure
 - 🎨 **Excel Tables** (2 tools, 27 ops) - Lifecycle, filtering, sorting, structured references
 - 📈 **PivotTables** (3 tools, 30 ops) - Creation, fields, aggregations, calculated members/fields
 - 📉 **Charts** (2 tools, 29 ops) - Create, configure, series, formatting, data labels, trendlines

--- a/skills/excel-cli/references/cli-commands.md
+++ b/skills/excel-cli/references/cli-commands.md
@@ -143,7 +143,7 @@ Data connections (OLEDB, ODBC, ODC import). TEXT/WEB/CSV: Use powerquery instead
 
 ### datamodel
 
-Data Model (Power Pivot) - DAX measures and table management. CRITICAL: WORKSHEET TABLES AND DATA MODEL ARE SEPARATE! - After table append changes, Data Model still has OLD data - MUST call refresh to sync changes - Power Query refresh auto-syncs (no manual refresh needed) PREREQUISITE: Tables must be added to the Data Model first. Use table add-to-datamodel for worksheet tables, or powerquery to import and load data directly to the Data Model. DAX MEASURES: - Create with DAX formulas like 'SUM(Sales[Amount])' - DAX formulas are auto-formatted on CREATE/UPDATE via Dax.Formatter (SQLBI) - Read operations return raw DAX as stored DAX EVALUATE QUERIES: - Use evaluate to execute DAX EVALUATE queries against the Data Model - Returns tabular results from queries like 'EVALUATE TableName' - Supports complex DAX: SUMMARIZE, FILTER, CALCULATETABLE, TOPN, etc. DMV (DYNAMIC MANAGEMENT VIEW) QUERIES: - Use execute-dmv to query Data Model metadata via SQL-like syntax - Syntax: SELECT * FROM $SYSTEM.SchemaRowset (ONLY SELECT * supported) - Use DISCOVER_SCHEMA_ROWSETS to list all available DMVs Use datamodelrel for relationships between tables.
+Data Model (Power Pivot) - DAX measures and table management. CRITICAL: WORKSHEET TABLES AND DATA MODEL ARE SEPARATE! - After table append changes, Data Model still has OLD data - MUST call refresh to sync changes - Power Query refresh auto-syncs (no manual refresh needed) PREREQUISITE: Tables must be added to the Data Model first. Use table add-to-datamodel for worksheet tables, or powerquery to import and load data directly to the Data Model. DAX MEASURES: - Create with DAX formulas like 'SUM(Sales[Amount])' - DAX formulas are preserved exactly by default - Set formatDax=true only with user consent; it sends formulas to daxformatter.com - Read operations return raw DAX as stored DAX EVALUATE QUERIES: - Use evaluate to execute DAX EVALUATE queries against the Data Model - Returns tabular results from queries like 'EVALUATE TableName' - Supports complex DAX: SUMMARIZE, FILTER, CALCULATETABLE, TOPN, etc. DMV (DYNAMIC MANAGEMENT VIEW) QUERIES: - Use execute-dmv to query Data Model metadata via SQL-like syntax - Syntax: SELECT * FROM $SYSTEM.SchemaRowset (ONLY SELECT * supported) - Use DISCOVER_SCHEMA_ROWSETS to list all available DMVs Use datamodelrel for relationships between tables.
 
 **Actions:** `list-tables`, `list-columns`, `read-table`, `read-info`, `list-measures`, `read`, `delete-measure`, `delete-table`, `rename-table`, `refresh`, `create-measure`, `update-measure`, `evaluate`, `execute-dmv`
 
@@ -154,9 +154,10 @@ Data Model (Power Pivot) - DAX measures and table management. CRITICAL: WORKSHEE
 | `--old-name` | Current name of the table (required for: rename-table) |
 | `--new-name` | New name for the table (required for: rename-table) |
 | `--timeout` | Optional: Timeout for the refresh operation |
-| `--dax-formula` | DAX formula for the measure (will be auto-formatted) (required for: create-measure) |
+| `--dax-formula` | DAX formula for the measure (required for: create-measure) |
 | `--format-type` | Optional: Format type (Currency, Decimal, Percentage, General) |
 | `--description` | Optional: Description of the measure |
+| `--format-dax` | Whether to send the DAX formula to the remote daxformatter.com service before saving. Defaults to false to preserve privacy. |
 | `--dax-query` | DAX EVALUATE query (e.g., "EVALUATE 'TableName'" or "EVALUATE SUMMARIZE(...)") (required for: evaluate) |
 | `--dmv-query` | DMV query in SQL-like syntax (e.g., "SELECT * FROM $SYSTEM.TMSCHEMA_TABLES") (required for: execute-dmv) |
 
@@ -275,7 +276,7 @@ PivotTable field management: add/remove/configure fields, filtering, sorting, an
 
 ### powerquery
 
-Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACTICE): 1. evaluate - Test M code WITHOUT persisting (catches syntax errors, validates sources, shows data preview) 2. create/update - Store VALIDATED query in workbook 3. refresh/load-to - Load data to destination Skip evaluate only for trivial literal tables. IF CREATE/UPDATE FAILS: Use evaluate to get the actual M engine error message, fix code, retry. DATETIME COLUMNS: Always include Table.TransformColumnTypes() in M code to set column types explicitly. Without explicit types, dates may be stored as numbers and Data Model relationships may fail. DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'. Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60 or similar. timeout=0 or omitted uses the 30 min default.
+Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACTICE): 1. evaluate - Test M code WITHOUT persisting (catches syntax errors, validates sources, shows data preview) 2. create/update - Store VALIDATED query in workbook 3. refresh/load-to - Load data to destination Skip evaluate only for trivial literal tables. IF CREATE/UPDATE FAILS: Use evaluate to get the actual M engine error message, fix code, retry. DATETIME COLUMNS: Always include Table.TransformColumnTypes() in M code to set column types explicitly. Without explicit types, dates may be stored as numbers and Data Model relationships may fail. DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'. Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures. M-CODE: Preserved exactly by default. Set formatMCode=true only with user consent; it sends M code to powerqueryformatter.com. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60 or similar. timeout=0 or omitted uses the 30 min default.
 
 **Actions:** `list`, `view`, `refresh`, `get-load-config`, `delete`, `create`, `update`, `load-to`, `refresh-all`, `rename`, `unload`, `evaluate`
 
@@ -288,6 +289,7 @@ Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACT
 | `--target-sheet` | Target worksheet name (required for LoadToTable and LoadToBoth; defaults to query name when omitted) |
 | `--target-cell-address` | Optional target cell address for worksheet loads (e.g., "B5"). Required when loading to an existing worksheet with other data. |
 | `--refresh` | Whether to refresh data after update (default: true) |
+| `--format-m-code` | Whether to send M code to the remote powerqueryformatter.com service before saving. Defaults to false to preserve privacy. |
 | `--old-name` | Current name of the query (required for: rename) |
 | `--new-name` | New name for the query (required for: rename) |
 

--- a/skills/excel-mcp/references/datamodel.md
+++ b/skills/excel-mcp/references/datamodel.md
@@ -64,16 +64,16 @@ datamodel(evaluate, daxQuery="...")               # Returns NEW values!
 | External file (CSV, etc.) | powerquery with loadDestination='data-model' |
 | Database/web source | powerquery with loadDestination='data-model' |
 
-**Automatic DAX Formatting**:
+**DAX Formatting**:
 
-DAX formulas are automatically formatted on WRITE operations only (create-measure, update-measure) using the official Dax.Formatter library (SQLBI). Read operations (list-measures, read) return raw DAX as stored in Excel. Formatting adds ~100-500ms network latency per write operation but ensures consistent, professional code formatting. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
+DAX formulas are preserved exactly by default on WRITE operations (create-measure, update-measure), subject to Excel locale separator translation. Set `formatDax=true` only with explicit user consent; it sends DAX to daxformatter.com. Remote formatting adds ~100-500ms network latency per write operation. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
 
 **Action disambiguation**:
 
 - list-tables: List all tables currently in the Data Model
 - list-measures: List all DAX measures (returns raw DAX from Excel)
-- create-measure: Create a new DAX measure (DAX auto-formatted before saving)
-- update-measure: Modify existing measure's formula/format/description (DAX auto-formatted before saving)
+- create-measure: Create a new DAX measure (DAX preserved by default; `formatDax=true` opts into remote formatting)
+- update-measure: Modify existing measure's formula/format/description (DAX preserved by default; `formatDax=true` opts into remote formatting)
 - delete-measure: Remove a measure
 - delete-table: Remove table AND ALL its measures (DESTRUCTIVE!)
 - read-info: Get Data Model metadata (culture, compatibility level)

--- a/skills/excel-mcp/references/powerquery.md
+++ b/skills/excel-mcp/references/powerquery.md
@@ -26,13 +26,13 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 
 ---
 
-**Automatic M-Code Formatting**:
+**M-Code Formatting**:
 
-- Create and Update operations automatically format M code using powerqueryformatter.com API
-- Formatting adds ~100-500ms network latency per call
-- Graceful fallback: returns original M code if formatting service unavailable
+- Create and Update preserve M code exactly by default and do not call remote services
+- Set `formatMCode=true` only with explicit user consent; it sends M code to powerqueryformatter.com
+- Remote formatting adds ~100-500ms network latency per call
+- Graceful fallback: saves original M code if the formatting service is unavailable
 - Read operations (List, View) return M code as stored (no formatting on read)
-- Formatting improves readability with proper indentation, spacing, and line breaks
 
 **Data Model workflow**:
 

--- a/skills/shared/datamodel.md
+++ b/skills/shared/datamodel.md
@@ -64,16 +64,16 @@ datamodel(evaluate, daxQuery="...")               # Returns NEW values!
 | External file (CSV, etc.) | powerquery with loadDestination='data-model' |
 | Database/web source | powerquery with loadDestination='data-model' |
 
-**Automatic DAX Formatting**:
+**DAX Formatting**:
 
-DAX formulas are automatically formatted on WRITE operations only (create-measure, update-measure) using the official Dax.Formatter library (SQLBI). Read operations (list-measures, read) return raw DAX as stored in Excel. Formatting adds ~100-500ms network latency per write operation but ensures consistent, professional code formatting. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
+DAX formulas are preserved exactly by default on WRITE operations (create-measure, update-measure), subject to Excel locale separator translation. Set `formatDax=true` only with explicit user consent; it sends DAX to daxformatter.com. Remote formatting adds ~100-500ms network latency per write operation. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
 
 **Action disambiguation**:
 
 - list-tables: List all tables currently in the Data Model
 - list-measures: List all DAX measures (returns raw DAX from Excel)
-- create-measure: Create a new DAX measure (DAX auto-formatted before saving)
-- update-measure: Modify existing measure's formula/format/description (DAX auto-formatted before saving)
+- create-measure: Create a new DAX measure (DAX preserved by default; `formatDax=true` opts into remote formatting)
+- update-measure: Modify existing measure's formula/format/description (DAX preserved by default; `formatDax=true` opts into remote formatting)
 - delete-measure: Remove a measure
 - delete-table: Remove table AND ALL its measures (DESTRUCTIVE!)
 - read-info: Get Data Model metadata (culture, compatibility level)

--- a/skills/shared/powerquery.md
+++ b/skills/shared/powerquery.md
@@ -26,13 +26,13 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 
 ---
 
-**Automatic M-Code Formatting**:
+**M-Code Formatting**:
 
-- Create and Update operations automatically format M code using powerqueryformatter.com API
-- Formatting adds ~100-500ms network latency per call
-- Graceful fallback: returns original M code if formatting service unavailable
+- Create and Update preserve M code exactly by default and do not call remote services
+- Set `formatMCode=true` only with explicit user consent; it sends M code to powerqueryformatter.com
+- Remote formatting adds ~100-500ms network latency per call
+- Graceful fallback: saves original M code if the formatting service is unavailable
 - Read operations (List, View) return M code as stored (no formatting on read)
-- Formatting improves readability with proper indentation, spacing, and line breaks
 
 **Data Model workflow**:
 

--- a/src/ExcelMcp.ComInterop/Formatting/DaxFormatter.cs
+++ b/src/ExcelMcp.ComInterop/Formatting/DaxFormatter.cs
@@ -3,14 +3,14 @@ using Dax.Formatter;
 namespace Sbroenne.ExcelMcp.ComInterop.Formatting;
 
 /// <summary>
-/// Formats DAX (Data Analysis Expressions) code using the official Dax.Formatter library.
-/// Provides automatic pretty-printing with proper indentation and line breaks.
+/// Formats DAX (Data Analysis Expressions) code using the remote Dax.Formatter service.
+/// Call only after explicit user consent because the DAX formula is sent to daxformatter.com.
 /// </summary>
 /// <remarks>
 /// <para><b>Design Principles:</b></para>
 /// <list type="bullet">
 /// <item>Never throws exceptions - returns original DAX on any failure</item>
-/// <item>Uses official Dax.Formatter NuGet package (by SQLBI)</item>
+/// <item>Uses official Dax.Formatter NuGet package (by SQLBI), which invokes a remote service</item>
 /// <item>Gracefully handles network failures, API errors, and rate limiting</item>
 /// <item>Formatting is best-effort - original DAX is always preserved if formatting fails</item>
 /// </list>
@@ -33,7 +33,7 @@ public static class DaxFormatter
     private static readonly DaxFormatterClient _formatterClient = new();
 
     /// <summary>
-    /// Formats DAX code using the official Dax.Formatter library.
+    /// Formats DAX code using the remote Dax.Formatter service.
     /// </summary>
     /// <param name="daxCode">The DAX code to format</param>
     /// <param name="cancellationToken">Cancellation token for the HTTP request</param>

--- a/src/ExcelMcp.ComInterop/Formatting/MCodeFormatter.cs
+++ b/src/ExcelMcp.ComInterop/Formatting/MCodeFormatter.cs
@@ -4,8 +4,8 @@ using System.Text.Json.Serialization;
 namespace Sbroenne.ExcelMcp.ComInterop.Formatting;
 
 /// <summary>
-/// Formats Power Query M code using the powerqueryformatter.com API.
-/// Provides automatic pretty-printing with proper indentation and line breaks.
+/// Formats Power Query M code using the remote powerqueryformatter.com API.
+/// Call only after explicit user consent because the M code is sent to the service.
 /// </summary>
 /// <remarks>
 /// <para><b>Design Principles:</b></para>
@@ -46,7 +46,7 @@ public static class MCodeFormatter
     };
 
     /// <summary>
-    /// Formats Power Query M code using the powerqueryformatter.com API.
+    /// Formats Power Query M code using the remote powerqueryformatter.com API.
     /// </summary>
     /// <param name="mCode">The M code to format</param>
     /// <param name="cancellationToken">Cancellation token for the HTTP request</param>

--- a/src/ExcelMcp.Core/Commands/DataModel/DataModelCommands.Write.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/DataModelCommands.Write.cs
@@ -202,13 +202,12 @@ public partial class DataModelCommands
 
     /// <inheritdoc />
     public OperationResult CreateMeasure(IExcelBatch batch, string tableName, string measureName,
-                              string daxFormula, string? formatType = null,
-                              string? description = null)
+                               string daxFormula, string? formatType = null,
+                               string? description = null, bool formatDax = false)
     {
-        // Format DAX before saving (outside ExecuteWithRetry for async operation)
-        // Formatting is done synchronously to maintain method signature compatibility
-        // Falls back to original if formatting fails
-        string formattedDax = DaxFormatter.FormatAsync(daxFormula).GetAwaiter().GetResult();
+        string daxToSave = formatDax
+            ? DaxFormatter.FormatAsync(daxFormula).GetAwaiter().GetResult()
+            : daxFormula;
 
         return ExecuteWithRetry(() =>
         {
@@ -247,9 +246,8 @@ public partial class DataModelCommands
                     // Translate DAX formula separators from US format (comma) to locale-specific format
                     // This fixes issues on European locales where semicolon is the list separator
                     // Example: DATEADD(Date[Date], -1, MONTH) → DATEADD(Date[Date]; -1; MONTH) on German Excel
-                    // NOTE: Translation is done on the FORMATTED DAX
                     var daxTranslator = new DaxFormulaTranslator(ctx.App);
-                    string localizedFormula = daxTranslator.TranslateToLocale(formattedDax);
+                    string localizedFormula = daxTranslator.TranslateToLocale(daxToSave);
 
                     // Get ModelMeasures collection from MODEL (not from table!)
                     // Reference: https://learn.microsoft.com/en-us/office/vba/api/excel.model.modelmeasures
@@ -266,7 +264,7 @@ public partial class DataModelCommands
                     newMeasure = measures.Add(
                         measureName,                                        // MeasureName (required)
                         table!,                                             // AssociatedTable (required)
-                        localizedFormula,                                   // Formula (required) - must be valid DAX, formatted and translated for locale
+                        localizedFormula,                                   // Formula (required) - must be valid DAX and translated for locale
                         formatObject!,                                      // FormatInformation (required) - NEVER null/Type.Missing
                         string.IsNullOrEmpty(description) ? Type.Missing : description  // Description (optional)
                     );
@@ -288,17 +286,15 @@ public partial class DataModelCommands
 
     /// <inheritdoc />
     public OperationResult UpdateMeasure(IExcelBatch batch, string measureName,
-                              string? daxFormula = null, string? formatType = null,
-                              string? description = null)
+                               string? daxFormula = null, string? formatType = null,
+                               string? description = null, bool formatDax = false)
     {
-        // Format DAX before saving (outside ExecuteWithRetry for async operation)
-        // Only format if daxFormula is provided
-        // Formatting is done synchronously to maintain method signature compatibility
-        // Falls back to original if formatting fails
-        string? formattedDax = null;
+        string? daxToSave = null;
         if (!string.IsNullOrEmpty(daxFormula))
         {
-            formattedDax = DaxFormatter.FormatAsync(daxFormula).GetAwaiter().GetResult();
+            daxToSave = formatDax
+                ? DaxFormatter.FormatAsync(daxFormula).GetAwaiter().GetResult()
+                : daxFormula;
         }
 
         return ExecuteWithRetry(() =>
@@ -329,13 +325,12 @@ public partial class DataModelCommands
 
                     // Update formula if provided
                     // Reference: https://learn.microsoft.com/en-us/office/vba/api/excel.modelmeasure (Formula property is Read/Write)
-                    if (!string.IsNullOrEmpty(formattedDax))
+                    if (!string.IsNullOrEmpty(daxToSave))
                     {
                         // Translate DAX formula separators from US format (comma) to locale-specific format
                         // This fixes issues on European locales where semicolon is the list separator
-                        // NOTE: Translation is done on the FORMATTED DAX
                         var daxTranslator = new DaxFormulaTranslator(ctx.App);
-                        string localizedFormula = daxTranslator.TranslateToLocale(formattedDax);
+                        string localizedFormula = daxTranslator.TranslateToLocale(daxToSave);
                         measure.Formula = localizedFormula;
                         updates.Add("Formula updated");
                     }

--- a/src/ExcelMcp.Core/Commands/DataModel/IDataModelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/IDataModelCommands.cs
@@ -18,7 +18,8 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 ///
 /// DAX MEASURES:
 /// - Create with DAX formulas like 'SUM(Sales[Amount])'
-/// - DAX formulas are auto-formatted on CREATE/UPDATE via Dax.Formatter (SQLBI)
+/// - DAX formulas are preserved exactly by default
+/// - Set formatDax=true only with user consent; it sends formulas to daxformatter.com
 /// - Read operations return raw DAX as stored
 ///
 /// DAX EVALUATE QUERIES:
@@ -35,7 +36,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 /// </summary>
 [ServiceCategory("datamodel", "DataModel")]
 [McpTool("datamodel", Title = "Data Model Operations", Destructive = true, Category = "analysis",
-    Description = "Data Model (Power Pivot) - DAX measures and table management. CRITICAL: Worksheet tables and Data Model are separate! After table(append), MUST call datamodel(refresh) to sync. Power Query refresh auto-syncs. DAX MEASURES: Create with formulas like SUM(Sales[Amount]), auto-formatted via daxformatter.com. DAX EVALUATE: Execute queries (SUMMARIZE, FILTER, CALCULATETABLE, TOPN). DMV QUERIES: SELECT * FROM $SYSTEM.SchemaRowset for metadata. DAX FILE INPUT: daxFormulaFile/daxQueryFile for complex multi-line DAX. TIMEOUT: 2 min. Use datamodel_relationship for relationships, table for add-to-datamodel.")]
+    Description = "Data Model (Power Pivot) - DAX measures and table management. CRITICAL: Worksheet tables and Data Model are separate! After table(append), MUST call datamodel(refresh) to sync. Power Query refresh auto-syncs. DAX MEASURES: Create with formulas like SUM(Sales[Amount]); DAX is preserved exactly by default. Set formatDax=true only with user consent; it sends formulas to daxformatter.com. DAX EVALUATE: Execute queries (SUMMARIZE, FILTER, CALCULATETABLE, TOPN). DMV QUERIES: SELECT * FROM $SYSTEM.SchemaRowset for metadata. DAX FILE INPUT: daxFormulaFile/daxQueryFile for complex multi-line DAX. TIMEOUT: 2 min. Use datamodel_relationship for relationships, table for add-to-datamodel.")]
 public interface IDataModelCommands
 {
     /// <summary>
@@ -139,15 +140,16 @@ public interface IDataModelCommands
 
     /// <summary>
     /// Creates a new DAX measure in the Data Model.
-    /// DAX formula is automatically formatted with proper indentation before saving.
+    /// DAX formula is preserved exactly by default.
     /// Uses Excel COM API: ModelMeasures.Add method (Office 2016+)
     /// </summary>
     /// <param name="batch">Excel batch context for accessing workbook</param>
     /// <param name="tableName">Name of the table to add the measure to</param>
     /// <param name="measureName">Name of the new measure</param>
-    /// <param name="daxFormula">DAX formula for the measure (will be auto-formatted)</param>
+    /// <param name="daxFormula">DAX formula for the measure</param>
     /// <param name="formatType">Optional: Format type (Currency, Decimal, Percentage, General)</param>
     /// <param name="description">Optional: Description of the measure</param>
+    /// <param name="formatDax">Whether to send the DAX formula to the remote daxformatter.com service before saving. Defaults to false to preserve privacy.</param>
     /// <exception cref="ArgumentException">Thrown when parameters are invalid</exception>
     /// <exception cref="InvalidOperationException">Thrown when table not found or creation fails</exception>
     [ServiceAction("create-measure")]
@@ -157,18 +159,20 @@ public interface IDataModelCommands
         [RequiredParameter] string measureName,
         [RequiredParameter, FileOrValue] string daxFormula,
         string? formatType = null,
-        string? description = null);
+        string? description = null,
+        bool formatDax = false);
 
     /// <summary>
     /// Updates an existing DAX measure in the Data Model.
-    /// DAX formula is automatically formatted with proper indentation before saving.
+    /// DAX formula is preserved exactly by default.
     /// Uses Excel COM API: ModelMeasure properties (Formula, Description, FormatInformation - all Read/Write)
     /// </summary>
     /// <param name="batch">Excel batch context for accessing workbook</param>
     /// <param name="measureName">Name of the measure to update</param>
-    /// <param name="daxFormula">Optional: New DAX formula (null to keep existing, will be auto-formatted if provided)</param>
+    /// <param name="daxFormula">Optional: New DAX formula (null to keep existing)</param>
     /// <param name="formatType">Optional: New format type (null to keep existing)</param>
     /// <param name="description">Optional: New description (null to keep existing)</param>
+    /// <param name="formatDax">Whether to send the DAX formula to the remote daxformatter.com service before saving. Defaults to false to preserve privacy.</param>
     /// <exception cref="ArgumentException">Thrown when measureName is invalid or all parameters are null</exception>
     /// <exception cref="InvalidOperationException">Thrown when measure not found or update fails</exception>
     [ServiceAction("update-measure")]
@@ -177,7 +181,8 @@ public interface IDataModelCommands
         [RequiredParameter] string measureName,
         [FileOrValue] string? daxFormula = null,
         string? formatType = null,
-        string? description = null);
+        string? description = null,
+        bool formatDax = false);
 
     /// <summary>
     /// Executes a DAX EVALUATE query against the Data Model and returns the results.

--- a/src/ExcelMcp.Core/Commands/PowerQuery/IPowerQueryCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/IPowerQueryCommands.cs
@@ -22,13 +22,16 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 /// DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'.
 /// Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures.
 ///
+/// M-CODE: Preserved exactly by default. Set formatMCode=true only with explicit user consent;
+/// it sends M code to powerqueryformatter.com.
+///
 /// TARGET CELL: targetCellAddress places tables without clearing sheet.
 /// TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60 or similar.
 /// timeout=0 or omitted uses the 30 min default.
 /// </summary>
 [ServiceCategory("powerquery", "PowerQuery")]
 [McpTool("powerquery", Title = "Power Query Operations", Destructive = true, Category = "query",
-    Description = "Power Query M code and data loading. TEST-FIRST WORKFLOW: 1. evaluate (test M code without persisting) 2. create/update (store validated query) 3. refresh/load-to (load data to destination). IF CREATE FAILS: Use evaluate for detailed M engine error. DATETIME: Always include Table.TransformColumnTypes() for explicit column types. DESTINATIONS: worksheet (default), data-model (for DAX), both, connection-only. M-CODE: Auto-formatted via powerqueryformatter.com. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60. timeout=0 or omitted uses the 30 min default.")]
+    Description = "Power Query M code and data loading. TEST-FIRST WORKFLOW: 1. evaluate (test M code without persisting) 2. create/update (store validated query) 3. refresh/load-to (load data to destination). IF CREATE FAILS: Use evaluate for detailed M engine error. DATETIME: Always include Table.TransformColumnTypes() for explicit column types. DESTINATIONS: worksheet (default), data-model (for DAX), both, connection-only. M-CODE: Preserved exactly by default. Set formatMCode=true only with user consent; it sends M code to powerqueryformatter.com. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60. timeout=0 or omitted uses the 30 min default.")]
 public interface IPowerQueryCommands
 {
     /// <summary>
@@ -82,6 +85,7 @@ public interface IPowerQueryCommands
     /// <param name="loadMode">Load destination mode</param>
     /// <param name="targetSheet">Target worksheet name (required for LoadToTable and LoadToBoth; defaults to query name when omitted)</param>
     /// <param name="targetCellAddress">Optional target cell address for worksheet loads (e.g., "B5"). Required when loading to an existing worksheet with other data.</param>
+    /// <param name="formatMCode">Whether to send M code to the remote powerqueryformatter.com service before saving. Defaults to false to preserve privacy.</param>
     /// <exception cref="InvalidOperationException">Thrown when query cannot be created, M code is invalid, or load operation fails</exception>
     OperationResult Create(
         IExcelBatch batch,
@@ -89,7 +93,8 @@ public interface IPowerQueryCommands
         [RequiredParameter][FileOrValue] string mCode,
         [FromString("loadDestination")] PowerQueryLoadMode loadMode = PowerQueryLoadMode.LoadToTable,
         string? targetSheet = null,
-        string? targetCellAddress = null);
+        string? targetCellAddress = null,
+        bool formatMCode = false);
 
     /// <summary>
     /// Updates M code. Optionally refreshes loaded data.
@@ -98,8 +103,9 @@ public interface IPowerQueryCommands
     /// <param name="queryName">Name of the query to update</param>
     /// <param name="mCode">Raw M code (inline string)</param>
     /// <param name="refresh">Whether to refresh data after update (default: true)</param>
+    /// <param name="formatMCode">Whether to send M code to the remote powerqueryformatter.com service before saving. Defaults to false to preserve privacy.</param>
     /// <exception cref="InvalidOperationException">Thrown when the query is not found, M code is invalid, or refresh fails</exception>
-    OperationResult Update(IExcelBatch batch, [RequiredParameter] string queryName, [RequiredParameter][FileOrValue] string mCode, bool refresh = true);
+    OperationResult Update(IExcelBatch batch, [RequiredParameter] string queryName, [RequiredParameter][FileOrValue] string mCode, bool refresh = true, bool formatMCode = false);
 
     /// <summary>
     /// Atomically sets load destination and refreshes data

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Create.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Create.cs
@@ -13,7 +13,7 @@ public partial class PowerQueryCommands
 {
     /// <summary>
     /// Creates new Power Query from M code with specified load destination.
-    /// M code is automatically formatted using the powerqueryformatter.com API before saving.
+    /// M code is preserved exactly by default. Remote formatting is only used when explicitly requested.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="queryName">Name for the new query</param>
@@ -29,7 +29,8 @@ public partial class PowerQueryCommands
         string mCode,
         PowerQueryLoadMode loadMode = PowerQueryLoadMode.LoadToTable,
         string? targetSheet = null,
-        string? targetCellAddress = null)
+        string? targetCellAddress = null,
+        bool formatMCode = false)
     {
         // Validate inputs
         if (string.IsNullOrWhiteSpace(queryName))
@@ -42,10 +43,9 @@ public partial class PowerQueryCommands
             throw new ArgumentException("M code cannot be empty", nameof(mCode));
         }
 
-        // Format M code before saving (outside batch.Execute for async operation)
-        // Formatting is done synchronously to maintain method signature compatibility
-        // Falls back to original if formatting fails
-        string formattedMCode = MCodeFormatter.FormatAsync(mCode).GetAwaiter().GetResult();
+        string mCodeToSave = formatMCode
+            ? MCodeFormatter.FormatAsync(mCode).GetAwaiter().GetResult()
+            : mCode;
 
         // Resolve target sheet name (default to query name)
         if (loadMode == PowerQueryLoadMode.LoadToTable || loadMode == PowerQueryLoadMode.LoadToBoth)
@@ -74,8 +74,7 @@ public partial class PowerQueryCommands
                 }
 
                 // Step 1: Create the query (always creates in ConnectionOnly mode initially)
-                // Uses formatted M code for better readability
-                query = queries.Add(queryName, formattedMCode);
+                query = queries.Add(queryName, mCodeToSave);
 
                 // Step 2: Apply load destination based on mode
                 var result = new PowerQueryCreateResult

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Update.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Update.cs
@@ -14,7 +14,7 @@ public partial class PowerQueryCommands
 {
     /// <summary>
     /// Update Power Query M code. Preserves load configuration (worksheet/data model).
-    /// M code is automatically formatted using the powerqueryformatter.com API before saving.
+    /// M code is preserved exactly by default. Remote formatting is only used when explicitly requested.
     /// - Worksheet queries: Uses QueryTable.Refresh(false) for synchronous refresh with column propagation
     /// - Data Model queries: Uses connection.Refresh() to update the Data Model
     /// </summary>
@@ -24,7 +24,7 @@ public partial class PowerQueryCommands
     /// <param name="refresh">Whether to refresh data after update (default: true)</param>
     /// <exception cref="ArgumentException">Thrown when queryName or mCode is invalid</exception>
     /// <exception cref="InvalidOperationException">Thrown when query not found or update fails</exception>
-    public OperationResult Update(IExcelBatch batch, string queryName, string mCode, bool refresh = true)
+    public OperationResult Update(IExcelBatch batch, string queryName, string mCode, bool refresh = true, bool formatMCode = false)
     {
         if (!ValidateQueryName(queryName, out string? validationError))
         {
@@ -36,10 +36,9 @@ public partial class PowerQueryCommands
             throw new ArgumentException("M code cannot be empty", nameof(mCode));
         }
 
-        // Format M code before saving (outside batch.Execute for async operation)
-        // Formatting is done synchronously to maintain method signature compatibility
-        // Falls back to original if formatting fails
-        string formattedMCode = MCodeFormatter.FormatAsync(mCode).GetAwaiter().GetResult();
+        string mCodeToSave = formatMCode
+            ? MCodeFormatter.FormatAsync(mCode).GetAwaiter().GetResult()
+            : mCode;
 
         return batch.Execute((ctx, ct) =>
         {
@@ -76,10 +75,10 @@ public partial class PowerQueryCommands
                     throw new InvalidOperationException($"Query '{queryName}' not found.");
                 }
 
-                // STEP 2: Update the M code with formatted version
+                // STEP 2: Update the M code
                 // Note: 0x800A03EC error can occur in certain workbook states (see Issue #323)
                 // Retry doesn't help - it's a workbook state issue, not transient
-                query.Formula = formattedMCode;
+                query.Formula = mCodeToSave;
 
                 // STEP 3: Refresh if requested using the same COM-safe helper as Refresh().
                 // This keeps Update aligned with the message-filter and cancellation behavior

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/DataModel/DataModelCommandsTests.DaxFormatting.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/DataModel/DataModelCommandsTests.DaxFormatting.cs
@@ -6,10 +6,9 @@ using Xunit;
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.DataModel;
 
 /// <summary>
-/// Integration tests for DAX formatting feature.
-/// Tests verify that DAX formulas are automatically formatted on write operations.
-/// Write operations (CreateMeasure, UpdateMeasure) format DAX via daxformatter.com API.
-/// Read operations (ListMeasures, Read) return raw DAX as stored in the Data Model.
+/// Integration tests for DAX formatting behavior.
+/// Tests verify that DAX formulas are preserved exactly by default.
+/// Remote formatting requires explicit opt-in on CreateMeasure and UpdateMeasure.
 /// </summary>
 [Collection("DataModel")]
 [Trait("Layer", "Core")]
@@ -68,11 +67,10 @@ public class DataModelCommandsTests_DaxFormatting
     }
 
     /// <summary>
-    /// Tests that CreateMeasure formats DAX before saving to Excel.
-    /// Verifies that the measure can be created and retrieved successfully.
+    /// Tests that CreateMeasure preserves DAX exactly by default.
     /// </summary>
     [Fact]
-    public async Task CreateMeasure_WithUnformattedDax_SavesFormattedVersion()
+    public async Task CreateMeasure_WithUnformattedDax_PreservesExactInputByDefault()
     {
         var measureName = $"Test_CreateFormatted_{Guid.NewGuid():N}";
         // Unformatted DAX (single line, no spaces around operators)
@@ -80,26 +78,20 @@ public class DataModelCommandsTests_DaxFormatting
 
         using var batch = ExcelSession.BeginBatch(_dataModelFile);
 
-        // Create measure (should format automatically)
+        // Create measure without remote formatting opt-in
         _ = _dataModelCommands.CreateMeasure(batch, "SalesTable", measureName, unformattedDax);
 
         // Retrieve and verify
         var viewResult = await _dataModelCommands.Read(batch, measureName);
         Assert.True(viewResult.Success, $"Read failed: {viewResult.ErrorMessage}");
-        Assert.Contains("CALCULATE", viewResult.DaxFormula, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("SUM", viewResult.DaxFormula, StringComparison.OrdinalIgnoreCase);
-
-        // The formatted version might have newlines or extra spaces
-        // but should still contain the core function names
-        Assert.NotEmpty(viewResult.DaxFormula);
+        Assert.Equal(unformattedDax, NormalizeDaxListSeparators(viewResult.DaxFormula));
     }
 
     /// <summary>
-    /// Tests that UpdateMeasure formats DAX before saving to Excel.
-    /// Verifies that the measure can be updated and retrieved successfully.
+    /// Tests that UpdateMeasure preserves DAX exactly by default.
     /// </summary>
     [Fact]
-    public async Task UpdateMeasure_WithUnformattedDax_SavesFormattedVersion()
+    public async Task UpdateMeasure_WithUnformattedDax_PreservesExactInputByDefault()
     {
         var measureName = $"Test_UpdateFormatted_{Guid.NewGuid():N}";
         var originalFormula = "SUM(SalesTable[Amount])";
@@ -111,17 +103,13 @@ public class DataModelCommandsTests_DaxFormatting
         // Create measure
         _ = _dataModelCommands.CreateMeasure(batch, "SalesTable", measureName, originalFormula);
 
-        // Update with unformatted DAX (should format automatically)
+        // Update without remote formatting opt-in
         _ = _dataModelCommands.UpdateMeasure(batch, measureName, daxFormula: unformattedUpdate);
 
         // Retrieve and verify
         var viewResult = await _dataModelCommands.Read(batch, measureName);
         Assert.True(viewResult.Success, $"Read failed: {viewResult.ErrorMessage}");
-        Assert.Contains("CALCULATE", viewResult.DaxFormula, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("AVERAGE", viewResult.DaxFormula, StringComparison.OrdinalIgnoreCase);
-
-        // Should NOT contain SUM (since we updated the formula)
-        Assert.DoesNotContain("SUM", viewResult.DaxFormula, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(unformattedUpdate, NormalizeDaxListSeparators(viewResult.DaxFormula));
     }
 
     /// <summary>
@@ -179,6 +167,11 @@ public class DataModelCommandsTests_DaxFormatting
         Assert.True(viewResult.Success, $"Read failed: {viewResult.ErrorMessage}");
         Assert.Equal(newDescription, viewResult.Description);
         Assert.Contains("SUM", viewResult.DaxFormula, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeDaxListSeparators(string daxFormula)
+    {
+        return daxFormula.Replace(';', ',');
     }
 }
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.MCodeFormatting.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.MCodeFormatting.cs
@@ -7,11 +7,9 @@ using Xunit;
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PowerQuery;
 
 /// <summary>
-/// Integration tests for M-code formatting feature.
-/// Tests verify that M code (Power Query) is automatically formatted on write operations.
-/// Write operations (Create, Update) format M code via powerqueryformatter.com API.
-/// Read operations (List, View) return M code as stored in the workbook.
-/// Note: Formatting may add newlines and spacing, but these tests focus on content preservation.
+/// Integration tests for M-code formatting behavior.
+/// Tests verify that write operations preserve M code exactly by default.
+/// Remote formatting requires explicit opt-in on Create and Update.
 /// </summary>
 [Trait("Layer", "Core")]
 [Trait("Category", "Integration")]
@@ -31,12 +29,10 @@ public class PowerQueryCommandsTests_MCodeFormatting : IClassFixture<PowerQueryT
     }
 
     /// <summary>
-    /// Tests that Create preserves M code content.
-    /// Verifies that the query can be created and the M code is stored correctly.
-    /// Formatting may add newlines/spacing, but core content should be preserved.
+    /// Tests that Create preserves M code exactly by default.
     /// </summary>
     [Fact]
-    public void Create_WithUnformattedMCode_PreservesContent()
+    public void Create_WithUnformattedMCode_PreservesExactInputByDefault()
     {
         var testFile = _fixture.CreateTestFile();
         var queryName = $"Test_CreateFormatted_{Guid.NewGuid():N}"[..30];
@@ -46,28 +42,21 @@ public class PowerQueryCommandsTests_MCodeFormatting : IClassFixture<PowerQueryT
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
-        // Create query (should format automatically)
+        // Create query without remote formatting opt-in
         _powerQueryCommands.Create(batch, queryName, unformattedMCode, PowerQueryLoadMode.ConnectionOnly);
 
         // Retrieve and verify
         var viewResult = _powerQueryCommands.View(batch, queryName);
         Assert.True(viewResult.Success, $"View failed: {viewResult.ErrorMessage}");
 
-        // The formatted version should contain the core function names
-        // (formatting may add whitespace/newlines but preserves content)
-        Assert.Contains("let", viewResult.MCode, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Excel.CurrentWorkbook", viewResult.MCode, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Table.SelectRows", viewResult.MCode, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("in", viewResult.MCode, StringComparison.OrdinalIgnoreCase);
-        Assert.NotEmpty(viewResult.MCode);
+        Assert.Equal(unformattedMCode, viewResult.MCode);
     }
 
     /// <summary>
-    /// Tests that Update preserves M code content.
-    /// Verifies that the query can be updated and the M code is stored correctly.
+    /// Tests that Update preserves M code exactly by default.
     /// </summary>
     [Fact]
-    public void Update_WithUnformattedMCode_PreservesContent()
+    public void Update_WithUnformattedMCode_PreservesExactInputByDefault()
     {
         var testFile = _fixture.CreateTestFile();
         var queryName = $"Test_UpdateFormatted_{Guid.NewGuid():N}"[..30];
@@ -85,22 +74,18 @@ in
         // Create query
         _powerQueryCommands.Create(batch, queryName, originalMCode, PowerQueryLoadMode.ConnectionOnly);
 
-        // Update with unformatted M code (should format automatically)
+        // Update without remote formatting opt-in
         _powerQueryCommands.Update(batch, queryName, unformattedUpdate, refresh: false);
 
         // Retrieve and verify
         var viewResult = _powerQueryCommands.View(batch, queryName);
         Assert.True(viewResult.Success, $"View failed: {viewResult.ErrorMessage}");
 
-        // The formatted version should contain the core function names
-        Assert.Contains("#table", viewResult.MCode);
-        Assert.Contains("Table.SelectRows", viewResult.MCode);
-        Assert.NotEmpty(viewResult.MCode);
+        Assert.Equal(unformattedUpdate, viewResult.MCode);
     }
 
     /// <summary>
-    /// Tests that pre-formatted M code is preserved/enhanced by the formatter.
-    /// Verifies that already-formatted code doesn't break.
+    /// Tests that pre-formatted M code is preserved exactly by default.
     /// </summary>
     [Fact]
     public void Create_WithPreformattedMCode_PreservesReadability()
@@ -129,12 +114,7 @@ in
         var viewResult = _powerQueryCommands.View(batch, queryName);
         Assert.True(viewResult.Success, $"View failed: {viewResult.ErrorMessage}");
 
-        // Should still contain the structure (formatting shouldn't break it)
-        Assert.Contains("#table", viewResult.MCode);
-        Assert.Contains("ProductID", viewResult.MCode);
-        Assert.Contains("let", viewResult.MCode, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("in", viewResult.MCode, StringComparison.OrdinalIgnoreCase);
-        Assert.NotEmpty(viewResult.MCode);
+        Assert.Equal(preformattedMCode, viewResult.MCode);
     }
 
     /// <summary>
@@ -159,7 +139,7 @@ in
     }
 
     /// <summary>
-    /// Tests that View returns M code as stored (formatter applied on write).
+    /// Tests that View returns M code as stored.
     /// Verifies that read operations don't re-format.
     /// </summary>
     [Fact]
@@ -232,19 +212,14 @@ in
 
         using var batch = ExcelSession.BeginBatch(testFile);
 
-        // Create query (should format automatically)
+        // Create query without remote formatting opt-in
         _powerQueryCommands.Create(batch, queryName, complexMCode, PowerQueryLoadMode.ConnectionOnly);
 
         // Retrieve and verify
         var viewResult = _powerQueryCommands.View(batch, queryName);
         Assert.True(viewResult.Success, $"View failed: {viewResult.ErrorMessage}");
 
-        // Verify all steps are present
-        Assert.Contains("#table", viewResult.MCode);
-        Assert.Contains("Table.SelectRows", viewResult.MCode);
-        Assert.Contains("Table.TransformColumnTypes", viewResult.MCode);
-        Assert.Contains("Table.AddColumn", viewResult.MCode);
-        Assert.NotEmpty(viewResult.MCode);
+        Assert.Equal(complexMCode, viewResult.MCode);
 
         // Verify the query can still be viewed without errors (formatting didn't corrupt it)
         var verifyResult = _powerQueryCommands.View(batch, queryName);
@@ -274,23 +249,14 @@ in
 
         var afterCreate = _powerQueryCommands.View(batch, queryName);
         Assert.True(afterCreate.Success);
-        Assert.NotEmpty(afterCreate.MCode);
+        Assert.Equal(createMCode, afterCreate.MCode);
 
         // Update query
         _powerQueryCommands.Update(batch, queryName, updateMCode, refresh: false);
 
         var afterUpdate = _powerQueryCommands.View(batch, queryName);
         Assert.True(afterUpdate.Success);
-        Assert.NotEmpty(afterUpdate.MCode);
-
-        // New content should be present
-        Assert.Contains("a", afterUpdate.MCode);
-        Assert.Contains("b", afterUpdate.MCode);
-        Assert.Contains("c", afterUpdate.MCode);
-
-        // Old unique values should be replaced (x=1, y=2)
-        Assert.DoesNotContain("x = 1", afterUpdate.MCode);
-        Assert.DoesNotContain("y = 2", afterUpdate.MCode);
+        Assert.Equal(updateMCode, afterUpdate.MCode);
     }
 }
 


### PR DESCRIPTION
## Summary
- Preserve Power Query M and DAX formulas by default instead of sending them to remote formatters
- Add explicit opt-in parameters/CLI flags for remote formatting: formatMCode/--format-m-code and formatDax/--format-dax
- Update tests, user docs, skill references, and changelog for the privacy-safe default

## Validation
- dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName~Create_WithUnformattedMCode_PreservesExactInputByDefault|FullyQualifiedName~CreateMeasure_WithUnformattedDax_PreservesExactInputByDefault" -- RunConfiguration.TestSessionTimeout=240000
- dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName~PowerQueryCommandsTests_MCodeFormatting|FullyQualifiedName~DataModelCommandsTests_DaxFormatting" -- RunConfiguration.TestSessionTimeout=600000
- dotnet build Sbroenne.ExcelMcp.sln --configuration Release --no-restore
- scripts\audit-core-coverage.ps1 -FailOnGaps
- git diff --check

Fixes #601