### PR TITLE
ci: upgrade GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -37,10 +37,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 
@@ -98,7 +98,7 @@ jobs:
       shell: pwsh
 
     - name: Upload CLI build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ExcelMcp-CLI-${{ github.sha }}
         path: src/ExcelMcp.CLI/bin/Release/net10.0-windows/

--- a/.github/workflows/build-mcp-server.yml
+++ b/.github/workflows/build-mcp-server.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 
@@ -71,7 +71,7 @@ jobs:
       shell: pwsh
 
     - name: Upload MCP Server build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ExcelMcp-MCP-Server-${{ github.sha }}
         path: src/ExcelMcp.McpServer/bin/Release/net10.0-windows/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,10 +51,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 
@@ -89,7 +89,7 @@ jobs:
     # Upload SARIF results as artifact for review
     - name: Upload CodeQL Results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: codeql-sarif-results-${{ matrix.language }}
         path: sarif-results

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           # Fail the build if vulnerabilities are found
           fail-on-severity: moderate

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: pip
@@ -54,16 +54,16 @@ jobs:
         run: mkdocs build --strict --clean
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'gh-pages/_site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Notify IndexNow (Bing/Yandex)
         run: |

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -90,7 +90,7 @@ jobs:
       trigger_mode: ${{ steps.extract_version.outputs.trigger_mode }}
     steps:
       - name: Checkout source repo with tags
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -160,7 +160,7 @@ jobs:
       reason: ${{ steps.diff.outputs.reason }}
     steps:
       - name: Checkout source repo with tags
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -245,19 +245,19 @@ jobs:
     if: ${{ needs.detect-plugin-surface.outputs.should_publish == 'true' }}
     steps:
       - name: Checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
 
       - name: Checkout published repo (plugin templates)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.PUBLISHED_REPO }}
           token: ${{ secrets.PLUGINS_REPO_TOKEN }}
           path: published
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -304,14 +304,14 @@ jobs:
           }
 
       - name: Upload excel-mcp plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: excel-mcp-plugin
           path: source/plugins/excel-mcp/
           retention-days: 1
 
       - name: Upload excel-cli plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: excel-cli-plugin
           path: source/plugins/excel-cli/
@@ -327,24 +327,24 @@ jobs:
     if: ${{ needs.detect-plugin-surface.outputs.should_publish == 'true' }}
     steps:
       - name: Download excel-mcp plugin
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: excel-mcp-plugin
           path: built-plugins/excel-mcp
 
       - name: Download excel-cli plugin
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: excel-cli-plugin
           path: built-plugins/excel-cli
 
       - name: Checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source-repo
 
       - name: Checkout published repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.PUBLISHED_REPO }}
           token: ${{ secrets.PLUGINS_REPO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       version: ${{ steps.calculate_version.outputs.version }}
       tag: ${{ steps.calculate_version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch all history and tags
 
@@ -114,10 +114,10 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -164,19 +164,19 @@ jobs:
       shell: pwsh
 
     - name: Upload CLI ZIP Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cli-zip
         path: ExcelMcp-CLI-*-windows.zip
 
     - name: Upload CLI NuGet Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cli-nupkg
         path: cli-nupkg/*.nupkg
 
     - name: Upload CLI Build Output (for other jobs)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cli-build
         path: cli-publish/
@@ -192,10 +192,10 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -272,13 +272,13 @@ jobs:
       shell: pwsh
 
     - name: Upload ZIP Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mcp-server-zip
         path: ExcelMcp-MCP-Server-*-windows.zip
 
     - name: Upload NuGet Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mcp-server-nupkg
         path: nupkg/*.nupkg
@@ -294,15 +294,15 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -361,7 +361,7 @@ jobs:
       shell: pwsh
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: vscode-vsix
         path: vscode-extension/excelmcp-*.vsix
@@ -377,10 +377,10 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -399,7 +399,7 @@ jobs:
         APPINSIGHTS_CONNECTION_STRING: ${{ secrets.APPINSIGHTS_CONNECTION_STRING }}
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mcpb-bundle
         path: mcpb/artifacts/excel-mcp-*.mcpb
@@ -415,10 +415,10 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
 
@@ -516,7 +516,7 @@ jobs:
       shell: pwsh
 
     - name: Upload Skills Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: agent-skills
         path: artifacts/skills/excel-skills-*.zip
@@ -532,7 +532,7 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set Version
       run: |
@@ -607,7 +607,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -635,15 +635,15 @@ jobs:
       id-token: write  # Required for NuGet OIDC
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -654,19 +654,19 @@ jobs:
       shell: pwsh
 
     - name: Download NuGet Package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: mcp-server-nupkg
         path: nupkg
 
     - name: Download CLI NuGet Package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: cli-nupkg
         path: cli-nupkg
 
     - name: Download VS Code VSIX
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: vscode-vsix
         path: vscode-vsix
@@ -713,14 +713,14 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set Version
       run: |
         echo "VERSION=${{ needs.version.outputs.version }}" >> $GITHUB_ENV
 
     - name: Download All Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         path: artifacts
 


### PR DESCRIPTION
## Summary

Resolves the **Node.js 20 Actions runtime deprecation** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) surfaced as a warning on the `Deploy GitHub Pages` run. Bumps every affected first-party action to the **earliest major that defaults to Node.js 24** (the most mature version that resolves the deprecation, rather than jumping to bleeding-edge majors).

Closes #695

## Changes

| Action | From | To |
|--------|------|----|
| actions/checkout | v4 | **v5** |
| actions/setup-dotnet | v4 | **v5** |
| actions/setup-node | v4 | **v5** |
| actions/setup-python | v5 | **v6** |
| actions/upload-artifact | v4 | **v6** |
| actions/download-artifact | v4 | **v7** |
| actions/configure-pages | v4 | **v6** |
| actions/upload-pages-artifact | v3 | **v5** |
| actions/deploy-pages | v4 | **v5** |
| actions/dependency-review-action | v4 | **v5** |

**Unchanged (already Node 24):** `actions/stale@v10`, `NuGet/login@v1`, `github/codeql-action@v4`.

**Known follow-up:** `HaaLeo/publish-vscode-extension@v2` still targets Node 20 and has no Node 24 major published yet — left as-is until upstream ships one.

## Compatibility verification

Confirmed our usage is unaffected by the behavioral changes in these majors:
- **setup-node v5/v6 caching changes** — we pass explicit `node-version` and no `cache:` input.
- **download-artifact v5 by-id path change** — all downloads use `name:` + `path:`, not by-id.
- **checkout v6/v7 fork-PR block** — not applicable (we use v5); and no checkout step checks out a fork PR head under `workflow_run`.
- **upload/download-artifact** bumped as a matched Node-24-default pair (v6 / v7).

## Testing

- All workflow YAML validated (parses cleanly).
- Full 15-gate pre-commit hook passed (no bypass).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>