### PR TITLE
docs: standardize Features page and fix docs inconsistencies

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -6,6 +6,9 @@
 
 ## 📁 File Operations (6 operations)
 
+Open, create, and close Excel workbooks. Every other tool works on a session opened here.
+
+**Operations:**
 - **List Sessions:** View all active Excel sessions
 - **Open:** Open workbook and create session (returns session ID for all subsequent operations). IRM/AIP-protected files are automatically detected and opened read-only with Excel visible for credential authentication — no extra parameters needed.
 - **Close:** Close session with optional save
@@ -17,6 +20,9 @@
 
 ## 🧮 Calculation Mode (3 operations)
 
+Control when and how Excel recalculates formulas — useful for speeding up bulk edits.
+
+**Operations:**
 - **Get Mode:** Query current calculation mode and calculation state
 - **Set Mode:** Switch between automatic, manual, and semi-automatic modes
 - **Calculate:** Explicitly recalculate workbook, sheet, or range
@@ -25,53 +31,73 @@
 
 ## 🔄 Power Query & M Code (12 operations)
 
-All operations are single-call atomic workflows:
+Import, transform, and refresh data with Power Query. Every operation is a single-call atomic workflow.
+
+**Discovery:**
 - **List:** List all Power Query queries in workbook
 - **View:** View the M code of a Power Query
+- **Get Load Config:** Get current load configuration
+
+**Lifecycle:**
 - **Create:** Import + load in one operation (atomic workflow), preserving M code by default
 - **Update:** Update M code, preserving M code by default, with optional auto-refresh
 - **Rename:** Rename a Power Query (trim + case-insensitive uniqueness check)
+- **Unload:** Remove data from all destinations (keeps query definition)
+- **Delete:** Remove Power Query from workbook
+
+**Loading & Refresh:**
 - **Refresh:** Refresh a Power Query with timeout detection
 - **Refresh All:** Batch refresh all queries in workbook
 - **Load To:** Configure load destination and refresh (atomic)
-- **Get Load Config:** Get current load configuration
-- **Unload:** Remove data from all destinations (keeps query definition)
-- **Delete:** Remove Power Query from workbook
+
+**Advanced:**
 - **Evaluate:** Execute M code directly and return results (without creating a permanent query)
 
-**M-Code Formatting:** M code is preserved exactly by default. Create and Update can opt in to remote formatting with `formatMCode=true`, which sends M code to powerqueryformatter.com and adds network latency. If remote formatting fails, the original M code is saved unchanged.
+**Notes:**
+- **M-code formatting:** M code is preserved exactly by default. Create and Update can opt in to remote formatting with `formatMCode=true`, which sends M code to powerqueryformatter.com and adds network latency. If remote formatting fails, the original M code is saved unchanged.
 
 ---
 
 ## 📊 Data Model & DAX (Power Pivot) (19 operations)
 
+Build a Power Pivot Data Model — manage tables, DAX measures, and relationships, then query it.
+
+**Tables & Columns:**
 - **List Tables:** Discover all tables in the Data Model
 - **Read Table:** Get specific table information
 - **Rename Table:** Rename a Data Model table (best-effort via Power Query; returns clear error if not supported)
+- **Delete Table:** Remove table from Data Model
 - **List Columns:** List columns for a table
+- **List Workbook Connections:** List Power Query sources available for integration
+
+**Measures:**
 - **List Measures:** List all DAX measures with formula previews
-- **Read Info:** Get comprehensive model information
 - **Create Measure:** Create new DAX measure, preserving DAX by default (format types: Currency, Percentage, Decimal, General)
 - **Update Measure:** Modify existing measure, preserving DAX by default
 - **Delete Measure:** Remove measure from model
-- **Delete Table:** Remove table from Data Model
+
+**Relationships:**
 - **List Relationships:** View all table relationships
 - **Read Relationship:** Get specific relationship info
 - **Create Relationship:** Create relationship between tables
 - **Update Relationship:** Modify relationship (toggle active/inactive)
 - **Delete Relationship:** Remove relationship
+
+**Model & Queries:**
+- **Read Info:** Get comprehensive model information
 - **Refresh:** Refresh entire Data Model
-- **List Workbook Connections:** List Power Query sources available for integration
 - **Evaluate:** Execute DAX EVALUATE queries and return tabular results (for ad-hoc analysis)
 - **Execute DMV:** Execute SQL-like DMV (Dynamic Management View) queries for metadata discovery
 
-**DAX Formatting:** DAX formulas are preserved exactly by default, subject to Excel locale separator translation. CreateMeasure and UpdateMeasure can opt in to remote formatting with `formatDax=true`, which sends DAX to daxformatter.com and adds network latency. If remote formatting fails, the original DAX is saved unchanged.
-
-**Note:** DAX calculated columns not supported - use Excel UI for calculated columns
+**Notes:**
+- **DAX formatting:** DAX formulas are preserved exactly by default, subject to Excel locale separator translation. CreateMeasure and UpdateMeasure can opt in to remote formatting with `formatDax=true`, which sends DAX to daxformatter.com and adds network latency. If remote formatting fails, the original DAX is saved unchanged.
+- DAX calculated columns are not supported — use the Excel UI for calculated columns.
 
 ---
 
-## 🎨 Excel Tables (ListObjects) (27 operations)
+## 📇 Excel Tables (ListObjects) (27 operations)
+
+Create and manage Excel Tables (ListObjects) — structured ranges with styling, filtering, and sorting.
 
 **Lifecycle:**
 - **List:** List Excel Tables in a worksheet or workbook
@@ -122,6 +148,8 @@ All operations are single-call atomic workflows:
 
 ## 📈 PivotTables (30 operations)
 
+Create and configure PivotTables from ranges, Excel Tables, or the Data Model.
+
 **Creation:**
 - **Create from Range:** Build a PivotTable from a cell range
 - **Create from Excel Table:** Build a PivotTable from an Excel Table
@@ -166,6 +194,8 @@ All operations are single-call atomic workflows:
 ---
 
 ## 📉 Charts (29 operations)
+
+Create and format charts and PivotCharts, with full control over series, axes, labels, and trendlines.
 
 **Creation:**
 - **Create from Range:** Build a chart from a cell range
@@ -227,7 +257,9 @@ All operations are single-call atomic workflows:
 
 ## 📋 Ranges (46 operations)
 
-Formatting split: use `range` for number display formats such as dates, currency, percentages, and text display. Use `range_format` for visual styling, validation, auto-fit, and size/layout changes.
+Read and write cell values, formulas, and formatting across any range of cells.
+
+**Formatting split:** use `range` for number display formats such as dates, currency, percentages, and text display. Use `range_format` for visual styling, validation, auto-fit, and size/layout changes.
 
 **Data Operations:**
 - **Get/Set Values:** Read or write cell values
@@ -285,6 +317,8 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 📄 Worksheets (16 operations)
 
+Add, rename, move, and manage worksheets — including tab colors and visibility.
+
 **Lifecycle:**
 - **List:** List worksheets in the workbook
 - **Create:** Add a new worksheet
@@ -313,6 +347,9 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 🔌 Data Connections (9 operations)
 
+Create and refresh external OLEDB/ODBC data connections.
+
+**Operations:**
 - **List:** View all data connections
 - **View:** Get connection details
 - **Create:** Create OLEDB/ODBC connections (requires provider installed)
@@ -323,18 +360,17 @@ Formatting split: use `range` for number display formats such as dates, currency
 - **Get Properties:** Get connection string and metadata
 - **Set Properties:** Update connection string, command text, and settings
 
-**Supported Types:**
-- OLEDB (requires Microsoft.ACE.OLEDB.16.0 or similar)
-- ODBC (requires ODBC driver installed)
-- Power Query connections (atomic redirect to `powerquery`)
-
-**Automatic Fallback:**
-- TEXT/WEB connections automatically redirect to `powerquery` for reliable imports
+**Notes:**
+- **Supported types:** OLEDB (requires Microsoft.ACE.OLEDB.16.0 or similar), ODBC (requires ODBC driver installed), and Power Query connections (atomic redirect to `powerquery`).
+- **Automatic fallback:** TEXT/WEB connections automatically redirect to `powerquery` for reliable imports.
 
 ---
 
 ## 🏷️ Named Ranges (Parameters) (6 operations)
 
+Manage named ranges — ideal for driving workbook parameters that Power Query and formulas react to.
+
+**Operations:**
 - **List:** List visible user-defined named ranges with references; hidden/internal Excel names (including Power Query `ExternalData_*` and AutoFilter names) are omitted before value inspection, and large ranges return metadata without materializing values
 - **Read:** Get value of a named range
 - **Write:** Set value of a named range (ideal for parameter automation)
@@ -342,14 +378,16 @@ Formatting split: use `range` for number display formats such as dates, currency
 - **Update:** Modify existing named range
 - **Delete:** Remove named range
 
-**Use Cases:**
-- Workbook parameter management without touching worksheets
-- Ideal for automation: update parameter → Power Query refreshes automatically
+**Notes:**
+- **Use cases:** Manage workbook parameters without touching worksheets. Ideal for automation — update a parameter and Power Query refreshes automatically.
 
 ---
 
 ## 📝 VBA Macros (6 operations)
 
+View, import, edit, and run VBA code in `.xlsm` workbooks.
+
+**Operations:**
 - **List:** List VBA components and discovered procedures
 - **View:** Display component code without exporting
 - **Import:** Create a new standard module from code or file input
@@ -357,14 +395,16 @@ Formatting split: use `range` for number display formats such as dates, currency
 - **Delete:** Remove a VBA component by name
 - **Run:** Execute a procedure with optional string parameters
 
-**Features:**
-- Procedural/module-focused VBA support for `.xlsm` workbooks
-- Manual VBA trust prerequisite in Excel (no trust-configuration command)
-- Import creates standard modules; list/view also cover class, form, and document components
+**Notes:**
+- Procedural/module-focused VBA support for `.xlsm` workbooks.
+- Requires the manual VBA trust prerequisite in Excel (no trust-configuration command).
+- Import creates standard modules; list/view also cover class, form, and document components.
 
 ---
 
 ## 🔪 Slicers (8 operations)
+
+Add interactive slicers to filter PivotTables and Excel Tables visually.
 
 **PivotTable Slicers:**
 - **Create Slicer:** Add slicer for PivotTable field with optional position
@@ -378,15 +418,16 @@ Formatting split: use `range` for number display formats such as dates, currency
 - **Set Table Selection:** Filter Table by slicer selection
 - **Delete Table Slicer:** Remove Table slicer
 
-**Use Cases:**
-- Interactive data filtering without modifying PivotTable/Table structure
-- Dashboard creation with visual filter controls
-- Multi-slicer filtering for complex data analysis
+**Notes:**
+- **Use cases:** Interactive data filtering without modifying PivotTable/Table structure, dashboard creation with visual filter controls, and multi-slicer filtering for complex data analysis.
 
 ---
 
-## 🎨 Conditional Formatting (2 operations)
+## 🌈 Conditional Formatting (2 operations)
 
+Apply rule-based formatting that highlights cells based on their values.
+
+**Operations:**
 - **Add Rule:** Create a conditional formatting rule — cell value comparison (>, <, =, etc.), expression-based formula (custom DAX/Excel formula), or color scale/data bar/icon set
 - **Clear Rules:** Remove formatting from ranges
 
@@ -394,6 +435,9 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 📸 Screenshot (2 operations)
 
+Capture ranges or worksheets as PNG images using Excel's own rendering.
+
+**Operations:**
 - **Capture Range:** Capture a specific range as a PNG image
 - **Capture Sheet:** Capture the entire used area of a worksheet as a PNG image, using Excel's built-in rendering (CopyPicture) — captures formatting, charts, and conditional formatting. MCP returns the image directly as `ImageContent` (base64 PNG); CLI returns JSON with base64-encoded image data.
 
@@ -401,36 +445,40 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 🐍 Python in Excel (2 operations)
 
-**REQUIRES:** a real Excel session signed into a licensed Microsoft 365 account with Python in Excel enabled, plus internet access — the Python code executes in a Microsoft-hosted cloud sandbox, not locally. Not available offline or with perpetual-license Excel.
+Write and read `=PY()` formulas that run in Excel's cloud Python engine.
 
+**Operations:**
 - **Set Formula:** Write a `=PY("<code>", returnType)` formula via `Range.Formula2`. `returnType` 0 = "Excel Value" (a plain value/array), 1 = "Python Object" (a rich data type card, e.g. a DataFrame). Must always be passed explicitly — omitting it causes a `#NAME?` error.
 - **Get Result:** Read back the computed value, polling briefly since cloud execution is not instantaneous. **Best-effort:** Excel exposes no reliable "still computing" signal via COM, so a freshly written formula may read back as unconverged; if the poll doesn't stabilize in time, the call reports failure and asks the caller to retry rather than guessing at a stale value.
-- **Data Binding:** Reference live worksheet data inside the Python code with `xl("A1:A6")`, `xl("Sheet1!A1:A6")`, or a named range `xl("MyRange")` — works the same as if typed interactively.
+
+**Notes:**
+- **Requires:** a real Excel session signed into a licensed Microsoft 365 account with Python in Excel enabled, plus internet access — the Python code executes in a Microsoft-hosted cloud sandbox, not locally. Not available offline or with perpetual-license Excel.
+- **Data binding:** Reference live worksheet data inside the Python code with `xl("A1:A6")`, `xl("Sheet1!A1:A6")`, or a named range `xl("MyRange")` — works the same as if typed interactively.
 
 ---
 
 ## 🪧 Window Management (9 operations)
 
+Show, position, and arrange the Excel window — great for watching the AI work in real time.
+
+**Visibility & Focus:**
 - **Show:** Make Excel visible and bring it to the foreground
 - **Hide:** Hide the Excel window
 - **Bring to Front:** Bring Excel to the foreground without changing visibility
+
+**Window State & Layout:**
 - **Get Info:** Get current window state (visibility, position, size, foreground status)
 - **Set State:** Set window state to normal, minimized, or maximized
 - **Set Position:** Set window position and size in points (left, top, width, height)
 - **Arrange:** Arrange the Excel window using preset layouts
+
+**Status Bar:**
 - **Set Status Bar:** Display custom text in Excel's status bar for real-time feedback
 - **Clear Status Bar:** Restore the default status bar text
 
-**Arrange Presets:**
-- `left-half` / `right-half` — Side-by-side with other applications
-- `top-half` / `bottom-half` — Stacked view
-- `center` — Centered window (60% of screen)
-- `full-screen` — Maximized
-
-**Use Cases:**
-- Interactive "agent mode" where users watch Excel respond to AI commands in real-time
-- Side-by-side: Excel on one half, AI assistant on the other
-- Visibility changes are reflected in session metadata (session list shows updated state)
+**Notes:**
+- **Arrange presets:** `left-half` / `right-half` (side-by-side with other applications), `top-half` / `bottom-half` (stacked view), `center` (centered window, 60% of screen), and `full-screen` (maximized).
+- **Use cases:** Interactive "agent mode" where users watch Excel respond to AI commands in real time, side-by-side layouts (Excel on one half, AI assistant on the other), and visibility changes that are reflected in session metadata.
 
 ---
 

--- a/docs/INSTALLATION-CLI.md
+++ b/docs/INSTALLATION-CLI.md
@@ -149,18 +149,18 @@ Before updating, check the [changelog](https://excelmcpserver.dev/changelog/) or
 ### Command Not Found After Installation
 
 ```powershell
-## Check excelcli.exe location
+# Check excelcli.exe location
 where.exe excelcli
 
-## If not found, ensure the directory containing excelcli.exe is in your PATH
-## The default location after extraction might be: C:\Tools\ExcelMcp\
+# If not found, ensure the directory containing excelcli.exe is in your PATH
+# The default location after extraction might be: C:\Tools\ExcelMcp\
 ```
 
 ### Excel Not Found
 
 ```powershell
-## Error: "Microsoft Excel is not installed"
-## Solution: Install Microsoft Excel (any version 2016+)
+# Error: "Microsoft Excel is not installed"
+# Solution: Install Microsoft Excel (any version 2016+)
 ```
 
 ### VBA Access Denied
@@ -197,8 +197,8 @@ excelcli session close --session 1 --save
 ### Permission Issues
 
 ```powershell
-## Run PowerShell/CMD as Administrator if you encounter permission errors
-## excelcli.exe is a standalone exe - no installation needed
+# Run PowerShell/CMD as Administrator if you encounter permission errors
+# excelcli.exe is a standalone exe - no installation needed
 ```
 
 ---

--- a/skills/README.md
+++ b/skills/README.md
@@ -32,23 +32,3 @@ npx skills add sbroenne/mcp-server-excel --skill excel-mcp
 
 **Via VS Code Extension (auto-installs excel-mcp):**
 Install the [Excel MCP VS Code Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp) — it registers the `excel-mcp` skill via `chatSkills`. For the `excel-cli` skill, use the plugin or `npx skills` methods above.
-
-## Building
-
-```powershell
-dotnet build -c Release
-```
-
-Generates `SKILL.md` and copies `shared/` references into each skill's `references/` folder.
-
-## Structure
-
-```
-skills/
-├── shared/          # Shared behavioral guidance (source of truth)
-├── excel-mcp/       # MCP Server skill (SKILL.md + references/)
-├── excel-cli/       # CLI skill (SKILL.md + references/)
-├── templates/       # Scriban templates for SKILL.md generation
-├── CLAUDE.md        # Claude Code project instructions
-└── .cursorrules     # Cursor-specific rules
-```

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -65,10 +65,6 @@ Drives the **actual Excel application** via COM — not a file-format parser —
 
 ---
 
-## 🤝 Related Tools & Support
-
----
-
 ## 📖 Complete Documentation
 
 - **[GitHub Releases](https://github.com/sbroenne/mcp-server-excel/releases/latest)** - Download latest standalone exe (primary)
@@ -101,7 +97,8 @@ where.exe excelcli
 
 ```powershell
 # Error: "Programmatic access to Visual Basic Project is not trusted"
-# Solution: Enable VBA trust (see VBA Operations Setup above)
+# Solution: In Excel, enable File → Options → Trust Center → Trust Center Settings
+#           → Macro Settings → "Trust access to the VBA project object model"
 ```
 
 ### Permission Issues
@@ -173,11 +170,7 @@ These tests open actual workbooks, issue `session open/list/close`, and call `ex
 
 ## 🤝 Related Tools
 
-- **[ExcelMcp MCP Server](https://github.com/sbroenne/mcp-server-excel/releases/latest)** - MCP server for AI assistant integration (`mcp-excel.exe`)
-- **[Excel MCP VS Code Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)** - One-click Excel automation in VS Code
->>>>>>> 08d2ec617123490fa4dad1d99da58d5a508e2a95
-
-- **[MCP Server](https://excelmcpserver.dev/mcp-server/)** - For conversational AI (Claude Desktop, VS Code Chat)
+- **[MCP Server](https://excelmcpserver.dev/mcp-server/)** - For conversational AI (Claude Desktop, VS Code Chat) — distributed as `mcp-excel.exe`
 - **[VS Code Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)** - One-click Excel automation in VS Code
 - **Issues & Discussions**: [GitHub](https://github.com/sbroenne/mcp-server-excel)
 - **Full docs**: [excelmcpserver.dev](https://excelmcpserver.dev/)


### PR DESCRIPTION
## Summary

Full review of the GitHub Pages docs (MkDocs site in `gh-pages/`, generated from repo sources). Makes the user-facing pages consistent and newcomer-friendly.

## Changes

- **`FEATURES.md`** — standardized all 20 tool sections into one shape: a plain-language intro sentence, operations grouped under bold category headers, and a single consistent `**Notes:**` block (replacing ad-hoc `Note/Features/Use Cases/Supported Types/Automatic Fallback` labels). Fixed the duplicate 🎨 emoji. Operation counts unchanged (232 across 17 sections).
- **`src/ExcelMcp.CLI/README.md`** — removed an unresolved git merge-conflict marker that was shipping to the CLI page, consolidated a duplicated/empty "Related Tools" section, and fixed a dangling "VBA Operations Setup above" cross-reference.
- **`docs/INSTALLATION-CLI.md`** — normalized PowerShell comment style (`##` → `#`).
- **`skills/README.md`** — removed developer-only `Building`/`Structure` sections from the public Agent Skills page.

## Verification

- `mkdocs build --strict` passes with no warnings/errors.
- Per-section operation counts preserved (sum = 232) so `check-doc-counts.ps1` stays green.
- Pre-commit hooks passed (docs-only; Release/Excel gates auto-skipped).

Docs-only → `skip-changelog`.