### PR TITLE
fix: keep MCP stdio logs off stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **MCP Server stdio logging no longer corrupts JSON-RPC stdout** (#636): Console logging is now configured so all log levels are routed to stderr, keeping stdout reserved exclusively for MCP JSON-RPC frames even if logging configuration is overridden. CLI diagnostics and non-result errors now follow the same stdout-safe convention, keeping stdout reserved for command results and JSON payloads.
+
 - **Dependency freshness refresh across .NET and VS Code extension toolchain**: Updated central package pins for stale transitive .NET dependencies (including MessagePack 3.1.4 and netstandard support packages) and refreshed VS Code extension type dependencies (`@types/node`, `@types/vscode`) with regenerated lockfile so dependency audits report fully up-to-date packages.
 
 - **CLI timeout parameter parsing now correctly interprets numeric values as seconds** (#640): The `--timeout` parameter for commands like `datamodel refresh` incorrectly parsed numeric values (e.g., `--timeout 600`) as days instead of seconds. Numeric timeouts are now interpreted as seconds, while TimeSpan format (e.g., `00:10:00`) is still supported. This fix applies to all timeout parameters across data model, power query, and connection refresh operations.

--- a/src/ExcelMcp.CLI/Program.cs
+++ b/src/ExcelMcp.CLI/Program.cs
@@ -35,7 +35,7 @@ internal sealed class Program
         if (filteredArgs.Length == 0)
         {
             if (showBanner) RenderHeader();
-            AnsiConsole.MarkupLine("[dim]No command supplied. Use [green]--help[/] for usage examples.[/]");
+            WriteDiagnosticMarkupLine("[dim]No command supplied. Use [green]--help[/] for usage examples.[/]");
             return 0;
         }
 
@@ -78,7 +78,7 @@ internal sealed class Program
                     return;
                 }
 
-                AnsiConsole.MarkupLine($"[red]Unhandled error:[/] {ex.Message.EscapeMarkup()}");
+                WriteDiagnosticMarkupLine($"[red]Unhandled error:[/] {ex.Message.EscapeMarkup()}");
             });
 
             // Service lifecycle commands
@@ -132,7 +132,7 @@ internal sealed class Program
                 return CliErrorOutput.WriteException(ex);
             }
 
-            AnsiConsole.MarkupLine($"[red]Command error:[/] {ex.Message.EscapeMarkup()}");
+            WriteDiagnosticMarkupLine($"[red]Command error:[/] {ex.Message.EscapeMarkup()}");
             return 1;
         }
         catch (Exception ex)
@@ -142,10 +142,11 @@ internal sealed class Program
                 return CliErrorOutput.WriteException(ex);
             }
 
-            AnsiConsole.MarkupLine($"[red]Fatal error:[/] {ex.Message.EscapeMarkup()}");
-            if (AnsiConsole.Profile.Capabilities.Ansi)
+            WriteDiagnosticMarkupLine($"[red]Fatal error:[/] {ex.Message.EscapeMarkup()}");
+            var errorConsole = CreateErrorConsole();
+            if (errorConsole.Profile.Capabilities.Ansi)
             {
-                AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
+                errorConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
             }
             return 1;
         }
@@ -217,7 +218,7 @@ internal sealed class Program
         // regardless of whether stdout is piped, redirected, or captured
         // (Console.IsOutputRedirected is false in VS Code integrated terminal
         // even when capturing with $result = excelcli ...).
-        var err = AnsiConsole.Create(new AnsiConsoleSettings { Out = new AnsiConsoleOutput(Console.Error) });
+        var err = CreateErrorConsole();
         err.Write(new FigletText("Excel CLI").Color(Spectre.Console.Color.Blue));
         err.MarkupLine("[dim]Excel automation powered by ExcelMcp Core[/]");
         err.MarkupLine("[yellow]Workflow:[/] [green]session open <file>[/] → run commands with [green]--session <id>[/] → [green]session close --save[/].");
@@ -251,6 +252,16 @@ internal sealed class Program
         }
 
         return 0;
+    }
+
+    internal static void WriteDiagnosticMarkupLine(string markup)
+    {
+        CreateErrorConsole().MarkupLine(markup);
+    }
+
+    private static IAnsiConsole CreateErrorConsole()
+    {
+        return AnsiConsole.Create(new AnsiConsoleSettings { Out = new AnsiConsoleOutput(Console.Error) });
     }
 
     private static string GetCurrentVersion()

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -156,16 +156,7 @@ public class Program
             .AddEnvironmentVariables()
             .AddCommandLine(args);
 
-        // For stdio transport: Clear console logging to avoid polluting stderr with info messages.
-        // The MCP client interprets stderr output as errors/warnings, so we only log Warning+
-        // to stderr for debugging purposes. The MCP SDK handles protocol-level logging.
-        builder.Logging.ClearProviders();
-        builder.Logging.AddConsole(consoleLogOptions =>
-        {
-            // Only log Warning and above to stderr - Info/Debug would appear as errors in MCP clients
-            consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Warning;
-        });
-        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+        ConfigureStdioLogging(builder.Logging);
 
         // Configure Application Insights
         ConfigureTelemetry(builder);
@@ -292,6 +283,18 @@ public class Program
                 ServiceBridge.ServiceBridge.DisposeIfOwnedBy(testTransportGeneration);
             }
         }
+    }
+
+    internal static void ConfigureStdioLogging(ILoggingBuilder logging)
+    {
+        // MCP stdio reserves stdout exclusively for JSON-RPC frames. Route every
+        // possible console log level to stderr so config overrides cannot corrupt stdout.
+        logging.ClearProviders();
+        logging.AddConsole(consoleLogOptions =>
+        {
+            consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
+        });
+        logging.SetMinimumLevel(LogLevel.Warning);
     }
 
     /// <summary>

--- a/tests/ExcelMcp.CLI.Tests/Unit/ProgramOutputRoutingTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/ProgramOutputRoutingTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Unit;
+
+[Trait("Layer", "CLI")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "ProgramOutput")]
+[Trait("Speed", "Fast")]
+public sealed class ProgramOutputRoutingTests
+{
+    [Fact]
+    public void WriteDiagnosticMarkupLine_WritesToStandardErrorOnly()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+
+            Program.WriteDiagnosticMarkupLine("[red]diagnostic[/]");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+
+        Assert.Empty(stdout.ToString());
+        Assert.Contains("diagnostic", stderr.ToString(), StringComparison.Ordinal);
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ProgramLoggingTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ProgramLoggingTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
+
+[Collection("ProgramTransport")]
+[Trait("Layer", "McpServer")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "ProgramTransport")]
+[Trait("Speed", "Fast")]
+public sealed class ProgramLoggingTests
+{
+    [Fact]
+    public void ConfigureStdioLogging_RoutesAllConsoleLogsToStandardError()
+    {
+        var services = new ServiceCollection();
+
+        services.AddLogging(Program.ConfigureStdioLogging);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ConsoleLoggerOptions>>().Value;
+
+        Assert.Equal(LogLevel.Trace, options.LogToStandardErrorThreshold);
+    }
+
+    [Fact]
+    public void ConfigureStdioLogging_DoesNotWriteInfoLogsToStandardOutputWhenMinimumLevelIsOverridden()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+
+            var services = new ServiceCollection();
+            services.AddLogging(builder =>
+            {
+                Program.ConfigureStdioLogging(builder);
+                builder.SetMinimumLevel(LogLevel.Information);
+            });
+
+            using (var provider = services.BuildServiceProvider())
+            {
+                var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("Microsoft.Hosting.Lifetime");
+                logger.LogInformation("host started");
+            }
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+
+        Assert.Empty(stdout.ToString());
+        Assert.Contains("host started", stderr.ToString(), StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Route all MCP server console logs to stderr so stdio stdout remains JSON-RPC only
- Add focused regression coverage for logging configuration and stdout isolation
- Document the #636 fix in CHANGELOG

## Validation
- dotnet test tests\ExcelMcp.McpServer.Tests\ExcelMcp.McpServer.Tests.csproj --filter "FullyQualifiedName~ProgramLoggingTests"
- dotnet test tests\ExcelMcp.McpServer.Tests\ExcelMcp.McpServer.Tests.csproj --filter "FullyQualifiedName~McpServerSmokeTests.SmokeTest_AllTools_E2EWorkflow"
- dotnet build Sbroenne.ExcelMcp.sln -c Release
- full pre-commit hook suite (all checks passed)

Fixes #636