### PR TITLE
Add Python in Excel (PY()) support

### DIFF
--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -64,7 +64,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## What You Can Do
 
-**17 command categories with 230 operations** for comprehensive Excel automation:
+**18 command categories with 232 operations** for comprehensive Excel automation:
 
 - **Power Query** (10 ops) — Create, update, refresh queries; M code management
 - **Data Model/DAX** (19 ops) — Measures, relationships, EVALUATE queries

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -53,7 +53,7 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ## What You Can Do
 
-**25 specialized tools with 230 operations** for comprehensive Excel automation:
+**26 specialized tools with 232 operations** for comprehensive Excel automation:
 
 ### Core Operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This changelog covers all components:
 
 ## [Unreleased]
 
+### Added
+
+- **Python in Excel (`=PY()`) support** (#691): New `pythoninexcel` MCP tool / CLI category with two operations. `set-formula` writes a `=PY("code", returnType)` formula via `Range.Formula2` (returnType 0 = Excel Value, 1 = Python Object). `get-result` reads back the computed value, polling with a stability heuristic (minimum settle window + required consecutive matching reads on `Value2`) since the Python code executes asynchronously in a Microsoft-hosted cloud sandbox with no reliable "still computing" signal exposed via COM. Classification of errors vs. rich "Python Object" results is derived from the `returnType` parsed out of the formula text and from well-known Excel error codes — not from `Range.Text`, which was found to render unreliably in non-visible/headless Excel automation. If polling doesn't stabilize in time, `get-result` reports failure and asks the caller to retry rather than returning a possibly-stale value. Requires a licensed Microsoft 365 account with Python in Excel enabled and internet access; not available offline or with perpetual-license Excel.
+
 ### Changed
 
 - **Dependency freshness refresh (June 2026)**: Bumped centrally managed packages to their latest stable versions: Dax.Formatter (1.2.0 → 1.2.2), Spectre.Console (0.56.0 → 0.57.1; Spectre.Console.Cli stays at 0.55.0 — no newer stable), the OpenTelemetry family (1.15.x → 1.16.0: Api, Extensions.Hosting, Instrumentation.Http, Instrumentation.SqlClient), Microsoft.Identity.Client + Extensions.Msal (4.84.2 → 4.85.2), Polly.Core/Extensions/RateLimiting (8.6.6 → 8.7.0), StreamJsonRpc (2.25.25 → 2.25.29), Nerdbank.MessagePack security pin (1.2.4 → 1.2.30), Microsoft.NET.StringTools + Build.Framework + Build.Utilities.Core (18.6.3 → 18.7.1), Microsoft.NET.Test.Sdk (18.6.0 → 18.7.0), coverlet.collector (6.1.0 → 10.0.1), and Scriban (7.2.4 → 7.2.5). VS Code extension dev dependency @types/node bumped to ^26.0.1; npm install reports 0 vulnerabilities. Solution builds clean (0 warnings/0 errors) and extension compiles.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # ExcelMcp - Complete Feature Reference
 
-**25 specialized tools with 230 operations for comprehensive Excel automation**
+**26 specialized tools with 232 operations for comprehensive Excel automation**
 
 ---
 
@@ -407,6 +407,18 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ---
 
+---
+
+## 🐍 Python in Excel (2 operations)
+
+**REQUIRES:** a real Excel session signed into a licensed Microsoft 365 account with Python in Excel enabled, plus internet access — the Python code executes in a Microsoft-hosted cloud sandbox, not locally. Not available offline or with perpetual-license Excel.
+
+- **Set Formula:** Writes a `=PY("<code>", returnType)` formula via `Range.Formula2`. `returnType` 0 = "Excel Value" (a plain value/array), 1 = "Python Object" (a rich data type card, e.g. a DataFrame). Must always be passed explicitly — omitting it causes a `#NAME?` error.
+- **Get Result:** Reads back the computed value, polling briefly since cloud execution is not instantaneous. **Best-effort:** Excel exposes no reliable "still computing" signal via COM, so a freshly written formula may read back as unconverged; if the poll doesn't stabilize in time, the call reports failure and asks the caller to retry rather than guessing at a stale value.
+- **Data binding:** reference live worksheet data inside the Python code with `xl("A1:A6")`, `xl("Sheet1!A1:A6")`, or a named range `xl("MyRange")` — works the same as if typed interactively.
+
+---
+
 ## 🪧 Window Management (9 operations)
 
 - **Show:** Makes Excel visible and brings it to the foreground
@@ -452,7 +464,8 @@ Formatting split: use `range` for number display formats such as dates, currency
 | Screenshot | 2 |
 | Calculation Mode | 3 |
 | Window Management | 9 |
-| **Total** | **230** |
+| Python in Excel | 2 |
+| **Total** | **232** |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **Automate Excel with AI** — A Model Context Protocol (MCP) server for comprehensive Excel automation through conversational AI.
 
-**MCP Server for Excel** enables AI assistants (GitHub Copilot, Claude, ChatGPT) to automate Excel through natural language commands. Automate Power Query, DAX measures, VBA macros, PivotTables, Charts, formatting, and data transformations (25 tools with 230 operations).
+**MCP Server for Excel** enables AI assistants (GitHub Copilot, Claude, ChatGPT) to automate Excel through natural language commands. Automate Power Query, DAX measures, VBA macros, PivotTables, Charts, formatting, and data transformations (26 tools with 232 operations).
 
 **🛡️ 100% Safe - Uses Excel's Native COM API** - Zero risk of file corruption. Unlike third-party libraries that manipulate `.xlsx` files directly, this project uses Excel's official API ensuring complete safety and compatibility.
 
@@ -29,7 +29,7 @@
 
 ## 🎯 What You Can Do
 
-**25 specialized tools with 230 operations:**
+**26 specialized tools with 232 operations:**
 
 - 🔄 **Power Query** (1 tool, 12 ops) - Atomic workflows, M code management, load destinations
 - 📊 **Data Model/DAX** (2 tools, 19 ops) - Measures, relationships, model structure
@@ -48,7 +48,7 @@
 - 📸 **Screenshot** (1 tool, 2 ops) - Capture ranges/sheets as PNG for LLM visual verification
 - 🪧 **Window Management** (1 tool, 9 ops) - Show/hide Excel, arrange, position, status bar feedback
 
-📚 **[Complete Feature Reference →](FEATURES.md)** - Detailed documentation of all 230 operations
+📚 **[Complete Feature Reference →](FEATURES.md)** - Detailed documentation of all 232 operations
 
 
 ## 💬 Example Prompts

--- a/gh-pages/404.md
+++ b/gh-pages/404.md
@@ -17,7 +17,7 @@ The page you're looking for doesn't exist or has been moved.
 
 ## Quick Links
 
-- [Features](/features/) — All 25 tools and 230 operations
+- [Features](/features/) — All 26 tools and 232 operations
 - [Installation](/installation/) — Setup guides for VS Code, Claude, and CLI
 - [Changelog](/changelog/) — Release notes and version history
 - [GitHub Repository](https://github.com/sbroenne/mcp-server-excel) — Source code and issues

--- a/gh-pages/features.md
+++ b/gh-pages/features.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Complete Feature Reference"
-description: "25 specialized tools with 230 operations for comprehensive Excel automation. Power Query, DAX, VBA, Charts, PivotTables, and more."
+description: "26 specialized tools with 232 operations for comprehensive Excel automation. Power Query, DAX, VBA, Charts, PivotTables, and more."
 keywords: "Excel MCP features, Power Query automation, DAX measures, VBA macros, Excel tools, MCP operations"
 permalink: /features/
 ---
@@ -10,7 +10,7 @@ permalink: /features/
   <div class="container">
     <div class="hero-content">
       <h1 class="hero-title">Complete Feature Reference</h1>
-      <p class="hero-subtitle">25 specialized tools with 230 operations for comprehensive Excel automation</p>
+      <p class="hero-subtitle">26 specialized tools with 232 operations for comprehensive Excel automation</p>
     </div>
   </div>
 </div>

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -109,6 +109,11 @@ It works with any MCP-compatible AI assistant like GitHub Copilot, Claude Deskto
 <h3>🧪 LLM-Tested Quality</h3>
 <p>Tool behavior validated with real LLM workflows using <a href="https://github.com/sbroenne/pytest-skill-engineering">pytest-skill-engineering</a>. We test that LLMs correctly understand and use our tools.</p>
 </div>
+
+<div class="feature-card">
+<h3>🐍 Python in Excel</h3>
+<p>Write and run <code>=PY()</code> formulas that execute in Excel's cloud-based Python engine — process worksheet data with pandas, NumPy, and more, directly from your AI assistant.</p>
+</div>
 </div>
 
 <p><a href="/features/">See all 26 tools and 232 operations →</a></p>

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -111,7 +111,7 @@ It works with any MCP-compatible AI assistant like GitHub Copilot, Claude Deskto
 </div>
 </div>
 
-<p><a href="/features/">See all 25 tools and 230 operations →</a></p>
+<p><a href="/features/">See all 26 tools and 232 operations →</a></p>
 
 ## What Can You Do With It?
 
@@ -246,7 +246,7 @@ The AI will display the Excel window so you can watch every operation happen liv
 
 ## Documentation
 
-📖 **[Complete Feature Reference](/features/)** — All 25 tools and 230 operations
+📖 **[Complete Feature Reference](/features/)** — All 26 tools and 232 operations
 
 📥 **[Installation Guide](/installation/)** — Setup for VS Code, Claude Desktop, other MCP clients, and CLI
 

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -13,7 +13,7 @@ Excel MCP Server lets you automate Excel through conversation with Claude:
 - **Automate** - VBA macros, batch operations, data refresh
 - **Agent Mode** - Say "show me Excel" and watch AI work in real-time, side-by-side with Claude
 
-**25 tools with 230 operations** for comprehensive Excel automation.
+**26 tools with 232 operations** for comprehensive Excel automation.
 
 ## Requirements
 

--- a/skills/excel-cli/SKILL.md
+++ b/skills/excel-cli/SKILL.md
@@ -178,7 +178,7 @@ excelcli -q batch --input commands.json
 
 Available command groups:
 
-`session`, `batch`, `service`, `calculationmode`, `chart`, `chartconfig`, `conditionalformat`, `connection`, `datamodel`, `datamodelrelationship`, `diag`, `namedrange`, `pivottable`, `pivottablecalc`, `pivottablefield`, `powerquery`, `range`, `rangeedit`, `rangeformat`, `rangelink`, `screenshot`, `sheet`, `worksheetstyle`, `slicer`, `table`, `tablecolumn`, `vba`, `window`
+`session`, `batch`, `service`, `calculationmode`, `chart`, `chartconfig`, `conditionalformat`, `connection`, `datamodel`, `datamodelrelationship`, `diag`, `namedrange`, `pivottable`, `pivottablecalc`, `pivottablefield`, `powerquery`, `pythoninexcel`, `range`, `rangeedit`, `rangeformat`, `rangelink`, `screenshot`, `sheet`, `worksheetstyle`, `slicer`, `table`, `tablecolumn`, `vba`, `window`
 
 ## Common Pitfalls
 

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 # Excel MCP Server Skill
 
-Provides 227 Excel operations via Model Context Protocol. The MCP Server forwards all requests to the shared ExcelMCP Service, enabling session sharing with CLI. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
+Provides 229 Excel operations via Model Context Protocol. The MCP Server forwards all requests to the shared ExcelMCP Service, enabling session sharing with CLI. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
 
 ## Workflow Checklist
 

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides 17 command categories with 230 operations matching the MCP Server. Uses **64% fewer tokens** than MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 25 tool schemas into context.
+The CLI provides 18 command categories with 232 operations matching the MCP Server. Uses **64% fewer tokens** than MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 26 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|
@@ -120,7 +120,7 @@ Descriptions are kept in sync with the CLI source so the help output always refl
 
 ## 📋 Command Categories
 
-ExcelMcp.CLI provides **230 operations** across 17 command categories:
+ExcelMcp.CLI provides **232 operations** across 18 command categories:
 
 📚 **[Complete Feature Reference →](../../FEATURES.md)** - Full documentation with all operations
 
@@ -143,6 +143,7 @@ ExcelMcp.CLI provides **230 operations** across 17 command categories:
 | **Named Ranges** | 6 | `namedrange create`, `namedrange read`, `namedrange write`, `namedrange update` |
 | **VBA** | 6 | `vba list`, `vba import`, `vba run`, `vba update` |
 | **Calculation Mode** | 3 | `calculation get-mode`, `calculation set-mode`, `calculation calculate` |
+| **Python in Excel** | 2 | `pythoninexcel set-formula`, `pythoninexcel get-result` |
 | **Screenshot** | 2 | `screenshot capture`, `screenshot capture-sheet` |
 
 **Note:** CLI uses session commands for multi-operation workflows.

--- a/src/ExcelMcp.Core/Commands/PythonInExcel/IPythonInExcelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PythonInExcel/IPythonInExcelCommands.cs
@@ -1,0 +1,67 @@
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Attributes;
+using Sbroenne.ExcelMcp.Core.Models;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
+
+/// <summary>
+/// Microsoft 365 "Python in Excel" (=PY()) formulas.
+/// REQUIRES: a real Excel session signed into a licensed Microsoft 365 account with Python in Excel
+/// enabled, plus internet access — the Python code executes in a Microsoft-hosted cloud sandbox, not
+/// locally. Not available offline or with perpetual-license Excel.
+/// SET-FORMULA writes '=PY("&lt;code&gt;", returnType)' via Range.Formula2. returnType 0 = "Excel Value"
+/// (a plain value/array), 1 = "Python Object" (a rich data type card, e.g. a DataFrame). The returnType
+/// argument must always be passed explicitly — omitting it causes a #NAME? error.
+/// GET-RESULT reads the computed value back, polling for a short time because cloud execution is not
+/// instantaneous (a fresh formula may transiently read as busy/connecting before the result is ready).
+/// IMPORTANT: polling is best-effort - Excel exposes no reliable "still computing" signal via COM, so a
+/// freshly written formula can briefly read back as a stale default (e.g. 0) that looks like a valid,
+/// stable value even though the real cloud result has not arrived yet. If a result looks suspicious
+/// (e.g. an unexpected 0/default), call get-result again after a few seconds rather than trusting the
+/// first read.
+/// DATA BINDING: reference live worksheet data inside the Python code with xl("A1:A6"),
+/// xl("Sheet1!A1:A6"), or a named range xl("MyRange") — all work when the formula is authored via this
+/// tool, the same as if typed interactively. TIP: xl() returns a pandas DataFrame/Series (not a plain
+/// list) unless you pass headers explicitly; prefer pandas methods (.sum()/.mean()/.max()) over Python
+/// builtins (sum()/len()) to avoid getting a Series back instead of a scalar total.
+/// </summary>
+[ServiceCategory("pythoninexcel", "PythonInExcel")]
+[McpTool("pythoninexcel", Title = "Python in Excel Operations", Destructive = true, Category = "data",
+    Description = "Write and read Microsoft 365 \"Python in Excel\" =PY() formulas. Requires a licensed M365 account with Python in Excel enabled and internet access - Python code executes in Microsoft's cloud sandbox, not locally. SET-FORMULA writes '=PY(code, returnType)' via Range.Formula2 (returnType: 0=Excel Value, 1=Python Object; always pass it explicitly). GET-RESULT reads back the result, polling briefly since cloud execution is not instantaneous; this is best-effort since Excel exposes no reliable \"still computing\" signal via COM, so a freshly written formula may briefly read back as a stale default (e.g. 0) - call get-result again after a few seconds if the value looks suspicious. Reference live worksheet data inside the Python code using xl(\"A1:A6\"), xl(\"Sheet1!A1:A6\"), or a named range xl(\"MyRange\") - this works reliably. TIP: xl() returns a DataFrame/Series, not a plain list, so prefer .sum()/.mean()/.max() methods over Python's builtin sum()/len().")]
+public interface IPythonInExcelCommands
+{
+    /// <summary>
+    /// Writes a =PY() formula to a cell/range via Range.Formula2. The Python code string is
+    /// automatically quote-escaped for embedding inside the Excel formula.
+    /// </summary>
+    /// <param name="batch">Excel batch session</param>
+    /// <param name="sheetName">Worksheet name</param>
+    /// <param name="rangeAddress">Target cell address (e.g. "D1")</param>
+    /// <param name="code">Python source code (e.g. "xl('A1:A6').sum()")</param>
+    /// <param name="returnType">0 = Excel Value (default), 1 = Python Object</param>
+    /// <exception cref="InvalidOperationException">If the range cannot be resolved</exception>
+    [ServiceAction("set-formula")]
+    OperationResult SetFormula(
+        IExcelBatch batch,
+        [RequiredParameter] string sheetName,
+        [RequiredParameter] string rangeAddress,
+        [RequiredParameter] string code,
+        int returnType = 0);
+
+    /// <summary>
+    /// Reads back the computed result of a =PY() cell, polling briefly since the Python code
+    /// executes asynchronously in Microsoft's cloud sandbox and may not be ready immediately
+    /// after the formula is (re)written.
+    /// </summary>
+    /// <param name="batch">Excel batch session</param>
+    /// <param name="sheetName">Worksheet name</param>
+    /// <param name="rangeAddress">Cell address containing the PY() formula</param>
+    /// <param name="maxWaitSeconds">Maximum seconds to poll for a non-transient result (default: 15)</param>
+    /// <exception cref="InvalidOperationException">If the range cannot be resolved</exception>
+    [ServiceAction("get-result")]
+    PythonInExcelResult GetResult(
+        IExcelBatch batch,
+        [RequiredParameter] string sheetName,
+        [RequiredParameter] string rangeAddress,
+        int maxWaitSeconds = 15);
+}

--- a/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
@@ -1,0 +1,229 @@
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
+using Sbroenne.ExcelMcp.Core.Models;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
+
+/// <summary>
+/// Implementation of Microsoft 365 "Python in Excel" (=PY()) formula commands.
+/// </summary>
+public sealed class PythonInExcelCommands : IPythonInExcelCommands
+{
+    /// <summary>
+    /// Transient result markers returned by Excel while the cloud Python sandbox is still
+    /// computing/connecting - not real errors, just "not ready yet".
+    /// </summary>
+    private static readonly string[] TransientMarkers = ["#BUSY!", "#CONNECT!", "#BLOCKED!"];
+
+    /// <inheritdoc />
+    public OperationResult SetFormula(IExcelBatch batch, string sheetName, string rangeAddress, string code, int returnType = 0)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            throw new ArgumentException("Python code must not be empty.", nameof(code));
+        }
+
+        var result = new OperationResult { FilePath = batch.WorkbookPath, Action = "set-formula" };
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic? range = null;
+            try
+            {
+                range = RangeHelpers.ResolveRange(ctx.Book, sheetName, rangeAddress, out string? specificError);
+                if (range == null)
+                {
+                    throw new InvalidOperationException(specificError ?? RangeHelpers.GetResolveError(sheetName, rangeAddress));
+                }
+
+                // Escape embedded double quotes for the Excel formula string literal (" -> "")
+                // The returnType argument (0=Excel Value, 1=Python Object) must always be passed
+                // explicitly - omitting it causes a #NAME? error when the formula is set via COM.
+                string escapedCode = code.Replace("\"", "\"\"", StringComparison.Ordinal);
+                string formula = $"=PY(\"{escapedCode}\",{returnType})";
+
+                range.Formula2 = formula;
+
+                result.Success = true;
+                result.Message = $"Set Python in Excel formula on '{range.Address}'. Use get-result to read the computed value once the cloud Python backend finishes.";
+                return result;
+            }
+            catch (System.Runtime.InteropServices.COMException comEx) when (comEx.HResult == unchecked((int)0x8007000E))
+            {
+                // E_OUTOFMEMORY - Excel's misleading error for sheet/range/session issues
+                throw new InvalidOperationException($"Cannot set Python in Excel formula on range '{rangeAddress}' on sheet '{sheetName}': {comEx.Message}", comEx);
+            }
+            finally
+            {
+                ComUtilities.Release(ref range);
+            }
+        });
+    }
+
+    /// <inheritdoc />
+    public PythonInExcelResult GetResult(IExcelBatch batch, string sheetName, string rangeAddress, int maxWaitSeconds = 15)
+    {
+        var result = new PythonInExcelResult
+        {
+            FilePath = batch.WorkbookPath,
+            SheetName = sheetName,
+            RangeAddress = rangeAddress
+        };
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic? range = null;
+            try
+            {
+                range = RangeHelpers.ResolveRange(ctx.Book, sheetName, rangeAddress, out string? specificError);
+                if (range == null)
+                {
+                    throw new InvalidOperationException(specificError ?? RangeHelpers.GetResolveError(sheetName, rangeAddress));
+                }
+
+                result.RangeAddress = range.Address;
+
+                string formula = range.Formula2?.ToString() ?? string.Empty;
+                result.Formula = formula;
+
+                if (!formula.Contains("PY(", StringComparison.Ordinal))
+                {
+                    result.Success = false;
+                    result.ErrorMessage = $"Cell '{result.RangeAddress}' does not contain a Python in Excel (PY()) formula.";
+                    return result;
+                }
+
+                // The Python code executes in a Microsoft-hosted cloud sandbox, not locally. There is
+                // no reliable "still computing" signal exposed via COM: Excel's local calculation
+                // engine considers itself done as soon as it dispatches the async call, so the cell
+                // shows a stale/default placeholder (e.g. plain "0", or even a transient error-shaped
+                // Value2) before the real cloud result ever arrives - and that placeholder can remain
+                // "stable" (identical across repeated reads) for a long time, indistinguishable from a
+                // genuinely converged result using only Value2/Text. A minimum settle window plus a
+                // longer stable-sample streak reduce (but cannot fully eliminate) false positives - this
+                // is a best-effort heuristic, not a guarantee. Classification below only trusts the
+                // final read once `stable` is true; if the deadline is reached without ever observing
+                // the required run of matching reads, GetResult reports failure and asks the caller to
+                // retry rather than guessing at an unconverged value.
+                // NOTE: Application.Wait() was tried as a message-pumping alternative to Thread.Sleep()
+                // (in case the cloud callback needs Excel's message queue pumped to be delivered) but it
+                // hung indefinitely in this non-visible automation context, so Thread.Sleep() is used.
+                const int MinSettleSeconds = 10;
+                const int RequiredStableSamples = 4;
+                const int PollIntervalMs = 2000;
+
+                // Well-known Excel error code for #PYTHON! (Python code raised an error), used only to
+                // look up the canonical human-readable message via MapErrorCodeToMessage. Detection of
+                // "this is a Python error" is NOT done by matching this exact code (the actual negative
+                // int Value2 returns for a Python-side error/object has been observed to vary and is not
+                // a reliable discriminator on its own) - see the returnType-based classification below.
+                const int PythonErrorCode = -2146826233;
+
+                object? value = null;
+                string text = string.Empty;
+                object? previousValue = null;
+                int consecutiveMatches = 0;
+                bool stable = false;
+
+                var startTime = DateTime.UtcNow;
+                var deadline = startTime.AddSeconds(Math.Max(MinSettleSeconds + 1, maxWaitSeconds));
+                do
+                {
+                    ctx.App.CalculateFullRebuild();
+                    value = range.Value2;
+                    text = range.Text?.ToString() ?? string.Empty;
+
+                    bool isTransient = Array.IndexOf(TransientMarkers, text) >= 0;
+                    // Match on Value2 only - range.Text has been observed to render inconsistently
+                    // (e.g. sometimes blank, sometimes a formatted error string) even while Value2
+                    // itself has already converged to a stable value/error code.
+                    bool matchesPrevious = previousValue != null && Equals(previousValue, value);
+
+                    consecutiveMatches = isTransient ? 0 : matchesPrevious ? consecutiveMatches + 1 : 1;
+
+                    bool minTimeElapsed = (DateTime.UtcNow - startTime).TotalSeconds >= MinSettleSeconds;
+                    if (!isTransient && consecutiveMatches >= RequiredStableSamples && minTimeElapsed)
+                    {
+                        stable = true;
+                        break;
+                    }
+
+                    previousValue = value;
+                    Thread.Sleep(PollIntervalMs);
+                }
+                while (DateTime.UtcNow < deadline);
+
+                if (!stable)
+                {
+                    // Never observed the required run of matching reads - the last read cannot be
+                    // trusted as the converged Python result (it may be a stale/default placeholder,
+                    // or an in-flight transient error code). Report failure rather than guessing.
+                    result.Success = false;
+                    result.ErrorMessage = $"Python in Excel result did not stabilize within {maxWaitSeconds}s and may not reflect the completed cloud computation. Try get-result again, or increase maxWaitSeconds.";
+                    return result;
+                }
+
+                // Which =PY(code, returnType) mode was requested - parsed from the formula text itself
+                // rather than trusting range.Text (which has been observed to render inconsistently in
+                // non-visible automation, seemingly because it depends on screen repaint rather than
+                // the underlying calculated value). 0 = Excel Value, 1 = Python Object.
+                var returnTypeMatch = System.Text.RegularExpressions.Regex.Match(formula, @",\s*(\d+)\s*\)\s*$");
+                int formulaReturnType = returnTypeMatch.Success
+                    ? int.Parse(returnTypeMatch.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture)
+                    : 0;
+
+                if (value is int errorCode && errorCode < 0)
+                {
+                    // Standard Excel error codes are well-known/fixed and mean the *formula itself*
+                    // failed to evaluate (e.g. bad range reference) - these are never Python results.
+                    bool isStandardExcelError = errorCode is -2146826288 or -2147483648 or -2146826259
+                        or -2146826246 or -2146826252 or -2142019887;
+
+                    if (isStandardExcelError)
+                    {
+                        result.Success = false;
+                        result.ErrorMessage = RangeCommands.MapErrorCodeToMessage(errorCode);
+                    }
+                    else if (formulaReturnType == 1)
+                    {
+                        // Python Object mode: Value2 is always an error-shaped placeholder for rich
+                        // data types (e.g. a DataFrame) since COM cannot represent them. Text would
+                        // normally carry a type-name label (e.g. "DataFrame") but is not reliable
+                        // enough here to depend on - report the object without assuming its type.
+                        result.Success = true;
+                        result.IsPythonObject = true;
+                        result.TypeName = !string.IsNullOrEmpty(text) && text.Any(char.IsLetter) ? text : null;
+                        result.Message = "Cell holds a Python Object (rich data type such as a DataFrame). "
+                            + "Value2 cannot expose rich Python object data via COM automation - set returnType=0 "
+                            + "(Excel Value) instead if you need to read the underlying data.";
+                    }
+                    else
+                    {
+                        // Excel Value mode (returnType=0) with a non-standard negative error code -
+                        // this is the Python code itself raising an error (syntax or runtime exception).
+                        result.Success = false;
+                        result.IsPythonError = true;
+                        result.ErrorMessage = RangeCommands.MapErrorCodeToMessage(PythonErrorCode);
+                    }
+                }
+                else
+                {
+                    result.Success = true;
+                    result.Value = value;
+                }
+
+                return result;
+            }
+            catch (System.Runtime.InteropServices.COMException comEx) when (comEx.HResult == unchecked((int)0x8007000E))
+            {
+                // E_OUTOFMEMORY - Excel's misleading error for sheet/range/session issues
+                throw new InvalidOperationException($"Cannot read Python in Excel result from range '{rangeAddress}' on sheet '{sheetName}': {comEx.Message}", comEx);
+            }
+            finally
+            {
+                ComUtilities.Release(ref range);
+            }
+        });
+    }
+}

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
@@ -120,9 +120,11 @@ public partial class RangeCommands
     }
 
     /// <summary>
-    /// Maps Excel error codes to human-readable error messages
+    /// Maps Excel error codes to human-readable error messages.
+    /// Internal (not private) so sibling feature areas (e.g. PythonInExcel) can reuse the same
+    /// mapping table instead of duplicating it - see Bug Fix Pattern Search rule.
     /// </summary>
-    private static string MapErrorCodeToMessage(int errorCode) =>
+    internal static string MapErrorCodeToMessage(int errorCode) =>
         errorCode switch
         {
             -2146826288 => "#NULL! - Invalid intersection of ranges",
@@ -131,6 +133,7 @@ public partial class RangeCommands
             -2146826246 => "#REF! - Invalid cell reference",
             -2146826252 => "#NUM! - Invalid numeric value",
             -2142019887 => "#N/A - Value not available",
+            -2146826233 => "#PYTHON! - Python code raised an error (syntax or runtime exception)",
             _ => $"#ERROR! - Unknown error code {errorCode}"
         };
 

--- a/src/ExcelMcp.Core/Models/PythonInExcelResult.cs
+++ b/src/ExcelMcp.Core/Models/PythonInExcelResult.cs
@@ -1,0 +1,56 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result of reading a Python in Excel (=PY()) cell's computed value.
+/// </summary>
+public class PythonInExcelResult : ResultBase
+{
+    /// <summary>
+    /// Worksheet name containing the cell
+    /// </summary>
+    public string SheetName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Resolved cell/range address
+    /// </summary>
+    public string RangeAddress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The full =PY(...) formula text found in the cell
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Formula { get; set; }
+
+    /// <summary>
+    /// The computed value, when the formula's return type is "Excel Value" (returnType=0).
+    /// Null when the cell holds a "Python Object" (see <see cref="IsPythonObject"/>) or an error.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object? Value { get; set; }
+
+    /// <summary>
+    /// True if the cell holds a "Python Object" (returnType=1) rich data type (e.g. a DataFrame).
+    /// Such cells cannot expose their underlying data via COM Value2 - only a type-name label is
+    /// available via <see cref="TypeName"/>. Switch the formula to returnType=0 to read actual data.
+    /// </summary>
+    public bool IsPythonObject { get; set; }
+
+    /// <summary>
+    /// The Python object's type name (e.g. "DataFrame"), only populated when <see cref="IsPythonObject"/> is true.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TypeName { get; set; }
+
+    /// <summary>
+    /// True if the Python code itself raised an error (surfaces in Excel as #PYTHON!).
+    /// </summary>
+    public bool IsPythonError { get; set; }
+
+    /// <summary>
+    /// Informational message (e.g. explaining Python Object limitations or polling timeout).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Message { get; set; }
+}

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -63,7 +63,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**25 specialized tools with 230 operations:**
+**26 specialized tools with 232 operations:**
 
 - 🔄 **Power Query** (1 tool, 12 ops) - Atomic workflows, M code management, load destinations
 - 📊 **Data Model/DAX** (2 tools, 19 ops) - Measures, relationships, model structure
@@ -82,7 +82,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 - 📸 **Screenshot** (1 tool, 2 ops) - Capture ranges/sheets as PNG for visual verification
 - 🪧 **Window Management** (1 tool, 9 ops) - Show/hide Excel, arrange, position, status bar feedback
 
-📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 230 operations
+📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 232 operations
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -8,6 +8,7 @@ using Sbroenne.ExcelMcp.Core.Commands.Calculation;
 using Sbroenne.ExcelMcp.Core.Commands.Chart;
 using Sbroenne.ExcelMcp.Core.Commands.Diag;
 using Sbroenne.ExcelMcp.Core.Commands.PivotTable;
+using Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
 using Sbroenne.ExcelMcp.Core.Commands.Range;
 using Sbroenne.ExcelMcp.Service.Rpc;
 using StreamJsonRpc;
@@ -54,6 +55,7 @@ public sealed class ExcelMcpService : IDisposable
     private readonly ScreenshotCommands _screenshotCommands = new();
     private readonly DiagCommands _diagCommands = new();
     private readonly WindowCommands _windowCommands = new();
+    private readonly PythonInExcelCommands _pythonInExcelCommands = new();
 
     public ExcelMcpService()
     {
@@ -302,6 +304,9 @@ public sealed class ExcelMcpService : IDisposable
                     (a, batch) => ServiceRegistry.Screenshot.DispatchToCore(_screenshotCommands, a, batch, request.Args)),
                 "window" => await DispatchWindowAsync(action, request),
                 "diag" => DispatchSessionless(action, request),
+                "pythoninexcel" => await DispatchSimpleAsync<PythonInExcelAction>(action, request,
+                    ServiceRegistry.PythonInExcel.TryParseAction,
+                    (a, batch) => ServiceRegistry.PythonInExcel.DispatchToCore(_pythonInExcelCommands, a, batch, request.Args)),
                 _ => new ServiceResponse { Success = false, ErrorMessage = $"Unknown command category: {category}" }
             };
 

--- a/tests/ExcelMcp.Core.Tests/Helpers/PythonInExcelTestsFixture.cs
+++ b/tests/ExcelMcp.Core.Tests/Helpers/PythonInExcelTestsFixture.cs
@@ -1,0 +1,105 @@
+// <copyright file="PythonInExcelTestsFixture.cs" company="Stephan Brenner">
+// Copyright (c) Stephan Brenner. All rights reserved.
+// </copyright>
+
+using System.Diagnostics;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Helpers;
+
+/// <summary>
+/// Fixture that creates ONE Python in Excel test file per test CLASS.
+/// Each test uses a unique target cell for isolation.
+/// - Created ONCE before any tests run
+/// - Shared by all tests in the class
+/// - Each test writes its own source data range and unique PY() target cell
+/// </summary>
+public class PythonInExcelTestsFixture : IAsyncLifetime
+{
+    private readonly string _tempDir;
+    private int _rowCounter;
+
+    /// <summary>
+    /// Path to the shared test file.
+    /// </summary>
+    public string TestFilePath { get; private set; } = null!;
+
+    /// <summary>
+    /// Results of fixture creation (exposed for validation).
+    /// </summary>
+    public FixtureCreationResult CreationResult { get; private set; } = null!;
+
+    /// <summary>
+    /// Initializes a new instance of the fixture.
+    /// </summary>
+    public PythonInExcelTestsFixture()
+    {
+        _tempDir = Path.Join(Path.GetTempPath(), $"PythonInExcelTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Gets a unique row block (10 rows apart) so each test can lay out its own
+    /// source data + PY() target cells without colliding with other tests.
+    /// </summary>
+    public int GetUniqueRowBlockStart()
+    {
+        // 10 rows per test block: enough room for source data + a couple of PY() targets
+        var counter = Interlocked.Increment(ref _rowCounter);
+        return 1 + ((counter - 1) * 10);
+    }
+
+    /// <summary>
+    /// Called ONCE before any tests in the class run.
+    /// Creates a workbook that tests will write source data and PY() formulas to.
+    /// </summary>
+    public Task InitializeAsync()
+    {
+        var sw = Stopwatch.StartNew();
+
+        TestFilePath = Path.Join(_tempDir, "PythonInExcelTest.xlsx");
+        CreationResult = new FixtureCreationResult();
+
+        try
+        {
+            using var manager = new SessionManager();
+            var sessionId = manager.CreateSessionForNewFile(TestFilePath, show: false);
+            manager.CloseSession(sessionId, save: true);
+            CreationResult.FileCreated = true;
+
+            sw.Stop();
+            CreationResult.Success = true;
+            CreationResult.CreationTimeSeconds = sw.Elapsed.TotalSeconds;
+        }
+        catch (Exception ex)
+        {
+            CreationResult.Success = false;
+            CreationResult.ErrorMessage = ex.Message;
+            sw.Stop();
+            throw;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Called ONCE after all tests in the class complete.
+    /// </summary>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PythonInExcel/PythonInExcelCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PythonInExcel/PythonInExcelCommandsTests.cs
@@ -1,0 +1,222 @@
+using System.Threading;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
+using Sbroenne.ExcelMcp.Core.Models;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PythonInExcel;
+
+/// <summary>
+/// Integration tests for Python in Excel (=PY()) Core operations.
+/// These tests require Excel installation, a Microsoft 365 subscription with the
+/// Python in Excel feature enabled, and network access to the Microsoft-hosted
+/// Python cloud sandbox. They are intentionally excluded from default CI runs via
+/// [Trait("RunType", "OnDemand")] since results depend on a real cloud round-trip
+/// (typically a few seconds, occasionally longer under cold-start conditions).
+/// Tests use Core commands directly (not through CLI wrapper).
+/// </summary>
+[Trait("Layer", "Core")]
+[Trait("Category", "Integration")]
+[Trait("RequiresExcel", "true")]
+[Trait("Feature", "PythonInExcel")]
+[Trait("RunType", "OnDemand")]
+public class PythonInExcelCommandsTests : IClassFixture<PythonInExcelTestsFixture>
+{
+    // Every test opens its own Excel process via ExcelSession.BeginBatch(), so every test hits a
+    // fresh cold start of the Microsoft-hosted Python cloud sandbox (no session/process reuse
+    // across test methods). A generous wait accounts for this cold-start latency.
+    private const int DefaultMaxWaitSeconds = 90;
+
+    // ExcelBatch's own per-operation watchdog defaults to 120s. A single CalculateFullRebuild()
+    // call during genuine cloud computation can itself block for many seconds, so the total time
+    // spent inside GetResult's poll loop can exceed the default operation timeout even though our
+    // own maxWaitSeconds deadline hasn't been reached yet. Give the batch extra headroom.
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(300);
+
+    private readonly Sbroenne.ExcelMcp.Core.Commands.PythonInExcel.PythonInExcelCommands _pythonCommands;
+    private readonly RangeCommands _rangeCommands;
+    private readonly PythonInExcelTestsFixture _fixture;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PythonInExcelCommandsTests"/> class.
+    /// </summary>
+    public PythonInExcelCommandsTests(PythonInExcelTestsFixture fixture)
+    {
+        _pythonCommands = new Sbroenne.ExcelMcp.Core.Commands.PythonInExcel.PythonInExcelCommands();
+        _rangeCommands = new RangeCommands();
+        _fixture = fixture;
+    }
+
+    /// <summary>
+    /// Begins a batch against the shared fixture file with a longer-than-default operation
+    /// timeout, to give the cloud Python round-trip enough headroom (see <see cref="OperationTimeout"/>).
+    /// </summary>
+    private IExcelBatch BeginBatch() => ExcelSession.BeginBatch(show: false, OperationTimeout, _fixture.TestFilePath);
+
+    /// <summary>
+    /// Calls GetResult repeatedly until <paramref name="isAcceptable"/> is satisfied or the retry
+    /// budget is exhausted. Core's completion-detection heuristic is intentionally best-effort (see
+    /// PythonInExcelCommands.GetResult remarks) - there is no COM-level signal that can definitively
+    /// distinguish a converged cloud result from a stale placeholder, so a single read can flakily
+    /// under-wait. Retrying here mirrors the documented "call get-result again" guidance for callers.
+    /// </summary>
+    private PythonInExcelResult GetResultWithRetry(
+        IExcelBatch batch,
+        string sheetName,
+        string cell,
+        Func<PythonInExcelResult, bool> isAcceptable,
+        int attempts = 3)
+    {
+        PythonInExcelResult result = _pythonCommands.GetResult(batch, sheetName, cell, DefaultMaxWaitSeconds);
+        for (int i = 1; i < attempts && !isAcceptable(result); i++)
+        {
+            Thread.Sleep(3000);
+            result = _pythonCommands.GetResult(batch, sheetName, cell, DefaultMaxWaitSeconds);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Writes a simple numeric column (5, 15, 25, 35, 45) starting at the given row, and
+    /// returns the sheet-qualified source range address (e.g. "A10:A14").
+    /// </summary>
+    private string WriteSourceData(IExcelBatch batch, int startRow)
+    {
+        var values = new List<List<object?>>
+        {
+            new() { 5 },
+            new() { 15 },
+            new() { 25 },
+            new() { 35 },
+            new() { 45 },
+        };
+        string sourceRange = $"A{startRow}:A{startRow + 4}";
+        var setResult = _rangeCommands.SetValues(batch, "Sheet1", sourceRange, values);
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+        return sourceRange;
+    }
+
+    /// <inheritdoc/>
+    [Fact]
+    public void SetFormula_ThenGetResult_ComputesMeanOfWorksheetRange()
+    {
+        // Arrange
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string sourceRange = WriteSourceData(batch, startRow);
+        string targetCell = $"D{startRow}";
+        string code = $"xl('{sourceRange}').mean()";
+
+        // Act
+        var setResult = _pythonCommands.SetFormula(batch, "Sheet1", targetCell, code, returnType: 0);
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+
+        var getResult = GetResultWithRetry(
+            batch, "Sheet1", targetCell,
+            r => r.Success && !r.IsPythonError && Convert.ToDouble(r.Value, System.Globalization.CultureInfo.InvariantCulture) == 25d);
+
+        // Assert
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.False(getResult.IsPythonError);
+        Assert.False(getResult.IsPythonObject);
+        Assert.NotNull(getResult.Value);
+        Assert.Equal(25d, Convert.ToDouble(getResult.Value, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    /// <inheritdoc/>
+    [Fact]
+    public void SetFormula_ThenGetResult_ComputesMaxOfWorksheetRange()
+    {
+        // Arrange
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string sourceRange = WriteSourceData(batch, startRow);
+        string targetCell = $"D{startRow}";
+        string code = $"xl('{sourceRange}').max()";
+
+        // Act
+        _pythonCommands.SetFormula(batch, "Sheet1", targetCell, code, returnType: 0);
+        var getResult = GetResultWithRetry(
+            batch, "Sheet1", targetCell,
+            r => r.Success && !r.IsPythonError && Convert.ToDouble(r.Value, System.Globalization.CultureInfo.InvariantCulture) == 45d);
+
+        // Assert
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.Equal(45d, Convert.ToDouble(getResult.Value, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    /// <inheritdoc/>
+    [Fact]
+    public void SetFormula_WithSyntaxError_GetResultReturnsPythonError()
+    {
+        // Arrange
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string targetCell = $"D{startRow}";
+
+        // Act - deliberately invalid Python syntax
+        _pythonCommands.SetFormula(batch, "Sheet1", targetCell, "this is not valid python (((", returnType: 0);
+        var getResult = GetResultWithRetry(batch, "Sheet1", targetCell, r => r.IsPythonError);
+
+        // Assert
+        Assert.False(getResult.Success);
+        Assert.True(getResult.IsPythonError);
+        Assert.NotNull(getResult.ErrorMessage);
+    }
+
+    /// <inheritdoc/>
+    [Fact]
+    public void SetFormula_WithReturnTypePythonObject_GetResultReportsObjectType()
+    {
+        // Arrange
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string sourceRange = WriteSourceData(batch, startRow);
+        string targetCell = $"D{startRow}";
+        // pandas.Series is a Python Object when returnType=1 (Python Object mode)
+        string code = $"xl('{sourceRange}').squeeze()";
+
+        // Act
+        _pythonCommands.SetFormula(batch, "Sheet1", targetCell, code, returnType: 1);
+        var getResult = GetResultWithRetry(batch, "Sheet1", targetCell, r => r.Success && r.IsPythonObject);
+
+        // Assert
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.True(getResult.IsPythonObject);
+        Assert.False(string.IsNullOrEmpty(getResult.TypeName));
+    }
+
+    /// <inheritdoc/>
+    [Fact]
+    public void GetResult_OnCellWithoutPyFormula_ReturnsFailure()
+    {
+        // Arrange
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string targetCell = $"D{startRow}";
+
+        // Act - target cell has no PY() formula at all
+        var getResult = _pythonCommands.GetResult(batch, "Sheet1", targetCell, DefaultMaxWaitSeconds);
+
+        // Assert
+        Assert.False(getResult.Success);
+        Assert.Contains("does not contain", getResult.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    [Fact]
+    public void SetFormula_WithEmptyCode_ThrowsArgumentException()
+    {
+        // Arrange
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string targetCell = $"D{startRow}";
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(
+            () => _pythonCommands.SetFormula(batch, "Sheet1", targetCell, string.Empty));
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
@@ -129,7 +129,7 @@ public class McpServerSmokeTests : IAsyncLifetime, IAsyncDisposable
     public async Task SmokeTest_AllTools_E2EWorkflow()
     {
         _output.WriteLine("=== MCP SERVER E2E SMOKE TEST (SDK CLIENT) ===");
-        _output.WriteLine("Testing all 25 tools via MCP protocol with real Excel...\n");
+        _output.WriteLine("Testing all 26 tools via MCP protocol with real Excel...\n");
 
         // =====================================================================
         // STEP 1: CREATE AND OPEN SESSION

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -16,7 +16,7 @@
 
 ## Features
 
-The Excel MCP Server (excel-mcp) provides **25 specialized tools with 230 operations** for comprehensive Excel automation:
+The Excel MCP Server (excel-mcp) provides **26 specialized tools with 232 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query** (1 tool, 12 ops) - Atomic workflows, M code management, load destinations
 - 📊 **Data Model/DAX** (2 tools, 19 ops) - Measures, relationships, model structure


### PR DESCRIPTION
## Summary

Adds a new `pythoninexcel` Core commands / MCP tool / CLI category (2 operations), closing #691:
- `set-formula`: writes a `=PY(code, returnType)` formula via `Range.Formula2`
- `get-result`: polls for the cloud-computed result and classifies it as a plain value, a Python error, or a rich "Python Object"

## Background

Python in Excel executes the Python code in a Microsoft-hosted cloud sandbox, not locally, and COM exposes no reliable "still computing" signal. `get-result` polls `Range.Value2` until it reads a stable value across several consecutive samples over a minimum settle window before classifying it.

## Bugs found and fixed during verification

Two real logic bugs were found while testing this, not just timing flakiness:

1. **`Range.Text` is unreliable in headless/non-visible Excel automation.** The original approach used `Text` both for stability-polling and for classifying "Python Object" vs. "Python error" results. `Text` can render inconsistently (e.g. showing `"0"` or never settling) even after `Value2` has genuinely converged. Fixed by comparing `Value2` only for stability.
2. **Classification now uses reliable, non-rendering-dependent signals**: the `returnType` argument (0 = Excel Value, 1 = Python Object) is parsed directly out of the formula's own text via regex, combined with a fixed list of well-known standard Excel error codes to separate ordinary formula errors from Python-specific errors/objects.

If polling doesn't stabilize before the timeout, `get-result` now reports failure and asks the caller to retry, rather than returning a possibly-stale value with `Success=true`.

**Known limitation:** completion detection remains best-effort by design — there's no COM-level "Python computation finished" event. This is disclosed in the tool's XML docs, with retry as the documented mitigation.

## Testing

- All 6 Core integration tests pass reliably (`Category=Integration`, `Feature=PythonInExcel`), verified across multiple full runs plus individual re-runs of previously-failing tests.
- Manual CLI verification of syntax-error detection and Python-Object detection via a live daemon session.
- Full pre-commit hook suite (14 gates) passed locally: COM leak check, coverage/naming audit, success-flag check, Release build, CLI/MCP smoke tests, CLI/MCP Server packaging, VS Code extension packaging, MCPB bundle, agent skills, plugin README validation, dynamic-cast audit.

## Docs

FEATURES.md, root/CLI/MCP Server/mcpb/vscode-extension READMEs, gh-pages, and plugin READMEs updated (26 tools / 232 operations). CHANGELOG.md updated. Issue #691 updated with the full technical write-up.

## Requirements

Requires a licensed Microsoft 365 account with Python in Excel enabled and internet access; not available offline or with perpetual-license Excel.
