### PR TITLE
test: add regression tests for StdinPipeMonitor (#654)

### DIFF
--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -521,8 +521,8 @@ internal static class StdinPipeMonitor
 
     private const int StdInputHandle = -10;
     private const uint FileTypePipe = 0x0003;
-    private const int ErrorBrokenPipe = 109;   // ERROR_BROKEN_PIPE
-    private const int ErrorNoData = 232;       // ERROR_NO_DATA (write end closed)
+    internal const int ErrorBrokenPipe = 109;   // ERROR_BROKEN_PIPE
+    internal const int ErrorNoData = 232;       // ERROR_NO_DATA (write end closed)
 
     /// <summary>
     /// Starts the stdin pipe monitor. Returns null if stdin is not a pipe
@@ -538,17 +538,22 @@ internal static class StdinPipeMonitor
         if (GetFileType(handle) != FileTypePipe)
             return null;
 
+        return StartCore(lifetime, handle);
+    }
+
+    internal static Timer StartCore(IHostApplicationLifetime lifetime, IntPtr pipeHandle,
+        TimeSpan? pollInterval = null)
+    {
+        var interval = pollInterval ?? TimeSpan.FromSeconds(5);
         return new Timer(_ =>
         {
-            uint totalBytesAvailable;
-            uint bytesLeftThisMessage;
-            if (!PeekNamedPipe(handle, IntPtr.Zero, 0, IntPtr.Zero, out totalBytesAvailable, out bytesLeftThisMessage))
+            if (!PeekNamedPipe(pipeHandle, IntPtr.Zero, 0, IntPtr.Zero, out uint _, out uint _))
             {
                 var error = Marshal.GetLastWin32Error();
                 if (error is ErrorBrokenPipe or ErrorNoData)
                     lifetime.StopApplication();
             }
-        }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+        }, null, interval, interval);
     }
 }
 

--- a/tests/ExcelMcp.McpServer.Tests/Unit/StdinPipeMonitorTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/StdinPipeMonitorTests.cs
@@ -1,0 +1,178 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
+
+[Trait("Layer", "McpServer")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "StdinPipeMonitor")]
+[Trait("Speed", "Fast")]
+public sealed class StdinPipeMonitorTests
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CreatePipe(
+        out IntPtr hReadPipe, out IntPtr hWritePipe,
+        IntPtr lpPipeAttributes, uint nSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    [Fact]
+    public void Start_WhenStdinIsPipe_ReturnsTimer()
+    {
+        // dotnet test spawns the test process with piped stdin,
+        // so Start() should detect the pipe and return a timer.
+        var lifetime = new FakeHostApplicationLifetime();
+
+        var timer = StdinPipeMonitor.Start(lifetime);
+
+        try
+        {
+            Assert.NotNull(timer);
+        }
+        finally
+        {
+            timer?.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task StartCore_WhenPipeAlreadyBroken_CallsStopApplication()
+    {
+        Assert.True(CreatePipe(out var readHandle, out var writeHandle, IntPtr.Zero, 0));
+        CloseHandle(writeHandle);
+
+        var lifetime = new FakeHostApplicationLifetime();
+
+        using var timer = StdinPipeMonitor.StartCore(lifetime, readHandle,
+            pollInterval: TimeSpan.FromMilliseconds(50));
+
+        try
+        {
+            await WaitForConditionAsync(
+                () => lifetime.StopCallCount > 0,
+                timeout: TimeSpan.FromSeconds(2));
+
+            Assert.True(lifetime.StopCallCount > 0,
+                "StopApplication should be called when the pipe is already broken at start");
+        }
+        finally
+        {
+            CloseHandle(readHandle);
+        }
+    }
+
+    [Fact]
+    public void StartCore_WithValidPipeHandle_ReturnsTimer()
+    {
+        Assert.True(CreatePipe(out var readHandle, out var writeHandle, IntPtr.Zero, 0));
+        try
+        {
+            var lifetime = new FakeHostApplicationLifetime();
+
+            using var timer = StdinPipeMonitor.StartCore(lifetime, readHandle,
+                pollInterval: TimeSpan.FromMilliseconds(50));
+
+            Assert.NotNull(timer);
+        }
+        finally
+        {
+            CloseHandle(readHandle);
+            CloseHandle(writeHandle);
+        }
+    }
+
+    [Fact]
+    public async Task StartCore_WhenWriteEndCloses_CallsStopApplication()
+    {
+        Assert.True(CreatePipe(out var readHandle, out var writeHandle, IntPtr.Zero, 0));
+        var lifetime = new FakeHostApplicationLifetime();
+
+        using var timer = StdinPipeMonitor.StartCore(lifetime, readHandle,
+            pollInterval: TimeSpan.FromMilliseconds(50));
+
+        CloseHandle(writeHandle);
+
+        try
+        {
+            await WaitForConditionAsync(
+                () => lifetime.StopCallCount > 0,
+                timeout: TimeSpan.FromSeconds(2));
+
+            Assert.True(lifetime.StopCallCount > 0,
+                "StopApplication should be called when the pipe breaks");
+        }
+        finally
+        {
+            CloseHandle(readHandle);
+        }
+    }
+
+    [Fact]
+    public async Task StartCore_WhenPipeIsHealthy_DoesNotCallStopApplication()
+    {
+        Assert.True(CreatePipe(out var readHandle, out var writeHandle, IntPtr.Zero, 0));
+        var lifetime = new FakeHostApplicationLifetime();
+
+        using var timer = StdinPipeMonitor.StartCore(lifetime, readHandle,
+            pollInterval: TimeSpan.FromMilliseconds(50));
+
+        try
+        {
+            await Task.Delay(300);
+            Assert.Equal(0, lifetime.StopCallCount);
+        }
+        finally
+        {
+            CloseHandle(readHandle);
+            CloseHandle(writeHandle);
+        }
+    }
+
+    [Fact]
+    public async Task StartCore_AfterDispose_DoesNotCallStopOnPipeBreak()
+    {
+        Assert.True(CreatePipe(out var readHandle, out var writeHandle, IntPtr.Zero, 0));
+        var lifetime = new FakeHostApplicationLifetime();
+
+        var timer = StdinPipeMonitor.StartCore(lifetime, readHandle,
+            pollInterval: TimeSpan.FromMilliseconds(50));
+
+        timer.Dispose();
+        await Task.Delay(100);
+
+        CloseHandle(writeHandle);
+
+        try
+        {
+            await Task.Delay(300);
+            Assert.Equal(0, lifetime.StopCallCount);
+        }
+        finally
+        {
+            CloseHandle(readHandle);
+        }
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!condition() && DateTime.UtcNow < deadline)
+            await Task.Delay(25);
+    }
+
+    private sealed class FakeHostApplicationLifetime : IHostApplicationLifetime
+    {
+        private int _stopCallCount;
+
+        public int StopCallCount => Volatile.Read(ref _stopCallCount);
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() => Interlocked.Increment(ref _stopCallCount);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 6 unit tests for `StdinPipeMonitor` using real Win32 anonymous pipes (`CreatePipe`/`CloseHandle`)
- Extract `internal StartCore(lifetime, handle, pollInterval?)` overload for test injection with configurable poll interval
- Widen `ErrorBrokenPipe`/`ErrorNoData` constant visibility from `private` to `internal` for test assertions

## Tests

| Test | Verifies |
|---|---|
| `Start_WhenStdinIsPipe_ReturnsTimer` | Production `Start()` correctly detects piped stdin |
| `StartCore_WithValidPipeHandle_ReturnsTimer` | Timer created for valid pipe handle |
| `StartCore_WhenWriteEndCloses_CallsStopApplication` | Broken pipe triggers graceful shutdown |
| `StartCore_WhenPipeAlreadyBroken_CallsStopApplication` | Pre-broken pipe detected on first poll |
| `StartCore_WhenPipeIsHealthy_DoesNotCallStopApplication` | Healthy pipe does **not** trigger false shutdown |
| `StartCore_AfterDispose_DoesNotCallStopOnPipeBreak` | Disposed monitor stops polling |

All 6 tests pass locally. Tests use 50ms poll interval for fast, deterministic execution.

Closes #654

## Test plan
- [x] All 6 `StdinPipeMonitorTests` pass locally
- [x] Existing `ProgramTestTransportLifecycleTests` still pass (no regressions)
- [ ] CI build (note: `main` currently has a pre-existing build failure from PR #661 — `ApplicationInsightsServiceOptions` property references — unrelated to this change)