### PR TITLE
Fail release loudly if changelog PR creation fails

### DIFF
--- a/.changeset/fix-changelog-pr-continue-on-error.md
+++ b/.changeset/fix-changelog-pr-continue-on-error.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Release automation hardening**: The post-release step that opens a PR to commit the compiled `CHANGELOG.md` no longer silently swallows failures. During the first live run of the new changesets-based release pipeline, this step failed (the repo didn't allow Actions to create pull requests) but was marked as a passing step, which is exactly the kind of silent failure the new pipeline was built to eliminate. The repo setting has been fixed and the step now fails the release run loudly if it can't create the PR.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -798,6 +798,9 @@ jobs:
           --title "chore: update CHANGELOG.md for v${VERSION} release" \
           --body "Automated post-release changelog update: compiles pending .changeset/*.md fragments into a new \`## [$VERSION]\` entry in CHANGELOG.md via \`scripts/Build-Changelog.ps1\`." \
           --label "documentation"
-      continue-on-error: true
+      # Intentionally NOT continue-on-error: a silently swallowed failure here
+      # (e.g. Actions lacking permission to create PRs) is exactly what caused
+      # several past releases to be missing their changelog commit-back PR.
+      # Let this step fail loudly so it gets noticed and fixed immediately.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
During the first live run of the new changesets release pipeline, the 'Commit Changelog Update' step failed silently (repo didn't allow Actions to create PRs) because of \continue-on-error: true\. Fixed the repo setting separately; this removes the error-swallowing so any future failure here surfaces immediately instead of being masked — this is the exact failure mode the changesets re-architecture was meant to eliminate.