### PR TITLE
docs: remove stale FEATURES.md footer, add PowerPoint MCP Server links

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -445,14 +445,3 @@ Formatting split: use `range` for number display formats such as dates, currency
 | Manage formulas | `range` (set-formulas) |
 | Format data | `range` / `range_format` (`format-range`, `format-ranges`, `validate-range`) |
 | Script automation | `vba` (run macro) |
-
----
-
-## 📚 Documentation
-
-- **[Installation Guide](https://excelmcpserver.dev/installation/)** - Choose MCP Server or CLI setup
-- **[MCP Server Guide](https://excelmcpserver.dev/mcp-server/)** - Tool documentation and examples
-- **[CLI Guide](https://excelmcpserver.dev/cli/)** - Command-line reference
-- **[Agent Skills](https://github.com/sbroenne/mcp-server-excel/blob/main/skills/excel-mcp/SKILL.md)** - Cross-platform AI assistant guidance (agentskills.io)
-- **[Contributing](https://excelmcpserver.dev/contributing/)** - Development guidelines
-- **[Releases](https://github.com/sbroenne/mcp-server-excel/releases)** - Latest updates and features

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The AI will display the Excel window so you can watch every operation happen liv
 
 Other projects by the author:
 
+- [PowerPoint MCP Server](https://powerpointmcpserver.dev/) — AI-powered PowerPoint automation via MCP, the sister project to this one
 - [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering) — LLM-powered testing framework for AI agents
 - [Windows MCP Server](https://windowsmcpserver.dev/) — AI-powered Windows automation via MCP
 - [OBS Studio MCP Server](https://github.com/sbroenne/mcp-server-obs) — AI-powered OBS Studio automation

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -152,3 +152,8 @@ workflow:
 | **MCP Server** | Conversational AI (Claude Desktop, VS Code Chat) | Rich tool discovery and a persistent connection. Better for interactive, exploratory workflows. |
 
 [MCP Server docs](mcp-server.md){ .md-button } [CLI docs](cli.md){ .md-button }
+
+!!! tip "Also building PowerPoint decks?"
+    Check out [PowerPoint MCP Server](https://powerpointmcpserver.dev/) — the
+    sister project to Excel MCP Server, bringing the same real-application
+    automation approach to PowerPoint.

--- a/gh-pages/docs/related-projects.md
+++ b/gh-pages/docs/related-projects.md
@@ -3,7 +3,7 @@ title: Related projects
 description: >-
   More open-source projects by Stefan Broenner — AI automation, testing and
   cloud tooling that complement Excel MCP Server.
-keywords: "Stefan Broenner projects, Windows MCP Server, OBS MCP Server, pytest-skill-engineering, RVToolsMerge"
+keywords: "Stefan Broenner projects, PowerPoint MCP Server, Windows MCP Server, OBS MCP Server, pytest-skill-engineering, RVToolsMerge"
 ---
 
 # Related projects
@@ -11,6 +11,15 @@ keywords: "Stefan Broenner projects, Windows MCP Server, OBS MCP Server, pytest-
 Other open-source projects by the author that pair well with Excel MCP Server:
 
 <div class="grid cards" markdown>
+
+-   :material-microsoft-powerpoint:{ .lg .middle } __PowerPoint MCP Server__
+
+    ---
+
+    AI-powered PowerPoint automation via MCP — the sister project to Excel
+    MCP Server, built the same way.
+
+    [:octicons-arrow-right-24: powerpointmcpserver.dev](https://powerpointmcpserver.dev/)
 
 -   :material-test-tube:{ .lg .middle } __pytest-skill-engineering__
 


### PR DESCRIPTION
Follow-up fixes after merging #703:

- Remove the stale `Documentation` footer section from `FEATURES.md` — it duplicated site navigation and linked to the old single installation page (pre-split into MCP Server/CLI guides).
- Add links to the new sister project [PowerPoint MCP Server](https://powerpointmcpserver.dev/) in README.md, the docs site's Related Projects page, and a homepage callout — it's the most relevant companion tool for Excel MCP Server users.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
