### PR TITLE
docs(readme): add sister-project tip under hero section

### DIFF
--- a/.changeset/add-readme-hero-tip.md
+++ b/.changeset/add-readme-hero-tip.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+Add a short "Also building PowerPoint decks?" tip right after the README's hero section, linking to PowerPoint MCP Server, mirroring the same repositioning done on the docs homepage.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 - ⚠️ **Excel Required** - Microsoft Excel 2016 or later must be installed
 - ⚠️ **Desktop Environment** - Controls actual Excel process (not for server-side processing)
 
+> [!TIP]
+> **Also building PowerPoint decks?** Check out [PowerPoint MCP Server](https://powerpointmcpserver.dev/) —
+> the sister project, built the same way.
+
 ## 🎯 What You Can Do
 
 **26 specialized tools with 232 operations:**


### PR DESCRIPTION
Adds a GitHub-alert style tip right after the README hero/technical-requirements block linking to PowerPoint MCP Server, mirroring the tip repositioning already done on the docs homepage. Related Projects section is unchanged.