### PR TITLE
Fix release changeset package metadata

### DIFF
--- a/.changeset/fix-gemini-schema-array-items.md
+++ b/.changeset/fix-gemini-schema-array-items.md
@@ -1,5 +1,5 @@
 ---
-"Sbroenne.ExcelMcp.McpServer": patch
+"excelmcp": patch
 ---
 
 Fix JSON Schema array items format for Gemini API compatibility (#672)


### PR DESCRIPTION
Corrects the issue #672 changeset to target the root Changesets workspace package. The previous package identifier was not part of the workspace, causing the v1.9.2 release workflow to fail while compiling release notes.\n\nThis is release-metadata only; all mandatory pre-commit gates passed.