### PR TITLE
Fix JSON Schema array items format for Gemini API compatibility (#672)

### DIFF
--- a/.changeset/fix-gemini-schema-array-items.md
+++ b/.changeset/fix-gemini-schema-array-items.md
@@ -1,0 +1,7 @@
+---
+"Sbroenne.ExcelMcp.McpServer": patch
+---
+
+Fix JSON Schema array items format for Gemini API compatibility (#672)
+
+Removes `nullable: true` from array nodes and adds explicit `type: string` fallback for C# `object` nodes. This prevents MCP clients from emitting missing types or union schemas that the strict Gemini API validator rejects.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Excel COM Interop PIA -->
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Office.Interop.Excel" Version="16.0.18925.20022" />
     <!-- UI Framework -->
     <PackageVersion Include="Dax.Formatter" Version="1.2.2" />

--- a/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
+++ b/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
@@ -226,7 +226,7 @@ System.IO.File.WriteAllText(OutputFile, sb.ToString());
     <ItemGroup>
       <Compile Include="$(SkillPromptsGenFile)" />
     </ItemGroup>
-    <Message Text="Generated $(SkillPromptsGenFile) from @(SkillSharedFiles->Count()) skill files" Importance="high" />
+    <Message Text="Generated $(SkillPromptsGenFile) from @(SkillSharedFiles-&gt;Count()) skill files" Importance="high" />
   </Target>
 
   <Target Name="GenerateTelemetryConfig" BeforeTargets="BeforeCompile;CoreCompile">
@@ -281,14 +281,10 @@ internal static class TelemetryConfig
     <ProjectReference Include="..\ExcelMcp.Service\ExcelMcp.Service.csproj" />
 
     <!-- MCP Tool Generator - generates [McpServerToolType] classes from Core [ServiceCategory] interfaces -->
-    <ProjectReference Include="..\ExcelMcp.Generators.Mcp\ExcelMcp.Generators.Mcp.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ExcelMcp.Generators.Mcp\ExcelMcp.Generators.Mcp.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 
     <!-- Build.Tasks - ensures skill generator is built before AfterBuild target runs -->
-    <ProjectReference Include="..\ExcelMcp.Build.Tasks\ExcelMcp.Build.Tasks.csproj"
-                      ReferenceOutputAssembly="false"
-                      PrivateAssets="all" />
+    <ProjectReference Include="..\ExcelMcp.Build.Tasks\ExcelMcp.Build.Tasks.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Allow test project to access internal members (e.g., McpProgressAdapter) -->
@@ -297,6 +293,7 @@ internal static class TelemetryConfig
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
@@ -328,13 +325,10 @@ internal static class TelemetryConfig
   </ItemGroup>
 
   <!-- Import the Build.Tasks project to use GenerateSkillFile task -->
-  <UsingTask TaskName="Sbroenne.ExcelMcp.Build.Tasks.GenerateSkillFile"
-             AssemblyFile="$(MSBuildProjectDirectory)\..\ExcelMcp.Build.Tasks\bin\$(Configuration)\netstandard2.0\Sbroenne.ExcelMcp.Build.Tasks.dll" />
+  <UsingTask TaskName="Sbroenne.ExcelMcp.Build.Tasks.GenerateSkillFile" AssemblyFile="$(MSBuildProjectDirectory)\..\ExcelMcp.Build.Tasks\bin\$(Configuration)\netstandard2.0\Sbroenne.ExcelMcp.Build.Tasks.dll" />
 
   <!-- Generate MCP Skill file from template after build -->
-  <Target Name="GenerateMcpSkill" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'"
-          Inputs="$(MSBuildProjectDirectory)\..\..\skills\templates\SKILL.mcp.sbn;$(MSBuildProjectDirectory)\..\ExcelMcp.Core\obj\GeneratedFiles\ExcelMcp.Generators\Sbroenne.ExcelMcp.Generators.ServiceRegistryGenerator\_SkillManifest.g.cs"
-          Outputs="$(MSBuildProjectDirectory)\..\..\skills\excel-mcp\SKILL.md">
+  <Target Name="GenerateMcpSkill" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'" Inputs="$(MSBuildProjectDirectory)\..\..\skills\templates\SKILL.mcp.sbn;$(MSBuildProjectDirectory)\..\ExcelMcp.Core\obj\GeneratedFiles\ExcelMcp.Generators\Sbroenne.ExcelMcp.Generators.ServiceRegistryGenerator\_SkillManifest.g.cs" Outputs="$(MSBuildProjectDirectory)\..\..\skills\excel-mcp\SKILL.md">
     <PropertyGroup>
       <SkillTemplatePath>$(MSBuildProjectDirectory)\..\..\skills\templates\SKILL.mcp.sbn</SkillTemplatePath>
       <SkillOutputPath>$(MSBuildProjectDirectory)\..\..\skills\excel-mcp\SKILL.md</SkillOutputPath>
@@ -342,13 +336,7 @@ internal static class TelemetryConfig
       <SkillManifestPath>$(MSBuildProjectDirectory)\..\ExcelMcp.Core\obj\GeneratedFiles\ExcelMcp.Generators\Sbroenne.ExcelMcp.Generators.ServiceRegistryGenerator\_SkillManifest.g.cs</SkillManifestPath>
     </PropertyGroup>
     <Message Text="Generating MCP Skill from template..." Importance="high" />
-    <GenerateSkillFile
-      TemplatePath="$(SkillTemplatePath)"
-      OutputPath="$(SkillOutputPath)"
-      ManifestPath="$(SkillManifestPath)"
-      ExcludeCommands="diag"
-      ExtraOperationCount="6"
-      ExtraToolCount="1" />
+    <GenerateSkillFile TemplatePath="$(SkillTemplatePath)" OutputPath="$(SkillOutputPath)" ManifestPath="$(SkillManifestPath)" ExcludeCommands="diag" ExtraOperationCount="6" ExtraToolCount="1" />
     <Message Text="Generated MCP Skill: $(SkillOutputPath)" Importance="high" />
   </Target>
 

--- a/src/ExcelMcp.McpServer/GeminiCompatibleToolRegistration.cs
+++ b/src/ExcelMcp.McpServer/GeminiCompatibleToolRegistration.cs
@@ -32,7 +32,31 @@ internal static class GeminiCompatibleToolRegistration
         {
             // Emit OpenAPI-3.0-style nullability (type:"array" + nullable:true) instead of
             // JSON-Schema-2020-12 union types (type:["array","null"]) that Gemini rejects.
-            UseNullableKeyword = true
+            UseNullableKeyword = true,
+            TransformSchemaNode = (context, node) =>
+            {
+                if (node is System.Text.Json.Nodes.JsonObject obj)
+                {
+                    // Fix 1: Gemini function calling API rejects `nullable: true` on arrays if the
+                    // client translator converts it into an `anyOf` but leaves `items` alongside it.
+                    // This causes a protobuf validation error: "field predicate failed: == Type.ARRAY"
+                    // because `items` is only allowed when `type` is EXACTLY `Type.ARRAY`.
+                    if (obj.TryGetPropertyValue("type", out var typeNode) && typeNode?.GetValue<string>() == "array")
+                    {
+                        obj.Remove("nullable");
+                    }
+
+                    // Fix 2: C# `object` generates an empty `{}` schema. Gemini strictly requires a `type`.
+                    // When an array contains objects/scalars without a type, Gemini validation fails.
+                    // We default empty item schemas to type "string" to satisfy the validator.
+                    if (obj.Count == 0 && context.IsCollectionElementSchema)
+                    {
+                        obj["type"] = "string";
+                        obj["description"] = "Any valid scalar (string/number/boolean) converted to string";
+                    }
+                }
+                return node;
+            }
         }
     };
 

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolProtocolRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolProtocolRegressionTests.cs
@@ -40,7 +40,7 @@ public sealed class ExcelFileToolProtocolRegressionTests : McpIntegrationTestBas
     public async Task FileOpen_FileLockedByAnotherProcess_ReturnsActionableError_AndNextOpenSucceeds()
     {
         var lockedFile = Path.Join(_tempDir, $"LockedOpen_{Guid.NewGuid():N}.xlsx");
-        ExcelSession.CreateNew<bool>(lockedFile, false, (ctx, ct) => true);
+        ExcelSession.CreateNew(lockedFile, false, (ctx, ct) => true);
 
         using (var fileLock = new FileStream(lockedFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
         {

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeminiSchemaCompatibilityTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeminiSchemaCompatibilityTests.cs
@@ -34,7 +34,7 @@ public sealed class GeminiSchemaCompatibilityTests : McpIntegrationTestBase
     }
 
     [Fact]
-    public async Task ListTools_AllToolSchemas_DoNotUseUnionTypeArrays()
+    public async Task ListTools_AllToolSchemas_MeetGeminiStrictConstraints()
     {
         var tools = await Client!.ListToolsAsync(cancellationToken: TestCancellationToken);
         Assert.NotEmpty(tools);
@@ -43,19 +43,18 @@ public sealed class GeminiSchemaCompatibilityTests : McpIntegrationTestBase
 
         foreach (var tool in tools)
         {
-            CollectUnionTypeViolations(tool.Name, tool.JsonSchema, "$", violations);
+            CollectViolations(tool.Name, tool.JsonSchema, "$", violations);
         }
 
-        Output.WriteLine($"Scanned {tools.Count} tools for Gemini-incompatible union 'type' arrays.");
+        Output.WriteLine($"Scanned {tools.Count} tools for Gemini-incompatible schema constructs.");
 
         Assert.True(
             violations.Count == 0,
-            "Gemini (OpenAPI 3.0 subset) rejects union 'type' arrays like [\"array\",\"null\"]. " +
-            "Nullability must use 'nullable: true' with a single scalar 'type'. Violations:" +
+            "Gemini (OpenAPI 3.0 subset) enforces strict schema rules. Violations:" +
             Environment.NewLine + string.Join(Environment.NewLine, violations));
     }
 
-    private static void CollectUnionTypeViolations(
+    private static void CollectViolations(
         string toolName,
         JsonElement node,
         string jsonPath,
@@ -64,14 +63,37 @@ public sealed class GeminiSchemaCompatibilityTests : McpIntegrationTestBase
         switch (node.ValueKind)
         {
             case JsonValueKind.Object:
-                if (node.TryGetProperty("type", out var typeProperty) && typeProperty.ValueKind == JsonValueKind.Array)
+                // Rule 1: No union types. type must be a string.
+                if (node.TryGetProperty("type", out var typeProperty))
                 {
-                    violations.Add($"{toolName} {jsonPath}.type = {typeProperty.GetRawText()}");
+                    if (typeProperty.ValueKind == JsonValueKind.Array)
+                    {
+                        violations.Add($"{toolName} {jsonPath}.type = {typeProperty.GetRawText()} (Must be scalar string)");
+                    }
+                }
+
+                // Rule 2: No `nullable: true` on array nodes. 
+                // Client translates this to `anyOf` which breaks Gemini's `items` predicate validator.
+                if (typeProperty.ValueKind == JsonValueKind.String && typeProperty.GetString() == "array")
+                {
+                    if (node.TryGetProperty("nullable", out var nullableProperty) && nullableProperty.GetBoolean())
+                    {
+                        violations.Add($"{toolName} {jsonPath} has both type:\"array\" and nullable:true (Gemini rejects due to anyOf translation)");
+                    }
+                }
+
+                // Rule 3: items schema must not be empty. It must have a type.
+                if (jsonPath.EndsWith(".items", StringComparison.Ordinal) || jsonPath.EndsWith("]items", StringComparison.Ordinal))
+                {
+                    if (!node.TryGetProperty("type", out _) && !node.TryGetProperty("anyOf", out _) && !node.TryGetProperty("enum", out _))
+                    {
+                        violations.Add($"{toolName} {jsonPath} is empty/untyped (Gemini requires explicit type on all items)");
+                    }
                 }
 
                 foreach (var property in node.EnumerateObject())
                 {
-                    CollectUnionTypeViolations(toolName, property.Value, $"{jsonPath}.{property.Name}", violations);
+                    CollectViolations(toolName, property.Value, $"{jsonPath}.{property.Name}", violations);
                 }
 
                 break;
@@ -80,7 +102,7 @@ public sealed class GeminiSchemaCompatibilityTests : McpIntegrationTestBase
                 var index = 0;
                 foreach (var item in node.EnumerateArray())
                 {
-                    CollectUnionTypeViolations(toolName, item, $"{jsonPath}[{index}]", violations);
+                    CollectViolations(toolName, item, $"{jsonPath}[{index}]", violations);
                     index++;
                 }
 

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
@@ -576,11 +576,11 @@ in
 
         // Step 1: Create source file with a sheet (use CreateNew for new files)
         _output.WriteLine("  1. Creating source file...");
-        ExcelSession.CreateNew<bool>(sourceFile, false, (ctx, ct) => true);
+        ExcelSession.CreateNew(sourceFile, false, (ctx, ct) => true);
 
         // Step 2: Create target file (empty, will receive the copied sheet)
         _output.WriteLine("  2. Creating target file...");
-        ExcelSession.CreateNew<bool>(targetFile, false, (ctx, ct) => true);
+        ExcelSession.CreateNew(targetFile, false, (ctx, ct) => true);
 
         // Step 3: Call worksheet copy-to-file WITHOUT session_id (ATOMIC OPERATION)
         // This is the CRITICAL TEST: the tool should accept this call without a session_id parameter

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ProgramLoggingTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ProgramLoggingTests.cs
@@ -1,8 +1,8 @@
+using Microsoft.ApplicationInsights.WorkerService;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
-using Microsoft.ApplicationInsights.WorkerService;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ServiceBridgeCancellationTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ServiceBridgeCancellationTests.cs
@@ -1,8 +1,8 @@
-using Bridge = Sbroenne.ExcelMcp.McpServer.ServiceBridge.ServiceBridge;
 using Sbroenne.ExcelMcp.McpServer.ServiceBridge;
 using Sbroenne.ExcelMcp.McpServer.Tools;
 using Sbroenne.ExcelMcp.Service;
 using Xunit;
+using Bridge = Sbroenne.ExcelMcp.McpServer.ServiceBridge.ServiceBridge;
 
 namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
 


### PR DESCRIPTION
Removes nullable: true from array nodes and adds explicit type: string fallback for C# object nodes. This prevents MCP clients from emitting missing types or union schemas that the strict Gemini API validator rejects.

Fixes #672