### PR TITLE
Fix generated CLI timeout parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **CLI timeout parameter parsing now correctly interprets numeric values as seconds** (#640): The `--timeout` parameter for commands like `datamodel refresh` incorrectly parsed numeric values (e.g., `--timeout 600`) as days instead of seconds. Numeric timeouts are now interpreted as seconds, while TimeSpan format (e.g., `00:10:00`) is still supported. This fix applies to all timeout parameters across data model, power query, and connection refresh operations.
+
 - **Remote DAX and M formatting is now explicit opt-in** (#601): `powerquery create/update` and `datamodel create-measure/update-measure` no longer send formulas to remote formatter services by default. M code and DAX formulas are preserved as provided (with Excel locale separator translation for DAX), and callers must set `formatMCode=true` or `formatDax=true` to opt in to remote formatting via powerqueryformatter.com or daxformatter.com.
 
 - **CLI daemon startup stability**: Hardened `excelcli` daemon startup against stale named mutex handles and simultaneous `service start` calls. Startup is now serialized with a process-wide semaphore, daemon liveness checks ignore unowned/abandoned mutexes, and the daemon can take over stale mutex handles instead of exiting as a duplicate instance. Added ServiceDaemon regressions for stale mutex recovery and concurrent start requests, plus a parallel multi-file CLI E2E workflow that exercises independent workbook sessions through the same daemon.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,8 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.7" />
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
+    <!-- Security override: StreamJsonRpc 2.24.84 transitively pins vulnerable Nerdbank.MessagePack 1.0.2 -->
+    <PackageVersion Include="Nerdbank.MessagePack" Version="1.1.62" />
     <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <!-- MCP SDK - Latest stable preview -->
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />

--- a/src/ExcelMcp.Core/Utilities/ParameterTransforms.cs
+++ b/src/ExcelMcp.Core/Utilities/ParameterTransforms.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Sbroenne.ExcelMcp.Core.Commands.Range;
@@ -316,5 +317,32 @@ public static class ParameterTransforms
     {
         RequireNotEmpty(value, parameterName, actionName);
         return value!;
+    }
+
+    /// <summary>
+    /// Parses a timeout value supplied via CLI.
+    /// Plain numeric values are interpreted as seconds; TimeSpan-formatted values are preserved.
+    /// Returns null for null/empty input.
+    /// </summary>
+    /// <param name="value">Timeout text from CLI</param>
+    /// <param name="parameterName">Parameter name for error messages</param>
+    /// <returns>Parsed timeout or null</returns>
+    /// <exception cref="FormatException">Thrown when the timeout cannot be parsed</exception>
+    public static TimeSpan? ParseTimeSpanOrSeconds(string? value, string parameterName = "timeout")
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
+            return TimeSpan.FromSeconds(seconds);
+
+        if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var parsed)
+            || TimeSpan.TryParse(value, CultureInfo.CurrentCulture, out parsed))
+        {
+            return parsed;
+        }
+
+        throw new FormatException(
+            $"Invalid {parameterName} value '{value}'. Use seconds (for example 600) or TimeSpan format (for example 00:10:00).");
     }
 }

--- a/src/ExcelMcp.Generators/ServiceRegistryGenerator.cs
+++ b/src/ExcelMcp.Generators/ServiceRegistryGenerator.cs
@@ -416,6 +416,10 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
                 var nonNullableType = p.TypeName.TrimEnd('?');
                 sb.AppendLine($"                {p.Name}: !string.IsNullOrWhiteSpace(settings.{StringHelper.ToPascalCase(p.Name)}) ? ServiceRegistry.DeserializeList<{nonNullableType}>(settings.{StringHelper.ToPascalCase(p.Name)}) : null{comma}");
             }
+            else if (IsTimeSpanType(p.TypeName))
+            {
+                sb.AppendLine($"                {p.Name}: Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ParseTimeSpanOrSeconds(settings.{StringHelper.ToPascalCase(p.Name)}, \"{p.Name}\"){comma}");
+            }
             else
             {
                 sb.AppendLine($"                {p.Name}: settings.{StringHelper.ToPascalCase(p.Name)}{comma}");
@@ -450,6 +454,11 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
     {
         return !IsNestedCollectionType(typeName) &&
                typeName.IndexOf("List<", StringComparison.Ordinal) >= 0;
+    }
+
+    private static bool IsTimeSpanType(string typeName)
+    {
+        return typeName.IndexOf("TimeSpan", StringComparison.Ordinal) >= 0;
     }
 
     /// <summary>
@@ -507,9 +516,11 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
             // raw JSON. LLMs pass JSON arrays instead of repeated CLI flags.
             // Deserialized back to the original type in RouteFromSettings.
             var isCollectionForJson = IsNestedCollectionType(p.TypeName) || IsSimpleListType(p.TypeName);
-            var cliTypeName = isCollectionForJson ? "string?" : p.TypeName;
+            var cliTypeName = isCollectionForJson || IsTimeSpanType(p.TypeName) ? "string?" : p.TypeName;
             if (isCollectionForJson && !escapedDescription.Contains("JSON"))
                 escapedDescription += " (JSON format)";
+            if (IsTimeSpanType(p.TypeName) && escapedDescription.IndexOf("seconds", StringComparison.OrdinalIgnoreCase) < 0)
+                escapedDescription += " Accepts seconds (e.g. 600) or TimeSpan format (e.g. 00:10:00).";
 
             // Add short aliases for backward compatibility with pre-generator CLI parameter names
             var shortAlias = GetShortAlias(p.Name);

--- a/tests/ExcelMcp.CLI.Tests/Integration/DataModelRefreshTimeoutRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/DataModelRefreshTimeoutRegressionTests.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Sbroenne.ExcelMcp.Service;
+using StreamJsonRpc;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+/// <summary>
+/// Regression coverage for issue #640.
+/// Proves the CLI forwards the caller-supplied datamodel refresh timeout end-to-end.
+/// </summary>
+[Trait("Layer", "CLI")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "DataModel")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class DataModelRefreshTimeoutRegressionTests
+{
+    [Fact]
+    public async Task Refresh_NumericTimeoutSeconds_ForwardsRequestedBudget()
+    {
+        var pipeName = $"excelmcp-cli-test-{Guid.NewGuid():N}";
+
+        await using var fakeDaemon = new EchoDaemon(pipeName);
+        await fakeDaemon.StartAsync();
+
+        var (result, json) = await CliProcessHelper.RunJsonAsync(
+            ["datamodel", "refresh", "--session", "session-issue-640", "--timeout", "600"],
+            timeoutMs: 20000,
+            environmentVariables: new Dictionary<string, string>
+            {
+                ["EXCELMCP_CLI_PIPE"] = pipeName
+            },
+            diagnosticLabel: "issue-640-datamodel-refresh-timeout");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("datamodel.refresh", json.RootElement.GetProperty("command").GetString());
+
+        using var argsJson = JsonDocument.Parse(json.RootElement.GetProperty("argsJson").GetString()!);
+        Assert.Equal("00:10:00", argsJson.RootElement.GetProperty("timeout").GetString());
+    }
+
+    [Fact]
+    public async Task Refresh_TimeSpanTimeout_ForwardsRequestedBudget()
+    {
+        var pipeName = $"excelmcp-cli-test-{Guid.NewGuid():N}";
+
+        await using var fakeDaemon = new EchoDaemon(pipeName);
+        await fakeDaemon.StartAsync();
+
+        var (result, json) = await CliProcessHelper.RunJsonAsync(
+            ["datamodel", "refresh", "--session", "session-issue-640", "--timeout", "00:10:00"],
+            timeoutMs: 20000,
+            environmentVariables: new Dictionary<string, string>
+            {
+                ["EXCELMCP_CLI_PIPE"] = pipeName
+            },
+            diagnosticLabel: "issue-640-datamodel-refresh-timespan-timeout");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+
+        using var argsJson = JsonDocument.Parse(json.RootElement.GetProperty("argsJson").GetString()!);
+        Assert.Equal("00:10:00", argsJson.RootElement.GetProperty("timeout").GetString());
+    }
+
+    [Fact]
+    [Trait("Feature", "PowerQuery")]
+    public async Task PowerQueryRefresh_NumericTimeoutSeconds_ForwardsRequestedBudget()
+    {
+        var pipeName = $"excelmcp-cli-test-{Guid.NewGuid():N}";
+
+        await using var fakeDaemon = new EchoDaemon(pipeName);
+        await fakeDaemon.StartAsync();
+
+        var (result, json) = await CliProcessHelper.RunJsonAsync(
+            ["powerquery", "refresh", "--session", "session-issue-640", "--query-name", "Issue640Query", "--timeout", "600"],
+            timeoutMs: 20000,
+            environmentVariables: new Dictionary<string, string>
+            {
+                ["EXCELMCP_CLI_PIPE"] = pipeName
+            },
+            diagnosticLabel: "issue-640-powerquery-refresh-timeout");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("powerquery.refresh", json.RootElement.GetProperty("command").GetString());
+
+        using var argsJson = JsonDocument.Parse(json.RootElement.GetProperty("argsJson").GetString()!);
+        Assert.Equal("00:10:00", argsJson.RootElement.GetProperty("timeout").GetString());
+    }
+
+    private sealed class EchoDaemon : IAsyncDisposable
+    {
+        private readonly string _pipeName;
+        private readonly CancellationTokenSource _shutdown = new();
+        private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly Task _runTask;
+
+        public EchoDaemon(string pipeName)
+        {
+            _pipeName = pipeName;
+            _runTask = RunAsync();
+        }
+
+        public Task StartAsync() => _listening.Task;
+
+        public async ValueTask DisposeAsync()
+        {
+            _shutdown.Cancel();
+
+            try
+            {
+                await _runTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            _shutdown.Dispose();
+        }
+
+        private async Task RunAsync()
+        {
+            _listening.TrySetResult();
+
+            while (!_shutdown.IsCancellationRequested)
+            {
+                using var server = ServiceSecurity.CreateSecureServer(_pipeName);
+                await server.WaitForConnectionAsync(_shutdown.Token);
+
+                var target = new EchoRpcTarget();
+                using var rpc = JsonRpc.Attach(server, target);
+
+                try
+                {
+                    await rpc.Completion.WaitAsync(_shutdown.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+    }
+
+    private sealed class EchoRpcTarget
+    {
+        private readonly string _pingCommand = "service.ping";
+
+        public Task<ServiceResponse> ProcessCommandAsync(ServiceRequest request)
+        {
+            if (string.Equals(request.Command, _pingCommand, StringComparison.Ordinal))
+            {
+                return Task.FromResult(new ServiceResponse
+                {
+                    Success = true,
+                    Command = request.Command,
+                    Result = JsonSerializer.Serialize(new
+                    {
+                        success = true,
+                        action = "ping",
+                        message = "pong"
+                    }, ServiceProtocol.JsonOptions)
+                });
+            }
+
+            return Task.FromResult(new ServiceResponse
+            {
+                Success = true,
+                Command = request.Command,
+                SessionId = request.SessionId,
+                Result = JsonSerializer.Serialize(new
+                {
+                    success = true,
+                    command = request.Command,
+                    sessionId = request.SessionId,
+                    argsJson = request.Args
+                }, ServiceProtocol.JsonOptions)
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- interpret numeric generated CLI timeout values as seconds instead of TimeSpan days
- preserve explicit TimeSpan-formatted timeout inputs
- add CLI daemon forwarding regressions for datamodel and powerquery refresh
- pin Nerdbank.MessagePack to a patched version so NuGet audit no longer blocks restore/pre-commit

## Validation
- `dotnet test tests\ExcelMcp.CLI.Tests\ExcelMcp.CLI.Tests.csproj --filter "FullyQualifiedName~DataModelRefreshTimeoutRegressionTests" --no-restore --blame-hang --blame-hang-timeout 5m`
- `dotnet restore Sbroenne.ExcelMcp.sln`
- `dotnet build Sbroenne.ExcelMcp.sln -c Release --no-restore`
- `dotnet list Sbroenne.ExcelMcp.sln package --vulnerable --include-transitive`
- pre-commit hook passed, including CLI workflow smoke test, MCP smoke test, release deliverables, VS Code package validation, MCPB bundle, agent skills package, plugin README validation, and dynamic cast audit

Fixes #640