### PR TITLE
Harden namedrange list hidden names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This changelog covers all components:
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP `namedrange list` avoids hidden Power Query `ExternalData_1` crash paths** (#653): Workbooks with hidden/internal defined names are now listed from workbook package metadata first, so large hidden Power Query and AutoFilter names are skipped before their COM `Name` objects or backing ranges are touched. Visible user-defined names still return references and safe value previews, and large visible ranges continue to return metadata instead of materialized values.
+
 ## [1.8.63] - 2026-05-20
 
 ### Fixed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -337,7 +337,7 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 🏷️ Named Ranges (Parameters) (6 operations)
 
-- **List:** List visible user-defined named ranges with references; hidden/internal Excel names are omitted, and large ranges return metadata without materializing values
+- **List:** List visible user-defined named ranges with references; hidden/internal Excel names (including Power Query `ExternalData_*` and AutoFilter names) are omitted before value inspection, and large ranges return metadata without materializing values
 - **Read:** Get value of a named range
 - **Write:** Set value of a named range (ideal for parameter automation)
 - **Create:** Create new named range

--- a/skills/excel-mcp/references/behavioral-rules.md
+++ b/skills/excel-mcp/references/behavioral-rules.md
@@ -142,7 +142,7 @@ Always convert tabular data to Excel Tables (ListObjects):
 - Layout areas with merged cells
 - Print-formatted reports with specific spacing
 
-**Named range listing:** `namedrange list` returns visible user-defined names. Hidden/internal Excel names are omitted, and large named ranges return metadata without a value preview; use `namedrange read` or `range get-values` when the actual value is needed.
+**Named range listing:** `namedrange list` returns visible user-defined names. Hidden/internal Excel names, including Power Query `ExternalData_*` and AutoFilter names, are omitted before value inspection. Large named ranges return metadata without a value preview; use `namedrange read` or `range get-values` when the actual value is needed.
 
 ### Report Results
 

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -142,7 +142,7 @@ Always convert tabular data to Excel Tables (ListObjects):
 - Layout areas with merged cells
 - Print-formatted reports with specific spacing
 
-**Named range listing:** `namedrange list` returns visible user-defined names. Hidden/internal Excel names are omitted, and large named ranges return metadata without a value preview; use `namedrange read` or `range get-values` when the actual value is needed.
+**Named range listing:** `namedrange list` returns visible user-defined names. Hidden/internal Excel names, including Power Query `ExternalData_*` and AutoFilter names, are omitted before value inspection. Large named ranges return metadata without a value preview; use `namedrange read` or `range get-values` when the actual value is needed.
 
 ### Report Results
 

--- a/src/ExcelMcp.Core/Commands/NamedRange/INamedRangeCommands.cs
+++ b/src/ExcelMcp.Core/Commands/NamedRange/INamedRangeCommands.cs
@@ -6,18 +6,18 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 
 /// <summary>
 /// Named ranges for formulas/parameters.
-/// LIST: returns visible user-defined names; hidden/internal Excel names are omitted, and large ranges return metadata without materializing values.
+/// LIST: returns visible user-defined names; hidden/internal Excel names are omitted before value inspection, and large ranges return metadata without materializing values.
 /// CREATE/UPDATE: value is cell reference (e.g., 'Sheet1!$A$1').
 /// WRITE: value is data to store.
 /// TIP: use range get-values/set-values with the named range as the range address for bulk data read/write.
 /// </summary>
 [ServiceCategory("namedrange", "NamedRange")]
 [McpTool("namedrange", Title = "Named Range Operations", Destructive = true, Category = "data",
-    Description = "Named ranges for formulas/parameters. LIST returns visible user-defined names; hidden/internal Excel names are omitted, and large ranges return metadata without materializing values. CREATE/UPDATE: value is cell reference (e.g., Sheet1!$A$1). WRITE: value is data to store in the named range. TIP: Use range(rangeAddress=namedRangeName) for bulk data operations.")]
+    Description = "Named ranges for formulas/parameters. LIST returns visible user-defined names; hidden/internal Excel names are omitted before value inspection, and large ranges return metadata without materializing values. CREATE/UPDATE: value is cell reference (e.g., Sheet1!$A$1). WRITE: value is data to store in the named range. TIP: Use range(rangeAddress=namedRangeName) for bulk data operations.")]
 public interface INamedRangeCommands
 {
     /// <summary>
-    /// Lists visible user-defined named ranges in the workbook. Hidden Excel internal names are omitted.
+    /// Lists visible user-defined named ranges in the workbook. Hidden Excel internal names are omitted before value inspection.
     /// Large ranges return metadata without materializing values.
     /// </summary>
     /// <returns>Structured result containing the list of named range information</returns>

--- a/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.Operations.cs
+++ b/src/ExcelMcp.Core/Commands/NamedRange/NamedRangeCommands.Operations.cs
@@ -1,4 +1,7 @@
+using System.IO.Compression;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Microsoft.CSharp.RuntimeBinder;
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
@@ -13,6 +16,10 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 public partial class NamedRangeCommands
 {
     private const long MaxListValuePreviewCellCount = 10_000;
+    private const long ExcelMaxRows = 1_048_576;
+    private const long ExcelMaxColumns = 16_384;
+
+    private sealed record WorkbookDefinedName(string Name, string RefersTo);
 
     /// <inheritdoc />
     public NamedRangeListResult List(IExcelBatch batch)
@@ -21,6 +28,12 @@ public partial class NamedRangeCommands
         {
             FilePath = batch.WorkbookPath
         };
+
+        var packageDefinedNames = TryReadVisibleDefinedNamesFromPackage(batch.WorkbookPath, out var hasHiddenOrInternalNames);
+        if (hasHiddenOrInternalNames && packageDefinedNames != null)
+        {
+            return ListFromWorkbookPackage(batch, result, packageDefinedNames);
+        }
 
         return batch.Execute((ctx, ct) =>
         {
@@ -92,6 +105,34 @@ public partial class NamedRangeCommands
         });
     }
 
+    private static NamedRangeListResult ListFromWorkbookPackage(
+        IExcelBatch batch,
+        NamedRangeListResult result,
+        List<WorkbookDefinedName> packageDefinedNames)
+    {
+        return batch.Execute((ctx, ct) =>
+        {
+            foreach (var definedName in packageDefinedNames)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var info = new NamedRangeInfo
+                {
+                    Name = definedName.Name,
+                    RefersTo = definedName.RefersTo,
+                    ValueType = "Unavailable",
+                    ValueOmittedReason = "Value preview unavailable from workbook defined-name metadata."
+                };
+
+                PopulateListValuePreviewFromReference(ctx.Book, definedName.RefersTo, info);
+                result.NamedRanges.Add(info);
+            }
+
+            result.Success = true;
+            return result;
+        });
+    }
+
     private static bool ShouldSkipNameFromList(dynamic nameObj, string name)
     {
         if (IsHiddenName(nameObj))
@@ -125,6 +166,248 @@ public partial class NamedRangeCommands
     {
         var bangIndex = name.LastIndexOf('!');
         return bangIndex >= 0 ? name[(bangIndex + 1)..].Trim('\'') : name;
+    }
+
+    private static List<WorkbookDefinedName>? TryReadVisibleDefinedNamesFromPackage(
+        string workbookPath,
+        out bool hasHiddenOrInternalNames)
+    {
+        hasHiddenOrInternalNames = false;
+
+        if (string.IsNullOrWhiteSpace(workbookPath) || !File.Exists(workbookPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = new FileStream(
+                workbookPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+            var workbookEntry = archive.GetEntry("xl/workbook.xml");
+            if (workbookEntry == null)
+            {
+                return null;
+            }
+
+            using var workbookStream = workbookEntry.Open();
+            var document = XDocument.Load(workbookStream);
+            var definedNames = document
+                .Descendants()
+                .Where(element => element.Name.LocalName == "definedName");
+
+            var visibleNames = new List<WorkbookDefinedName>();
+            foreach (var definedName in definedNames)
+            {
+                var name = definedName.Attribute("name")?.Value ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+
+                if (IsTruthyOpenXmlBoolean(definedName.Attribute("hidden")?.Value) || IsBuiltInName(name))
+                {
+                    hasHiddenOrInternalNames = true;
+                    continue;
+                }
+
+                visibleNames.Add(new WorkbookDefinedName(name, definedName.Value));
+            }
+
+            return visibleNames;
+        }
+        catch (InvalidDataException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+        catch (System.Xml.XmlException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsTruthyOpenXmlBoolean(string? value)
+    {
+        return value != null
+            && (value.Equals("1", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("true", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void PopulateListValuePreviewFromReference(dynamic workbook, string refersTo, NamedRangeInfo info)
+    {
+        if (!TrySplitRangeReference(refersTo, out var sheetName, out var rangeAddress))
+        {
+            return;
+        }
+
+        if (rangeAddress.Contains(',', StringComparison.Ordinal))
+        {
+            info.ValueType = "MultiAreaRange";
+            info.ValueOmittedReason = "Named range resolves to multiple areas; list omits multi-area value previews.";
+            return;
+        }
+
+        if (TryGetCellCountFromAddress(rangeAddress, out var cellCount))
+        {
+            info.CellCount = cellCount;
+            if (cellCount > MaxListValuePreviewCellCount)
+            {
+                info.ValueType = "RangeTooLarge";
+                info.ValueOmittedReason =
+                    $"Named range contains {cellCount} cells, which exceeds the list preview limit of {MaxListValuePreviewCellCount}.";
+                return;
+            }
+        }
+
+        dynamic? sheet = null;
+        dynamic? range = null;
+        try
+        {
+            sheet = ComUtilities.FindSheet(workbook, sheetName);
+            if (sheet == null)
+            {
+                return;
+            }
+
+            range = sheet.Range[rangeAddress];
+            PopulateListValuePreview(range, info);
+        }
+        catch (Exception ex) when (IsRecoverableNamedRangeException(ex))
+        {
+            info.ValueType = "Unavailable";
+            info.ValueOmittedReason = ex.Message;
+        }
+        finally
+        {
+            ComUtilities.Release(ref range);
+            ComUtilities.Release(ref sheet);
+        }
+    }
+
+    private static bool TrySplitRangeReference(string refersTo, out string sheetName, out string rangeAddress)
+    {
+        sheetName = string.Empty;
+        rangeAddress = string.Empty;
+
+        var reference = refersTo.Trim();
+        if (reference.StartsWith('='))
+        {
+            reference = reference[1..];
+        }
+
+        if (reference.Contains('[', StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var bangIndex = reference.LastIndexOf('!');
+        if (bangIndex <= 0 || bangIndex == reference.Length - 1)
+        {
+            return false;
+        }
+
+        sheetName = reference[..bangIndex].Trim();
+        if (sheetName.Length >= 2 && sheetName[0] == '\'' && sheetName[^1] == '\'')
+        {
+            sheetName = sheetName[1..^1].Replace("''", "'", StringComparison.Ordinal);
+        }
+
+        rangeAddress = reference[(bangIndex + 1)..].Trim();
+        return sheetName.Length > 0 && rangeAddress.Length > 0;
+    }
+
+    private static bool TryGetCellCountFromAddress(string rangeAddress, out long cellCount)
+    {
+        cellCount = 0;
+        var address = rangeAddress.Replace("$", string.Empty, StringComparison.Ordinal).Trim();
+
+        var cellMatch = Regex.Match(
+            address,
+            @"^(?<col1>[A-Za-z]{1,3})(?<row1>\d+)(:(?<col2>[A-Za-z]{1,3})(?<row2>\d+))?$",
+            RegexOptions.CultureInvariant);
+        if (cellMatch.Success)
+        {
+            var col1 = ColumnNameToNumber(cellMatch.Groups["col1"].Value);
+            var row1 = long.Parse(cellMatch.Groups["row1"].Value, System.Globalization.CultureInfo.InvariantCulture);
+            var col2 = cellMatch.Groups["col2"].Success ? ColumnNameToNumber(cellMatch.Groups["col2"].Value) : col1;
+            var row2 = cellMatch.Groups["row2"].Success
+                ? long.Parse(cellMatch.Groups["row2"].Value, System.Globalization.CultureInfo.InvariantCulture)
+                : row1;
+
+            cellCount = (Math.Abs(row2 - row1) + 1) * (Math.Abs(col2 - col1) + 1);
+            return true;
+        }
+
+        var columnMatch = Regex.Match(
+            address,
+            @"^(?<col1>[A-Za-z]{1,3}):(?<col2>[A-Za-z]{1,3})$",
+            RegexOptions.CultureInvariant);
+        if (columnMatch.Success)
+        {
+            var col1 = ColumnNameToNumber(columnMatch.Groups["col1"].Value);
+            var col2 = ColumnNameToNumber(columnMatch.Groups["col2"].Value);
+            cellCount = (Math.Abs(col2 - col1) + 1) * ExcelMaxRows;
+            return true;
+        }
+
+        var rowMatch = Regex.Match(
+            address,
+            @"^(?<row1>\d+):(?<row2>\d+)$",
+            RegexOptions.CultureInvariant);
+        if (rowMatch.Success)
+        {
+            var row1 = long.Parse(rowMatch.Groups["row1"].Value, System.Globalization.CultureInfo.InvariantCulture);
+            var row2 = long.Parse(rowMatch.Groups["row2"].Value, System.Globalization.CultureInfo.InvariantCulture);
+            cellCount = (Math.Abs(row2 - row1) + 1) * ExcelMaxColumns;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static long ColumnNameToNumber(string columnName)
+    {
+        long number = 0;
+        foreach (var character in columnName.ToUpperInvariant())
+        {
+            number = (number * 26) + character - 'A' + 1;
+        }
+
+        return number;
+    }
+
+    private static Excel.Name? FindNameByKey(dynamic workbook, string name)
+    {
+        dynamic? names = null;
+        Excel.Name? nameObj = null;
+        try
+        {
+            names = workbook.Names;
+            nameObj = (Excel.Name)names.Item(name);
+            var result = nameObj;
+            nameObj = null;
+            return result;
+        }
+        catch (Exception ex) when (IsRecoverableNamedRangeException(ex))
+        {
+            return null;
+        }
+        finally
+        {
+            ComUtilities.Release(ref nameObj);
+            ComUtilities.Release(ref names);
+        }
     }
 
     private static void PopulateListValuePreview(dynamic refersToRange, NamedRangeInfo info)
@@ -200,7 +483,7 @@ public partial class NamedRangeCommands
 
             try
             {
-                nameObj = ComUtilities.FindName(ctx.Book, name);
+                nameObj = FindNameByKey(ctx.Book, name);
                 if (nameObj == null)
                 {
                     throw new InvalidOperationException($"Named range '{name}' not found.");
@@ -260,7 +543,7 @@ public partial class NamedRangeCommands
             dynamic? refersToRange = null;
             try
             {
-                nameObj = ComUtilities.FindName(ctx.Book, name);
+                nameObj = FindNameByKey(ctx.Book, name);
                 if (nameObj == null)
                 {
                     throw new InvalidOperationException($"Named range '{name}' not found.");
@@ -319,7 +602,7 @@ public partial class NamedRangeCommands
             try
             {
                 // Check if parameter already exists
-                existing = ComUtilities.FindName(ctx.Book, name);
+                existing = FindNameByKey(ctx.Book, name);
                 if (existing != null)
                 {
                     throw new InvalidOperationException($"Named range '{name}' already exists");
@@ -362,7 +645,7 @@ public partial class NamedRangeCommands
             Excel.Name? nameObj = null;
             try
             {
-                nameObj = ComUtilities.FindName(ctx.Book, name);
+                nameObj = FindNameByKey(ctx.Book, name);
                 if (nameObj == null)
                 {
                     throw new InvalidOperationException($"Named range '{name}' not found.");
@@ -393,7 +676,7 @@ public partial class NamedRangeCommands
             Excel.Name? nameObj = null;
             try
             {
-                nameObj = ComUtilities.FindName(ctx.Book, name);
+                nameObj = FindNameByKey(ctx.Book, name);
                 if (nameObj == null)
                 {
                     throw new InvalidOperationException($"Named range '{name}' not found.");

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsListRegressionTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/NamedRange/NamedRangeCommandsListRegressionTests.cs
@@ -58,6 +58,55 @@ public sealed class NamedRangeCommandsListRegressionTests : IClassFixture<TempDi
         Assert.Contains("exceeds", listedRange.ValueOmittedReason, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void List_MultipleLargeHiddenExternalDataNames_ReturnsOnlyVisibleUserNames()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var visibleName = NamedRangeTestsFixture.GetUniqueNamedRangeName();
+
+        AddWorksheet(batch, "Users");
+        AddWorksheet(batch, "Notifications");
+        SetCellValue(batch, "Sheet1", "$B$4", "C:\\Data");
+        AddNamedRange(batch, visibleName, "Sheet1!$B$4");
+        AddHiddenSheetScopedName(batch, "Users", "ExternalData_1", "Users!$A$6:$AH$19132");
+        AddHiddenSheetScopedName(batch, "Notifications", "ExternalData_1", "Notifications!$A$6:$P$28365");
+        batch.Save();
+
+        var result = _commands.List(batch);
+
+        Assert.True(result.Success, $"List failed: {result.ErrorMessage}");
+        var listedRange = Assert.Single(result.NamedRanges);
+        Assert.Equal(visibleName, listedRange.Name);
+        Assert.DoesNotContain(result.NamedRanges, namedRange => namedRange.Name.Contains("ExternalData_1", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void List_JapaneseSheetsWithMultipleLargeHiddenExternalDataNames_ReturnsVisibleUserName()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var visibleName = NamedRangeTestsFixture.GetUniqueNamedRangeName();
+
+        AddWorksheet(batch, "PQ_設定");
+        AddWorksheet(batch, "ユーザーテーブル_users");
+        AddWorksheet(batch, "通知テーブル_notifications");
+        SetCellValue(batch, "PQ_設定", "$B$4", "C:\\Data");
+        AddNamedRange(batch, visibleName, "PQ_設定!$B$4");
+        AddHiddenSheetScopedName(batch, "ユーザーテーブル_users", "ExternalData_1", "ユーザーテーブル_users!$A$6:$AH$19132");
+        AddHiddenSheetScopedName(batch, "通知テーブル_notifications", "ExternalData_1", "通知テーブル_notifications!$A$6:$P$28365");
+        batch.Save();
+
+        var result = _commands.List(batch);
+
+        Assert.True(result.Success, $"List failed: {result.ErrorMessage}");
+        var listedRange = Assert.Single(result.NamedRanges);
+        Assert.Equal(visibleName, listedRange.Name);
+        Assert.Contains("PQ_設定", listedRange.RefersTo, StringComparison.Ordinal);
+        Assert.Equal("C:\\Data", listedRange.Value);
+        Assert.DoesNotContain(result.NamedRanges, namedRange => namedRange.Name.Contains("ExternalData_1", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static void AddHiddenUserDefinedName(IExcelBatch batch, string name)
     {
         batch.Execute((ctx, ct) =>
@@ -89,6 +138,69 @@ public sealed class NamedRangeCommandsListRegressionTests : IClassFixture<TempDi
             {
                 names = ctx.Book.Names;
                 nameObj = names.Add(name, $"={reference.TrimStart('=')}");
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref nameObj);
+                ComUtilities.Release(ref names);
+            }
+        });
+    }
+
+    private static void AddWorksheet(IExcelBatch batch, string sheetName)
+    {
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheets = null;
+            dynamic? sheet = null;
+            try
+            {
+                sheets = ctx.Book.Worksheets;
+                sheet = sheets.Add();
+                sheet.Name = sheetName;
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheet);
+                ComUtilities.Release(ref sheets);
+            }
+        });
+    }
+
+    private static void SetCellValue(IExcelBatch batch, string sheetName, string rangeAddress, string value)
+    {
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            dynamic? range = null;
+            try
+            {
+                sheet = ComUtilities.FindSheet(ctx.Book, sheetName);
+                range = sheet.Range[rangeAddress];
+                range.Value2 = value;
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref range);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+    }
+
+    private static void AddHiddenSheetScopedName(IExcelBatch batch, string sheetName, string name, string reference)
+    {
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? names = null;
+            dynamic? nameObj = null;
+            try
+            {
+                names = ctx.Book.Names;
+                nameObj = names.Add($"{sheetName}!{name}", $"={reference.TrimStart('=')}");
+                nameObj.Visible = false;
                 return 0;
             }
             finally

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/NamedRangeToolProtocolRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/NamedRangeToolProtocolRegressionTests.cs
@@ -181,6 +181,42 @@ public sealed class NamedRangeToolProtocolRegressionTests : McpIntegrationTestBa
         await CloseSessionAsync(sessionId, save: false);
     }
 
+    [Fact]
+    public async Task NamedRangeList_MultipleLargeHiddenExternalDataNames_ReturnsVisibleNames_AndSessionRemainsUsable()
+    {
+        var workbookPath = Path.Join(_tempDir, $"HiddenExternalData_{Guid.NewGuid():N}.xlsx");
+        var name = $"CsvFolder_{Guid.NewGuid():N}";
+        CreateWorkbookWithHiddenExternalDataNames(workbookPath, name);
+        var sessionId = await OpenWorkbookSessionAsync(workbookPath);
+
+        var listResult = await CallToolAsync("namedrange", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+
+        using (var listJson = JsonDocument.Parse(listResult))
+        {
+            var root = listJson.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(), $"namedrange list failed: {listResult}");
+            var namedRanges = root.GetProperty("namedRanges").EnumerateArray().ToList();
+            var listedRange = Assert.Single(namedRanges);
+            Assert.Equal(name, listedRange.GetProperty("name").GetString());
+            Assert.DoesNotContain(
+                namedRanges,
+                range => range.GetProperty("name").GetString()?.Contains("ExternalData_1", StringComparison.OrdinalIgnoreCase) == true);
+        }
+
+        var worksheetListResult = await CallToolAsync("worksheet", new Dictionary<string, object?>
+        {
+            ["action"] = "list",
+            ["session_id"] = sessionId
+        }, TimeSpan.FromSeconds(30));
+        AssertSuccess(worksheetListResult, "worksheet list after namedrange list");
+
+        await CloseSessionAsync(sessionId, save: false);
+    }
+
     private async Task<string> OpenWorkbookSessionAsync(string workbookPath)
     {
         var openJson = await CallToolAsync("file", new Dictionary<string, object?>
@@ -240,6 +276,57 @@ public sealed class NamedRangeToolProtocolRegressionTests : McpIntegrationTestBa
                 {
                     ComUtilities.Release(ref nameObj);
                     ComUtilities.Release(ref names);
+                }
+            });
+        });
+    }
+
+    private static void CreateWorkbookWithHiddenExternalDataNames(string workbookPath, string visibleName)
+    {
+        CreateWorkbook(workbookPath, batch =>
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                dynamic? sheets = null;
+                dynamic? usersSheet = null;
+                dynamic? notificationsSheet = null;
+                dynamic? sheet1 = null;
+                dynamic? visibleRange = null;
+                dynamic? names = null;
+                dynamic? visibleNameObj = null;
+                dynamic? usersExternalDataName = null;
+                dynamic? notificationsExternalDataName = null;
+                try
+                {
+                    sheets = ctx.Book.Worksheets;
+                    usersSheet = sheets.Add();
+                    usersSheet.Name = "Users";
+                    notificationsSheet = sheets.Add();
+                    notificationsSheet.Name = "Notifications";
+
+                    sheet1 = ctx.Book.Worksheets["Sheet1"];
+                    visibleRange = sheet1.Range["$B$4"];
+                    visibleRange.Value2 = "C:\\Data";
+
+                    names = ctx.Book.Names;
+                    visibleNameObj = names.Add(visibleName, "=Sheet1!$B$4");
+                    usersExternalDataName = names.Add("Users!ExternalData_1", "=Users!$A$6:$AH$19132");
+                    usersExternalDataName.Visible = false;
+                    notificationsExternalDataName = names.Add("Notifications!ExternalData_1", "=Notifications!$A$6:$P$28365");
+                    notificationsExternalDataName.Visible = false;
+                    return 0;
+                }
+                finally
+                {
+                    ComUtilities.Release(ref notificationsExternalDataName);
+                    ComUtilities.Release(ref usersExternalDataName);
+                    ComUtilities.Release(ref visibleNameObj);
+                    ComUtilities.Release(ref names);
+                    ComUtilities.Release(ref visibleRange);
+                    ComUtilities.Release(ref sheet1);
+                    ComUtilities.Release(ref notificationsSheet);
+                    ComUtilities.Release(ref usersSheet);
+                    ComUtilities.Release(ref sheets);
                 }
             });
         });


### PR DESCRIPTION
## Summary
- Harden `namedrange list` so workbooks with hidden/internal defined names are listed from workbook package metadata first, avoiding COM inspection of large hidden Power Query `ExternalData_*` names.
- Keep explicit named range operations from enumerating every workbook name by using direct keyed lookup.
- Add Core and MCP regressions for multiple large hidden `ExternalData_1` names, including Japanese sheet names, and update user/LLM guidance plus changelog.

## Root Cause
The remaining issue #653 repro appears to involve multiple hidden Power Query-generated `ExternalData_1` defined names over very large ranges. The previous hardening skipped hidden names after retrieving COM `Name` objects and checking `Visible`, but that still allowed Excel COM to touch hidden/internal names before deciding to skip them.

## Same-Pattern Search
Searched named range list/read/write/create/update/delete paths for workbook name enumeration and direct COM `Names` access. `List` now uses package metadata before COM enumeration when hidden/internal names exist, and explicit operations now use direct keyed lookup instead of enumerating all workbook names.

## Tests
- `dotnet build Sbroenne.ExcelMcp.sln --no-restore --nologo`
- `dotnet test tests\ExcelMcp.Core.Tests\ExcelMcp.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~Commands.NamedRange" --blame-hang-timeout 5m --logger "console;verbosity=minimal"`
- `dotnet test tests\ExcelMcp.McpServer.Tests\ExcelMcp.McpServer.Tests.csproj --no-restore --filter "FullyQualifiedName~NamedRangeToolProtocolRegressionTests" --blame-hang-timeout 5m --logger "console;verbosity=minimal"`
- Pre-commit gates passed, including Release build, CLI workflow smoke test, MCP smoke test, release deliverable builds, VS Code package validation, MCPB bundle, and agent skills deliverables.

## Notes
This is defensive hardening based on the latest issue diagnostics. The exact private workbook still needs reporter confirmation after release.