### PR TITLE
Re-architect changelog generation and release notes

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,64 @@
+# Changesets
+
+This folder holds **changeset fragments** — small markdown files that describe a
+user-facing change before it ships. They are compiled into [`CHANGELOG.md`](../CHANGELOG.md)
+and GitHub Release notes automatically when a release is cut (see
+[Release Strategy](../docs/RELEASE-STRATEGY.md#changelog-generation)).
+
+> This repo is Windows/.NET-first (MCP Server, CLI, VS Code Extension, MCPB). The
+> `@changesets/cli` tool is Node-based, but it is used **only** to manage
+> `CHANGELOG.md` content — it does not build, version, or publish any ExcelMcp
+> component. `package.json` at the repo root exists solely to host this tool.
+
+## Add a changeset for your PR
+
+After making a user-facing change, run from the repo root:
+
+```powershell
+npx changeset
+```
+
+This asks two questions:
+
+1. **Bump type** (major/minor/patch) — pick whichever feels right; it's metadata
+   only and does not control the actual ExcelMcp release version (that's chosen
+   by the maintainer when running the release workflow).
+2. **Summary** — write 1-3 sentences **for end users**, not for other engineers.
+
+Commit the generated `.changeset/<random-name>.md` file with your PR.
+
+### What makes a good entry
+
+The changelog is end-user facing. Favor plain language over implementation detail.
+
+```md
+✅ Good:
+**Faster range reads** (#123): `range get-values` now batches COM calls,
+cutting read time for large ranges by roughly half.
+
+❌ Too technical / internal:
+Refactored ComUtilities.ForEach to use a shared iterator and reduced
+Marshal.ReleaseComObject calls in RangeCommands.GetValues by batching
+Range.Value2 access via a single COM round-trip instead of per-cell reads.
+```
+
+Keep root-cause analysis, stack traces, and implementation notes in the PR
+description or commit — not in the changeset summary.
+
+### Which PRs need one
+
+Any PR that changes user-visible behavior of the MCP Server, CLI, VS Code
+Extension, or MCPB needs a changeset. Docs-only, test-only, CI-only, and
+dependency-bump PRs generally don't — add the `skip-changelog` label instead of
+a changeset (a CI check enforces this; see
+`.github/workflows/changeset-check.yml`).
+
+### Multiple changes in one PR
+
+Add multiple changeset files if a PR bundles unrelated user-facing changes —
+each renders as its own bullet.
+
+## Full changesets documentation
+
+- [Common questions](https://github.com/changesets/changesets/blob/main/docs/common-questions.md)
+- [Main repository](https://github.com/changesets/changesets)

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
+  "changelog": ["@changesets/changelog-github", { "repo": "sbroenne/mcp-server-excel" }],
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.github/instructions/critical-rules.instructions.md
+++ b/.github/instructions/critical-rules.instructions.md
@@ -115,7 +115,7 @@ Discovered while debugging a Power Query that referenced a column with a hyphen
 | 7. PRs | Always use PRs, never direct commit | Always |
 | 24. Post-change sync | Verify ALL sync points (CLI, SKILLs, READMEs, counts) | 5-10 min |
 | 26. No confidential info | No customer/project names in commits/PRs/issues | Always |
-| 27. CHANGELOG | Update CHANGELOG.md before merging PRs | 2-5 min |
+| 27. Changeset | Add a changeset before merging PRs (see .changeset/README.md) | 2-5 min |
 | 28. COM API naming | Match COM param names when clear in flat schema | Always |
 
 **During PR Process:**
@@ -916,53 +916,49 @@ Select-String -Path "**/*.md" -Pattern '```bash' -Recurse
 
 ---
 
-## Rule 27: Update CHANGELOG Before Merging PRs (CRITICAL)
+## Rule 27: Add a Changeset Before Merging PRs (CRITICAL)
 
-**ALWAYS update CHANGELOG.md before merging any PR that adds features, fixes bugs, or makes breaking changes.**
+**ALWAYS add a changeset fragment before merging any PR that adds features, fixes bugs, or makes breaking changes. `CHANGELOG.md` is generated from these fragments — it is NOT hand-edited.**
 
-**Why Critical:** 
-- Users and LLMs rely on CHANGELOG to understand what changed
-- Release workflow extracts version notes from CHANGELOG
+**Why Critical:**
+- Users and LLMs rely on CHANGELOG.md (end-user facing) to understand what changed
+- The release workflow compiles pending changesets into the new version's CHANGELOG.md section and GitHub Release notes via `scripts/Build-Changelog.ps1`
 - Missing entries make releases incomplete and confusing
-- Git history is not a substitute for curated change documentation
+- Git history is not a substitute for curated, end-user-facing change documentation
+- Hand-editing a shared `## [Unreleased]` section caused real incidents: it went stale for months because the auto-rename PR silently failed to merge, leaving multiple already-released versions (v1.8.64–v1.9.0) mislabeled as "Unreleased" — changesets fixes this structurally by giving each PR its own fragment file instead of one contested shared section
 
-**What Requires CHANGELOG Entry:**
+**What Requires a Changeset:**
 - ✅ Bug fixes (with issue number)
 - ✅ New features or actions
 - ✅ Breaking changes
 - ✅ Significant behavior changes
-- ✅ New pre-commit checks or tooling
-- ❌ Internal refactoring (no user-visible change)
-- ❌ Documentation-only changes (unless significant)
-- ❌ Test-only changes
-
-**Format (Keep a Changelog):**
-```markdown
-## [Unreleased]
-
-### Added
-- **Feature Name** (#issue): Brief description
-
-### Fixed
-- **Bug Title** (#issue): Brief description
-  - ROOT CAUSE: What caused it
-  - FIX: How it was fixed
-
-### Changed
-- **Change Title**: Brief description
-```
+- ✅ New pre-commit checks or tooling that affects contributors
+- ❌ Internal refactoring (no user-visible change) — label PR `skip-changelog`
+- ❌ Documentation-only changes (unless significant) — label PR `skip-changelog`
+- ❌ Test-only / CI-only / dependency-bump changes — label PR `skip-changelog`
 
 **Process:**
-1. Before merging PR, check if changes need CHANGELOG entry
-2. Add entry under `## [Unreleased]` section
-3. Use appropriate category: Added, Fixed, Changed, Removed, Security
-4. Include issue/PR number for traceability
-5. Commit CHANGELOG update with the PR or as final commit before merge
+```powershell
+npx changeset
+# → pick a bump type (major/minor/patch — metadata only, doesn't set the real release version)
+# → write a short, end-user-facing summary (not implementation detail)
+# → commit the generated .changeset/<name>.md file with the PR
+```
+
+**Format (written by end users, for end users):**
+```md
+✅ Good:
+**Faster range reads** (#123): `range get-values` now batches COM calls,
+cutting read time for large ranges by roughly half.
+
+❌ Too technical:
+Refactored ComUtilities.ForEach to reduce Marshal.ReleaseComObject calls...
+```
 
 **Enforcement:**
-- Review CHANGELOG.md before every PR merge
-- Agent must ask: "Does this change need a CHANGELOG entry?"
-- Merging without CHANGELOG update for user-visible changes = bug
+- `.github/workflows/changeset-check.yml` fails the PR if no `.changeset/*.md` fragment was added and the PR lacks the `skip-changelog` label
+- Agent must ask: "Does this change need a changeset?" before opening/merging a PR
+- See `.changeset/README.md` and `docs/RELEASE-STRATEGY.md#changelog-generation` for the full workflow
 
 ---
 

--- a/.github/instructions/development-workflow.instructions.md
+++ b/.github/instructions/development-workflow.instructions.md
@@ -23,7 +23,7 @@ All PRs are merged using **squash merge** (single commit to `main`). This keeps 
 
 1. **Create feature branch**: `git checkout -b feature/name`
 2. **Standards**: Zero warnings, tests pass, docs updated, security rules followed
-3. **PR Checklist**: Build passes, tests pass, docs updated, patterns followed
+4. **PR Checklist**: Build passes, tests pass, docs updated, patterns followed, changeset added (see Rule 27)
 4. **Check PR review comments**: After creating PR, retrieve automated review feedback and fix all issues
 5. **Versions**: Automated via release workflow - don't update manually
 
@@ -103,7 +103,7 @@ Quick reference:
 - MCPB → Claude Desktop bundle
 
 **Before Releasing:**
-1. Ensure all changes are documented under `## [Unreleased]` in `CHANGELOG.md`
+1. Nothing manual — changesets accumulate in `.changeset/` from individual PRs (see Rule 27); the release workflow compiles them into `CHANGELOG.md` automatically
 2. Go to Actions → Release All Components → Run workflow
 3. Select version bump type (patch/minor/major) or enter a custom version
 

--- a/.github/instructions/readme-management.instructions.md
+++ b/.github/instructions/readme-management.instructions.md
@@ -75,11 +75,11 @@ Before committing README changes:
 
 ## CHANGELOG.md
 
-The project uses a **centralized changelog** at `/CHANGELOG.md` covering all components.
+The project uses a **centralized changelog** at `/CHANGELOG.md` covering all components. It is generated from [changesets](../../.changeset/README.md), not hand-edited — see `docs/RELEASE-STRATEGY.md#changelog-generation` and Rule 27.
 
 **When to update:**
-- Before creating a `v*` tag, ensure the version section exists in CHANGELOG.md
-- The release workflow extracts the specific version's changes for release notes
+- Add a changeset (`npx changeset`) with your PR, not by editing CHANGELOG.md directly
+- The release workflow (`scripts/Build-Changelog.ps1`) compiles pending changesets into a new version section and uses it verbatim for release notes
 - Uses standard Keep a Changelog format: `## [version] - YYYY-MM-DD`
 
 | Mistake | Fix |
@@ -91,7 +91,8 @@ The project uses a **centralized changelog** at `/CHANGELOG.md` covering all com
 | Overclaiming features | Use actual counts, not estimates |
 | Missing safety callout | Add COM API benefits |
 | Manual version updates | Let workflow handle it |
-| Missing CHANGELOG entry | Add before creating release tag |
+| Missing changeset | Add via `npx changeset` before merging (CI enforces this) |
+| Hand-editing CHANGELOG.md directly | Add a changeset fragment instead — it's compiled automatically |
 | External GitHub links in gh-pages | Use local pages (see gh-pages pattern below) |
 
 ## gh-pages Local Documentation Pattern

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,10 @@ Brief description of what this PR does.
 Closes #[issue number]
 Relates to #[issue number]
 
+## Changeset
+- [ ] Added a changeset (`npx changeset`) describing this change for end users — see `.changeset/README.md`
+- [ ] Not applicable (docs/tests/CI/dependency-only) — added `skip-changelog` label instead
+
 ## Changes Made
 - Change 1
 - Change 2

--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -1,0 +1,43 @@
+## ExcelMcp {{VERSION}}
+
+### What's New
+{{CHANGELOG}}
+
+### Installation Options
+
+**VS Code Extension** (Recommended)
+- Search "ExcelMcp" in VS Code Marketplace and click Install
+- Or download `excelmcp-{{VERSION}}.vsix` below
+- Self-contained: no .NET runtime or SDK required
+- Includes both MCP Server and CLI (`excelcli`)
+- Agent skills (excel-mcp + excel-cli) registered automatically via `chatSkills`
+
+**Claude Desktop (MCPB)**
+- Download `excel-mcp-{{VERSION}}.mcpb` and double-click to install
+
+**Standalone Executables** (Primary — no .NET runtime required)
+- MCP Server: Download `ExcelMcp-MCP-Server-{{VERSION}}-windows.zip`, extract `mcp-excel.exe`
+- CLI: Download `ExcelMcp-CLI-{{VERSION}}-windows.zip`, extract `excelcli.exe`
+- Add the exe(s) to your PATH, then configure your MCP client with command `mcp-excel`
+
+**NuGet (.NET Tool)** (Secondary — requires .NET 10 runtime)
+```powershell
+dotnet tool install --global Sbroenne.ExcelMcp.McpServer
+dotnet tool install --global Sbroenne.ExcelMcp.CLI
+```
+
+**Agent Skills** (for AI coding assistants)
+- VS Code Extension includes both skills automatically (excel-mcp + excel-cli)
+- Install via Skills CLI: `npx skills add sbroenne/mcp-server-excel --skill excel-cli` or `--skill excel-mcp`
+- Or download `excel-skills-v{{VERSION}}.zip`
+
+### Requirements
+- Windows OS
+- Microsoft Excel 2016+
+- No .NET runtime required for VS Code Extension, MCPB, or standalone executables
+- .NET 10 Runtime required for NuGet (.NET tool) installation only
+
+### Documentation
+- [Website](https://excelmcpserver.dev/)
+- [GitHub Repository](https://github.com/sbroenne/mcp-server-excel)
+- [Changelog](https://github.com/sbroenne/mcp-server-excel/blob/main/CHANGELOG.md)

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,51 @@
+# Changeset Check Workflow
+#
+# Enforces that pull requests changing user-facing code include a changeset
+# fragment (.changeset/*.md) describing the change for CHANGELOG.md. See
+# .changeset/README.md for how to add one, and docs/RELEASE-STRATEGY.md for
+# how fragments are compiled into CHANGELOG.md at release time.
+#
+# PRs that don't need a changelog entry (docs-only, test-only, CI-only,
+# dependency bumps, internal refactors) should add the "skip-changelog" label
+# instead of a changeset.
+
+name: 'Changeset Check'
+
+on:
+  pull_request:
+    branches: ['main']
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changeset-check:
+    name: Verify changeset present
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install changesets CLI
+        run: npm install --no-save --registry https://registry.npmjs.org/
+
+      - name: Check for a changeset
+        run: |
+          set +e
+          npx changeset status --since=origin/${{ github.event.pull_request.base.ref }}
+          STATUS=$?
+          set -e
+          if [ $STATUS -ne 0 ]; then
+            echo "::error::No changeset found for this PR. Run 'npx changeset' from the repo root and commit the generated .changeset/*.md file — see .changeset/README.md. If this PR doesn't need a changelog entry (docs/tests/CI/dependency-only), add the 'skip-changelog' label instead."
+            exit 1
+          fi

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,7 +26,10 @@ jobs:
           
           # Fail if GPL/AGPL/LGPL licenses detected; allow common permissive/OSI-approved licenses
           license-check: true
-          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, LicenseRef-scancode-generic-cla, BlueOak-1.0.0, CC0-1.0, MPL-2.0
+          # Python-2.0 allowed for the npm `argparse` package (a JS port of Python's
+          # argparse, transitive dep of @changesets/cli via js-yaml) - it's an
+          # OSI-approved, permissive, non-copyleft license.
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, LicenseRef-scancode-generic-cla, BlueOak-1.0.0, CC0-1.0, MPL-2.0, Python-2.0
           
           # Comment on PR with summary
           comment-summary-in-pr: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -729,78 +729,33 @@ jobs:
         echo "Downloaded artifacts:"
         find artifacts -type f -name "*" | head -20
 
-    - name: Extract Changelog from [Unreleased]
-      id: changelog
-      run: |
-        CHANGELOG_FILE="CHANGELOG.md"
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ env.NODE_VERSION }}
 
-        if [ -f "$CHANGELOG_FILE" ]; then
-          # Extract content between ## [Unreleased] and the next ## [ section
-          CONTENT=$(awk '/^## \[Unreleased\]/,/^## \[/' "$CHANGELOG_FILE" | head -n -1 | tail -n +2)
-          if [ -n "$CONTENT" ]; then
-            echo "Found changelog under [Unreleased]"
-            echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-            echo "$CONTENT" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          else
-            echo "No content under [Unreleased]"
-            echo "CHANGELOG=See repository for details." >> $GITHUB_OUTPUT
-          fi
-        else
-          echo "CHANGELOG=See repository for details." >> $GITHUB_OUTPUT
-        fi
+    - name: Install changesets CLI
+      run: npm install --no-save --registry https://registry.npmjs.org/
+
+    - name: Compile changesets into CHANGELOG.md
+      id: changelog
+      shell: pwsh
+      run: |
+        $releaseDate = Get-Date -AsUTC -Format 'yyyy-MM-dd'
+        ./scripts/Build-Changelog.ps1 -Version "${{ env.VERSION }}" -Date $releaseDate
+
+    - name: Render Release Notes
+      shell: pwsh
+      run: |
+        $template = Get-Content -Raw '.github/release-notes-template.md'
+        $changelogBody = Get-Content -Raw release_notes_body.md
+        $notes = $template.Replace('{{VERSION}}', $env:VERSION).Replace('{{CHANGELOG}}', $changelogBody.Trim())
+        Set-Content -Path release_notes.md -Value $notes -NoNewline
 
     - name: Create Release
       run: |
         VERSION=${{ env.VERSION }}
         TAG=${{ needs.version.outputs.tag }}
-
-        # Build release notes
-        cat > release_notes.md << 'NOTES'
-        ## ExcelMcp ${{ env.VERSION }}
-
-        ### What's New
-        ${{ steps.changelog.outputs.CHANGELOG }}
-
-        ### Installation Options
-
-        **VS Code Extension** (Recommended)
-        - Search "ExcelMcp" in VS Code Marketplace and click Install
-        - Or download `excelmcp-${{ env.VERSION }}.vsix` below
-        - Self-contained: no .NET runtime or SDK required
-        - Includes both MCP Server and CLI (`excelcli`)
-        - Agent skills (excel-mcp + excel-cli) registered automatically via `chatSkills`
-
-        **Claude Desktop (MCPB)**
-        - Download `excel-mcp-${{ env.VERSION }}.mcpb` and double-click to install
-
-        **Standalone Executables** (Primary — no .NET runtime required)
-        - MCP Server: Download `ExcelMcp-MCP-Server-${{ env.VERSION }}-windows.zip`, extract `mcp-excel.exe`
-        - CLI: Download `ExcelMcp-CLI-${{ env.VERSION }}-windows.zip`, extract `excelcli.exe`
-        - Add the exe(s) to your PATH, then configure your MCP client with command `mcp-excel`
-
-        **NuGet (.NET Tool)** (Secondary — requires .NET 10 runtime)
-        ```powershell
-        dotnet tool install --global Sbroenne.ExcelMcp.McpServer
-        dotnet tool install --global Sbroenne.ExcelMcp.CLI
-        ```
-
-        **Agent Skills** (for AI coding assistants)
-        - VS Code Extension includes both skills automatically (excel-mcp + excel-cli)
-        - Install via Skills CLI: `npx skills add sbroenne/mcp-server-excel --skill excel-cli` or `--skill excel-mcp`
-        - Or download `excel-skills-v${{ env.VERSION }}.zip`
-
-        ### Requirements
-        - Windows OS
-        - Microsoft Excel 2016+
-        - No .NET runtime required for VS Code Extension, MCPB, or standalone executables
-        - .NET 10 Runtime required for NuGet (.NET tool) installation only
-
-        ### Documentation
-        - [Website](https://excelmcpserver.dev/)
-        - [GitHub Repository](https://github.com/sbroenne/mcp-server-excel)
-        - [Changelog](https://github.com/sbroenne/mcp-server-excel/blob/main/CHANGELOG.md)
-        NOTES
 
         # Collect all artifacts
         ARTIFACTS=""
@@ -818,33 +773,27 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # Create a PR to update CHANGELOG.md since branch protection prevents direct push
-    - name: Update Changelog (rename Unreleased to version)
+    # Create a PR to commit the CHANGELOG.md/package.json changes produced by
+    # Build-Changelog.ps1 above (and the consumed .changeset/*.md deletions),
+    # since branch protection prevents direct push.
+    - name: Commit Changelog Update
       run: |
         VERSION=${{ env.VERSION }}
-        DATE=$(date +%Y-%m-%d)
         BRANCH="chore/changelog-v${VERSION}"
 
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-        # Create branch from main
         git checkout -b "$BRANCH"
-
-        # Replace [Unreleased] with [version] - date, add fresh [Unreleased]
-        sed -i "s/^## \[Unreleased\]/## [$VERSION] - $DATE/" CHANGELOG.md
-        sed -i "/^## \[$VERSION\] - $DATE/i ## [Unreleased]\n" CHANGELOG.md
-
-        git add CHANGELOG.md
+        git add CHANGELOG.md package.json .changeset
         git commit -m "chore: update CHANGELOG.md for v${VERSION} release [skip ci]"
         git push origin "$BRANCH"
 
-        # Create PR
         gh pr create \
           --base main \
           --head "$BRANCH" \
           --title "chore: update CHANGELOG.md for v${VERSION} release" \
-          --body "Automated post-release changelog update: renames \`[Unreleased]\` to \`[$VERSION] - $DATE\` and adds a fresh \`[Unreleased]\` section." \
+          --body "Automated post-release changelog update: compiles pending .changeset/*.md fragments into a new \`## [$VERSION]\` entry in CHANGELOG.md via \`scripts/Build-Changelog.ps1\`." \
           --label "documentation"
       continue-on-error: true
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,43 +3,40 @@
 All notable changes to ExcelMcp will be documented in this file.
 
 This changelog covers all components:
+
 - **MCP Server** - Model Context Protocol server for AI assistants
 - **CLI** - Command-line interface for scripting and coding agents
 - **VS Code Extension** - One-click installation with bundled MCP Server
 - **MCPB** - Claude Desktop bundle for one-click installation
 
+Entries are short and end-user-facing. Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses [Semantic Versioning](https://semver.org/). Starting with this file, entries are compiled automatically from [changesets](.changeset/README.md) at release time — see [Release Strategy](docs/RELEASE-STRATEGY.md#changelog-generation) for how to add one.
+
 ## [Unreleased]
+
+_No pending changes. New entries are added automatically from [changesets](.changeset/README.md) when a release is cut — see [Release Strategy](docs/RELEASE-STRATEGY.md#changelog-generation)._
+
+## [1.9.0] - 2026-07-08
+
+> **Note:** Entries below were previously stuck under `[Unreleased]` for several releases (v1.8.64–v1.9.0) due to a broken auto-changelog step (see Release Strategy for the fix); they have already shipped and are consolidated here under the last version that included them.
 
 ### Added
 
-- **Python in Excel (`=PY()`) support** (#691): New `pythoninexcel` MCP tool / CLI category with two operations. `set-formula` writes a `=PY("code", returnType)` formula via `Range.Formula2` (returnType 0 = Excel Value, 1 = Python Object). `get-result` reads back the computed value, polling with a stability heuristic (minimum settle window + required consecutive matching reads on `Value2`) since the Python code executes asynchronously in a Microsoft-hosted cloud sandbox with no reliable "still computing" signal exposed via COM. Classification of errors vs. rich "Python Object" results is derived from the `returnType` parsed out of the formula text and from well-known Excel error codes — not from `Range.Text`, which was found to render unreliably in non-visible/headless Excel automation. If polling doesn't stabilize in time, `get-result` reports failure and asks the caller to retry rather than returning a possibly-stale value. Requires a licensed Microsoft 365 account with Python in Excel enabled and internet access; not available offline or with perpetual-license Excel.
+- **Python in Excel (`=PY()`) support** (#691): New `pythoninexcel` tool lets you write and read `=PY()` formulas — write Python code into a cell and read back its computed value. Requires a licensed Microsoft 365 account with Python in Excel enabled and internet access.
 
 ### Changed
 
-- **Dependency freshness refresh (June 2026)**: Bumped centrally managed packages to their latest stable versions: Dax.Formatter (1.2.0 → 1.2.2), Spectre.Console (0.56.0 → 0.57.1; Spectre.Console.Cli stays at 0.55.0 — no newer stable), the OpenTelemetry family (1.15.x → 1.16.0: Api, Extensions.Hosting, Instrumentation.Http, Instrumentation.SqlClient), Microsoft.Identity.Client + Extensions.Msal (4.84.2 → 4.85.2), Polly.Core/Extensions/RateLimiting (8.6.6 → 8.7.0), StreamJsonRpc (2.25.25 → 2.25.29), Nerdbank.MessagePack security pin (1.2.4 → 1.2.30), Microsoft.NET.StringTools + Build.Framework + Build.Utilities.Core (18.6.3 → 18.7.1), Microsoft.NET.Test.Sdk (18.6.0 → 18.7.0), coverlet.collector (6.1.0 → 10.0.1), and Scriban (7.2.4 → 7.2.5). VS Code extension dev dependency @types/node bumped to ^26.0.1; npm install reports 0 vulnerabilities. Solution builds clean (0 warnings/0 errors) and extension compiles.
-
-
-- **Excel COM interop is PIA-first on the 16.x Excel PIA** (#559): Updated `Microsoft.Office.Interop.Excel` to 16.x and moved Power Query (`Workbook.Queries`, `WorkbookQuery`) plus Data Model measure/format APIs (`ModelMeasures`, `ModelMeasure`, `ModelFormat*`) back to strongly typed PIA access. Remaining `dynamic` usage is limited to APIs still outside the referenced Excel PIA or external Office/VBE object models.
-
-- **Excel PIA is now genuinely embedded; the hand-rolled `office.dll` assembly resolver is removed** (#559): `EmbedInteropTypes=true` set as metadata on a `<PackageReference>` is silently ignored by the .NET SDK, so the Excel PIA was being *referenced* (not embedded). The built assemblies therefore carried a transitive dependency on `office v16.0.0.0`, which forced a runtime `office.dll` load and a `FileNotFoundException: office, Version=16.0.0.0` in any host without the hand-rolled resolver (e.g. test hosts with no `Main`). The fix forces real interop embedding via a repo-root `Directory.Build.targets` target (sets `EmbedInteropTypes` on the resolved reference path) and makes the PIA compile-only with `<ExcludeAssets>runtime</ExcludeAssets>`. Only the Excel interop types actually used are baked into `ExcelMcp.ComInterop`/`ExcelMcp.Core` — none of which are Office.Core types — so the assemblies no longer reference `office.dll` at all. Consequently `RegisterOfficeAssemblyResolver()`/`ResolveOfficeDll()` were deleted from the MCP Server and CLI startup paths, and no test-side resolver is needed; Core/ComInterop tests (which have no `Main`) now load and run without it. `AutomationSecurity` continues to be accessed late-bound via `((dynamic)(object))` because the Office.Core enum type is intentionally not referenced.
-
-- **Dependency audit pin refreshed**: Updated the central `Nerdbank.MessagePack` security override to a non-vulnerable version so NuGet audit restore/build checks no longer fail on the prior pinned package.
-
-- **Dependency freshness refresh**: Bumped all outdated centrally managed packages to their latest stable versions: Azure.Core (1.57.0 → 1.59.0), the `Microsoft.Extensions.*` / `System.*` 10.0.8 family → 10.0.9 (Hosting, Logging, Logging.Abstractions, Caching.Abstractions, Configuration, Configuration.Binder, DependencyInjection, Diagnostics, Diagnostics.Abstractions, ObjectPool, Options, Options.ConfigurationExtensions, Bcl.AsyncInterfaces, Collections.Immutable, Reflection.Metadata, Text.Encoding.CodePages, Memory.Data, Security.Cryptography.ProtectedData, Text.Json, Threading.RateLimiting), Microsoft.Extensions.AI.Abstractions and Microsoft.Extensions.Resilience (10.6.0 → 10.7.0), Microsoft.Identity.Client + Microsoft.Identity.Client.Extensions.Msal (4.84.1 → 4.84.2), MessagePack + MessagePack.Annotations (3.1.6 → 3.1.7), System.ClientModel (1.13.0 → 1.14.0), Scriban (7.2.3 → 7.2.4), Microsoft.CodeAnalysis.NetAnalyzers (10.0.300 → 10.0.301), ModelContextProtocol (1.3.0 → 1.4.0), and Spectre.Console (0.55.2 → 0.56.0; Spectre.Console.Cli stays at 0.55.0 as it has no 0.56.0 stable). Microsoft.Office.Interop.Excel stays at 16.0.18925.20022 (already latest). Refreshed the VS Code extension dev dependencies (@types/node, @vscode/vsce, oxlint) and regenerated its lockfile with 0 npm audit vulnerabilities.
+- **Excel automation now uses Microsoft's official 16.x interop assembly, fully embedded** (#559): Improves reliability and removes a class of "missing office.dll" startup failures on machines without the exact matching Office version installed.
+- Routine dependency updates across the .NET and VS Code extension toolchains to keep packages current and free of known vulnerabilities.
 
 ### Fixed
 
-- **Documentation tool/operation counts are now consistent and enforced (26 tools / 232 operations)**: Several docs had drifted apart on the advertised counts — the generated MCP `SKILL.md` said "229 operations" while README/FEATURES/gh-pages said "232", and `FEATURES.md`'s Charts section header said "28 operations" (chart 8 + chartconfig 21 = 29), making its section headers sum to 231 instead of 232. ROOT CAUSE: the generated skill manifest tallies the CLI/service surface (every Core `[ServiceCategory]`, which includes the CLI-only `diag` self-test but excludes the hand-written `file`/session tool), so the skill files under-reported the user-facing count by exactly `file`(6) − `diag`(3) = 3. FIX: (1) corrected the `FEATURES.md` Charts header to 29 and fixed two corrupted section-header emoji; (2) `GenerateSkillFile` now excludes CLI-only commands and adds hand-written tool operations (both skills report the true user-facing 232); (3) refreshed the stale per-category table in the CLI README (Power Query 10→12, Charts 14→8, Chart Config 14→21, added the missing Window Management row) so its 18 categories sum to 232, and removed a stale "22 command categories" claim in the root README. PREVENTION: added a new pre-commit gate (`scripts/check-doc-counts.ps1`) that derives the canonical tool/operation counts from code (skill manifest + `FileAction` enum, cross-checked against the real `[McpServerTool]` surface) and fails the commit if any user-facing doc, or the generated `SKILL.md`, advertises a mismatching count. This makes the count-drift class of bug impossible to reintroduce. Nullable parameters (e.g. the 2D-array `values`, `formulas`, `formats`, and table `rows` parameters typed as `List<List<object?>>?` / `List<List<string>>?`) were emitted using the JSON Schema 2020-12 union form `"type": ["array","null"]` at every structural level. Gemini only accepts a subset of the OpenAPI 3.0.3 Schema object, which requires a single scalar `type` plus a separate `nullable: true` field, so it rejected these tools with HTTP 400 (`field predicate failed: == Type.ARRAY`). The MCP Server now generates all tool schemas with `AIJsonSchemaTransformOptions.UseNullableKeyword = true`, converting unions to the OpenAPI-3.0 form (`type:"array"` + `nullable:true`) that Gemini accepts while remaining valid JSON Schema 2020-12 for other clients. A regression test walks every generated tool schema and fails if any `type` keyword is a union array.
-
-- **VBA commands no longer misreport generic COM errors as "VBA trust access is not enabled"** (#671): `vba(import)` (and `list`, `view`, `update`, `delete`) caught every `COMException` with HRESULT `0x800A03EC` and rethrew it as the trust error. `0x800A03EC` is the *generic* Office automation error ("Exception occurred"), reused for many unrelated failures, so a real COM failure raised while VBA trust was actually enabled was masked as a trust problem — sending users to re-check Trust Center settings that were already correct (reported on a Japanese Office Click-to-Run build where the COM message text also differs from the English "programmatic access"). The catch filters now use a shared `IsVbaTrustError` classifier that only treats `0x800A03EC` as a trust error when the registry confirms trust is actually disabled (locale-independent); otherwise the original failure is surfaced. A genuine (non-trust) `0x800A03EC` is now wrapped with COM environment diagnostics (Office channel/version, bitness, CLSID, registered PIA) so the real, still-unknown underlying cause can be triaged on the first re-run instead of being hidden. The English "programmatic access" message remains a fast path.
-
-- **MCP Server stdio no longer emits Application Insights info noise during startup** (#559): Application Insights informational logs are now explicitly filtered out of the console provider so stdio clients no longer see lines such as `info: Microsoft.ApplicationInsights.TelemetryClient[0]` on stderr during MCP initialization. Warning and error logs still go to stderr, while stdout remains reserved for JSON-RPC frames.
-
-- **Session open/create timeouts are shorter and more actionable** (#559): The default Excel session startup/operation timeout is now 120 seconds instead of 5 minutes, while MCP `timeout_seconds` and CLI `--timeout` continue to override it for slow workbooks. Startup timeout errors now explicitly identify likely prompt/auth/IRM causes and tell agents to retry with a longer timeout or `show=true` / `--show`.
-
-- **Session startup diagnostics for `Specified cast is not valid` on Office Click-to-Run** (#559): COM diagnostics now report the registered Excel TypeLib primary interop assembly for faster environment triage.
-
-- **MCP `namedrange list` avoids hidden Power Query `ExternalData_1` crash paths** (#653): Workbooks with hidden/internal defined names are now listed from workbook package metadata first, so large hidden Power Query and AutoFilter names are skipped before their COM `Name` objects or backing ranges are touched. Visible user-defined names still return references and safe value previews, and large visible ranges continue to return metadata instead of materialized values.
+- **MCP tool schemas now work with Gemini-based clients**: Optional array-type parameters (e.g. range values, formulas, table rows) were rejected by Gemini with an HTTP 400 error; schemas are now generated in a form all MCP clients accept.
+- **Documentation now consistently reports accurate tool/operation counts** (26 tools / 232 operations), with an automated check preventing future drift.
+- **VBA commands no longer misreport unrelated COM errors as "VBA trust access is not enabled"** (#671): the error is now only shown when trust is actually disabled; other failures surface with real diagnostics instead.
+- **MCP Server and CLI no longer emit stray log noise on startup** (#559) that could interfere with output parsing.
+- **Excel session startup timeouts are shorter (120s) and error messages more actionable** (#559), with clearer guidance when a prompt, sign-in dialog, or IRM policy is the likely cause.
+- **Better diagnostics for `Specified cast is not valid` startup errors** on Office Click-to-Run installs (#559).
+- **`namedrange list` no longer crashes on workbooks with hidden Power Query-generated names** (#653).
 
 ## [1.8.63] - 2026-05-20
 
@@ -202,6 +199,7 @@ This changelog covers all components:
 ### Added
 
 - **In-Process Service Architecture** (#454): MCP Server and CLI each host ExcelMCP Service in-process instead of sharing a separate service process
+
   - Eliminates service discovery failures (especially NuGet tool installs) and cross-process coordination
 
 - **Separate CLI NuGet Package** (#452): CLI published as `Sbroenne.ExcelMcp.CLI` alongside MCP Server
@@ -287,6 +285,7 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ### Fixed
 
 - **CLI Banner Cleanup**: Removed PowerShell warning from startup banner
+
   - Guidance moved to skill documentation (Rule 2: Use File-Based Input)
   - CLI output is now cleaner and less cluttered
 
@@ -333,6 +332,7 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ### Fixed
 
 - **Power Query Refresh Error Propagation** (#399): Fixed bug where `refresh` action returned `success: true` even when Power Query had formula errors
+
   - ROOT CAUSE: `Connection.Refresh()` silently swallows errors for worksheet queries (InModel=false)
   - FIX: Now uses `QueryTable.Refresh(false)` for worksheet queries which properly throws errors
   - Data Model queries (InModel=true) continue using `Connection.Refresh()` which does throw errors
@@ -346,6 +346,7 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ### Added
 
 - **Power Query Evaluate** (#400): New `evaluate` action to execute M code directly and return results
+
   - Execute arbitrary M code without creating a permanent query
   - Returns tabular results (columns, rows) in JSON format
   - Automatically cleans up temporary query and worksheet
@@ -353,6 +354,7 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
   - Example: `excelcli powerquery evaluate --file data.xlsx --mcode "let Source = #table({\"Name\",...})"`
 
 - **MCP Power Query mCodeFile Parameter**: Read M code from file instead of inline string
+
   - New `mCodeFile` parameter on `powerquery` tool for `create`, `update`, `evaluate` actions
   - Avoids JSON escaping issues with complex M code containing special characters
   - File takes precedence if both `mCode` and `mCodeFile` provided
@@ -381,7 +383,9 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ### Added
 
 #### CLI Redesign (Breaking Change)
+
 - **Complete CLI Rewrite** (#387): Redesigned CLI for coding agents and scripting - **NOT backwards compatible**
+
   - 14 unified command categories with 210 operations matching MCP Server
   - All commands now use `--session` parameter (was positional in some commands)
   - Comprehensive `--help` descriptions on all commands synced with MCP tool descriptions
@@ -390,11 +394,13 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
   - Exit code standardization (0=success, 1=error, 2=validation)
 
 - **Quiet Mode**: `-q`/`--quiet` flag suppresses banner for agent-friendly JSON-only output
+
   - Auto-detects piped/redirected stdout and suppresses banner automatically
 
 - **Version Check**: `excelcli version --check` queries NuGet to show if update available
 
 - **Session Close --save**: Single `--save` flag for atomic save-and-close workflow
+
   - Replaces separate save + close sequence for cleaner scripting
 
 - **CLI Action Coverage Pre-commit Check**: New `check-cli-action-coverage.ps1` script
@@ -402,13 +408,16 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
   - Prevents "action not handled" bugs from reaching production
   - Validates 210 operations across 21 CLI commands
 
-#### MCP Server Enhancements  
+#### MCP Server Enhancements
+
 - **Session Operation Timeout** (#388): Configurable timeout prevents infinite hangs
+
   - New `timeoutSeconds` parameter on `file(open)` and `file(create)` actions
   - Default: 300 seconds (5 minutes), configurable range: 10-3600 seconds
   - Applies to ALL operations within session; exceeding timeout throws `TimeoutException`
 
 - **Create Action** (#385): Renamed `create-and-open` to simpler `create` action
+
   - Single-action file creation and session opening
   - Performance: ~3.8 seconds (vs ~7-8 seconds with separate create+open)
 
@@ -416,7 +425,9 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
   - Keeps query definition intact while clearing worksheet/model data
 
 #### Testing & Quality
+
 - **LLM Integration Tests**: Comprehensive pytest-aitest test suite for CLI
+
   - 9 test scenarios covering all major Excel operations
   - Chart positioning, PivotTable layout, Power Query, slicers, tables, ranges
   - Financial report automation workflow tests
@@ -427,17 +438,21 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
   - `skills/shared/` - Shared workflows, anti-patterns, behavioral rules
 
 ### Fixed
+
 - **Calculated Field Bug**: Fixed PivotTable calculated field creation error
 - **COM Diagnostics**: Improved error reporting for COM object lifecycle issues
 
 ### Changed
+
 - CLI timeout option uses `--timeout <seconds>` (was `--timeout-seconds`)
 - All CLI commands now require explicit `--session` parameter
 
 ## [1.5.13] - 2025-01-24
 
 ### Added
+
 - **Chart Formatting** (#384): Enhanced chart formatting capabilities
+
   - **Data Labels**: Configure label position and visibility (showValue, showCategory, showPercentage, etc.)
   - **Axis Scale**: Get/set axis scale properties (min, max, units, auto-scale flags)
   - **Gridlines**: Control major/minor gridlines visibility on chart axes
@@ -454,20 +469,24 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ## [1.5.11] - 2025-01-22
 
 ### Added
+
 - Added Agent Skill to all artifacts
 
 ### Changed
+
 - **MCPB Submission Compliance**: Bundle now includes LICENSE and CHANGELOG.md per Anthropic requirements
 - **Documentation Updates**: All READMEs updated with LLM-tested example prompts and accurate tool counts (22 tools, 194 operations)
 
 ## [1.5.8] - 2025-01-20
 
 ### Added
+
 - Now available as a Claude Desktop MCPB Extension
-  
+
 ## [1.5.6] - 2025-01-20
 
 ### Added
+
 - **PivotTable & Table Slicers** (#363): New `slicer` tool for interactive filtering
   - **PivotTable Slicers**: Create, list, filter, and delete slicers for PivotTable fields
   - **Table Slicers**: Create, list, filter, and delete slicers for Excel Table columns
@@ -476,6 +495,7 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ## [1.5.5] - 2025-01-19
 
 ### Added
+
 - **DMV Query Execution** (#353): Query Data Model metadata using Dynamic Management Views
   - New `execute-dmv` action on `datamodel` tool
   - Query TMSCHEMA_MEASURES, TMSCHEMA_RELATIONSHIPS, DISCOVER_CALC_DEPENDENCY, etc.
@@ -483,6 +503,7 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ## [1.5.4] - 2025-01-19
 
 ### Added
+
 - **DAX EVALUATE Query Execution** (#356): Execute DAX queries against the Data Model
   - New `evaluate` action on `datamodel` tool for ad-hoc DAX queries
 - **DAX-Backed Excel Tables** (#356): Create worksheet tables populated by DAX queries
@@ -491,6 +512,7 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ## [1.5.0] - 2025-01-10
 
 ### Changed
+
 - **Tool Reorganization** (#341): Split 12 monolithic tools into 21 focused tools
   - 186 operations total, better organized for AI assistants
   - Ranges: 4 tools (range, range_edit, range_format, range_link)
@@ -501,25 +523,30 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
   - Worksheets: 2 tools (worksheet, worksheet_style)
 
 ### Added
+
 - **LLM Integration Testing** (#341): Real AI agent testing using [pytest-aitest](https://github.com/sbroenne/pytest-aitest)
 
 ### Changed
+
 - **.NET 10 Upgrade**: Requires .NET 10.0 instead of .NET 8.0
 
 ## [1.4.42] - 2025-12-15
 
 ### Added
+
 - **Power Query Rename** (#326, #327): New `rename` action for Power Query queries
 - **Data Model Table Rename** (#326, #327): New `rename-table` action for Data Model tables
 
 ## [1.4.41] - 2025-12-14
 
 ### Fixed
+
 - **Power Query Data Model Fix** (#324): Fixed "0x800A03EC" error when updating Power Query in workbooks with Data Model present
 
 ## [1.4.40] - 2025-12-14
 
 ### Changed
+
 - **MCP SDK Upgrade** (#301): Upgraded ModelContextProtocol SDK from 0.4.1-preview.1 to 0.5.0-preview.1
   - Proper `isError` signaling for tool execution failures
   - Deterministic exit codes (0 = success, 1 = fatal error)
@@ -527,70 +554,85 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ## [1.4.37] - 2025-12-06
 
 ### Changed
+
 - **PivotTable Performance** (#286): Optimized `RefreshTable()` calls
 
 ### Added
+
 - **Data Model Members** (#288): Added support for Data Model table members
 
 ## [1.4.36] - 2025-12-06
 
 ### Changed
+
 - **Documentation Updates** (#290): Updated tool/operation counts
 
 ### Fixed
+
 - **SEO Fix** (#292): Fixed robots.txt sitemap URL
 
 ## [1.4.35] - 2025-12-05
 
 ### Added
+
 - **Data Model Relationships** (#278): Full support for creating, updating, and deleting relationships
 - **Custom Domain** (#276): excelmcpserver.dev
 
 ## [1.4.34] - 2025-12-05
 
 ### Fixed
+
 - **DAX Formula Locale Handling** (#281): DAX formulas now work on European locales
 
 ## [1.4.33] - 2025-12-04
 
 ### Changed
+
 - **Atomic Cross-File Worksheet Operations** (#273): New `copy-to-file` and `move-to-file` actions
 
 ## [1.4.32] - 2025-12-04
 
 ### Fixed
+
 - **OLAP PivotChart Creation** (#267): `CreateFromPivotTable` now works with OLAP/Data Model PivotTables
 - **Power Query LoadToBoth Detection** (#271): Fixed incorrect detection
 
 ## [1.4.31] - 2025-12-04
 
 ### Fixed
+
 - **Locale-Independent Number Formatting** (#263): Number and date formats now work on non-US locales
 
 ## [1.4.30] - 2025-12-03
 
 ### Fixed
+
 - **OLAP PivotTable AddValueField** (#261): Fixed errors when adding value fields to Data Model PivotTables
 
 ### Added
+
 - **Show Excel Mode**: Open with `showExcel: true` to watch AI changes live
 
 ## [1.4.28] - 2025-12-01
 
 ### Fixed
+
 - **VS Code Extension Display Name** (#257): Corrected MCP server display name
 
 ## [1.4.25] - 2025-12-01
 
 ### Changed
+
 - **89% Smaller Extension Size** (#250): Switched to framework-dependent deployment
 
 ## [1.4.24] - 2025-12-01
 
 ### Fixed
+
 - **Session Stability** (#245): Fixed Excel MCP Server stopping due to network errors
 
 ### Added
+
 - **PivotTable Grand Totals Control**: Show/hide row and column grand totals
 - **PivotTable Grouping**: Group dates by days/months/quarters/years
 - **PivotTable Calculated Fields**: Create calculated fields with formulas
@@ -600,33 +642,40 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 ## [1.4.0] - 2025-11-24
 
 ### Added
+
 - **Excel Table Get Data** (#234): New `get-data` action returns table rows
 
 ### Fixed
+
 - **Power Query Error Query Fix** (#236): Fixed spurious "Error Query" entries
 
 ## [1.3.0] - 2025-11-22
 
 ### Added
+
 - **Chart Operations** (#229): 15 new chart actions
 - **Connection Delete** (#226): New `delete` action
 - **OLAP PivotTable Measures** (#217): Auto-create DAX measures
 
 ### Changed
+
 - **PivotTable Enhancements** (#219, #220): Date/numeric grouping, calculated fields
 
 ## [1.2.0] - 2025-11-17
 
 ### Added
+
 - **Worksheet Reordering** (#186): New `move` action
 
 ### Fixed
+
 - **MCP Server Crash Fix** (#192): Fixed crashes with disconnected COM proxies
 - **Connection Create Fix** (#190): Fixed COM dispatch error
 
 ## [1.1.0] - 2025-11-10
 
 ### Fixed
+
 - **File Lock Fix** (#173): Fixed "file already open" errors
 - **LoadTo Silent Failure Fix** (#170): LoadTo now properly fails on duplicates
 - **Validation InputTitle/Message** (#167): Fixed empty values
@@ -636,6 +685,7 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 - **Power Query Persistence** (#42): Fixed load-to-data-model not persisting
 
 ### Added
+
 - **PivotTable Discovery** (#155): Improved LLM discoverability
 - **CLI Batch Support** (#152): Batch mode for bulk operations
 - **Timeout Support** (#131): Configurable timeouts for all tools
@@ -644,11 +694,13 @@ LLMs pick up these changes automatically via `tools/list` (MCP) and `--help` (CL
 - **PivotTable from Data Model** (#109): Create PivotTables from Power Pivot
 
 ### Changed
+
 - **Numeric Column Names** (#136): Column names can now be numeric
 
 ## [1.0.0] - 2025-10-29
 
 ### Added
+
 - Initial release of ExcelMcp
 - MCP Server with 11 tools and 100+ operations
 - CLI for command-line scripting

--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -50,27 +50,24 @@ When you run the release workflow, all components are released together:
 
 ## Release Process
 
-### 1. Update Changelog
+### 1. Add a Changeset (every PR, not just before release)
 
-Before creating a release tag, ensure all changes are documented under `## [Unreleased]` in `CHANGELOG.md`:
+`CHANGELOG.md` is no longer hand-edited. Every PR that changes user-visible
+behavior adds a small **changeset fragment** describing the change, and a CI
+check (`.github/workflows/changeset-check.yml`) fails the PR if one is missing
+(unless the PR is labeled `skip-changelog`). See [`.changeset/README.md`](../.changeset/README.md)
+for the full guide and examples of good vs. too-technical entries.
 
-```markdown
-## [Unreleased]
-
-### Added
-- New feature description
-
-### Changed
-- Changed feature description
-
-### Fixed
-- Bug fix description
-
-## [1.5.6] - 2025-01-15
-...
+```powershell
+npx changeset
+# → pick a bump type (metadata only, doesn't drive the real release version)
+# → write a short, end-user-facing summary
+# → commit the generated .changeset/<name>.md with your PR
 ```
 
-> **Important:** Do NOT rename `[Unreleased]` to a version number manually. The release workflow extracts content from `[Unreleased]` for release notes, then creates an auto-PR to rename it to `[X.Y.Z] - date` and add a fresh `[Unreleased]` section.
+Nothing needs to happen "before creating a release tag" — fragments accumulate
+in `.changeset/` across PRs and are compiled automatically when the release
+workflow runs (see [Changelog Generation](#changelog-generation) below).
 
 ### 2. Run the Release Workflow
 
@@ -101,7 +98,7 @@ The main release workflow runs automatically (10 jobs), then the plugin publish 
 6. **create-tag** → Creates git tag (waits for all builds)
 7. **publish-mcp-registry** (10-30 min) → Waits for NuGet propagation, updates MCP Registry
 8. **publish** → Publishes to NuGet.org and VS Code Marketplace
-9. **create-release** → Creates GitHub Release with all artifacts, then creates auto-PR to update CHANGELOG
+9. **create-release** → Creates GitHub Release with all artifacts (release notes generated from compiled changesets), then creates auto-PR to commit the updated CHANGELOG.md
 10. **publish-plugins.yml** (follow-on workflow) → Sync-gated republish of `excel-mcp` and `excel-cli` to `sbroenne/mcp-server-excel-plugins` when plugin-facing install artifacts changed
 
 ### 4. Verify Release
@@ -113,7 +110,7 @@ After workflow completes:
 - [ ] VS Code Marketplace updated (verify self-contained extension works without .NET)
 - [ ] MCP Registry updated
 - [ ] `publish-plugins.yml` completed; if the sync gate detected plugin-facing changes, `sbroenne/mcp-server-excel-plugins` was updated
-- [ ] Auto-PR created for CHANGELOG rename (merge it to update `[Unreleased]` → `[X.Y.Z]`)
+- [ ] Auto-PR created and merged to persist the `CHANGELOG.md` / `package.json` / consumed `.changeset/*.md` updates generated during the release
 
 ### 5. Agent Plugin Publishing (Automatic)
 
@@ -200,30 +197,39 @@ During development, use placeholder version `1.0.0` in:
 
 The release workflow injects the correct version from the tag.
 
-## Changelog Format
+## Changelog Generation
 
-The root `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/) format:
+`CHANGELOG.md` is **end-user facing** and generated from [changesets](https://github.com/changesets/changesets), not hand-edited. This replaced a manual `## [Unreleased]` section that repeatedly went stale — the auto-rename step below relied on a PR merge that didn't always happen, so several released versions (v1.8.64–v1.9.0) sat mislabeled as "Unreleased" for weeks. See the changeset fragments' own guide at [`.changeset/README.md`](../.changeset/README.md) for day-to-day usage.
+
+**How it works:**
+
+1. **Every PR** that changes user-visible behavior adds a small markdown fragment via `npx changeset` (from repo root), describing the change in 1-3 end-user-facing sentences. This is committed to `.changeset/<random-name>.md` alongside the PR.
+2. **CI enforces this** via `.github/workflows/changeset-check.yml`, which fails the PR if no fragment was added — unless the PR carries the `skip-changelog` label (docs/tests/CI/dependency-only changes).
+3. **At release time**, the `create-release` job in `release.yml` runs `scripts/Build-Changelog.ps1 -Version <version> -Date <date>`, which:
+   - Runs `npx changeset version` to consume every pending fragment, deleting them.
+   - Normalizes the tool's generated version header to this repo's `## [X.Y.Z] - YYYY-MM-DD` (Keep a Changelog) style.
+   - Extracts the new section verbatim into `release_notes_body.md`, used directly as the "What's New" body of the GitHub Release.
+4. **The updated `CHANGELOG.md`, `package.json` (a bookkeeping-only root manifest that hosts the changesets tool — never published to npm), and consumed `.changeset/*.md` deletions** are committed via the same auto-PR-to-`main` pattern used previously (branch protection requires a PR; the workflow step uses `continue-on-error: true`).
+
+Root `package.json` and `.changeset/config.json` (using `@changesets/changelog-github` for PR-linked entries) exist solely to drive this tooling — they have no bearing on the actual MCP Server / CLI / VS Code Extension / MCPB version, which remains fully controlled by the `version_bump` / `custom_version` workflow inputs as described above.
 
 ```markdown
 # Changelog
 
 ## [Unreleased]
 
-## [1.5.7] - 2025-01-21
+_No pending changes. New entries are added automatically from changesets when a release is cut._
 
-### Added
-- Feature description
+## [1.9.1] - 2025-01-21
 
-### Changed
-- Change description
+### Minor Changes
+- **Feature description** (#123): what changed and why it matters to users.
 
-### Fixed
-- Bug fix description
+### Patch Changes
+- **Bug fix description** (#124): what was broken and what's fixed now.
 ```
 
-The release workflow extracts content from `## [Unreleased]` for GitHub Release notes. After the release is created, an auto-PR renames `[Unreleased]` to `[X.Y.Z] - date` and adds a fresh `[Unreleased]` section.
-
-> **Why auto-PR instead of direct push?** Branch protection requires pull requests for all changes to `main`. The `github-actions[bot]` cannot be added to the bypass list in GitHub Rulesets, so the workflow creates a PR with `continue-on-error: true` to handle this gracefully.
+> **Why auto-PR instead of direct push?** Branch protection requires pull requests for all changes to `main`. The `github-actions[bot]` cannot be added to the bypass list in GitHub Rulesets, so the workflow creates a PR with `continue-on-error: true` to handle this gracefully. Unlike the old sed-based rename, a missed merge here only delays committing an already-published release's changelog — it can no longer mislabel released content as "Unreleased" since the section is always left empty going forward.
 
 ## Required Secrets and Variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1363 @@
+{
+  "name": "excelmcp",
+  "version": "1.9.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "excelmcp",
+      "version": "1.9.0",
+      "devDependencies": {
+        "@changesets/changelog-github": "^0.5.2",
+        "@changesets/cli": "^2.29.7"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+      "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/config": "^3.1.4",
+        "@changesets/get-version-range-type": "^0.4.0",
+        "@changesets/git": "^3.0.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "detect-indent": "^6.0.0",
+        "fs-extra": "^7.0.1",
+        "lodash.startcase": "^4.4.0",
+        "outdent": "^0.5.0",
+        "prettier": "^2.7.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+      "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/changelog-git": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/changelog-github": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.2.tgz",
+      "integrity": "sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/get-github-info": "^0.7.0",
+        "@changesets/types": "^6.1.0",
+        "dotenv": "^8.1.0"
+      }
+    },
+    "node_modules/@changesets/cli": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
+      "integrity": "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/apply-release-plan": "^7.1.1",
+        "@changesets/assemble-release-plan": "^6.0.10",
+        "@changesets/changelog-git": "^0.2.1",
+        "@changesets/config": "^3.1.4",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/get-release-plan": "^4.0.16",
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@changesets/write": "^0.4.0",
+        "@inquirer/external-editor": "^1.0.2",
+        "@manypkg/get-packages": "^1.1.3",
+        "ansi-colors": "^4.1.3",
+        "enquirer": "^2.4.1",
+        "fs-extra": "^7.0.1",
+        "mri": "^1.2.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3",
+        "spawndamnit": "^3.0.1",
+        "term-size": "^2.1.0"
+      },
+      "bin": {
+        "changeset": "bin.js"
+      }
+    },
+    "node_modules/@changesets/config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+      "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1",
+        "micromatch": "^4.0.8"
+      }
+    },
+    "node_modules/@changesets/errors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extendable-error": "^0.1.5"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+      "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "picocolors": "^1.1.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/get-github-info": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.7.0.tgz",
+      "integrity": "sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dataloader": "^1.4.0",
+        "node-fetch": "^2.5.0"
+      }
+    },
+    "node_modules/@changesets/get-release-plan": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+      "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/assemble-release-plan": "^6.0.10",
+        "@changesets/config": "^3.1.4",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/get-version-range-type": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/git": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
+      }
+    },
+    "node_modules/@changesets/logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/parse": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+      "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "js-yaml": "^4.1.1"
+      }
+    },
+    "node_modules/@changesets/pre": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1"
+      }
+    },
+    "node_modules/@changesets/read": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+      "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/parse": "^0.4.3",
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/should-skip-package": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/write": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "human-id": "^4.1.1",
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@manypkg/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@types/node": "^12.7.1",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/find-root/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@manypkg/get-packages": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@changesets/types": "^4.0.1",
+        "@manypkg/find-root": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "^11.0.0",
+        "read-yaml-file": "^1.1.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extendable-error": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/human-id": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+      "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "human-id": "dist/cli.js"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-subdir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/outdent": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quansync": "^0.2.7"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/read-yaml-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.5",
+        "js-yaml": "^3.6.1",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spawndamnit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "excelmcp",
+  "version": "1.9.0",
+  "private": true,
+  "description": "ExcelMcp is a Windows-only Excel automation toolset (MCP Server, CLI, VS Code Extension, MCPB). This package.json exists solely to host Changesets tooling for CHANGELOG.md generation — it is never published to npm and has no runtime dependencies.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sbroenne/mcp-server-excel"
+  },
+  "scripts": {
+    "changeset": "changeset",
+    "changeset:status": "changeset status --since=main",
+    "changeset:version": "changeset version"
+  },
+  "devDependencies": {
+    "@changesets/changelog-github": "^0.5.2",
+    "@changesets/cli": "^2.29.7"
+  }
+}

--- a/scripts/Build-Changelog.ps1
+++ b/scripts/Build-Changelog.ps1
@@ -1,0 +1,148 @@
+<#
+.SYNOPSIS
+    Compiles pending .changeset/*.md fragments into CHANGELOG.md for a release.
+
+.DESCRIPTION
+    Wraps `npx changeset version`, which consumes every pending changeset fragment,
+    bumps the (bookkeeping-only) root package.json version, and inserts a new section
+    at the top of CHANGELOG.md. This script then:
+      1. Normalizes the changesets-generated version header to the Keep a Changelog
+         style already used in this file: `## [X.Y.Z] - YYYY-MM-DD`.
+      2. Forces the root package.json version to exactly match the real release
+         version (the source of truth remains the git tag / workflow input — this
+         package.json only exists to host the changesets tool and must not drift).
+      3. Extracts the newly-inserted section body to a separate file so it can be
+         used verbatim as GitHub Release notes.
+
+    Safe to run locally for a dry run: it mutates CHANGELOG.md, package.json, and
+    deletes consumed fragments in .changeset/, same as the real release step. Use
+    `git checkout -- CHANGELOG.md package.json` and `git clean -fd .changeset` to
+    revert a local dry run.
+
+.PARAMETER Version
+    The version being released, e.g. "1.9.1" (no leading "v").
+
+.PARAMETER Date
+    Release date in YYYY-MM-DD format. Defaults to today (UTC).
+
+.PARAMETER RepoRoot
+    Path to the repository root (where package.json and CHANGELOG.md live).
+    Defaults to the current directory.
+
+.PARAMETER OutputNotesPath
+    Path to write the extracted release-notes body to. Defaults to
+    "release_notes_body.md" in RepoRoot.
+
+.EXAMPLE
+    pwsh scripts/Build-Changelog.ps1 -Version 1.9.1
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [string]$Date = (Get-Date -AsUTC -Format 'yyyy-MM-dd'),
+
+    [string]$RepoRoot = (Get-Location).Path,
+
+    [string]$OutputNotesPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = (Resolve-Path $RepoRoot).Path
+$changelogPath = Join-Path $RepoRoot 'CHANGELOG.md'
+$packageJsonPath = Join-Path $RepoRoot 'package.json'
+if (-not $OutputNotesPath) {
+    $OutputNotesPath = Join-Path $RepoRoot 'release_notes_body.md'
+}
+
+if (-not (Test-Path $changelogPath)) {
+    throw "CHANGELOG.md not found at $changelogPath"
+}
+if (-not (Test-Path $packageJsonPath)) {
+    throw "package.json not found at $packageJsonPath (required to host the changesets tool)"
+}
+if ($Version -notmatch '^\d+\.\d+\.\d+$') {
+    throw "Version '$Version' must be a plain semver value without a leading 'v' (e.g. 1.9.1)."
+}
+
+# --- Step 1: snapshot the changelog body (everything after the title line) before
+# changesets mutates the file. changesets always inserts its new section
+# immediately after line 1, leaving everything else untouched, so a suffix match
+# after the run tells us exactly what it inserted.
+$beforeLines = Get-Content -LiteralPath $changelogPath
+if ($beforeLines.Count -lt 1) {
+    throw "CHANGELOG.md is empty — expected at least a title line."
+}
+$titleLine = $beforeLines[0]
+$beforeBody = ($beforeLines | Select-Object -Skip 1) -join "`n"
+
+# --- Step 2: run changeset version from the repo root.
+Push-Location $RepoRoot
+try {
+    & npx changeset version
+    if ($LASTEXITCODE -ne 0) {
+        throw "npx changeset version failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Pop-Location
+}
+
+# --- Step 3: isolate the newly-inserted section via suffix match against the
+# untouched body captured in Step 1.
+$afterLines = Get-Content -LiteralPath $changelogPath
+$afterRest = ($afterLines | Select-Object -Skip 1) -join "`n"
+
+$idx = $afterRest.IndexOf($beforeBody, [System.StringComparison]::Ordinal)
+if ($idx -lt 0) {
+    throw "Could not locate the pre-existing CHANGELOG.md content after 'npx changeset version' ran. " +
+          "Aborting without writing changes to avoid corrupting the changelog. " +
+          "This usually means CHANGELOG.md's existing content was hand-edited in a way changesets doesn't expect."
+}
+$newSection = $afterRest.Substring(0, $idx).Trim("`r", "`n")
+
+if ([string]::IsNullOrWhiteSpace($newSection)) {
+    Write-Output 'No pending changesets found — nothing to add to the changelog.'
+    Set-Content -LiteralPath $OutputNotesPath -Value "_No changes recorded for this release._" -NoNewline
+    exit 0
+}
+
+# --- Step 4: normalize the first non-blank line (changesets' own version header,
+# e.g. "## excelmcp@1.9.1" or "## 1.9.1") to the Keep a Changelog style used here.
+$newSectionLines = $newSection -split "`r?`n"
+$headerIdx = 0
+while ($headerIdx -lt $newSectionLines.Count -and [string]::IsNullOrWhiteSpace($newSectionLines[$headerIdx])) {
+    $headerIdx++
+}
+if ($headerIdx -ge $newSectionLines.Count -or $newSectionLines[$headerIdx] -notmatch '^##\s') {
+    throw "Expected the changesets-generated section to start with a '## ' version header, got: '$($newSectionLines[$headerIdx])'"
+}
+$newSectionLines[$headerIdx] = "## [$Version] - $Date"
+$newSection = ($newSectionLines -join "`n").Trim()
+
+# --- Step 5: reassemble CHANGELOG.md: title + normalized new section + untouched body.
+$beforeBodyTrimmed = $beforeBody.TrimStart("`r", "`n")
+$finalContent = "$titleLine`n`n$newSection`n`n$beforeBodyTrimmed".TrimEnd() + "`n"
+Set-Content -LiteralPath $changelogPath -Value $finalContent -NoNewline
+
+# --- Step 6: keep package.json's bookkeeping version in exact sync with the real
+# release version (changesets' own auto-bump may not match if a contributor picked
+# a different bump type than the maintainer ultimately released).
+$packageJson = Get-Content -LiteralPath $packageJsonPath -Raw | ConvertFrom-Json
+$packageJson.version = $Version
+# Preserve key order/formatting reasonably well: ConvertTo-Json + npm-style 2-space indent.
+($packageJson | ConvertTo-Json -Depth 10) -replace "`r?`n", "`n" | Set-Content -LiteralPath $packageJsonPath -NoNewline
+Add-Content -LiteralPath $packageJsonPath -Value "`n"
+
+# --- Step 7: write the release-notes body (verbatim section content, no header
+# duplication needed since GitHub Release titles already carry the version).
+$notesBody = ($newSectionLines[($headerIdx + 1)..($newSectionLines.Count - 1)] -join "`n").Trim()
+if ([string]::IsNullOrWhiteSpace($notesBody)) {
+    $notesBody = '_No notable changes recorded for this release._'
+}
+Set-Content -LiteralPath $OutputNotesPath -Value $notesBody -NoNewline
+
+Write-Output "CHANGELOG.md updated with ## [$Version] - $Date"
+Write-Output "Release notes body written to $OutputNotesPath"


### PR DESCRIPTION
## Summary

Replaces manual `CHANGELOG.md` editing and fragile awk/sed extraction with changesets (`@changesets/cli`), the industry-standard pattern for human-curated, end-user-facing changelogs used by many open source JS/TS projects (React, Remix, Vite, etc.).

## What changed

**Changesets tooling**
- Added `package.json` + `.changeset/config.json` (using `@changesets/changelog-github` for PR-linked entries) + `.changeset/README.md` with contributor guidance
- Added `.github/workflows/changeset-check.yml`: fails a PR if no changeset fragment was added, unless labeled `skip-changelog`

**Release automation**
- Added `scripts/Build-Changelog.ps1`: compiles pending changesets into `CHANGELOG.md` and a release-notes body - replaces the old awk-based `[Unreleased]` extraction and sed-based rename step in `release.yml`
- Extracted the GitHub Release body into `.github/release-notes-template.md` (with `{{VERSION}}`/`{{CHANGELOG}}` placeholders), rendered via a small PowerShell step instead of an inline bash heredoc mixed with GitHub Actions expression syntax

**Changelog cleanup**
- Collapsed several releases' worth of content that had been mislabeled as `[Unreleased]` (root cause: the old auto-PR-rename step silently failed to merge for months) into one accurate `1.9.0` entry
- Condensed verbose engineering prose into concise, end-user-facing bullets
- Deleted the 4 orphaned `chore/changelog-v*` branches left over from the broken automation

**Docs/instructions**
- Updated Rule 27, `development-workflow`, `readme-management`, `RELEASE-STRATEGY.md`, and the PR template to describe the new changeset-based workflow

## Testing
- All 14 pre-commit gates passed locally (COM leak check, coverage audit, Release build, CLI/MCP smoke tests, packaging deliverables, dynamic-cast audit, etc.)
- `Build-Changelog.ps1` tested end-to-end with fake changeset fragments (multi-changeset, header normalization, package.json version sync)
- `changeset status --since=` verified to correctly fail when a changeset is missing
- Release notes template substitution verified locally
- YAML syntax of both workflows validated

## Note
`@changesets/cli`'s native output groups entries by bump type (`Major/Minor/Patch Changes`) rather than Keep a Changelog's `Added/Changed/Fixed`. Kept as-is since it's the tool's native convention.
