### PR TITLE
Harden namedrange list for large workbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This changelog covers all components:
 
 ### Fixed
 
-- **MCP `namedrange list` and `chart list` no longer return raw arrays or risk closing the session** (#653): Both list commands now return standard structured result envelopes with `success` and item collections, keep the active session usable after listing empty or populated workbooks, and normalize named range values to JSON-safe types before serialization.
+- **MCP `namedrange list` and `chart list` no longer return raw arrays or risk closing the session** (#653): Both list commands now return standard structured result envelopes with `success` and item collections, keep the active session usable after listing empty or populated workbooks, omit hidden/internal Excel names from `namedrange list`, cap large named-range value previews, and normalize returned named range values to JSON-safe types before serialization.
 
 - **Release workflow `dotnet pack` failure for CLI and MCP Server NuGet packages**: The dependency-update PR added `<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>` to both tool csproj files, which combined with `PackAsTool=true` routed `dotnet pack` through the RID-aware publish path and made it look for `bin/Release/net10.0-windows/win-x64/` outputs. The CI release workflow builds each project per-csproj without a runtime flag and writes plain `bin/Release/net10.0-windows/`, so pack failed with MSB3030. Removed the property from `ExcelMcp.CLI.csproj` and `ExcelMcp.McpServer.csproj` and documented why it must not be re-added; the standalone-exe publish step still passes the runtime on the command line.
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -337,7 +337,7 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 🏷️ Named Ranges (Parameters) (6 operations)
 
-- **List:** List all named ranges with references
+- **List:** List visible user-defined named ranges with references; hidden/internal Excel names are omitted, and large ranges return metadata without materializing values
 - **Read:** Get value of a named range
 - **Write:** Set value of a named range (ideal for parameter automation)
 - **Create:** Create new named range

--- a/skills/excel-cli/references/cli-commands.md
+++ b/skills/excel-cli/references/cli-commands.md
@@ -198,7 +198,7 @@ Diagnostic commands for testing CLI/MCP infrastructure without Excel. These comm
 
 ### namedrange
 
-Named ranges for formulas/parameters. CREATE/UPDATE: value is cell reference (e.g., 'Sheet1!$A$1'). WRITE: value is data to store. TIP: use `range get-values` or `range set-values` with the named range as `--range-address` for bulk data read/write.
+Named ranges for formulas/parameters. LIST returns visible user-defined names; hidden/internal Excel names are omitted, and large ranges return metadata without materializing values. CREATE/UPDATE: value is cell reference (e.g., 'Sheet1!$A$1'). WRITE: value is data to store. TIP: use `range get-values` or `range set-values` with the named range as `--range-address` for bulk data read/write.
 
 **Actions:** `list`, `write`, `read`, `update`, `create`, `delete`
 

--- a/skills/excel-mcp/references/behavioral-rules.md
+++ b/skills/excel-mcp/references/behavioral-rules.md
@@ -142,6 +142,8 @@ Always convert tabular data to Excel Tables (ListObjects):
 - Layout areas with merged cells
 - Print-formatted reports with specific spacing
 
+**Named range listing:** `namedrange list` returns visible user-defined names. Hidden/internal Excel names are omitted, and large named ranges return metadata without a value preview; use `namedrange read` or `range get-values` when the actual value is needed.
+
 ### Report Results
 
 After completing operations, report:

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -142,6 +142,8 @@ Always convert tabular data to Excel Tables (ListObjects):
 - Layout areas with merged cells
 - Print-formatted reports with specific spacing
 
+**Named range listing:** `namedrange list` returns visible user-defined names. Hidden/internal Excel names are omitted, and large named ranges return metadata without a value preview; use `namedrange read` or `range get-values` when the actual value is needed.
+
 ### Report Results
 
 After completing operations, report:

--- a/specs/RANGE-API-SPECIFICATION.md
+++ b/specs/RANGE-API-SPECIFICATION.md
@@ -57,7 +57,7 @@ This specification defines a unified **Range API** that consolidates and replace
 
 **NamedRangeCommands** (Named ranges, separate concern):
 - ✅ Create, delete, update named range definitions
-- ✅ List all named ranges
+- ✅ List visible user-defined named ranges
 - ✅ Get/set single values (parameters)
 - ✅ Should remain separate (named range lifecycle management)
 - ⚠️ RangeCommands will ADD bulk read/write to named ranges (data operations)

--- a/src/ExcelMcp.Core/Commands/NamedRange/INamedRangeCommands.cs
+++ b/src/ExcelMcp.Core/Commands/NamedRange/INamedRangeCommands.cs
@@ -6,17 +6,19 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 
 /// <summary>
 /// Named ranges for formulas/parameters.
+/// LIST: returns visible user-defined names; hidden/internal Excel names are omitted, and large ranges return metadata without materializing values.
 /// CREATE/UPDATE: value is cell reference (e.g., 'Sheet1!$A$1').
 /// WRITE: value is data to store.
 /// TIP: use range get-values/set-values with the named range as the range address for bulk data read/write.
 /// </summary>
 [ServiceCategory("namedrange", "NamedRange")]
 [McpTool("namedrange", Title = "Named Range Operations", Destructive = true, Category = "data",
-    Description = "Named ranges for formulas/parameters. CREATE/UPDATE: value is cell reference (e.g., Sheet1!$A$1). WRITE: value is data to store in the named range. TIP: Use range(rangeAddress=namedRangeName) for bulk data operations.")]
+    Description = "Named ranges for formulas/parameters. LIST returns visible user-defined names; hidden/internal Excel names are omitted, and large ranges return metadata without materializing values. CREATE/UPDATE: value is cell reference (e.g., Sheet1!$A$1). WRITE: value is data to store in the named range. TIP: Use range(rangeAddress=namedRangeName) for bulk data operations.")]
 public interface INamedRangeCommands
 {
     /// <summary>
-    /// Lists all named ranges in the workbook
+    /// Lists visible user-defined named ranges in the workbook. Hidden Excel internal names are omitted.
+    /// Large ranges return metadata without materializing values.
     /// </summary>
     /// <returns>Structured result containing the list of named range information</returns>
     /// <exception cref="InvalidOperationException">If workbook access fails</exception>

--- a/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.Operations.cs
+++ b/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.Operations.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Microsoft.CSharp.RuntimeBinder;
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Models;
@@ -11,6 +12,8 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 /// </summary>
 public partial class NamedRangeCommands
 {
+    private const long MaxListValuePreviewCellCount = 10_000;
+
     /// <inheritdoc />
     public NamedRangeListResult List(IExcelBatch batch)
     {
@@ -29,49 +32,45 @@ public partial class NamedRangeCommands
 
                 for (int i = 1; i <= count; i++)
                 {
+                    ct.ThrowIfCancellationRequested();
+
                     dynamic? nameObj = null;
                     dynamic? refersToRange = null;
                     try
                     {
                         nameObj = namesCollection.Item(i);
                         string name = nameObj.Name?.ToString() ?? string.Empty;
+
+                        if (ShouldSkipNameFromList(nameObj, name))
+                        {
+                            continue;
+                        }
+
                         string refersTo = nameObj.RefersTo?.ToString() ?? string.Empty;
 
-                        // Try to get value
-                        object? value = null;
-                        string valueType = "null";
-                        try
-                        {
-                            refersToRange = nameObj.RefersToRange;
-                            var rawValue = refersToRange?.Value2;
-
-                            // Convert 2D array to List<List<object?>> for JSON serialization
-                            if (rawValue is object[,] array2D)
-                            {
-                                value = ConvertArrayToList(array2D);
-                                valueType = "Array";
-                            }
-                            else
-                            {
-                                value = ConvertValueForJson(rawValue);
-                                valueType = rawValue?.GetType().Name ?? "null";
-                            }
-                        }
-                        catch (COMException)
-                        {
-                            // Named range may not have a valid RefersToRange (e.g., formula-based or external reference)
-                            // Continue with null value - this is expected for some named ranges
-                        }
-
-                        result.NamedRanges.Add(new NamedRangeInfo
+                        var info = new NamedRangeInfo
                         {
                             Name = name,
                             RefersTo = refersTo,
-                            Value = value,
-                            ValueType = valueType
-                        });
+                            ValueType = "null"
+                        };
+
+                        try
+                        {
+                            refersToRange = nameObj.RefersToRange;
+                            PopulateListValuePreview(refersToRange, info);
+                        }
+                        catch (Exception ex) when (IsRecoverableNamedRangeException(ex))
+                        {
+                            // Named range may not have a valid RefersToRange (e.g., formula-based or external reference)
+                            // Continue with metadata only - this is expected for some named ranges.
+                            info.ValueType = "Unavailable";
+                            info.ValueOmittedReason = ex.Message;
+                        }
+
+                        result.NamedRanges.Add(info);
                     }
-                    catch (COMException)
+                    catch (Exception ex) when (IsRecoverableNamedRangeException(ex))
                     {
                         // Skip corrupted or inaccessible named ranges - continue listing remaining
                         continue;
@@ -92,6 +91,102 @@ public partial class NamedRangeCommands
             }
         });
     }
+
+    private static bool ShouldSkipNameFromList(dynamic nameObj, string name)
+    {
+        if (IsHiddenName(nameObj))
+        {
+            return true;
+        }
+
+        return IsBuiltInName(name);
+    }
+
+    private static bool IsHiddenName(dynamic nameObj)
+    {
+        try
+        {
+            return !Convert.ToBoolean(nameObj.Visible);
+        }
+        catch (Exception ex) when (IsRecoverableNamedRangeException(ex))
+        {
+            return true;
+        }
+    }
+
+    private static bool IsBuiltInName(string name)
+    {
+        var localName = GetLocalName(name);
+        return localName.StartsWith("_xlnm.", StringComparison.OrdinalIgnoreCase)
+            || localName.Equals("_FilterDatabase", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetLocalName(string name)
+    {
+        var bangIndex = name.LastIndexOf('!');
+        return bangIndex >= 0 ? name[(bangIndex + 1)..].Trim('\'') : name;
+    }
+
+    private static void PopulateListValuePreview(dynamic refersToRange, NamedRangeInfo info)
+    {
+        var areaCount = GetAreaCount(refersToRange);
+        if (areaCount > 1)
+        {
+            info.ValueType = "MultiAreaRange";
+            info.ValueOmittedReason = "Named range resolves to multiple areas; list omits multi-area value previews.";
+            return;
+        }
+
+        var cellCount = GetCellCount(refersToRange);
+        info.CellCount = cellCount;
+
+        if (cellCount > MaxListValuePreviewCellCount)
+        {
+            info.ValueType = "RangeTooLarge";
+            info.ValueOmittedReason =
+                $"Named range contains {cellCount} cells, which exceeds the list preview limit of {MaxListValuePreviewCellCount}.";
+            return;
+        }
+
+        var rawValue = refersToRange?.Value2;
+
+        if (rawValue is object[,] array2D)
+        {
+            info.Value = ConvertArrayToList(array2D);
+            info.ValueType = "Array";
+        }
+        else
+        {
+            info.Value = ConvertValueForJson(rawValue);
+            info.ValueType = rawValue?.GetType().Name ?? "null";
+        }
+    }
+
+    private static int GetAreaCount(dynamic range)
+    {
+        dynamic? areas = null;
+        try
+        {
+            areas = range.Areas;
+            return Convert.ToInt32(areas.Count);
+        }
+        finally
+        {
+            ComUtilities.Release(ref areas);
+        }
+    }
+
+    private static long GetCellCount(dynamic range)
+    {
+        return Convert.ToInt64(range.CountLarge);
+    }
+
+    private static bool IsRecoverableNamedRangeException(Exception ex) =>
+        ex is COMException
+            or InvalidCastException
+            or RuntimeBinderException
+            or SafeArrayRankMismatchException
+            or SafeArrayTypeMismatchException;
 
     /// <inheritdoc />
     public OperationResult Write(IExcelBatch batch, string name, string value)

--- a/src/ExcelMcp.Core/Models/ResultTypes.cs
+++ b/src/ExcelMcp.Core/Models/ResultTypes.cs
@@ -618,6 +618,18 @@ public class NamedRangeInfo
     /// Type of the value
     /// </summary>
     public string ValueType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of cells referenced by the named range, when available
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? CellCount { get; set; }
+
+    /// <summary>
+    /// Reason the value preview was omitted, when the list operation skips value materialization
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ValueOmittedReason { get; set; }
 }
 
 /// <summary>

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsListRegressionTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsListRegressionTests.cs
@@ -1,0 +1,101 @@
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.NamedRange;
+
+/// <summary>
+/// Regression tests for named range list behavior on workbooks with hidden/internal names and large ranges.
+/// </summary>
+[Trait("Layer", "Core")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Feature", "Parameters")]
+[Trait("RequiresExcel", "true")]
+public sealed class NamedRangeCommandsListRegressionTests : IClassFixture<TempDirectoryFixture>
+{
+    private readonly NamedRangeCommands _commands = new();
+    private readonly TempDirectoryFixture _fixture;
+
+    public NamedRangeCommandsListRegressionTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void List_HiddenUserDefinedName_DoesNotExposeHiddenNameByDefault()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var name = NamedRangeTestsFixture.GetUniqueNamedRangeName();
+
+        AddHiddenUserDefinedName(batch, name);
+
+        var result = _commands.List(batch);
+
+        Assert.True(result.Success, $"List failed: {result.ErrorMessage}");
+        Assert.DoesNotContain(result.NamedRanges, namedRange => namedRange.Name == name);
+    }
+
+    [Fact]
+    public void List_LargeNamedRange_OmitsValuePreview()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var name = NamedRangeTestsFixture.GetUniqueNamedRangeName();
+
+        AddNamedRange(batch, name, "Sheet1!$A$1:$A$10001");
+
+        var result = _commands.List(batch);
+
+        Assert.True(result.Success, $"List failed: {result.ErrorMessage}");
+        var listedRange = Assert.Single(result.NamedRanges, namedRange => namedRange.Name == name);
+        Assert.Equal("RangeTooLarge", listedRange.ValueType);
+        Assert.Null(listedRange.Value);
+        Assert.Equal(10001, listedRange.CellCount);
+        Assert.Contains("exceeds", listedRange.ValueOmittedReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AddHiddenUserDefinedName(IExcelBatch batch, string name)
+    {
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? names = null;
+            dynamic? nameObj = null;
+            try
+            {
+                names = ctx.Book.Names;
+                nameObj = names.Add(name, "=Sheet1!$B$4");
+                nameObj.Visible = false;
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref nameObj);
+                ComUtilities.Release(ref names);
+            }
+        });
+    }
+
+    private static void AddNamedRange(IExcelBatch batch, string name, string reference)
+    {
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? names = null;
+            dynamic? nameObj = null;
+            try
+            {
+                names = ctx.Book.Names;
+                nameObj = names.Add(name, $"={reference.TrimStart('=')}");
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref nameObj);
+                ComUtilities.Release(ref names);
+            }
+        });
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/NamedRangeToolProtocolRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/NamedRangeToolProtocolRegressionTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -93,8 +95,7 @@ public sealed class NamedRangeToolProtocolRegressionTests : McpIntegrationTestBa
             var root = listJson.RootElement;
             Assert.True(root.GetProperty("success").GetBoolean(), $"namedrange list failed: {listResult}");
             var namedRanges = root.GetProperty("namedRanges").EnumerateArray().ToList();
-            var matches = namedRanges.Where(range => range.GetProperty("name").GetString() == name).ToList();
-            var listedRange = Assert.Single(matches);
+            var listedRange = Assert.Single(namedRanges, range => range.GetProperty("name").GetString() == name);
             Assert.Contains("$B$4", listedRange.GetProperty("refersTo").GetString(), StringComparison.OrdinalIgnoreCase);
             Assert.Equal("C:\\Data", listedRange.GetProperty("value").GetString());
         }
@@ -107,5 +108,151 @@ public sealed class NamedRangeToolProtocolRegressionTests : McpIntegrationTestBa
         AssertSuccess(worksheetListResult, "worksheet list after namedrange list");
 
         await CloseSessionAsync(sessionId, save: false);
+    }
+
+    [Fact]
+    public async Task NamedRangeList_WorkbookWithHiddenName_ReturnsEmptyList_AndSessionRemainsUsable()
+    {
+        var workbookPath = Path.Join(_tempDir, $"HiddenName_{Guid.NewGuid():N}.xlsx");
+        var name = $"HiddenName_{Guid.NewGuid():N}";
+        CreateWorkbookWithHiddenName(workbookPath, name);
+        var sessionId = await OpenWorkbookSessionAsync(workbookPath);
+
+        var listResult = await CallToolAsync("namedrange", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+
+        using (var listJson = JsonDocument.Parse(listResult))
+        {
+            var root = listJson.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(), $"namedrange list failed: {listResult}");
+            var namedRanges = root.GetProperty("namedRanges").EnumerateArray().ToList();
+            Assert.Empty(namedRanges);
+        }
+
+        var worksheetListResult = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+        AssertSuccess(worksheetListResult, "worksheet list after namedrange list");
+
+        await CloseSessionAsync(sessionId, save: false);
+    }
+
+    [Fact]
+    public async Task NamedRangeList_LargeNamedRange_OmitsValuePreview_AndSessionRemainsUsable()
+    {
+        var workbookPath = Path.Join(_tempDir, $"LargeNamedRange_{Guid.NewGuid():N}.xlsx");
+        var name = $"LargePreview_{Guid.NewGuid():N}";
+        CreateWorkbookWithNamedRange(workbookPath, name, "Sheet1!$A$1:$A$10001");
+        var sessionId = await OpenWorkbookSessionAsync(workbookPath);
+
+        var listResult = await CallToolAsync("namedrange", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+
+        using (var listJson = JsonDocument.Parse(listResult))
+        {
+            var root = listJson.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(), $"namedrange list failed: {listResult}");
+            var namedRanges = root.GetProperty("namedRanges").EnumerateArray().ToList();
+            var listedRange = Assert.Single(namedRanges, range => range.GetProperty("name").GetString() == name);
+            Assert.Equal("RangeTooLarge", listedRange.GetProperty("valueType").GetString());
+            Assert.False(listedRange.TryGetProperty("value", out _), $"large named range list should omit value: {listResult}");
+            Assert.Equal(10001, listedRange.GetProperty("cellCount").GetInt64());
+            Assert.Contains(
+                "exceeds",
+                listedRange.GetProperty("valueOmittedReason").GetString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        var worksheetListResult = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+        AssertSuccess(worksheetListResult, "worksheet list after namedrange list");
+
+        await CloseSessionAsync(sessionId, save: false);
+    }
+
+    private async Task<string> OpenWorkbookSessionAsync(string workbookPath)
+    {
+        var openJson = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "open",
+            ["path"] = workbookPath
+        });
+
+        AssertSetupSuccess(openJson, $"file.open ({Path.GetFileName(workbookPath)})");
+
+        using var openDoc = ParseJsonResult(openJson, $"file.open ({Path.GetFileName(workbookPath)})");
+        var sessionId = openDoc.RootElement.GetProperty("session_id").GetString();
+        TrackSession(sessionId);
+        Assert.False(string.IsNullOrWhiteSpace(sessionId));
+        return sessionId!;
+    }
+
+    private static void CreateWorkbookWithHiddenName(string workbookPath, string name)
+    {
+        CreateWorkbook(workbookPath, batch =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                dynamic? names = null;
+                dynamic? nameObj = null;
+                try
+                {
+                    names = ctx.Book.Names;
+                    nameObj = names.Add(name, "=Sheet1!$B$4");
+                    nameObj.Visible = false;
+                    return 0;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref nameObj);
+                    ComUtilities.Release(ref names);
+                }
+            });
+        });
+    }
+
+    private static void CreateWorkbookWithNamedRange(string workbookPath, string name, string reference)
+    {
+        CreateWorkbook(workbookPath, batch =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                dynamic? names = null;
+                dynamic? nameObj = null;
+                try
+                {
+                    names = ctx.Book.Names;
+                    nameObj = names.Add(name, $"={reference.TrimStart('=')}");
+                    return 0;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref nameObj);
+                    ComUtilities.Release(ref names);
+                }
+            });
+        });
+    }
+
+    private static void CreateWorkbook(string workbookPath, Action<IExcelBatch> configure)
+    {
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSessionForNewFile(workbookPath, show: false);
+        manager.CloseSession(sessionId, save: true);
+
+        using var batch = ExcelSession.BeginBatch(workbookPath);
+        configure(batch);
+        batch.Save();
     }
 }


### PR DESCRIPTION
## Summary
- Hardens `namedrange list` to skip hidden/internal Excel names such as AutoFilter and `_xlnm` entries.
- Avoids materializing large named-range value previews; list results now return `cellCount` and `valueOmittedReason` metadata when previews are omitted.
- Adds Core and MCP protocol regressions to verify hidden names and large named ranges do not break the active session, and updates docs/skill guidance.

Fixes #653

## Validation
- `dotnet build Sbroenne.ExcelMcp.sln --no-restore`
- `dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName~NamedRangeCommandsListRegressionTests" --blame-hang --blame-hang-timeout 2m --no-restore`
- `dotnet test tests\ExcelMcp.McpServer.Tests\ExcelMcp.McpServer.Tests.csproj --filter "FullyQualifiedName~NamedRangeToolProtocolRegressionTests" --blame-hang --blame-hang-timeout 3m --no-restore`
- `dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --filter "FullyQualifiedName~NamedRangeCommandsTests" --blame-hang --blame-hang-timeout 3m --no-restore`
- `scripts\check-com-leaks.ps1`
- Pre-commit checks passed