### PR TITLE
fix: replace retired VS Code installs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ExcelMcp - MCP Server for Microsoft Excel
 
-[![VS Code Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/sbroenne.excel-mcp?label=VS%20Code%20Installs)](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)
+[![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/installs-short/sbroenne.excel-mcp.svg?label=VS%20Code%20Installs)](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)
 [![Downloads](https://img.shields.io/github/downloads/sbroenne/mcp-server-excel/total?label=GitHub%20Downloads)](https://github.com/sbroenne/mcp-server-excel/releases)
 
 [![Build MCP Server](https://github.com/sbroenne/mcp-server-excel/actions/workflows/build-mcp-server.yml/badge.svg)](https://github.com/sbroenne/mcp-server-excel/actions/workflows/build-mcp-server.yml)

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -19,7 +19,7 @@ canonical_url: "https://excelmcpserver.dev/"
 <div class="badges-section">
   <div class="container">
     <div class="hero-badges">
-      <a href="https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp"><img src="https://img.shields.io/visual-studio-marketplace/i/sbroenne.excel-mcp?label=VS%20Code%20Installs" alt="VS Code Marketplace Installs"></a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp"><img src="https://vsmarketplacebadges.dev/installs-short/sbroenne.excel-mcp.svg?label=VS%20Code%20Installs" alt="VS Code Marketplace Installs"></a>
       <a href="https://github.com/sbroenne/mcp-server-excel"><img src="https://img.shields.io/github/stars/sbroenne/mcp-server-excel?style=flat&label=GitHub%20Stars" alt="GitHub Stars"></a>
       <a href="https://github.com/sbroenne/mcp-server-excel/releases"><img src="https://img.shields.io/github/downloads/sbroenne/mcp-server-excel/total?label=GitHub%20Downloads" alt="GitHub Downloads"></a>
       <a href="https://www.nuget.org/packages/Sbroenne.ExcelMcp.McpServer"><img src="https://img.shields.io/nuget/dt/Sbroenne.ExcelMcp.McpServer.svg?label=NuGet%20MCP%20Downloads" alt="NuGet MCP Server Downloads"></a>


### PR DESCRIPTION
## Problem

The `VS Code Installs` badge (README + landing page) renders **"retired badge"** instead of an install count. shields.io retired its `visual-studio-marketplace/i/` endpoint after the upstream Marketplace API broke.

## Fix

Switch both badges to [vsmarketplacebadges.dev](https://vsmarketplacebadges.dev), which reports the live install count. A `?label=VS%20Code%20Installs` query keeps the existing label.

Verified the new endpoint returns `VS Code Installs: 5.4K` for `sbroenne.excel-mcp`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>