### PR TITLE
Fix merge info for mixed merged ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **Range merge info no longer fails on multiple separate merged regions** (#647): `range_format get-merge-info` now handles Excel's `DBNull`/Variant Null response from `Range.MergeCells` when a queried range contains heterogeneous merge state, and returns distinct `mergedRanges` for merge areas contained in the range.
+
 - **Intermittent session loss and daemon startup failures during Excel automation** (#645): Excel COM disconnects such as `RPC_E_DISCONNECTED` are now classified as fatal session loss, dead sessions are cleaned up consistently during save/close and service dispatch, and `excelcli` daemon startup/connection-loss messages provide clearer recovery guidance. Screenshot capture is also hardened with additional window activation, `CopyPicture` fallback modes, and range-copy fallback when Excel's rendering clipboard path is temporarily unavailable.
 
 - **PivotTable numeric value fields with currency formatting no longer get misclassified as text** (#635): `pivottable_field list-fields` and `add-value-field` now use Excel's PivotField data type metadata before falling back to sampled PivotItem captions, so formatted numeric table columns such as `Amount` can be summed correctly instead of being rejected as Text-only fields.

--- a/src/ExcelMcp.Core/Commands/Range/IRangeFormatCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Range/IRangeFormatCommands.cs
@@ -254,7 +254,7 @@ public interface IRangeFormatCommands
     OperationResult UnmergeCells(IExcelBatch batch, string sheetName, [RequiredParameter] string rangeAddress);
 
     /// <summary>
-    /// Checks if range contains merged cells.
+    /// Checks if range contains merged cells and returns distinct merge areas.
     /// Excel COM: Range.MergeCells
     /// </summary>
     /// <param name="sheetName">Name of the worksheet</param>

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Advanced.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Advanced.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Models;
@@ -98,8 +99,11 @@ public partial class RangeCommands
                 // Get range
                 range = sheet.Range[rangeAddress];
 
-                // Check if merged
-                var isMerged = range.MergeCells ?? false;
+                object? mergeCells = range.MergeCells;
+                bool? isMergedState = GetMergeCellsState(mergeCells);
+                IReadOnlyList<string> mergedRanges = isMergedState == false
+                    ? []
+                    : CollectMergedRanges(range, ct);
 
                 return new RangeMergeInfoResult
                 {
@@ -107,7 +111,8 @@ public partial class RangeCommands
                     FilePath = batch.WorkbookPath,
                     SheetName = sheetName,
                     RangeAddress = rangeAddress,
-                    IsMerged = isMerged
+                    IsMerged = isMergedState ?? mergedRanges.Count > 0,
+                    MergedRanges = mergedRanges
                 };
             }
             finally
@@ -116,6 +121,65 @@ public partial class RangeCommands
                 ComUtilities.Release(ref sheet!);
             }
         });
+    }
+
+    private static bool? GetMergeCellsState(object? mergeCells)
+    {
+        if (mergeCells is null || mergeCells == DBNull.Value)
+        {
+            return null;
+        }
+
+        return Convert.ToBoolean(mergeCells, CultureInfo.InvariantCulture);
+    }
+
+    private static List<string> CollectMergedRanges(dynamic range, CancellationToken cancellationToken)
+    {
+        dynamic? cells = null;
+        var mergedRanges = new List<string>();
+        var seenRanges = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            cells = range.Cells;
+            int cellCount = Convert.ToInt32(cells.Count);
+
+            for (int i = 1; i <= cellCount; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                dynamic? cell = null;
+                dynamic? mergeArea = null;
+                try
+                {
+                    cell = cells.Item[i];
+                    object? cellMergeCells = cell.MergeCells;
+
+                    if (GetMergeCellsState(cellMergeCells) != true)
+                    {
+                        continue;
+                    }
+
+                    mergeArea = cell.MergeArea;
+                    string address = mergeArea.Address?.ToString() ?? string.Empty;
+                    if (address.Length > 0 && seenRanges.Add(address))
+                    {
+                        mergedRanges.Add(address);
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref mergeArea);
+                    ComUtilities.Release(ref cell);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref cells);
+        }
+
+        return mergedRanges;
     }
 
     /// <inheritdoc />

--- a/src/ExcelMcp.Core/Models/ResultTypes.cs
+++ b/src/ExcelMcp.Core/Models/ResultTypes.cs
@@ -2402,6 +2402,11 @@ public class RangeMergeInfoResult : ResultBase
     /// Whether the range contains merged cells
     /// </summary>
     public bool IsMerged { get; set; }
+
+    /// <summary>
+    /// Distinct merged ranges contained in the queried range
+    /// </summary>
+    public IReadOnlyList<string> MergedRanges { get; set; } = [];
 }
 
 /// <summary>

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Advanced.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Advanced.cs
@@ -258,6 +258,54 @@ public partial class RangeCommandsTests
         Assert.Equal("https://example.com/", hyperlink.Address); // Excel normalizes URLs by adding trailing slash
         Assert.Contains("Example", hyperlink.DisplayText);
     }
+
+    [Fact]
+    [Trait("Speed", "Medium")]
+    public void GetMergeInfo_RangeSpanningMultipleMergedRegions_ReturnsMergedRanges()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.MergeCells(batch, sheetName, "B4:F4");
+        _commands.MergeCells(batch, sheetName, "G4:K4");
+        _commands.MergeCells(batch, sheetName, "L4:P4");
+
+        var result = _commands.GetMergeInfo(batch, sheetName, "A4:P4");
+
+        Assert.True(result.Success, $"GetMergeInfo failed: {result.ErrorMessage}");
+        Assert.True(result.IsMerged);
+        Assert.Equal(["$B$4:$F$4", "$G$4:$K$4", "$L$4:$P$4"], result.MergedRanges);
+    }
+
+    [Fact]
+    [Trait("Speed", "Medium")]
+    public void GetMergeInfo_PartiallyMergedRange_ReturnsContainedMergedRange()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.MergeCells(batch, sheetName, "B4:F4");
+
+        var result = _commands.GetMergeInfo(batch, sheetName, "B4:G4");
+
+        Assert.True(result.Success, $"GetMergeInfo failed: {result.ErrorMessage}");
+        Assert.True(result.IsMerged);
+        Assert.Equal(["$B$4:$F$4"], result.MergedRanges);
+    }
+
+    [Fact]
+    [Trait("Speed", "Medium")]
+    public void GetMergeInfo_UnmergedRange_ReturnsFalseAndNoMergedRanges()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        var result = _commands.GetMergeInfo(batch, sheetName, "A1:D4");
+
+        Assert.True(result.Success, $"GetMergeInfo failed: {result.ErrorMessage}");
+        Assert.False(result.IsMerged);
+        Assert.Empty(result.MergedRanges);
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- Handle Excel COM `DBNull` / Variant Null from `Range.MergeCells` when a range has heterogeneous merge state.
- Return distinct `mergedRanges` in `get-merge-info` while preserving `isMerged`.
- Add regression coverage for multi-merge, partial-merge, and unmerged ranges.
- Update CHANGELOG for #647.

## Validation
- dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName~GetMergeInfo_"
- dotnet build Sbroenne.ExcelMcp.sln --no-restore
- pre-commit checks

Closes #647