### PR TITLE
chore: update CHANGELOG.md for v1.9.1 release

### DIFF
--- a/.changeset/changelog-rearchitecture.md
+++ b/.changeset/changelog-rearchitecture.md
@@ -1,5 +1,0 @@
----
-"excelmcp": patch
----
-
-**Changelog generation now uses changesets** (#698): Each PR adds a small, human-written note describing what changed for users, and these notes are compiled automatically into `CHANGELOG.md` and the GitHub Release notes when a new version ships. This replaces the old manual process, which had let several releases' worth of changes sit mislabeled as "Unreleased" for months. The changelog itself has also been cleaned up — the mislabeled entries were consolidated and condensed into clearer, less technical summaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.9.1] - 2026-07-09
+
+### Patch Changes
+
+- [#699](https://github.com/sbroenne/mcp-server-excel/pull/699) [`0e1c4eb`](https://github.com/sbroenne/mcp-server-excel/commit/0e1c4eb773185cfe164cadadb3ad3d23839417ec) Thanks [@sbroenne](https://github.com/sbroenne)! - **Changelog generation now uses changesets** (#698): Each PR adds a small, human-written note describing what changed for users, and these notes are compiled automatically into `CHANGELOG.md` and the GitHub Release notes when a new version ships. This replaces the old manual process, which had let several releases' worth of changes sit mislabeled as "Unreleased" for months. The changelog itself has also been cleaned up — the mislabeled entries were consolidated and condensed into clearer, less technical summaries.
+
 All notable changes to ExcelMcp will be documented in this file.
 
 This changelog covers all components:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "excelmcp",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "description": "ExcelMcp is a Windows-only Excel automation toolset (MCP Server, CLI, VS Code Extension, MCPB). This package.json exists solely to host Changesets tooling for CHANGELOG.md generation — it is never published to npm and has no runtime dependencies.",
   "repository": {
@@ -17,3 +17,4 @@
     "@changesets/cli": "^2.29.7"
   }
 }
+


### PR DESCRIPTION
Automated post-release changelog update: compiles pending .changeset/*.md fragments into a new \## [1.9.1]\ entry in CHANGELOG.md via \scripts/Build-Changelog.ps1\.