### PR TITLE
Fix MCP list result envelopes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -148,6 +148,8 @@ public void TestMethod()
 
 **Golden Rule (Diagnose Before Coding):** No changes without a failing test first. Write a test that proves the bug exists, watch it fail, then fix it, then watch it pass. Diagnose root cause before writing any code — spent a full session implementing the wrong fix once (issue was daemon dying, but coded a UI fix + 4 tests, all reverted).
 
+**Bug Fix Pattern Search:** Every bug fix must include a same-pattern search across sibling tools, Core interfaces, generated MCP/CLI surfaces, and tests. Fix matching cases in the same PR or document why each similar case is not affected.
+
 **COM Fix Patterns (2026):**
 - `OleMessageFilter.MessagePending` must return `WAITDEFPROCESS` (1), not `WAITNOPROCESS` (2) — causes STA deadlock on re-entrant COM callbacks (e.g. conditional formatting on formula cells).
 - `OleMessageFilter.RetryRejectedCall` must retry `SERVERCALL_REJECTED` (dwRejectType=1) for 120s — enterprise auth dialogs cause repeated rejections.

--- a/.github/instructions/bug-fixing-checklist.instructions.md
+++ b/.github/instructions/bug-fixing-checklist.instructions.md
@@ -4,16 +4,17 @@ applyTo: "**/*.cs,**/*.md"
 
 # Bug Fixing Checklist
 
-> **6-step process for comprehensive bug fixes**
+> **7-step process for comprehensive bug fixes**
 
 ## Process
 
 1. **Root Cause** - Trace flow from entry point to bug, identify what's missing/wrong/ignored
-2. **Fix Code** - Minimal changes at correct layer, maintain backwards compatibility
-3. **Add Tests** - Minimum 5-8 tests: regression + edge cases + backwards compat + MCP end-to-end
-4. **Update Docs** - Minimum 3 files: tool/method docs, user docs, SuggestedNextActions, LLM prompts
-5. **Verify Quality** - Build passes (0 warnings), all tests pass, no TODOs left
-6. **PR Description** - Bug summary, root cause, fix explanation, test coverage, docs updated
+2. **Same-Pattern Search** - Search sibling tools, Core interfaces, generated MCP/CLI surfaces, and tests for the same bug pattern
+3. **Fix Code** - Minimal changes at correct layer, maintain backwards compatibility
+4. **Add Tests** - Minimum 5-8 tests: regression + edge cases + backwards compat + MCP end-to-end
+5. **Update Docs** - Minimum 3 files: tool/method docs, user docs, SuggestedNextActions, LLM prompts
+6. **Verify Quality** - Build passes (0 warnings), all tests pass, no TODOs left
+7. **PR Description** - Bug summary, root cause, same-pattern search result, fix explanation, test coverage, docs updated
 
 ## Test Coverage Requirements
 
@@ -44,6 +45,7 @@ applyTo: "**/*.cs,**/*.md"
 
 **Before marking bug as fixed**:
 - [ ] Root cause documented
+- [ ] Same-pattern search completed; matching cases fixed or explicitly ruled out
 - [ ] Minimal code changes (surgical fix)
 - [ ] Parameters wired through all layers
 - [ ] 5-8 new tests added (Core + MCP)
@@ -64,6 +66,7 @@ applyTo: "**/*.cs,**/*.md"
 | Breaking changes | Make params optional, use defaults |
 | Parameter ignored | Trace from tool → implementation |
 | Symptoms fixed, not root cause | Understand WHY it broke |
+| Fixing one instance only | Search for the same pattern in sibling tools/layers and fix or document each match |
 | Incomplete PR | Document bug, fix, tests, docs updated |
 
 ## PR Description Template
@@ -77,6 +80,9 @@ Issue: #[number]
 
 ### Root Cause
 [Technical explanation]
+
+### Same-Pattern Search
+[Searches performed and matching cases fixed or ruled out]
 
 ### Solution
 **Files Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **MCP `namedrange list` and `chart list` no longer return raw arrays or risk closing the session** (#653): Both list commands now return standard structured result envelopes with `success` and item collections, keep the active session usable after listing empty or populated workbooks, and normalize named range values to JSON-safe types before serialization.
+
 - **Release workflow `dotnet pack` failure for CLI and MCP Server NuGet packages**: The dependency-update PR added `<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>` to both tool csproj files, which combined with `PackAsTool=true` routed `dotnet pack` through the RID-aware publish path and made it look for `bin/Release/net10.0-windows/win-x64/` outputs. The CI release workflow builds each project per-csproj without a runtime flag and writes plain `bin/Release/net10.0-windows/`, so pack failed with MSB3030. Removed the property from `ExcelMcp.CLI.csproj` and `ExcelMcp.McpServer.csproj` and documented why it must not be re-added; the standalone-exe publish step still passes the runtime on the command line.
 
 - **Range merge info no longer fails on multiple separate merged regions** (#647): `range_format get-merge-info` now handles Excel's `DBNull`/Variant Null response from `Range.MergeCells` when a queried range contains heterogeneous merge state, and returns distinct `mergedRanges` for merge areas contained in the range.

--- a/src/ExcelMcp.Core/Commands/Chart/ChartCommands.Lifecycle.cs
+++ b/src/ExcelMcp.Core/Commands/Chart/ChartCommands.Lifecycle.cs
@@ -13,70 +13,82 @@ public partial class ChartCommands : IChartCommands, IChartConfigCommands
     private readonly PivotChartStrategy _pivotStrategy = new();
 
     /// <inheritdoc />
-    public List<ChartInfo> List(IExcelBatch batch)
+    public ChartListResult List(IExcelBatch batch)
     {
+        var result = new ChartListResult
+        {
+            Action = "list",
+            FilePath = batch.WorkbookPath
+        };
+
         return batch.Execute((ctx, ct) =>
         {
-            var charts = new List<ChartInfo>();
-
-            dynamic worksheets = ctx.Book.Worksheets;
-            int wsCount = Convert.ToInt32(worksheets.Count);
-
-            for (int i = 1; i <= wsCount; i++)
+            dynamic? worksheets = null;
+            try
             {
-                dynamic? worksheet = null;
-                dynamic? shapes = null;
+                worksheets = ctx.Book.Worksheets;
+                int wsCount = Convert.ToInt32(worksheets.Count);
 
-                try
+                for (int i = 1; i <= wsCount; i++)
                 {
-                    worksheet = worksheets.Item(i);
-                    string sheetName = worksheet.Name?.ToString() ?? $"Sheet{i}";
-                    shapes = worksheet.Shapes;
-                    int shapeCount = Convert.ToInt32(shapes.Count);
+                    dynamic? worksheet = null;
+                    dynamic? shapes = null;
 
-                    for (int j = 1; j <= shapeCount; j++)
+                    try
                     {
-                        dynamic? shape = null;
-                        dynamic? chart = null;
+                        worksheet = worksheets.Item(i);
+                        string sheetName = worksheet.Name?.ToString() ?? $"Sheet{i}";
+                        shapes = worksheet.Shapes;
+                        int shapeCount = Convert.ToInt32(shapes.Count);
 
-                        try
+                        for (int j = 1; j <= shapeCount; j++)
                         {
-                            shape = shapes.Item(j);
+                            dynamic? shape = null;
+                            dynamic? chart = null;
 
-                            // Check if this is a chart (msoChart = 3)
-                            if (Convert.ToInt32(shape.Type) != 3)
+                            try
                             {
-                                continue;
-                            }
+                                shape = shapes.Item(j);
 
-                            chart = shape.Chart;
-                            string chartName = shape.Name?.ToString() ?? $"Chart{j}";
+                                // Check if this is a chart (msoChart = 3)
+                                if (Convert.ToInt32(shape.Type) != 3)
+                                {
+                                    continue;
+                                }
 
-                            // Determine strategy and get info
-                            IChartStrategy strategy = _pivotStrategy.CanHandle(chart) ? _pivotStrategy : _regularStrategy;
+                                chart = shape.Chart;
+                                string chartName = shape.Name?.ToString() ?? $"Chart{j}";
+
+                                // Determine strategy and get info
+                                IChartStrategy strategy = _pivotStrategy.CanHandle(chart) ? _pivotStrategy : _regularStrategy;
 #pragma warning disable CS8604 // CodeQL false positive: Both strategies implement IChartStrategy.GetInfo with dynamic parameters
-                            var chartInfo = strategy.GetInfo(chart, chartName, sheetName, shape);
+                                var chartInfo = strategy.GetInfo(chart, chartName, sheetName, shape);
 #pragma warning restore CS8604
 
-                            charts.Add(chartInfo);
-                        }
-                        finally
-                        {
-                            ComUtilities.Release(ref chart!);
-                            ComUtilities.Release(ref shape!);
+                                result.Charts.Add(chartInfo);
+                            }
+                            finally
+                            {
+                                ComUtilities.Release(ref chart!);
+                                ComUtilities.Release(ref shape!);
+                            }
                         }
                     }
+                    finally
+                    {
+                        ComUtilities.Release(ref shapes!);
+                        ComUtilities.Release(ref worksheet!);
+                    }
                 }
-                finally
-                {
-                    ComUtilities.Release(ref shapes!);
-                    ComUtilities.Release(ref worksheet!);
-                }
+
+                result.Success = true;
+
+                return result;
             }
-
-            ComUtilities.Release(ref worksheets!);
-
-            return charts;
+            finally
+            {
+                ComUtilities.Release(ref worksheets!);
+            }
         });
     }
 

--- a/src/ExcelMcp.Core/Commands/Chart/IChartCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Chart/IChartCommands.cs
@@ -36,9 +36,9 @@ public interface IChartCommands
     /// Lists all charts in workbook (Regular and PivotCharts).
     /// </summary>
     /// <param name="batch">Excel batch session</param>
-    /// <returns>List of charts with names, types, sheets, positions, data sources</returns>
+    /// <returns>Structured result with charts, names, types, sheets, positions, and data sources</returns>
     [ServiceAction("list")]
-    List<ChartInfo> List(IExcelBatch batch);
+    ChartListResult List(IExcelBatch batch);
 
     /// <summary>
     /// Gets complete chart configuration.

--- a/src/ExcelMcp.Core/Commands/NamedRange/INamedRangeCommands.cs
+++ b/src/ExcelMcp.Core/Commands/NamedRange/INamedRangeCommands.cs
@@ -18,10 +18,10 @@ public interface INamedRangeCommands
     /// <summary>
     /// Lists all named ranges in the workbook
     /// </summary>
-    /// <returns>List of named range information</returns>
+    /// <returns>Structured result containing the list of named range information</returns>
     /// <exception cref="InvalidOperationException">If workbook access fails</exception>
     [ServiceAction("list")]
-    List<NamedRangeInfo> List(IExcelBatch batch);
+    NamedRangeListResult List(IExcelBatch batch);
 
     /// <summary>
     /// Sets the value of a named range

--- a/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.Operations.cs
+++ b/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.Operations.cs
@@ -12,16 +12,20 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 public partial class NamedRangeCommands
 {
     /// <inheritdoc />
-    public List<NamedRangeInfo> List(IExcelBatch batch)
+    public NamedRangeListResult List(IExcelBatch batch)
     {
+        var result = new NamedRangeListResult
+        {
+            FilePath = batch.WorkbookPath
+        };
+
         return batch.Execute((ctx, ct) =>
         {
-            var namedRanges = new List<NamedRangeInfo>();
             dynamic? namesCollection = null;
             try
             {
                 namesCollection = ctx.Book.Names;
-                int count = namesCollection.Count;
+                int count = Convert.ToInt32(namesCollection.Count);
 
                 for (int i = 1; i <= count; i++)
                 {
@@ -30,8 +34,8 @@ public partial class NamedRangeCommands
                     try
                     {
                         nameObj = namesCollection.Item(i);
-                        string name = nameObj.Name;
-                        string refersTo = nameObj.RefersTo ?? "";
+                        string name = nameObj.Name?.ToString() ?? string.Empty;
+                        string refersTo = nameObj.RefersTo?.ToString() ?? string.Empty;
 
                         // Try to get value
                         object? value = null;
@@ -49,7 +53,7 @@ public partial class NamedRangeCommands
                             }
                             else
                             {
-                                value = rawValue;
+                                value = ConvertValueForJson(rawValue);
                                 valueType = rawValue?.GetType().Name ?? "null";
                             }
                         }
@@ -59,7 +63,7 @@ public partial class NamedRangeCommands
                             // Continue with null value - this is expected for some named ranges
                         }
 
-                        namedRanges.Add(new NamedRangeInfo
+                        result.NamedRanges.Add(new NamedRangeInfo
                         {
                             Name = name,
                             RefersTo = refersTo,
@@ -79,7 +83,8 @@ public partial class NamedRangeCommands
                     }
                 }
 
-                return namedRanges;
+                result.Success = true;
+                return result;
             }
             finally
             {
@@ -168,8 +173,19 @@ public partial class NamedRangeCommands
 
                 string refersTo = nameObj.RefersTo?.ToString() ?? "";
                 refersToRange = nameObj.RefersToRange;
-                object? value = refersToRange?.Value2;
-                string valueType = value?.GetType().Name ?? "null";
+                object? rawValue = refersToRange?.Value2;
+                object? value;
+                string valueType;
+                if (rawValue is object[,] array2D)
+                {
+                    value = ConvertArrayToList(array2D);
+                    valueType = "Array";
+                }
+                else
+                {
+                    value = ConvertValueForJson(rawValue);
+                    valueType = rawValue?.GetType().Name ?? "null";
+                }
 
                 return new NamedRangeValue
                 {

--- a/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.cs
+++ b/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.cs
@@ -9,21 +9,42 @@ public partial class NamedRangeCommands : INamedRangeCommands
     {
         var result = new List<List<object?>>();
 
-        // Excel arrays are 1-based, get the bounds
-        int rows = array2D.GetLength(0);
-        int cols = array2D.GetLength(1);
+        var rowLower = array2D.GetLowerBound(0);
+        var rowUpper = array2D.GetUpperBound(0);
+        var colLower = array2D.GetLowerBound(1);
+        var colUpper = array2D.GetUpperBound(1);
 
-        for (int row = 1; row <= rows; row++)
+        for (var row = rowLower; row <= rowUpper; row++)
         {
             var rowList = new List<object?>();
-            for (int col = 1; col <= cols; col++)
+            for (var col = colLower; col <= colUpper; col++)
             {
-                rowList.Add(array2D[row, col]);
+                rowList.Add(ConvertValueForJson(array2D[row, col]));
             }
             result.Add(rowList);
         }
 
         return result;
+    }
+
+    private static object? ConvertValueForJson(object? value)
+    {
+        if (value == null || value == DBNull.Value)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            string or bool or int or long or decimal => value,
+            DateTime dateTime => dateTime.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+            double doubleValue when double.IsNaN(doubleValue) || double.IsInfinity(doubleValue)
+                => doubleValue.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            float floatValue when float.IsNaN(floatValue) || float.IsInfinity(floatValue)
+                => floatValue.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            double or float => value,
+            _ => value.ToString()
+        };
     }
 }
 

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -540,7 +540,9 @@ internal static class StdinPipeMonitor
 
         return new Timer(_ =>
         {
-            if (!PeekNamedPipe(handle, IntPtr.Zero, 0, IntPtr.Zero, out _, out _))
+            uint totalBytesAvailable;
+            uint bytesLeftThisMessage;
+            if (!PeekNamedPipe(handle, IntPtr.Zero, 0, IntPtr.Zero, out totalBytesAvailable, out bytesLeftThisMessage))
             {
                 var error = Marshal.GetLastWin32Error();
                 if (error is ErrorBrokenPipe or ErrorNoData)

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.BugRegression.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.BugRegression.cs
@@ -65,7 +65,8 @@ public partial class ChartCommandsTests
 
         // Verify chart actually exists in workbook
         var charts = _commands.List(batch);
-        Assert.Contains(charts, c => c.Name == "BugRegression_NonFirstRow");
+        Assert.True(charts.Success);
+        Assert.Contains(charts.Charts, c => c.Name == "BugRegression_NonFirstRow");
     }
 
     /// <summary>

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Lifecycle.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.Lifecycle.cs
@@ -34,7 +34,8 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
         var charts = _commands.List(batch);
 
         // Assert
-        Assert.Empty(charts);
+        Assert.True(charts.Success);
+        Assert.Empty(charts.Charts);
     }
 
     [Fact]
@@ -63,8 +64,9 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
 
         // Verify chart exists
         var charts = _commands.List(batch);
-        Assert.Single(charts);
-        Assert.Equal("TestChart", charts[0].Name);
+        Assert.True(charts.Success);
+        var chart = Assert.Single(charts.Charts);
+        Assert.Equal("TestChart", chart.Name);
     }
 
     [Fact]
@@ -128,8 +130,9 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
 
         // Verify chart exists
         var charts = _commands.List(batch);
-        Assert.Single(charts);
-        Assert.Equal("TableChart", charts[0].Name);
+        Assert.True(charts.Success);
+        var chart = Assert.Single(charts.Charts);
+        Assert.Equal("TableChart", chart.Name);
     }
 
     [Fact]
@@ -228,7 +231,8 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
 
         // Verify chart exists in list
         var charts = _commands.List(batch);
-        Assert.Contains(charts, c => c.Name == result.ChartName && c.IsPivotChart);
+        Assert.True(charts.Success);
+        Assert.Contains(charts.Charts, c => c.Name == result.ChartName && c.IsPivotChart);
     }
 
     [Fact]
@@ -359,15 +363,17 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
         _commands.CreateFromRange(batch, "Sheet1", "A1:B3", ChartType.Line, 50, 50);
 
         var chartsBefore = _commands.List(batch);
-        Assert.Single(chartsBefore);
-        string chartName = chartsBefore[0].Name;
+        Assert.True(chartsBefore.Success);
+        var chartBefore = Assert.Single(chartsBefore.Charts);
+        string chartName = chartBefore.Name;
 
         // Act
         _commands.Delete(batch, chartName);
 
         // Assert - Verify chart removed
         var chartsAfter = _commands.List(batch);
-        Assert.Empty(chartsAfter);
+        Assert.True(chartsAfter.Success);
+        Assert.Empty(chartsAfter.Charts);
     }
 
     [Fact]
@@ -404,10 +410,11 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
         var charts = _commands.List(batch);
 
         // Assert
-        Assert.Equal(3, charts.Count);
-        Assert.Contains(charts, c => c.Name == "Chart1" && c.ChartType == ChartType.ColumnClustered);
-        Assert.Contains(charts, c => c.Name == "Chart2" && c.ChartType == ChartType.Pie);
-        Assert.Contains(charts, c => c.Name == "Chart3" && c.ChartType == ChartType.Line);
+        Assert.True(charts.Success);
+        Assert.Equal(3, charts.Charts.Count);
+        Assert.Contains(charts.Charts, c => c.Name == "Chart1" && c.ChartType == ChartType.ColumnClustered);
+        Assert.Contains(charts.Charts, c => c.Name == "Chart2" && c.ChartType == ChartType.Pie);
+        Assert.Contains(charts.Charts, c => c.Name == "Chart3" && c.ChartType == ChartType.Line);
     }
 
     [Fact]
@@ -437,7 +444,8 @@ public partial class ChartCommandsTests : IClassFixture<ChartTestsFixture>
 
         // Verify all created
         var charts = _commands.List(batch);
-        Assert.Equal(chartTypes.Length, charts.Count);
+        Assert.True(charts.Success);
+        Assert.Equal(chartTypes.Length, charts.Charts.Count);
     }
 }
 

--- a/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.OlapPivotChart.cs
+++ b/tests/ExcelMcp.Core.Tests/Commands/ChartCommandsTests.OlapPivotChart.cs
@@ -63,7 +63,8 @@ public class ChartCommandsOlapTests
 
         // Verify chart exists in list
         var charts = _commands.List(batch);
-        Assert.Contains(charts, c => c.Name == result.ChartName);
+        Assert.True(charts.Success);
+        Assert.Contains(charts.Charts, c => c.Name == result.ChartName);
     }
 
     [Fact]
@@ -152,7 +153,8 @@ public class ChartCommandsOlapTests
 
         // Verify chart appears in list
         var charts = _commands.List(batch);
-        Assert.Contains(charts, c => c.Name == "OlapLineChart" && c.ChartType == ChartType.Line);
+        Assert.True(charts.Success);
+        Assert.Contains(charts.Charts, c => c.Name == "OlapLineChart" && c.ChartType == ChartType.Line);
     }
 
     [Fact]
@@ -183,7 +185,8 @@ public class ChartCommandsOlapTests
 
         // Verify chart exists
         var charts = _commands.List(batch);
-        Assert.Contains(charts, c => c.Name == "DisambiguationChart");
+        Assert.True(charts.Success);
+        Assert.Contains(charts.Charts, c => c.Name == "DisambiguationChart");
     }
 
     [Fact]

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.Lifecycle.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.Lifecycle.cs
@@ -23,6 +23,8 @@ public partial class NamedRangeCommandsTests
 
         // Assert - List should return without error
         Assert.NotNull(namedRanges);
+        Assert.True(namedRanges.Success);
+        Assert.NotNull(namedRanges.NamedRanges);
     }
     /// <inheritdoc/>
 
@@ -39,7 +41,8 @@ public partial class NamedRangeCommandsTests
 
         // Assert - Verify the parameter was actually created by listing parameters
         var namedRanges = _parameterCommands.List(batch);
-        Assert.Contains(namedRanges, p => p.Name == paramName);
+        Assert.True(namedRanges.Success);
+        Assert.Contains(namedRanges.NamedRanges, p => p.Name == paramName);
     }
     /// <inheritdoc/>
 
@@ -59,7 +62,8 @@ public partial class NamedRangeCommandsTests
 
         // Assert - Verify the parameter was actually deleted by checking it's not in the list
         var namedRanges = _parameterCommands.List(batch);
-        Assert.DoesNotContain(namedRanges, p => p.Name == paramName);
+        Assert.True(namedRanges.Success);
+        Assert.DoesNotContain(namedRanges.NamedRanges, p => p.Name == paramName);
     }
     /// <inheritdoc/>
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.Validation.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsTests.Validation.cs
@@ -54,7 +54,8 @@ public partial class NamedRangeCommandsTests
 
         // Assert - Verify the parameter was actually created
         var namedRanges = _parameterCommands.List(batch);
-        Assert.Contains(namedRanges, p => p.Name == paramName);
+        Assert.True(namedRanges.Success);
+        Assert.Contains(namedRanges.NamedRanges, p => p.Name == paramName);
     }
     /// <inheritdoc/>
 

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ChartToolProtocolRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ChartToolProtocolRegressionTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+/// <summary>
+/// End-to-end regressions for chart tool behavior through the MCP protocol.
+/// </summary>
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Charts")]
+[Trait("RequiresExcel", "true")]
+public sealed class ChartToolProtocolRegressionTests : McpIntegrationTestBase
+{
+    private readonly string _tempDir;
+
+    public ChartToolProtocolRegressionTests(ITestOutputHelper output)
+        : base(output, "ChartToolProtocolRegressionClient")
+    {
+        _tempDir = CreateTempDirectory("ChartToolProtocolRegressionTests");
+    }
+
+    [Fact]
+    public async Task ChartList_EmptyWorkbook_ReturnsStructuredEmptyList_AndSessionRemainsUsable()
+    {
+        var workbookPath = Path.Join(_tempDir, $"NoCharts_{Guid.NewGuid():N}.xlsx");
+        var sessionId = await CreateWorkbookSessionAsync(workbookPath);
+
+        var listResult = await CallToolAsync("chart", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+
+        using (var listJson = JsonDocument.Parse(listResult))
+        {
+            var root = listJson.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(), $"chart list failed: {listResult}");
+            Assert.True(root.TryGetProperty("charts", out var charts), $"chart list should return charts: {listResult}");
+            Assert.Equal(JsonValueKind.Array, charts.ValueKind);
+            Assert.Empty(charts.EnumerateArray());
+        }
+
+        var worksheetListResult = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+        AssertSuccess(worksheetListResult, "worksheet list after chart list");
+
+        await CloseSessionAsync(sessionId, save: false);
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
@@ -371,8 +371,8 @@ in
             ["action"] = "list",
             ["session_id"] = sessionId
         });
-        // Chart List returns array directly
-        Assert.NotNull(listChartsResult);
+        AssertSuccess(listChartsResult, "List Charts");
+        Assert.Contains("DataChart", listChartsResult);
         _output.WriteLine("  ✓ chart: Create and List passed");
 
         // =====================================================================

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/NamedRangeToolProtocolRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/NamedRangeToolProtocolRegressionTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+/// <summary>
+/// End-to-end regressions for named range tool behavior through the MCP protocol.
+/// </summary>
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Parameters")]
+[Trait("RequiresExcel", "true")]
+public sealed class NamedRangeToolProtocolRegressionTests : McpIntegrationTestBase
+{
+    private readonly string _tempDir;
+
+    public NamedRangeToolProtocolRegressionTests(ITestOutputHelper output)
+        : base(output, "NamedRangeToolProtocolRegressionClient")
+    {
+        _tempDir = CreateTempDirectory("NamedRangeToolProtocolRegressionTests");
+    }
+
+    [Fact]
+    public async Task NamedRangeList_EmptyWorkbook_ReturnsStructuredEmptyList_AndSessionRemainsUsable()
+    {
+        var workbookPath = Path.Join(_tempDir, $"NoNamedRanges_{Guid.NewGuid():N}.xlsx");
+        var sessionId = await CreateWorkbookSessionAsync(workbookPath);
+
+        var listResult = await CallToolAsync("namedrange", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+
+        using (var listJson = JsonDocument.Parse(listResult))
+        {
+            var root = listJson.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(), $"namedrange list failed: {listResult}");
+            Assert.True(root.TryGetProperty("namedRanges", out var namedRanges), $"namedrange list should return namedRanges: {listResult}");
+            Assert.Equal(JsonValueKind.Array, namedRanges.ValueKind);
+            Assert.Empty(namedRanges.EnumerateArray());
+        }
+
+        var worksheetListResult = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+        AssertSuccess(worksheetListResult, "worksheet list after namedrange list");
+
+        await CloseSessionAsync(sessionId, save: false);
+    }
+
+    [Fact]
+    public async Task NamedRangeList_WorkbookWithNamedRange_ReturnsStructuredList_AndSessionRemainsUsable()
+    {
+        var workbookPath = Path.Join(_tempDir, $"OneNamedRange_{Guid.NewGuid():N}.xlsx");
+        var sessionId = await CreateWorkbookSessionAsync(workbookPath);
+        var name = $"CsvFolder_{Guid.NewGuid():N}";
+
+        var createResult = await CallToolAsync("namedrange", new Dictionary<string, object?>
+        {
+            ["action"] = "create",
+            ["session_id"] = sessionId,
+            ["name"] = name,
+            ["reference"] = "Sheet1!$B$4"
+        }, TimeSpan.FromSeconds(30));
+        AssertSuccess(createResult, "namedrange create setup");
+
+        var writeResult = await CallToolAsync("namedrange", new Dictionary<string, object?>
+        {
+            ["action"] = "write",
+            ["session_id"] = sessionId,
+            ["name"] = name,
+            ["value"] = "C:\\Data"
+        }, TimeSpan.FromSeconds(30));
+        AssertSuccess(writeResult, "namedrange write setup");
+
+        var listResult = await CallToolAsync("namedrange", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+
+        using (var listJson = JsonDocument.Parse(listResult))
+        {
+            var root = listJson.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(), $"namedrange list failed: {listResult}");
+            var namedRanges = root.GetProperty("namedRanges").EnumerateArray().ToList();
+            var matches = namedRanges.Where(range => range.GetProperty("name").GetString() == name).ToList();
+            var listedRange = Assert.Single(matches);
+            Assert.Contains("$B$4", listedRange.GetProperty("refersTo").GetString(), StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("C:\\Data", listedRange.GetProperty("value").GetString());
+        }
+
+        var worksheetListResult = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+        AssertSuccess(worksheetListResult, "worksheet list after namedrange list");
+
+        await CloseSessionAsync(sessionId, save: false);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #653.

- Return structured success envelopes for `namedrange list` instead of raw JSON arrays, keeping MCP sessions usable after empty and populated list calls.
- Normalize named range values to JSON-safe types before serialization.
- Apply the same envelope fix to `chart list`, which had the same raw-array issue.
- Add MCP protocol regressions and update Core/MCP tests.
- Add a permanent bug-fix checklist requirement to search for the same pattern elsewhere.

## Same-pattern search

Searched Core command interfaces for `List<T>` methods that accept `IExcelBatch` and are serialized directly by generated MCP/CLI dispatch. After the named range fix, `chart list` was the only remaining matching list action, so this PR fixes it too. No remaining Core list actions return raw collections.

## Dependency check

Checked NuGet, npm, and Python dependency status. No vulnerable direct dependencies were found. Only routine patch/minor updates were available, so this PR does not change dependency files.

## Tests

- `dotnet test tests\ExcelMcp.McpServer.Tests\ExcelMcp.McpServer.Tests.csproj --filter "FullyQualifiedName~NamedRangeToolProtocolRegressionTests" --blame-hang --blame-hang-timeout 3m --no-restore --tl:off -v minimal`
- `dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "Feature=Parameters" --blame-hang --blame-hang-timeout 3m --no-restore --tl:off -v minimal`
- `dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName=Sbroenne.ExcelMcp.Core.Tests.Commands.ChartCommandsTests.List_EmptyWorkbook_ReturnsEmptyList|FullyQualifiedName=Sbroenne.ExcelMcp.Core.Tests.Commands.ChartCommandsTests.List_MultipleCharts_ReturnsAll" --blame-hang --blame-hang-timeout 3m --no-restore --tl:off -v minimal`
- `dotnet test tests\ExcelMcp.McpServer.Tests\ExcelMcp.McpServer.Tests.csproj --filter "FullyQualifiedName~ChartToolProtocolRegressionTests" --blame-hang --blame-hang-timeout 3m --no-restore --tl:off -v minimal`
- `dotnet build Sbroenne.ExcelMcp.sln -c Debug --no-restore --tl:off`
- `git diff --check`
- `scripts\check-com-leaks.ps1`
- `scripts\audit-core-coverage.ps1 -FailOnGaps`
- Full pre-commit hook suite passed during commit.
