### PR TITLE
Fix formatted numeric PivotTable field detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **PivotTable numeric value fields with currency formatting no longer get misclassified as text** (#635): `pivottable_field list-fields` and `add-value-field` now use Excel's PivotField data type metadata before falling back to sampled PivotItem captions, so formatted numeric table columns such as `Amount` can be summed correctly instead of being rejected as Text-only fields.
+
 - **MCP Server stdio logging no longer corrupts JSON-RPC stdout** (#636): Console logging is now configured so all log levels are routed to stderr, keeping stdout reserved exclusively for MCP JSON-RPC frames even if logging configuration is overridden. CLI diagnostics and non-result errors now follow the same stdout-safe convention, keeping stdout reserved for command results and JSON payloads.
 
 - **Dependency freshness refresh across .NET and VS Code extension toolchain**: Updated central package pins for stale transitive .NET dependencies (including MessagePack 3.1.4 and netstandard support packages) and refreshed VS Code extension type dependencies (`@types/node`, `@types/vscode`) with regenerated lockfile so dependency audits report fully up-to-date packages.

--- a/src/ExcelMcp.Core/Commands/PivotTable/PivotTableHelpers.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/PivotTableHelpers.cs
@@ -120,6 +120,12 @@ internal static class PivotTableHelpers
     /// <returns>Data type string: "Date", "Number", "Boolean", "Text", or "Unknown"</returns>
     public static string DetectFieldDataType(dynamic field)
     {
+        string? fieldDataType = TryDetectFromPivotFieldDataType(field);
+        if (fieldDataType != null)
+        {
+            return fieldDataType;
+        }
+
         dynamic? pivotItems = null;
         try
         {
@@ -166,6 +172,25 @@ internal static class PivotTableHelpers
         finally
         {
             ComUtilities.Release(ref pivotItems);
+        }
+    }
+
+    private static string? TryDetectFromPivotFieldDataType(dynamic field)
+    {
+        try
+        {
+            int dataType = Convert.ToInt32(field.DataType);
+            return dataType switch
+            {
+                XlPivotFieldDataType.xlDate => "Date",
+                XlPivotFieldDataType.xlNumber => "Number",
+                XlPivotFieldDataType.xlText => "Text",
+                _ => null
+            };
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            return null;
         }
     }
 

--- a/tests/ExcelMcp.Core.Tests/Helpers/DataModelPivotTableFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/DataModelPivotTableFixture.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Commands;
 using Sbroenne.ExcelMcp.Core.Commands.PivotTable;
@@ -28,6 +29,8 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
 public class DataModelPivotTableFixture : IAsyncLifetime
 {
     private readonly string _tempDir;
+    private readonly object _salesDataTemplateLock = new();
+    private string? _salesDataTemplatePath;
 
     /// <summary>
     /// Temp directory for test files (auto-cleaned on disposal)
@@ -444,6 +447,81 @@ public class DataModelPivotTableFixture : IAsyncLifetime
         var sessionId = manager.CreateSessionForNewFile(filePath, show: false);
         manager.CloseSession(sessionId, save: true);
         return filePath;
+    }
+
+    /// <summary>
+    /// Creates a unique copy of the standard PivotTable sales-data workbook.
+    /// </summary>
+    public string CreateSalesDataTestFile([CallerMemberName] string testName = "")
+    {
+        var templatePath = EnsureSalesDataTemplate();
+        var fileName = $"{testName}_{Guid.NewGuid():N}.xlsx";
+        var filePath = Path.Join(_tempDir, fileName);
+        File.Copy(templatePath, filePath);
+        return filePath;
+    }
+
+    private string EnsureSalesDataTemplate()
+    {
+        if (_salesDataTemplatePath != null)
+        {
+            return _salesDataTemplatePath;
+        }
+
+        lock (_salesDataTemplateLock)
+        {
+            if (_salesDataTemplatePath != null)
+            {
+                return _salesDataTemplatePath;
+            }
+
+            var templatePath = Path.Join(_tempDir, "SalesDataTemplate.xlsx");
+            CreateSalesDataTemplate(templatePath);
+            _salesDataTemplatePath = templatePath;
+            return templatePath;
+        }
+    }
+
+    private static void CreateSalesDataTemplate(string templatePath)
+    {
+        using (var manager = new SessionManager())
+        {
+            var sessionId = manager.CreateSessionForNewFile(templatePath, show: false);
+            manager.CloseSession(sessionId, save: true);
+        }
+
+        using var batch = ExcelSession.BeginBatch(templatePath);
+        var rangeCommands = new RangeCommands();
+        rangeCommands.SetValues(
+            batch,
+            "Sheet1",
+            "A1:D6",
+            [
+                ["Region", "Product", "Sales", "Date"],
+                ["North", "Widget", 100, new DateTime(2025, 1, 15)],
+                ["North", "Widget", 150, new DateTime(2025, 1, 20)],
+                ["South", "Gadget", 200, new DateTime(2025, 2, 10)],
+                ["North", "Gadget", 75, new DateTime(2025, 2, 15)],
+                ["South", "Widget", 125, new DateTime(2025, 3, 5)]
+            ]);
+
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            try
+            {
+                sheet = ctx.Book.Worksheets["Sheet1"];
+                sheet.Name = "SalesData";
+                sheet.Range["D2:D6"].NumberFormat = "m/d/yyyy";
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheet);
+            }
+        });
+
+        batch.Save();
     }
 
     public Task DisposeAsync()

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.Fields.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.Fields.cs
@@ -1,4 +1,6 @@
+using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Table;
 using Sbroenne.ExcelMcp.Core.Models;
 using Xunit;
 
@@ -56,6 +58,113 @@ public partial class PivotTableCommandsTests
         Assert.True(result.Success, $"AddValueField failed: {result.ErrorMessage}");
         Assert.Equal("Sales", result.FieldName);
         Assert.Equal(PivotFieldArea.Value, result.Area);
+    }
+
+    [Fact]
+    [Trait("Speed", "Medium")]
+    [Trait("Category", "Regular")]
+    public void AddValueField_FromTableNumericColumn_AllowsSumAggregation()
+    {
+        // Arrange
+        var testFile = _olapFixture.CreateTestFile(nameof(AddValueField_FromTableNumericColumn_AllowsSumAggregation));
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            try
+            {
+                sheet = ctx.Book.Worksheets[1];
+                sheet.Name = "SalesData";
+
+                sheet.Range["A1"].Value2 = "Date";
+                sheet.Range["B1"].Value2 = "Region";
+                sheet.Range["C1"].Value2 = "Product";
+                sheet.Range["D1"].Value2 = "Amount";
+
+                sheet.Range["A2"].Value2 = new DateTime(2026, 1, 1);
+                sheet.Range["B2"].Value2 = "North";
+                sheet.Range["C2"].Value2 = "Widget";
+                sheet.Range["D2"].Value2 = 100;
+
+                sheet.Range["A3"].Value2 = new DateTime(2026, 1, 2);
+                sheet.Range["B3"].Value2 = "South";
+                sheet.Range["C3"].Value2 = "Widget";
+                sheet.Range["D3"].Value2 = 150;
+
+                sheet.Range["A4"].Value2 = new DateTime(2026, 1, 3);
+                sheet.Range["B4"].Value2 = "North";
+                sheet.Range["C4"].Value2 = "Gadget";
+                sheet.Range["D4"].Value2 = 200;
+
+                sheet.Range["A5"].Value2 = new DateTime(2026, 1, 4);
+                sheet.Range["B5"].Value2 = "West";
+                sheet.Range["C5"].Value2 = "Widget";
+                sheet.Range["D5"].Value2 = 75;
+
+                sheet.Range["A6"].Value2 = new DateTime(2026, 1, 5);
+                sheet.Range["B6"].Value2 = "East";
+                sheet.Range["C6"].Value2 = "Gadget";
+                sheet.Range["D6"].Value2 = 125;
+
+                sheet.Range["A7"].Value2 = new DateTime(2026, 1, 6);
+                sheet.Range["B7"].Value2 = "North";
+                sheet.Range["C7"].Value2 = "Widget";
+                sheet.Range["D7"].Value2 = 90;
+
+                sheet.Range["A8"].Value2 = new DateTime(2026, 1, 7);
+                sheet.Range["B8"].Value2 = "South";
+                sheet.Range["C8"].Value2 = "Gadget";
+                sheet.Range["D8"].Value2 = 60;
+
+                sheet.Range["A9"].Value2 = new DateTime(2026, 1, 8);
+                sheet.Range["B9"].Value2 = "West";
+                sheet.Range["C9"].Value2 = "Widget";
+                sheet.Range["D9"].Value2 = 110;
+
+                sheet.Range["A10"].Value2 = new DateTime(2026, 1, 9);
+                sheet.Range["B10"].Value2 = "East";
+                sheet.Range["C10"].Value2 = "Gadget";
+                sheet.Range["D10"].Value2 = 80;
+
+                sheet.Range["A11"].Value2 = new DateTime(2026, 1, 10);
+                sheet.Range["B11"].Value2 = "North";
+                sheet.Range["C11"].Value2 = "Gadget";
+                sheet.Range["D11"].Value2 = 130;
+
+                sheet.Range["A2:A11"].NumberFormat = "m/d/yyyy";
+                sheet.Range["D2:D11"].NumberFormat = "$#,##0.00";
+
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheet);
+            }
+        });
+
+        var tableCommands = new TableCommands();
+        tableCommands.Create(batch, "SalesData", "tblSales", "A1:D11", true, TableStylePresets.Medium2);
+
+        var createResult = _pivotCommands.CreateFromTable(
+            batch, "tblSales", "SalesData", "F1", "TestPivot");
+        Assert.True(createResult.Success, $"CreateFromTable failed: {createResult.ErrorMessage}");
+
+        // Act
+        var fieldsResult = _pivotCommands.ListFields(batch, "TestPivot");
+        var addResult = _pivotCommands.AddValueField(
+            batch, "TestPivot", "Amount", AggregationFunction.Sum, "Total Amount");
+
+        // Assert
+        Assert.True(fieldsResult.Success, $"ListFields failed: {fieldsResult.ErrorMessage}");
+        var amountField = Assert.Single(fieldsResult.Fields, field => field.Name == "Amount");
+        Assert.Equal("Number", amountField.DataType);
+
+        Assert.True(addResult.Success, $"AddValueField failed: {addResult.ErrorMessage}");
+        Assert.Equal("Amount", addResult.FieldName);
+        Assert.Equal(PivotFieldArea.Value, addResult.Area);
+        Assert.Equal(AggregationFunction.Sum, addResult.Function);
+        Assert.Equal("Number", addResult.DataType);
     }
     /// <inheritdoc/>
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PivotTable/PivotTableCommandsTests.cs
@@ -43,61 +43,10 @@ public partial class PivotTableCommandsTests
     }
 
     /// <summary>
-    /// Helper to create unique test file with sales data for pivot table tests.
+    /// Helper to create a unique copy of the shared sales-data template for pivot table tests.
     /// Used when tests need unique files for specific scenarios.
     /// </summary>
-    private string CreateTestFileWithData(string testName)
-    {
-        var testFile = _olapFixture.CreateTestFile(testName);
-
-        using var batch = ExcelSession.BeginBatch(testFile);
-
-        batch.Execute((ctx, ct) =>
-        {
-            dynamic sheet = ctx.Book.Worksheets[1];
-            sheet.Name = "SalesData";
-
-            sheet.Range["A1"].Value2 = "Region";
-            sheet.Range["B1"].Value2 = "Product";
-            sheet.Range["C1"].Value2 = "Sales";
-            sheet.Range["D1"].Value2 = "Date";
-
-            sheet.Range["A2"].Value2 = "North";
-            sheet.Range["B2"].Value2 = "Widget";
-            sheet.Range["C2"].Value2 = 100;
-            sheet.Range["D2"].Value2 = new DateTime(2025, 1, 15);
-
-            sheet.Range["A3"].Value2 = "North";
-            sheet.Range["B3"].Value2 = "Widget";
-            sheet.Range["C3"].Value2 = 150;
-            sheet.Range["D3"].Value2 = new DateTime(2025, 1, 20);
-
-            sheet.Range["A4"].Value2 = "South";
-            sheet.Range["B4"].Value2 = "Gadget";
-            sheet.Range["C4"].Value2 = 200;
-            sheet.Range["D4"].Value2 = new DateTime(2025, 2, 10);
-
-            sheet.Range["A5"].Value2 = "North";
-            sheet.Range["B5"].Value2 = "Gadget";
-            sheet.Range["C5"].Value2 = 75;
-            sheet.Range["D5"].Value2 = new DateTime(2025, 2, 15);
-
-            sheet.Range["A6"].Value2 = "South";
-            sheet.Range["B6"].Value2 = "Widget";
-            sheet.Range["C6"].Value2 = 125;
-            sheet.Range["D6"].Value2 = new DateTime(2025, 3, 5);
-
-            // CRITICAL: Format Date column with date format so PivotTable recognizes dates
-            // Without this, dates are stored as serial numbers (45672) and Excel won't group them
-            sheet.Range["D2:D6"].NumberFormat = "m/d/yyyy";
-
-            return 0;
-        });
-
-        batch.Save();
-
-        return testFile;
-    }
+    private string CreateTestFileWithData(string testName) => _olapFixture.CreateSalesDataTestFile(testName);
 
     /// <summary>
     /// Explicit test that validates the fixture creation results.


### PR DESCRIPTION
## Summary
- Fixes #635 by using Excel PivotField DataType metadata before falling back to sampled PivotItem captions.
- Adds a regression for a currency-formatted numeric Amount column from tblSales.
- Speeds up common PivotTable integration tests by caching the sales-data workbook template and copying it per test.

## Validation
- dotnet build Sbroenne.ExcelMcp.sln
- dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --no-build --filter "Feature=PivotTables&RunType!=OnDemand&Category=Regular"
- dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --no-build --filter "FullyQualifiedName~PivotTableCommandsTests.Slicer|FullyQualifiedName~PivotTableCommandsTests.CreateSlicer|FullyQualifiedName~PivotTableCommandsTests.ListSlicers|FullyQualifiedName~PivotTableCommandsTests.SetSlicerSelection|FullyQualifiedName~PivotTableCommandsTests.DeleteSlicer"
- scripts\check-com-leaks.ps1
- full pre-commit hook