### PR TITLE
Fix release workflow: pass GITHUB_TOKEN to changeset changelog compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -740,6 +740,9 @@ jobs:
     - name: Compile changesets into CHANGELOG.md
       id: changelog
       shell: pwsh
+      env:
+        # @changesets/changelog-github needs a token to look up PR/commit info for changelog entries.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         $releaseDate = Get-Date -AsUTC -Format 'yyyy-MM-dd'
         ./scripts/Build-Changelog.ps1 -Version "${{ env.VERSION }}" -Date $releaseDate


### PR DESCRIPTION
The v1.9.1 release run failed at the 'Compile changesets into CHANGELOG.md' step because @changesets/changelog-github requires a GITHUB_TOKEN environment variable to look up PR/commit info. This wires up the standard Actions GITHUB_TOKEN for that step.