### PR TITLE
Disable unused AppInsights metric modules to reduce Log Analytics costs

### DIFF
--- a/infrastructure/azure/appinsights-resources.bicep
+++ b/infrastructure/azure/appinsights-resources.bicep
@@ -21,7 +21,7 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
       enableLogAccessUsingOnlyResourcePermissions: true
     }
     workspaceCapping: {
-      dailyQuotaGb: -1 // No cap
+      dailyQuotaGb: 2 // Cap at 2 GB/day to prevent runaway costs
     }
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -343,9 +343,12 @@ public class Program
             // Set connection string if available
             ConnectionString = connectionString,
 
-            // Disable features not needed for MCP server (reduces overhead)
+            // Disable features not needed for MCP server (reduces overhead and AppMetrics ingestion)
             EnableQuickPulseMetricStream = false,  // Live Metrics not needed for CLI tool
             EnablePerformanceCounterCollectionModule = false,  // Perf counters not useful for short-lived CLI
+            EnableEventCounterCollectionModule = false,  // .NET runtime counters not needed
+            EnableHeartbeat = false,  // Heartbeat metrics not needed for short-lived CLI
+            EnableAdaptiveSampling = false,  // We send low volume; sampling not needed
 
             // Disable dependency tracking for HTTP calls
             EnableDependencyTrackingTelemetryModule = false,

--- a/src/ExcelMcp.McpServer/Telemetry/ExcelMcpTelemetry.cs
+++ b/src/ExcelMcp.McpServer/Telemetry/ExcelMcpTelemetry.cs
@@ -86,8 +86,8 @@ public static class ExcelMcpTelemetry
         try
         {
             // Flush with timeout to avoid hanging on shutdown
-            // 5 seconds is typically sufficient for small batches
-            _telemetryClient.FlushAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(5));
+            // 2 seconds is sufficient; longer waits risk stalling on DNS/network failures
+            _telemetryClient.FlushAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(2));
         }
         catch (Exception)
         {


### PR DESCRIPTION
These modules were generating ~48 GB/month of AppMetrics data (92% of Log Analytics ingestion) by measuring the SDK's own HTTP calls.

## Changes
- Disable EventCounterCollectionModule, Heartbeat, AdaptiveSampling
- Add 2 GB/day ingestion cap
- Reduce flush timeout 5s to 2s to prevent shutdown hangs on network failures

Estimated savings: ~$130/month