### PR TITLE
Fix intermittent Excel session loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **Intermittent session loss and daemon startup failures during Excel automation** (#645): Excel COM disconnects such as `RPC_E_DISCONNECTED` are now classified as fatal session loss, dead sessions are cleaned up consistently during save/close and service dispatch, and `excelcli` daemon startup/connection-loss messages provide clearer recovery guidance. Screenshot capture is also hardened with additional window activation, `CopyPicture` fallback modes, and range-copy fallback when Excel's rendering clipboard path is temporarily unavailable.
+
 - **PivotTable numeric value fields with currency formatting no longer get misclassified as text** (#635): `pivottable_field list-fields` and `add-value-field` now use Excel's PivotField data type metadata before falling back to sampled PivotItem captions, so formatted numeric table columns such as `Amount` can be summed correctly instead of being rejected as Text-only fields.
 
 - **MCP Server stdio logging no longer corrupts JSON-RPC stdout** (#636): Console logging is now configured so all log levels are routed to stderr, keeping stdout reserved exclusively for MCP JSON-RPC frames even if logging configuration is overridden. CLI diagnostics and non-result errors now follow the same stdout-safe convention, keeping stdout reserved for command results and JSON payloads.

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonAutoStart.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonAutoStart.cs
@@ -219,6 +219,20 @@ internal static class DaemonAutoStart
                 await Task.Delay(StartupReadyRetryInterval, cancellationToken);
                 if (daemonProcess.HasExited)
                 {
+                    if (daemonProcess.ExitCode == 0)
+                    {
+                        if (await WaitForResponsiveDaemonAsync(pipeName, waitUntil - DateTime.UtcNow, cancellationToken))
+                        {
+                            GC.KeepAlive(daemonProcess);
+                            return;
+                        }
+
+                        throw new InvalidOperationException(
+                            "Daemon process exited cleanly before becoming ready, but no responsive daemon was found. " +
+                            "This usually means a stale startup race or a daemon that shut down immediately. " +
+                            "Run 'excelcli service stop' and retry.");
+                    }
+
                     throw new InvalidOperationException(
                         $"Daemon process exited before becoming ready (exit code {daemonProcess.ExitCode}).");
                 }

--- a/src/ExcelMcp.ComInterop/Session/ExcelShutdownService.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelShutdownService.cs
@@ -83,6 +83,9 @@ public static class ExcelShutdownService
                 unchecked((int)0x800AC472) =>
                     $"Cannot save '{fileName}'. " +
                     "The file is locked for editing by another user or process.",
+                ResiliencePipelines.RPC_E_DISCONNECTED =>
+                    $"Cannot save '{fileName}'. Excel disconnected from automation before the save completed. " +
+                    "The session is no longer usable; reopen the workbook and verify whether changes were saved.",
                 _ => $"Failed to save workbook '{fileName}': {ex.Message}"
             };
 
@@ -160,9 +163,19 @@ public static class ExcelShutdownService
                     }
                     catch (COMException ex)
                     {
-                        logger.LogWarning(ex,
-                            "Failed to close workbook {FileName} (HResult: 0x{HResult:X8}) - continuing with cleanup",
-                            fileName, ex.HResult);
+                        if (ex.HResult == ResiliencePipelines.RPC_E_DISCONNECTED)
+                        {
+                            logger.LogWarning(ex,
+                                "Workbook COM proxy disconnected while closing {FileName} (HResult: 0x{HResult:X8}) - continuing with cleanup",
+                                fileName, ex.HResult);
+                        }
+                        else
+                        {
+                            logger.LogWarning(ex,
+                                "Failed to close workbook {FileName} (HResult: 0x{HResult:X8}) - continuing with cleanup",
+                                fileName, ex.HResult);
+                        }
+
                         break; // Non-transient error, move on
                     }
                     catch (MissingMemberException ex)
@@ -245,6 +258,13 @@ public static class ExcelShutdownService
                         $"[DIAG-QUIT-RPC-FAILED] Excel RPC connection FAILED (0x800706BE) for {fileName}. Excel is unreachable - this is a FATAL error that cannot be retried. Proceeding with forced COM cleanup. Excel process should be force-killed by caller.");
                     lastException = ex;
                     // Don't retry - RPC connection is dead, Excel is gone
+                }
+                catch (COMException ex) when (ex.HResult == ResiliencePipelines.RPC_E_DISCONNECTED)
+                {
+                    logger.LogWarning(ex,
+                        "Excel COM proxy was disconnected while calling Quit for {FileName} - proceeding with COM cleanup",
+                        fileName);
+                    lastException = ex;
                 }
                 catch (COMException ex)
                 {

--- a/src/ExcelMcp.ComInterop/Session/ResiliencePipelines.cs
+++ b/src/ExcelMcp.ComInterop/Session/ResiliencePipelines.cs
@@ -34,6 +34,12 @@ public static class ResiliencePipelines
     public const int RPC_S_SERVER_UNAVAILABLE = unchecked((int)0x800706BA);     // -2147023174
 
     /// <summary>
+    /// RPC_E_DISCONNECTED - COM proxy disconnected from Excel.
+    /// FATAL ERROR - Session must be cleaned up.
+    /// </summary>
+    public const int RPC_E_DISCONNECTED = unchecked((int)0x80010108);            // -2147417848
+
+    /// <summary>
     /// CO_E_SERVER_EXEC_FAILURE - COM class factory failed to start the server (Excel).
     /// Transient during session creation when system resources are constrained.
     /// </summary>
@@ -132,6 +138,7 @@ public static class ResiliencePipelines
                 ShouldHandle = new PredicateBuilder().Handle<COMException>(ex =>
                     ex.HResult != RPC_E_CALL_FAILED &&
                     ex.HResult != RPC_S_SERVER_UNAVAILABLE &&
+                    ex.HResult != RPC_E_DISCONNECTED &&
                     (ex.HResult == RPC_E_SERVERCALL_RETRYLATER ||
                      ex.HResult == RPC_E_CALL_REJECTED ||
                      config.AdditionalHResults.Contains(ex.HResult))),

--- a/src/ExcelMcp.Core/Commands/Screenshot/ScreenshotCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Screenshot/ScreenshotCommands.cs
@@ -11,9 +11,12 @@ public class ScreenshotCommands : IScreenshotCommands
 {
     // Excel COM constants
     private const int XlScreen = 1;      // xlScreen - required for CopyPicture to render correctly
+    private const int XlPrinter = 2;     // xlPrinter - fallback when xlScreen rendering is unavailable
     private const int XlPicture = -4147; // xlPicture - more reliable than xlBitmap for range capture
+    private const int XlBitmap = 2;      // xlBitmap - fallback when xlPicture fails
     private const int XlNormal = -4143;  // xlNormal
     private const int XlMinimized = -4140; // xlMinimized
+    private const int SwRestore = 9;
 
     // CopyPicture retry configuration
     // After Save or large operations, Excel rendering can take several seconds.
@@ -152,6 +155,7 @@ public class ScreenshotCommands : IScreenshotCommands
                 Thread.Sleep(500);
             }
 
+            BringExcelToForeground(app);
             PrepareRangeForCapture(app, sheet, range);
 
             // Get range dimensions for the chart
@@ -192,7 +196,7 @@ public class ScreenshotCommands : IScreenshotCommands
             // Copy range as picture (with retry — CopyPicture is clipboard-dependent
             // and intermittently fails when Excel is still rendering after chart/table operations)
             try { app.CutCopyMode = false; } catch (COMException) { }
-            CopyPictureWithRetry(range);
+            CopyPictureWithRetry(app, sheet, range);
             Thread.Sleep(250);
 
             // Create a temporary ChartObject to paste into and export
@@ -268,20 +272,64 @@ public class ScreenshotCommands : IScreenshotCommands
     /// intermittently fails with COMException when Excel is busy rendering
     /// (e.g., after chart/table operations). Retries with increasing delay.
     /// </summary>
-    private static void CopyPictureWithRetry(dynamic range)
+    private static void CopyPictureWithRetry(dynamic app, dynamic sheet, dynamic range)
     {
+        COMException? lastException = null;
+        (int Appearance, int Format)[] modes =
+        [
+            (XlScreen, XlPicture),
+            (XlPrinter, XlPicture),
+            (XlScreen, XlBitmap),
+            (XlPrinter, XlBitmap)
+        ];
+
+        for (int attempt = 0; attempt < CopyPictureMaxRetries; attempt++)
+        {
+            foreach (var mode in modes)
+            {
+                try
+                {
+                    try { app.CutCopyMode = false; } catch (COMException) { }
+                    range.CopyPicture(mode.Appearance, mode.Format);
+                    return;
+                }
+                catch (COMException ex)
+                {
+                    lastException = ex;
+                }
+            }
+
+            if (attempt < CopyPictureMaxRetries - 1)
+            {
+                Thread.Sleep(CopyPictureRetryDelayMs * (attempt + 1));
+                PrepareRangeForCapture(app, sheet, range);
+            }
+        }
+
         for (int attempt = 0; attempt < CopyPictureMaxRetries; attempt++)
         {
             try
             {
-                range.CopyPicture(XlScreen, XlPicture);
+                try { app.CutCopyMode = false; } catch (COMException) { }
+                range.Copy();
                 return;
             }
-            catch (COMException) when (attempt < CopyPictureMaxRetries - 1)
+            catch (COMException ex)
             {
-                Thread.Sleep(CopyPictureRetryDelayMs * (attempt + 1));
+                lastException = ex;
+                if (attempt < CopyPictureMaxRetries - 1)
+                {
+                    Thread.Sleep(CopyPictureRetryDelayMs * (attempt + 1));
+                    PrepareRangeForCapture(app, sheet, range);
+                }
             }
         }
+
+        throw new InvalidOperationException(
+            $"Excel could not capture the range after {CopyPictureMaxRetries} attempts because CopyPicture and the range copy fallback kept failing. " +
+            "Excel may still be rendering, busy, minimized, or unable to access the clipboard. " +
+            "Retry the screenshot after the workbook finishes refreshing, or capture a smaller range.",
+            lastException);
     }
 
     private static void PrepareRangeForCapture(dynamic app, dynamic sheet, dynamic range)
@@ -291,6 +339,7 @@ public class ScreenshotCommands : IScreenshotCommands
 
         try
         {
+            BringExcelToForeground(app);
             try { sheet.Activate(); } catch (COMException) { }
 
             try
@@ -321,6 +370,30 @@ public class ScreenshotCommands : IScreenshotCommands
         }
     }
 
+    private static void BringExcelToForeground(dynamic app)
+    {
+        try
+        {
+            IntPtr hwnd = new(Convert.ToInt64(app.Hwnd));
+            if (hwnd != IntPtr.Zero)
+            {
+                ShowWindow(hwnd, SwRestore);
+                SetForegroundWindow(hwnd);
+                Thread.Sleep(250);
+            }
+        }
+        catch (COMException) { }
+        catch (InvalidCastException) { }
+        catch (FormatException) { }
+        catch (OverflowException) { }
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
     private static void PastePictureWithRetry(dynamic app, dynamic sheet, dynamic range, dynamic chart)
     {
         for (int attempt = 0; attempt < CopyPictureMaxRetries; attempt++)
@@ -339,7 +412,7 @@ public class ScreenshotCommands : IScreenshotCommands
                 Thread.Sleep(CopyPictureRetryDelayMs * (attempt + 1));
                 PrepareRangeForCapture(app, sheet, range);
                 try { app.CutCopyMode = false; } catch (COMException) { }
-                CopyPictureWithRetry(range);
+                CopyPictureWithRetry(app, sheet, range);
             }
         }
     }

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -394,7 +394,19 @@ public sealed class ExcelMcpService : IDisposable
         }
 
         var args = ServiceRegistry.DeserializeArgs<SessionCloseArgs>(request.Args);
-        var closed = _sessionManager.CloseSession(request.SessionId, save: args?.Save ?? false);
+        var shouldSave = args?.Save ?? false;
+        bool closed;
+        try
+        {
+            closed = _sessionManager.CloseSession(request.SessionId, save: shouldSave);
+        }
+        catch (Exception ex) when (IsFatalExcelDisconnect(ex))
+        {
+            CleanupDeadSession(request.SessionId);
+            return CreateExcelDisconnectedResponse(request.SessionId, ex, shouldSave
+                ? "Excel disconnected while saving before close. Session has been cleaned up; reopen the workbook and verify whether the save completed."
+                : "Excel disconnected while closing. Session has been cleaned up; reopen the workbook with a new session.");
+        }
 
         if (closed)
         {
@@ -428,8 +440,17 @@ public sealed class ExcelMcpService : IDisposable
             return sessionError;
         }
 
-        batch!.Save();
-        return new ServiceResponse { Success = true };
+        try
+        {
+            batch!.Save();
+            return new ServiceResponse { Success = true };
+        }
+        catch (Exception ex) when (IsFatalExcelDisconnect(ex))
+        {
+            CleanupDeadSession(request.SessionId);
+            return CreateExcelDisconnectedResponse(request.SessionId, ex,
+                "Excel disconnected while saving. Session has been cleaned up; reopen the workbook and verify whether the save completed.");
+        }
     }
 
     private ServiceResponse HandleSessionList()
@@ -722,17 +743,11 @@ public sealed class ExcelMcpService : IDisposable
         }
         catch (COMException ex) when (
             ex.HResult == ResiliencePipelines.RPC_S_SERVER_UNAVAILABLE ||
-            ex.HResult == ResiliencePipelines.RPC_E_CALL_FAILED)
+            ex.HResult == ResiliencePipelines.RPC_E_CALL_FAILED ||
+            ex.HResult == ResiliencePipelines.RPC_E_DISCONNECTED)
         {
             // Excel process died during the operation — clean up the dead session
-            try
-            {
-                _sessionManager.CloseSession(sessionId, save: false, force: true);
-            }
-            catch (Exception cleanupEx)
-            {
-                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
-            }
+            CleanupDeadSession(sessionId);
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
@@ -748,14 +763,7 @@ public sealed class ExcelMcpService : IDisposable
             ex.Message.Contains("process", StringComparison.OrdinalIgnoreCase))
         {
             // Excel process detected as dead before COM call (ExcelBatch pre-check)
-            try
-            {
-                _sessionManager.CloseSession(sessionId, save: false, force: true);
-            }
-            catch (Exception cleanupEx)
-            {
-                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
-            }
+            CleanupDeadSession(sessionId);
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
@@ -767,22 +775,79 @@ public sealed class ExcelMcpService : IDisposable
         }
         catch (Exception ex)
         {
+            if (IsFatalExcelDisconnect(ex))
+            {
+                CleanupDeadSession(sessionId);
+                return Task.FromResult(CreateExcelDisconnectedResponse(sessionId, ex,
+                    $"Excel process for session '{sessionId}' disconnected during the operation. Session has been cleaned up. Please reopen the file with a new session."));
+            }
+
             // Check if Excel died with a non-COM exception — clean up dead session
             if (batch != null && !batch.IsExcelProcessAlive())
             {
-                try
-                {
-                    _sessionManager.CloseSession(sessionId, save: false, force: true);
-                }
-                catch (Exception cleanupEx)
-                {
-                    System.Diagnostics.Debug.WriteLine($"Dead session cleanup failed for {sessionId}: {cleanupEx.Message}");
-                }
+                CleanupDeadSession(sessionId);
             }
 
             return Task.FromResult(CreateErrorResponse(ex));
         }
     }
+
+    private void CleanupDeadSession(string sessionId)
+    {
+        try
+        {
+            _sessionManager.CloseSession(sessionId, save: false, force: true);
+        }
+        catch (Exception cleanupEx)
+        {
+            System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+        }
+    }
+
+    private static ServiceResponse CreateExcelDisconnectedResponse(string sessionId, Exception ex, string message)
+    {
+        return new ServiceResponse
+        {
+            Success = false,
+            SessionId = sessionId,
+            ErrorCategory = "ExcelProcessDied",
+            ErrorMessage = message,
+            ExceptionType = ex.GetType().Name,
+            HResult = TryGetFatalComHResult(ex) is { } hresult ? $"0x{hresult:X8}" : null,
+            InnerError = ex.InnerException?.Message
+        };
+    }
+
+    private static bool IsFatalExcelDisconnect(Exception ex) => TryGetFatalComHResult(ex).HasValue;
+
+    private static int? TryGetFatalComHResult(Exception ex)
+    {
+        for (var current = ex; current != null; current = current.InnerException!)
+        {
+            if (current is COMException comEx &&
+                (IsFatalComHResult(comEx.HResult) || IsFatalComHResult(comEx.ErrorCode)))
+            {
+                return IsFatalComHResult(comEx.HResult) ? comEx.HResult : comEx.ErrorCode;
+            }
+
+            if (current.Message.Contains("disconnected", StringComparison.OrdinalIgnoreCase))
+            {
+                return ResiliencePipelines.RPC_E_DISCONNECTED;
+            }
+
+            if (current.Message.Contains("RPC server is unavailable", StringComparison.OrdinalIgnoreCase))
+            {
+                return ResiliencePipelines.RPC_S_SERVER_UNAVAILABLE;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsFatalComHResult(int hresult) =>
+        hresult == ResiliencePipelines.RPC_S_SERVER_UNAVAILABLE ||
+        hresult == ResiliencePipelines.RPC_E_CALL_FAILED ||
+        hresult == ResiliencePipelines.RPC_E_DISCONNECTED;
 
     private static ServiceResponse AttachRequestContext(ServiceRequest request, ServiceResponse response)
     {

--- a/src/ExcelMcp.Service/ServiceClient.cs
+++ b/src/ExcelMcp.Service/ServiceClient.cs
@@ -97,7 +97,7 @@ public sealed class ServiceClient : IDisposable
                 Command = request.Command,
                 SessionId = request.SessionId,
                 ErrorCategory = "ServiceUnavailable",
-                ErrorMessage = "Connection to service lost. Is it running?",
+                ErrorMessage = "Connection to service lost while waiting for a response. The daemon may have exited or restarted; run 'excelcli service status' or 'excelcli service stop' and retry.",
                 ExceptionType = nameof(ConnectionLostException)
             };
         }

--- a/tests/ExcelMcp.CLI.Tests/Unit/ExcelMcpServiceErrorTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/ExcelMcpServiceErrorTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Service;
@@ -165,6 +167,46 @@ public sealed class ExcelMcpServiceErrorTests
         Assert.Equal(1, batch.SaveCalls);
     }
 
+    [Fact]
+    public async Task ProcessAsync_SessionCloseSaveAfterRpcDisconnected_CleansSessionAndReturnsActionableError()
+    {
+        using var service = new ExcelMcpService();
+        var batch = new FakeBatch
+        {
+#pragma warning disable CA2201
+            SaveException = new InvalidOperationException(
+                "Failed to save workbook 'book.xlsx': The object invoked has disconnected from its clients.",
+                new COMException("The object invoked has disconnected from its clients.", unchecked((int)0x80010108))),
+#pragma warning restore CA2201
+            IsAliveAfterSaveException = false
+        };
+        const string sessionId = "disconnected-close-save";
+
+        RegisterSession(service, sessionId, batch);
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.close",
+            SessionId = sessionId,
+            Args = JsonSerializer.Serialize(new { save = true }, ServiceProtocol.JsonOptions)
+        });
+
+        Assert.False(response.Success);
+        Assert.True(
+            response.ErrorCategory == "ExcelProcessDied",
+            $"Expected ExcelProcessDied but got '{response.ErrorCategory}'. Message: {response.ErrorMessage}");
+        Assert.NotNull(response.ErrorMessage);
+        Assert.Contains("disconnected", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Session has been cleaned up", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, batch.SaveCalls);
+        Assert.Equal(1, batch.DisposeCalls);
+
+        var listResponse = await service.ProcessAsync(new ServiceRequest { Command = "session.list" });
+        Assert.True(listResponse.Success);
+        Assert.NotNull(listResponse.Result);
+        Assert.DoesNotContain(sessionId, listResponse.Result, StringComparison.Ordinal);
+    }
+
     private static void RegisterSession(ExcelMcpService service, string sessionId, FakeBatch batch)
     {
         var sessionManager = GetPrivateField<SessionManager>(service, "_sessionManager");
@@ -199,8 +241,12 @@ public sealed class ExcelMcpServiceErrorTests
         public Microsoft.Extensions.Logging.ILogger Logger { get; } = NullLogger.Instance;
         public IReadOnlyDictionary<string, Excel.Workbook> Workbooks { get; } = new Dictionary<string, Excel.Workbook>();
         public bool HasTimedOutOperation { get; init; }
+        public bool IsAlive { get; private set; } = true;
+        public bool IsAliveAfterSaveException { get; init; } = true;
+        public Exception? SaveException { get; init; }
         public int ExecuteCalls { get; private set; }
         public int SaveCalls { get; private set; }
+        public int DisposeCalls { get; private set; }
         public int? ExcelProcessId => 1234;
         public TimeSpan OperationTimeout => TimeSpan.FromSeconds(5);
 
@@ -221,12 +267,18 @@ public sealed class ExcelMcpServiceErrorTests
         public void Save(CancellationToken cancellationToken = default)
         {
             SaveCalls++;
+            if (SaveException != null)
+            {
+                IsAlive = IsAliveAfterSaveException;
+                throw SaveException;
+            }
         }
 
-        public bool IsExcelProcessAlive() => true;
+        public bool IsExcelProcessAlive() => IsAlive;
 
         public void Dispose()
         {
+            DisposeCalls++;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Treat disconnected Excel COM proxies as fatal session loss and clean up dead sessions during save, close, and service dispatch.
- Improve daemon startup race handling and connection-loss recovery guidance.
- Harden screenshot capture with window restore/foreground handling, CopyPicture fallback modes, and range-copy fallback.
- Update CHANGELOG for the fix.

## Validation
- dotnet build Sbroenne.ExcelMcp.sln --no-restore
- dotnet test tests\ExcelMcp.CLI.Tests\ExcelMcp.CLI.Tests.csproj --filter "FullyQualifiedName~ExcelMcpServiceErrorTests|FullyQualifiedName~ServiceRun_SecondInstance_ExitsImmediatelyWithoutDuplicate"
- dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName~ScreenshotCommandsTests.CaptureRange_SmallRange_ReturnsValidPng"
- dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName~ScreenshotCommandsTests.CaptureRange_ConsecutiveCalls_AllSucceed"
- pre-commit checks

Closes #645