### PR TITLE
Suppress telemetry info logs on MCP stdio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog covers all components:
 
 ### Fixed
 
+- **MCP Server stdio no longer emits Application Insights info noise during startup** (#559): Application Insights informational logs are now explicitly filtered out of the console provider so stdio clients no longer see lines such as `info: Microsoft.ApplicationInsights.TelemetryClient[0]` on stderr during MCP initialization. Warning and error logs still go to stderr, while stdout remains reserved for JSON-RPC frames.
+
 - **Session open/create timeouts are shorter and more actionable** (#559): The default Excel session startup/operation timeout is now 120 seconds instead of 5 minutes, while MCP `timeout_seconds` and CLI `--timeout` continue to override it for slow workbooks. Startup timeout errors now explicitly identify likely prompt/auth/IRM causes and tell agents to retry with a longer timeout or `show=true` / `--show`.
 
 - **Session startup `Specified cast is not valid` on Office Click-to-Run** (#559): ExcelMcp now compiles against the 15.x Excel PIA that Microsoft 365 Click-to-Run registers as the primary interop assembly for the Excel 16.0 type library, preserving the PIA-based architecture while avoiding startup casts that can fail on modern .NET when Office registry metadata points at `Microsoft.Office.Interop.Excel, Version=15.0.0.0`. COM diagnostics now also report the registered Excel TypeLib primary interop assembly for faster environment triage.

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 using Sbroenne.ExcelMcp.McpServer.Telemetry;
 
 namespace Sbroenne.ExcelMcp.McpServer;
@@ -302,6 +303,7 @@ public class Program
             consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
         });
         logging.SetMinimumLevel(LogLevel.Warning);
+        logging.AddFilter<ConsoleLoggerProvider>("Microsoft.ApplicationInsights", LogLevel.Warning);
     }
 
     /// <summary>
@@ -556,5 +558,3 @@ internal static class StdinPipeMonitor
         }, null, interval, interval);
     }
 }
-
-

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ProgramLoggingTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ProgramLoggingTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
+using Microsoft.ApplicationInsights.WorkerService;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
@@ -60,5 +61,43 @@ public sealed class ProgramLoggingTests
 
         Assert.Empty(stdout.ToString());
         Assert.Contains("host started", stderr.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConfigureStdioLogging_SuppressesApplicationInsightsInfoLogs()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+
+            var services = new ServiceCollection();
+            services.AddLogging(Program.ConfigureStdioLogging);
+            services.AddApplicationInsightsTelemetryWorkerService(new ApplicationInsightsServiceOptions
+            {
+                ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000"
+            });
+
+            using (var provider = services.BuildServiceProvider())
+            {
+                var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("Microsoft.ApplicationInsights.TelemetryClient");
+                logger.LogInformation("telemetry configured");
+                logger.LogWarning("telemetry warning");
+            }
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+
+        Assert.Empty(stdout.ToString());
+        Assert.DoesNotContain("telemetry configured", stderr.ToString(), StringComparison.Ordinal);
+        Assert.Contains("telemetry warning", stderr.ToString(), StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary
- Suppress Application Insights informational console logs in MCP stdio mode
- Preserve Application Insights warnings/errors on stderr while keeping stdout reserved for JSON-RPC frames
- Add regression coverage for the reporter-observed `Microsoft.ApplicationInsights.TelemetryClient` startup noise
- Update CHANGELOG under Unreleased

## Validation
- `dotnet test tests\ExcelMcp.McpServer.Tests\ExcelMcp.McpServer.Tests.csproj --filter FullyQualifiedName~ProgramLoggingTests --no-restore --verbosity:minimal`
- `dotnet build Sbroenne.ExcelMcp.sln --no-restore --verbosity:minimal`
- Pre-commit gates: COM leak check, coverage/naming checks, success flag check, Release solution build, CLI workflow smoke test, MCP Server smoke test, CLI/MCP release deliverables, VS Code extension package, MCPB bundle, agent skills deliverables, plugin README validation, dynamic cast audit

Fixes the telemetry/logging noise portion of #559.