### PR TITLE
Update .NET package dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,28 +17,51 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <!-- Application Insights Worker Service SDK for telemetry (Users, Sessions, Funnels, User Flows) -->
     <!-- Worker Service SDK provides proper DI integration, auto-collection modules, and host lifetime awareness -->
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.1" />
     <!-- Base SDK needed for tests that directly use TelemetryClient -->
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="3.1.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="3.1.1" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
+    <PackageVersion Include="Azure.Core" Version="1.55.0" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.2" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.0" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="8.18.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="OpenTelemetry.PersistentStorage.Abstractions" Version="1.1.0" />
+    <PackageVersion Include="OpenTelemetry.PersistentStorage.FileSystem" Version="1.1.0" />
+    <PackageVersion Include="Polly.Core" Version="8.6.6" />
+    <PackageVersion Include="Polly.Extensions" Version="8.6.6" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.6.6" />
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
     <!-- Security override: StreamJsonRpc 2.24.84 transitively pins vulnerable Nerdbank.MessagePack 1.0.2 -->
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.1.62" />
+    <PackageVersion Include="System.ClientModel" Version="1.11.0" />
+    <PackageVersion Include="System.Memory.Data" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.7" />
     <PackageVersion Include="System.Text.Json" Version="10.0.7" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.7" />
     <!-- MCP SDK - Latest stable preview -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <!-- Testing Framework -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.analyzers" Version="1.27.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="6.1.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />


### PR DESCRIPTION
## Summary
- Updates current .NET package dependencies in central package management.
- Moves the MCP SDK to 1.3.0 and refreshes related safe same-major dependencies.
- Keeps high-risk transitive major upgrades deferred where they come through other package dependency chains.

## Validation
- dotnet restore Sbroenne.ExcelMcp.sln
- dotnet list Sbroenne.ExcelMcp.sln package --vulnerable --include-transitive
- dotnet build Sbroenne.ExcelMcp.sln -c Release --no-restore
- Full pre-commit hook