### PR TITLE
docs(gh-pages): move sister-project tip under hero section

### DIFF
--- a/.changeset/move-hero-tip-position.md
+++ b/.changeset/move-hero-tip-position.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+Move the "Also building PowerPoint decks?" sister-project tip on the docs homepage to appear directly under the hero section (success callout + intro video) instead of at the bottom of the page, and simplify its wording so it doesn't depend on the Key Features section that now follows it.

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -36,6 +36,10 @@ hide:
 ▶️ [Watch the intro video (1 min)](https://youtu.be/B6eIQ5BIbNc)
 </div>
 
+!!! tip "Also building PowerPoint decks?"
+    Check out [PowerPoint MCP Server](https://powerpointmcpserver.dev/) — the
+    sister project, built the same way.
+
 ## Key features
 
 <div class="grid cards" markdown>
@@ -152,8 +156,3 @@ workflow:
 | **MCP Server** | Conversational AI (Claude Desktop, VS Code Chat) | Rich tool discovery and a persistent connection. Better for interactive, exploratory workflows. |
 
 [MCP Server docs](mcp-server.md){ .md-button } [CLI docs](cli.md){ .md-button }
-
-!!! tip "Also building PowerPoint decks?"
-    Check out [PowerPoint MCP Server](https://powerpointmcpserver.dev/) — the
-    sister project to Excel MCP Server, bringing the same real-application
-    automation approach to PowerPoint.


### PR DESCRIPTION
Moves the `Also building PowerPoint decks?` sister-project tip on the docs homepage from the bottom of the page to directly under the hero section (success callout + intro video), and simplifies its wording so it doesn't depend on the Key Features section that now follows it. Mirrors the same change on PowerPoint MCP Server.