### PR TITLE
docs: add newcomer onboarding (Features intro, Troubleshooting/FAQ page)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,6 +4,22 @@
 
 ---
 
+**New to Excel MCP Server?** You don't need to learn these operations — your AI
+assistant picks the right tool for what you ask in plain language. This page is
+the full reference. The tools most people reach for first:
+
+- **`powerquery`** — import and reshape data from files, databases, and APIs
+- **`range` / `range_format`** — read and write cell values, formulas, and formatting
+- **`pivottable`** — summarize and analyze data
+- **`chart`** — visualize results
+- **`datamodel`** — build a Power Pivot model with DAX measures
+- **`vba`** — run macros and scripted automation
+
+Every tool below lists its operations grouped by category. Use the **"On this
+page"** menu to jump to a specific tool.
+
+---
+
 ## 📁 File Operations (6 operations)
 
 Open, create, and close Excel workbooks. Every other tool works on a session opened here.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -6,6 +6,9 @@
 
 ## 📁 File Operations (6 operations)
 
+Open, create, and close Excel workbooks. Every other tool works on a session opened here.
+
+**Operations:**
 - **List Sessions:** View all active Excel sessions
 - **Open:** Open workbook and create session (returns session ID for all subsequent operations). IRM/AIP-protected files are automatically detected and opened read-only with Excel visible for credential authentication — no extra parameters needed.
 - **Close:** Close session with optional save
@@ -17,6 +20,9 @@
 
 ## 🧮 Calculation Mode (3 operations)
 
+Control when and how Excel recalculates formulas — useful for speeding up bulk edits.
+
+**Operations:**
 - **Get Mode:** Query current calculation mode and calculation state
 - **Set Mode:** Switch between automatic, manual, and semi-automatic modes
 - **Calculate:** Explicitly recalculate workbook, sheet, or range
@@ -25,53 +31,73 @@
 
 ## 🔄 Power Query & M Code (12 operations)
 
-All operations are single-call atomic workflows:
+Import, transform, and refresh data with Power Query. Every operation is a single-call atomic workflow.
+
+**Discovery:**
 - **List:** List all Power Query queries in workbook
 - **View:** View the M code of a Power Query
+- **Get Load Config:** Get current load configuration
+
+**Lifecycle:**
 - **Create:** Import + load in one operation (atomic workflow), preserving M code by default
 - **Update:** Update M code, preserving M code by default, with optional auto-refresh
 - **Rename:** Rename a Power Query (trim + case-insensitive uniqueness check)
+- **Unload:** Remove data from all destinations (keeps query definition)
+- **Delete:** Remove Power Query from workbook
+
+**Loading & Refresh:**
 - **Refresh:** Refresh a Power Query with timeout detection
 - **Refresh All:** Batch refresh all queries in workbook
 - **Load To:** Configure load destination and refresh (atomic)
-- **Get Load Config:** Get current load configuration
-- **Unload:** Remove data from all destinations (keeps query definition)
-- **Delete:** Remove Power Query from workbook
+
+**Advanced:**
 - **Evaluate:** Execute M code directly and return results (without creating a permanent query)
 
-**M-Code Formatting:** M code is preserved exactly by default. Create and Update can opt in to remote formatting with `formatMCode=true`, which sends M code to powerqueryformatter.com and adds network latency. If remote formatting fails, the original M code is saved unchanged.
+**Notes:**
+- **M-code formatting:** M code is preserved exactly by default. Create and Update can opt in to remote formatting with `formatMCode=true`, which sends M code to powerqueryformatter.com and adds network latency. If remote formatting fails, the original M code is saved unchanged.
 
 ---
 
 ## 📊 Data Model & DAX (Power Pivot) (19 operations)
 
+Build a Power Pivot Data Model — manage tables, DAX measures, and relationships, then query it.
+
+**Tables & Columns:**
 - **List Tables:** Discover all tables in the Data Model
 - **Read Table:** Get specific table information
 - **Rename Table:** Rename a Data Model table (best-effort via Power Query; returns clear error if not supported)
+- **Delete Table:** Remove table from Data Model
 - **List Columns:** List columns for a table
+- **List Workbook Connections:** List Power Query sources available for integration
+
+**Measures:**
 - **List Measures:** List all DAX measures with formula previews
-- **Read Info:** Get comprehensive model information
 - **Create Measure:** Create new DAX measure, preserving DAX by default (format types: Currency, Percentage, Decimal, General)
 - **Update Measure:** Modify existing measure, preserving DAX by default
 - **Delete Measure:** Remove measure from model
-- **Delete Table:** Remove table from Data Model
+
+**Relationships:**
 - **List Relationships:** View all table relationships
 - **Read Relationship:** Get specific relationship info
 - **Create Relationship:** Create relationship between tables
 - **Update Relationship:** Modify relationship (toggle active/inactive)
 - **Delete Relationship:** Remove relationship
+
+**Model & Queries:**
+- **Read Info:** Get comprehensive model information
 - **Refresh:** Refresh entire Data Model
-- **List Workbook Connections:** List Power Query sources available for integration
 - **Evaluate:** Execute DAX EVALUATE queries and return tabular results (for ad-hoc analysis)
 - **Execute DMV:** Execute SQL-like DMV (Dynamic Management View) queries for metadata discovery
 
-**DAX Formatting:** DAX formulas are preserved exactly by default, subject to Excel locale separator translation. CreateMeasure and UpdateMeasure can opt in to remote formatting with `formatDax=true`, which sends DAX to daxformatter.com and adds network latency. If remote formatting fails, the original DAX is saved unchanged.
-
-**Note:** DAX calculated columns not supported - use Excel UI for calculated columns
+**Notes:**
+- **DAX formatting:** DAX formulas are preserved exactly by default, subject to Excel locale separator translation. CreateMeasure and UpdateMeasure can opt in to remote formatting with `formatDax=true`, which sends DAX to daxformatter.com and adds network latency. If remote formatting fails, the original DAX is saved unchanged.
+- DAX calculated columns are not supported — use the Excel UI for calculated columns.
 
 ---
 
-## 🎨 Excel Tables (ListObjects) (27 operations)
+## 📇 Excel Tables (ListObjects) (27 operations)
+
+Create and manage Excel Tables (ListObjects) — structured ranges with styling, filtering, and sorting.
 
 **Lifecycle:**
 - **List:** List Excel Tables in a worksheet or workbook
@@ -122,6 +148,8 @@ All operations are single-call atomic workflows:
 
 ## 📈 PivotTables (30 operations)
 
+Create and configure PivotTables from ranges, Excel Tables, or the Data Model.
+
 **Creation:**
 - **Create from Range:** Build a PivotTable from a cell range
 - **Create from Excel Table:** Build a PivotTable from an Excel Table
@@ -166,6 +194,8 @@ All operations are single-call atomic workflows:
 ---
 
 ## 📉 Charts (29 operations)
+
+Create and format charts and PivotCharts, with full control over series, axes, labels, and trendlines.
 
 **Creation:**
 - **Create from Range:** Build a chart from a cell range
@@ -227,7 +257,9 @@ All operations are single-call atomic workflows:
 
 ## 📋 Ranges (46 operations)
 
-Formatting split: use `range` for number display formats such as dates, currency, percentages, and text display. Use `range_format` for visual styling, validation, auto-fit, and size/layout changes.
+Read and write cell values, formulas, and formatting across any range of cells.
+
+**Formatting split:** use `range` for number display formats such as dates, currency, percentages, and text display. Use `range_format` for visual styling, validation, auto-fit, and size/layout changes.
 
 **Data Operations:**
 - **Get/Set Values:** Read or write cell values
@@ -285,6 +317,8 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 📄 Worksheets (16 operations)
 
+Add, rename, move, and manage worksheets — including tab colors and visibility.
+
 **Lifecycle:**
 - **List:** List worksheets in the workbook
 - **Create:** Add a new worksheet
@@ -313,6 +347,9 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 🔌 Data Connections (9 operations)
 
+Create and refresh external OLEDB/ODBC data connections.
+
+**Operations:**
 - **List:** View all data connections
 - **View:** Get connection details
 - **Create:** Create OLEDB/ODBC connections (requires provider installed)
@@ -323,18 +360,17 @@ Formatting split: use `range` for number display formats such as dates, currency
 - **Get Properties:** Get connection string and metadata
 - **Set Properties:** Update connection string, command text, and settings
 
-**Supported Types:**
-- OLEDB (requires Microsoft.ACE.OLEDB.16.0 or similar)
-- ODBC (requires ODBC driver installed)
-- Power Query connections (atomic redirect to `powerquery`)
-
-**Automatic Fallback:**
-- TEXT/WEB connections automatically redirect to `powerquery` for reliable imports
+**Notes:**
+- **Supported types:** OLEDB (requires Microsoft.ACE.OLEDB.16.0 or similar), ODBC (requires ODBC driver installed), and Power Query connections (atomic redirect to `powerquery`).
+- **Automatic fallback:** TEXT/WEB connections automatically redirect to `powerquery` for reliable imports.
 
 ---
 
 ## 🏷️ Named Ranges (Parameters) (6 operations)
 
+Manage named ranges — ideal for driving workbook parameters that Power Query and formulas react to.
+
+**Operations:**
 - **List:** List visible user-defined named ranges with references; hidden/internal Excel names (including Power Query `ExternalData_*` and AutoFilter names) are omitted before value inspection, and large ranges return metadata without materializing values
 - **Read:** Get value of a named range
 - **Write:** Set value of a named range (ideal for parameter automation)
@@ -342,14 +378,16 @@ Formatting split: use `range` for number display formats such as dates, currency
 - **Update:** Modify existing named range
 - **Delete:** Remove named range
 
-**Use Cases:**
-- Workbook parameter management without touching worksheets
-- Ideal for automation: update parameter → Power Query refreshes automatically
+**Notes:**
+- **Use cases:** Manage workbook parameters without touching worksheets. Ideal for automation — update a parameter and Power Query refreshes automatically.
 
 ---
 
 ## 📝 VBA Macros (6 operations)
 
+View, import, edit, and run VBA code in `.xlsm` workbooks.
+
+**Operations:**
 - **List:** List VBA components and discovered procedures
 - **View:** Display component code without exporting
 - **Import:** Create a new standard module from code or file input
@@ -357,14 +395,16 @@ Formatting split: use `range` for number display formats such as dates, currency
 - **Delete:** Remove a VBA component by name
 - **Run:** Execute a procedure with optional string parameters
 
-**Features:**
-- Procedural/module-focused VBA support for `.xlsm` workbooks
-- Manual VBA trust prerequisite in Excel (no trust-configuration command)
-- Import creates standard modules; list/view also cover class, form, and document components
+**Notes:**
+- Procedural/module-focused VBA support for `.xlsm` workbooks.
+- Requires the manual VBA trust prerequisite in Excel (no trust-configuration command).
+- Import creates standard modules; list/view also cover class, form, and document components.
 
 ---
 
 ## 🔪 Slicers (8 operations)
+
+Add interactive slicers to filter PivotTables and Excel Tables visually.
 
 **PivotTable Slicers:**
 - **Create Slicer:** Add slicer for PivotTable field with optional position
@@ -378,15 +418,16 @@ Formatting split: use `range` for number display formats such as dates, currency
 - **Set Table Selection:** Filter Table by slicer selection
 - **Delete Table Slicer:** Remove Table slicer
 
-**Use Cases:**
-- Interactive data filtering without modifying PivotTable/Table structure
-- Dashboard creation with visual filter controls
-- Multi-slicer filtering for complex data analysis
+**Notes:**
+- **Use cases:** Interactive data filtering without modifying PivotTable/Table structure, dashboard creation with visual filter controls, and multi-slicer filtering for complex data analysis.
 
 ---
 
-## 🎨 Conditional Formatting (2 operations)
+## 🌈 Conditional Formatting (2 operations)
 
+Apply rule-based formatting that highlights cells based on their values.
+
+**Operations:**
 - **Add Rule:** Create a conditional formatting rule — cell value comparison (>, <, =, etc.), expression-based formula (custom DAX/Excel formula), or color scale/data bar/icon set
 - **Clear Rules:** Remove formatting from ranges
 
@@ -394,6 +435,9 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 📸 Screenshot (2 operations)
 
+Capture ranges or worksheets as PNG images using Excel's own rendering.
+
+**Operations:**
 - **Capture Range:** Capture a specific range as a PNG image
 - **Capture Sheet:** Capture the entire used area of a worksheet as a PNG image, using Excel's built-in rendering (CopyPicture) — captures formatting, charts, and conditional formatting. MCP returns the image directly as `ImageContent` (base64 PNG); CLI returns JSON with base64-encoded image data.
 
@@ -401,36 +445,40 @@ Formatting split: use `range` for number display formats such as dates, currency
 
 ## 🐍 Python in Excel (2 operations)
 
-**REQUIRES:** a real Excel session signed into a licensed Microsoft 365 account with Python in Excel enabled, plus internet access — the Python code executes in a Microsoft-hosted cloud sandbox, not locally. Not available offline or with perpetual-license Excel.
+Write and read `=PY()` formulas that run in Excel's cloud Python engine.
 
+**Operations:**
 - **Set Formula:** Write a `=PY("<code>", returnType)` formula via `Range.Formula2`. `returnType` 0 = "Excel Value" (a plain value/array), 1 = "Python Object" (a rich data type card, e.g. a DataFrame). Must always be passed explicitly — omitting it causes a `#NAME?` error.
 - **Get Result:** Read back the computed value, polling briefly since cloud execution is not instantaneous. **Best-effort:** Excel exposes no reliable "still computing" signal via COM, so a freshly written formula may read back as unconverged; if the poll doesn't stabilize in time, the call reports failure and asks the caller to retry rather than guessing at a stale value.
-- **Data Binding:** Reference live worksheet data inside the Python code with `xl("A1:A6")`, `xl("Sheet1!A1:A6")`, or a named range `xl("MyRange")` — works the same as if typed interactively.
+
+**Notes:**
+- **Requires:** a real Excel session signed into a licensed Microsoft 365 account with Python in Excel enabled, plus internet access — the Python code executes in a Microsoft-hosted cloud sandbox, not locally. Not available offline or with perpetual-license Excel.
+- **Data binding:** Reference live worksheet data inside the Python code with `xl("A1:A6")`, `xl("Sheet1!A1:A6")`, or a named range `xl("MyRange")` — works the same as if typed interactively.
 
 ---
 
 ## 🪧 Window Management (9 operations)
 
+Show, position, and arrange the Excel window — great for watching the AI work in real time.
+
+**Visibility & Focus:**
 - **Show:** Make Excel visible and bring it to the foreground
 - **Hide:** Hide the Excel window
 - **Bring to Front:** Bring Excel to the foreground without changing visibility
+
+**Window State & Layout:**
 - **Get Info:** Get current window state (visibility, position, size, foreground status)
 - **Set State:** Set window state to normal, minimized, or maximized
 - **Set Position:** Set window position and size in points (left, top, width, height)
 - **Arrange:** Arrange the Excel window using preset layouts
+
+**Status Bar:**
 - **Set Status Bar:** Display custom text in Excel's status bar for real-time feedback
 - **Clear Status Bar:** Restore the default status bar text
 
-**Arrange Presets:**
-- `left-half` / `right-half` — Side-by-side with other applications
-- `top-half` / `bottom-half` — Stacked view
-- `center` — Centered window (60% of screen)
-- `full-screen` — Maximized
-
-**Use Cases:**
-- Interactive "agent mode" where users watch Excel respond to AI commands in real-time
-- Side-by-side: Excel on one half, AI assistant on the other
-- Visibility changes are reflected in session metadata (session list shows updated state)
+**Notes:**
+- **Arrange presets:** `left-half` / `right-half` (side-by-side with other applications), `top-half` / `bottom-half` (stacked view), `center` (centered window, 60% of screen), and `full-screen` (maximized).
+- **Use cases:** Interactive "agent mode" where users watch Excel respond to AI commands in real time, side-by-side layouts (Excel on one half, AI assistant on the other), and visibility changes that are reflected in session metadata.
 
 ---
 

--- a/docs/INSTALLATION-CLI.md
+++ b/docs/INSTALLATION-CLI.md
@@ -217,6 +217,7 @@ dotnet tool uninstall --global Sbroenne.ExcelMcp.CLI
 
 ## Getting Help
 
+- **Troubleshooting:** [Troubleshooting & FAQ](https://excelmcpserver.dev/troubleshooting/)
 - **Documentation:** [GitHub Repository](https://github.com/sbroenne/mcp-server-excel)
 - **Issues:** [GitHub Issues](https://github.com/sbroenne/mcp-server-excel/issues)
 - **Contributing:** [Contributing Guide](https://excelmcpserver.dev/contributing/)

--- a/docs/INSTALLATION-CLI.md
+++ b/docs/INSTALLATION-CLI.md
@@ -149,18 +149,18 @@ Before updating, check the [changelog](https://excelmcpserver.dev/changelog/) or
 ### Command Not Found After Installation
 
 ```powershell
-## Check excelcli.exe location
+# Check excelcli.exe location
 where.exe excelcli
 
-## If not found, ensure the directory containing excelcli.exe is in your PATH
-## The default location after extraction might be: C:\Tools\ExcelMcp\
+# If not found, ensure the directory containing excelcli.exe is in your PATH
+# The default location after extraction might be: C:\Tools\ExcelMcp\
 ```
 
 ### Excel Not Found
 
 ```powershell
-## Error: "Microsoft Excel is not installed"
-## Solution: Install Microsoft Excel (any version 2016+)
+# Error: "Microsoft Excel is not installed"
+# Solution: Install Microsoft Excel (any version 2016+)
 ```
 
 ### VBA Access Denied
@@ -197,8 +197,8 @@ excelcli session close --session 1 --save
 ### Permission Issues
 
 ```powershell
-## Run PowerShell/CMD as Administrator if you encounter permission errors
-## excelcli.exe is a standalone exe - no installation needed
+# Run PowerShell/CMD as Administrator if you encounter permission errors
+# excelcli.exe is a standalone exe - no installation needed
 ```
 
 ---

--- a/docs/INSTALLATION-MCP-SERVER.md
+++ b/docs/INSTALLATION-MCP-SERVER.md
@@ -387,6 +387,7 @@ dotnet tool uninstall --global Sbroenne.ExcelMcp.McpServer
 
 ## Getting Help
 
+- **Troubleshooting:** [Troubleshooting & FAQ](https://excelmcpserver.dev/troubleshooting/)
 - **Documentation:** [GitHub Repository](https://github.com/sbroenne/mcp-server-excel)
 - **Issues:** [GitHub Issues](https://github.com/sbroenne/mcp-server-excel/issues)
 - **Contributing:** [Contributing Guide](https://excelmcpserver.dev/contributing/)

--- a/gh-pages/docs/troubleshooting.md
+++ b/gh-pages/docs/troubleshooting.md
@@ -1,0 +1,126 @@
+---
+title: Troubleshooting & FAQ
+description: >-
+  Fixes for the most common Excel MCP Server issues — Excel must be closed,
+  VBA trust, DAX/MSOLAP setup, PATH problems, and protected workbooks.
+keywords: "Excel MCP troubleshooting, VBA trust, MSOLAP DAX, workbook locked, mcp-excel not recognized, IRM AIP Excel"
+---
+
+# Troubleshooting & FAQ
+
+Hitting a snag? Most first-time issues fall into one of the cases below. If none
+of these help, open a [GitHub issue](https://github.com/sbroenne/mcp-server-excel/issues).
+
+## Frequently asked questions
+
+??? question "Do I need to know how Excel automation works to use this?"
+    No. You talk to your AI assistant in plain language ("build a PivotTable of
+    sales by product and chart it") and it drives Excel for you. The
+    [feature reference](features.md) is there when you want to see everything
+    that's possible — you don't need to memorize it.
+
+??? question "Does it require Microsoft Excel to be installed?"
+    Yes. Excel MCP Server drives the **real Excel application** through its COM
+    API, so it's **Windows-only** and needs **Excel 2016 or later** installed
+    locally. It is not a file-format parser and does not run on macOS or Linux.
+
+??? question "Will it damage my existing workbooks?"
+    No. Excel itself opens and saves the file, so formulas, PivotTables, charts,
+    macros, the Data Model, and formatting are all preserved. Other tools that
+    rewrite the `.xlsx` file directly can silently drop those; here Excel does
+    the work.
+
+??? question "CLI or MCP Server — which should I install?"
+    Both expose the **same 232 operations**. Use the **MCP Server** for
+    conversational AI (Claude Desktop, VS Code Chat); use the **CLI**
+    (`excelcli`) for coding agents and scripting, where it uses ~64% fewer
+    tokens. You can install both. See [Installation](installation.md).
+
+??? question "Does it cost anything or send my data anywhere?"
+    Excel MCP Server is free and open source (MIT). It runs locally against your
+    own Excel. A few opt-in features reach the internet (remote M/DAX
+    formatting, and Python in Excel, which runs in Microsoft's cloud). See
+    [Privacy](privacy.md) for details.
+
+## Common issues
+
+### "Workbook is locked" or "Cannot open file"
+
+Close **all** open Excel windows before running Excel MCP Server. It needs
+exclusive access to the workbook (an Excel COM limitation), so a file that's
+already open in Excel can't be opened for automation.
+
+### `mcp-excel` / `excelcli` is not recognized
+
+The executable isn't on your `PATH`.
+
+```powershell
+# Confirm where it is (if anywhere)
+where.exe mcp-excel
+where.exe excelcli
+```
+
+Either add the folder containing the `.exe` to your `PATH` (see the
+[MCP Server](installation-mcp-server.md) or [CLI](installation-cli.md)
+installation guide), or use the full path in your MCP client config, e.g.
+`"command": "C:\\Tools\\ExcelMcp\\mcp-excel.exe"`.
+
+### VBA commands fail: "Programmatic access to Visual Basic Project is not trusted"
+
+VBA operations need one manual Excel setting turned on:
+
+1. Open Excel → **File → Options → Trust Center**
+2. Click **Trust Center Settings**
+3. Select **Macro Settings**
+4. Check **"Trust access to the VBA project object model"**
+5. Click **OK** twice
+
+This is a Windows security setting — Excel MCP Server never changes it for you.
+Also remember VBA lives in **`.xlsm`** workbooks, not `.xlsx`.
+
+### DAX queries fail (`evaluate`, `execute-dmv`)
+
+DAX query execution needs the **Microsoft Analysis Services OLE DB Provider
+(MSOLAP)**, which isn't always installed with Office.
+
+- **Easiest:** install [Power BI Desktop](https://powerbi.microsoft.com/desktop) (it includes MSOLAP).
+- **Alternative:** install the [OLE DB Driver for Analysis Services](https://learn.microsoft.com/analysis-services/client-libraries).
+
+### Protected (IRM / AIP) workbooks won't open
+
+Rights-managed files need Excel visible so the sign-in or policy prompt can
+appear. Keep Excel on screen while opening:
+
+```powershell
+excelcli session open "D:\Docs\Protected.xlsx" --show --timeout 120
+```
+
+With the MCP Server, ask your assistant to *"show me Excel while you work"* so
+the authentication prompt is interactable. These files are opened read-only.
+
+### Changes aren't taking effect / old version still running
+
+Fully restart your MCP client (close VS Code or Claude Desktop completely,
+including any background windows, then reopen). MCP servers are launched by the
+client, so a stale process can linger until you restart it.
+
+```powershell
+# Confirm which version you're on
+mcp-excel --version
+excelcli --version
+```
+
+### `npx` commands fail
+
+Auto-configuration (`add-mcp`) and skill installation use `npx`, which needs
+**Node.js**:
+
+```powershell
+winget install OpenJS.NodeJS.LTS
+```
+
+## Still stuck?
+
+- **Installation details:** [MCP Server](installation-mcp-server.md) · [CLI](installation-cli.md)
+- **How it works:** [Architecture](architecture.md)
+- **Report a bug or ask a question:** [GitHub Issues](https://github.com/sbroenne/mcp-server-excel/issues)

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
   - CLI: cli.md
   - More:
     - Agent Skills: skills.md
+    - Troubleshooting & FAQ: troubleshooting.md
     - Architecture: architecture.md
     - Changelog: changelog.md
     - Contributing: contributing.md

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,14 @@
 # Excel MCP Server - Agent Skills
 
-Two skill packages for different integration models:
+**Skills teach your AI assistant how to use Excel MCP Server well.** A skill is a
+small package of guidance and examples that your coding agent (GitHub Copilot,
+Cursor, Windsurf, Claude Code, and others) loads automatically — so it knows the
+right workflow, the correct parameters, and the common gotchas without you
+having to spell them out each time. Installing a skill makes the assistant
+noticeably more reliable at driving Excel.
+
+There are two packages — pick the one that matches how you connect to Excel (or
+install both):
 
 | Skill | Component | Distribution | Best For |
 |-------|-----------|--------------|----------|

--- a/skills/README.md
+++ b/skills/README.md
@@ -32,23 +32,3 @@ npx skills add sbroenne/mcp-server-excel --skill excel-mcp
 
 **Via VS Code Extension (auto-installs excel-mcp):**
 Install the [Excel MCP VS Code Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp) — it registers the `excel-mcp` skill via `chatSkills`. For the `excel-cli` skill, use the plugin or `npx skills` methods above.
-
-## Building
-
-```powershell
-dotnet build -c Release
-```
-
-Generates `SKILL.md` and copies `shared/` references into each skill's `references/` folder.
-
-## Structure
-
-```
-skills/
-├── shared/          # Shared behavioral guidance (source of truth)
-├── excel-mcp/       # MCP Server skill (SKILL.md + references/)
-├── excel-cli/       # CLI skill (SKILL.md + references/)
-├── templates/       # Scriban templates for SKILL.md generation
-├── CLAUDE.md        # Claude Code project instructions
-└── .cursorrules     # Cursor-specific rules
-```

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides 18 command categories with 232 operations matching the MCP Server. Uses **64% fewer tokens** than MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 26 tool schemas into context.
+The CLI provides the **same 232 operations** as the MCP Server, grouped into 18 command categories (the MCP Server exposes those same operations as 26 tools — same capabilities, packaged differently for each entry point). It uses **64% fewer tokens** than the MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 26 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -65,10 +65,6 @@ Drives the **actual Excel application** via COM — not a file-format parser —
 
 ---
 
-## 🤝 Related Tools & Support
-
----
-
 ## 📖 Complete Documentation
 
 - **[GitHub Releases](https://github.com/sbroenne/mcp-server-excel/releases/latest)** - Download latest standalone exe (primary)
@@ -101,7 +97,8 @@ where.exe excelcli
 
 ```powershell
 # Error: "Programmatic access to Visual Basic Project is not trusted"
-# Solution: Enable VBA trust (see VBA Operations Setup above)
+# Solution: In Excel, enable File → Options → Trust Center → Trust Center Settings
+#           → Macro Settings → "Trust access to the VBA project object model"
 ```
 
 ### Permission Issues
@@ -173,11 +170,7 @@ These tests open actual workbooks, issue `session open/list/close`, and call `ex
 
 ## 🤝 Related Tools
 
-- **[ExcelMcp MCP Server](https://github.com/sbroenne/mcp-server-excel/releases/latest)** - MCP server for AI assistant integration (`mcp-excel.exe`)
-- **[Excel MCP VS Code Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)** - One-click Excel automation in VS Code
->>>>>>> 08d2ec617123490fa4dad1d99da58d5a508e2a95
-
-- **[MCP Server](https://excelmcpserver.dev/mcp-server/)** - For conversational AI (Claude Desktop, VS Code Chat)
+- **[MCP Server](https://excelmcpserver.dev/mcp-server/)** - For conversational AI (Claude Desktop, VS Code Chat) — distributed as `mcp-excel.exe`
 - **[VS Code Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)** - One-click Excel automation in VS Code
 - **Issues & Discussions**: [GitHub](https://github.com/sbroenne/mcp-server-excel)
 - **Full docs**: [excelmcpserver.dev](https://excelmcpserver.dev/)

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides the **same 232 operations** as the MCP Server, grouped into 18 command categories (the MCP Server exposes those same operations as 26 tools — same capabilities, packaged differently for each entry point). It uses **64% fewer tokens** than the MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 26 tool schemas into context.
+The CLI provides 18 command categories with 232 operations matching the MCP Server — the same capabilities, just packaged as 18 CLI command categories instead of the MCP Server's 26 tools. It uses **64% fewer tokens** than the MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 26 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|


### PR DESCRIPTION
## Summary

Newcomer-focused follow-up to the docs review (#718). Makes the site friendlier for people new to Excel MCP Server.

## Changes

- **`FEATURES.md`** — added a "New here?" intro that reassures readers they don't need to learn the 232 operations (the AI picks tools for them) and lists the most-used tools.
- **New Troubleshooting & FAQ page** (`gh-pages/docs/troubleshooting.md`) — consolidates the common first-timer issues that were scattered across the install guides: Excel must be closed, VBA trust, DAX/MSOLAP, PATH, IRM/AIP, npx. Added to the nav and linked from both install guides.
- **`skills/README.md`** — added a plain-language "what is a skill and why you want one" intro before the comparison table.
- **`src/ExcelMcp.CLI/README.md`** — clarified that the CLI's 18 command categories are the same 232 operations the MCP Server exposes as 26 tools.

## Verification

- `mkdocs build --strict` passes; new page renders and is in the nav.
- FEATURES.md operation counts unchanged (232) so `check-doc-counts.ps1` stays green.

Docs-only → `skip-changelog`.