### PR TITLE
Fix Python in Excel result flakiness with deterministic completion detection

### DIFF
--- a/.changeset/python-in-excel-reliable-result.md
+++ b/.changeset/python-in-excel-reliable-result.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**More reliable Python in Excel results.** `pythoninexcel get-result` now detects when the Microsoft-hosted Python backend has finished computing by reading Excel's calculation state and the cell's `#BUSY!` placeholder directly, instead of guessing based on whether the value looked "stable" across repeated reads. The old heuristic could lock onto a stale placeholder and return the wrong value, which is why it needed retry loops to be dependable. A single `get-result` call now converges deterministically, and the default wait was raised from 15s to 30s to comfortably cover cold-start round-trips.

--- a/src/ExcelMcp.Core/Commands/PythonInExcel/IPythonInExcelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PythonInExcel/IPythonInExcelCommands.cs
@@ -12,13 +12,12 @@ namespace Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
 /// SET-FORMULA writes '=PY("&lt;code&gt;", returnType)' via Range.Formula2. returnType 0 = "Excel Value"
 /// (a plain value/array), 1 = "Python Object" (a rich data type card, e.g. a DataFrame). The returnType
 /// argument must always be passed explicitly — omitting it causes a #NAME? error.
-/// GET-RESULT reads the computed value back, polling for a short time because cloud execution is not
-/// instantaneous (a fresh formula may transiently read as busy/connecting before the result is ready).
-/// IMPORTANT: polling is best-effort - Excel exposes no reliable "still computing" signal via COM, so a
-/// freshly written formula can briefly read back as a stale default (e.g. 0) that looks like a valid,
-/// stable value even though the real cloud result has not arrived yet. If a result looks suspicious
-/// (e.g. an unexpected 0/default), call get-result again after a few seconds rather than trusting the
-/// first read.
+/// GET-RESULT reads the computed value back, polling until the cloud round-trip finishes (a fresh
+/// formula reads as #BUSY! while the cloud Python sandbox is still computing). Completion is detected
+/// deterministically from Excel's calculation state plus a per-cell #BUSY! guard, so a converged
+/// result is not confused with the in-flight #BUSY! placeholder. If the cloud backend is still busy
+/// at the deadline (e.g. a cold start), GET-RESULT reports that and asks the caller to retry or raise
+/// maxWaitSeconds rather than returning a placeholder.
 /// DATA BINDING: reference live worksheet data inside the Python code with xl("A1:A6"),
 /// xl("Sheet1!A1:A6"), or a named range xl("MyRange") — all work when the formula is authored via this
 /// tool, the same as if typed interactively. TIP: xl() returns a pandas DataFrame/Series (not a plain
@@ -27,7 +26,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
 /// </summary>
 [ServiceCategory("pythoninexcel", "PythonInExcel")]
 [McpTool("pythoninexcel", Title = "Python in Excel Operations", Destructive = true, Category = "data",
-    Description = "Write and read Microsoft 365 \"Python in Excel\" =PY() formulas. Requires a licensed M365 account with Python in Excel enabled and internet access - Python code executes in Microsoft's cloud sandbox, not locally. SET-FORMULA writes '=PY(code, returnType)' via Range.Formula2 (returnType: 0=Excel Value, 1=Python Object; always pass it explicitly). GET-RESULT reads back the result, polling briefly since cloud execution is not instantaneous; this is best-effort since Excel exposes no reliable \"still computing\" signal via COM, so a freshly written formula may briefly read back as a stale default (e.g. 0) - call get-result again after a few seconds if the value looks suspicious. Reference live worksheet data inside the Python code using xl(\"A1:A6\"), xl(\"Sheet1!A1:A6\"), or a named range xl(\"MyRange\") - this works reliably. TIP: xl() returns a DataFrame/Series, not a plain list, so prefer .sum()/.mean()/.max() methods over Python's builtin sum()/len().")]
+    Description = "Write and read Microsoft 365 \"Python in Excel\" =PY() formulas. Requires a licensed M365 account with Python in Excel enabled and internet access - Python code executes in Microsoft's cloud sandbox, not locally. SET-FORMULA writes '=PY(code, returnType)' via Range.Formula2 (returnType: 0=Excel Value, 1=Python Object; always pass it explicitly). GET-RESULT reads back the result, polling until the cloud round-trip completes (a fresh formula reads as #BUSY! while still computing); completion is detected deterministically from Excel's calculation state, so a real result is not confused with the #BUSY! placeholder. If the backend is still busy at the deadline (e.g. a cold start), GET-RESULT says so - call it again or raise maxWaitSeconds. Reference live worksheet data inside the Python code using xl(\"A1:A6\"), xl(\"Sheet1!A1:A6\"), or a named range xl(\"MyRange\") - this works reliably. TIP: xl() returns a DataFrame/Series, not a plain list, so prefer .sum()/.mean()/.max() methods over Python's builtin sum()/len().")]
 public interface IPythonInExcelCommands
 {
     /// <summary>
@@ -49,19 +48,21 @@ public interface IPythonInExcelCommands
         int returnType = 0);
 
     /// <summary>
-    /// Reads back the computed result of a =PY() cell, polling briefly since the Python code
-    /// executes asynchronously in Microsoft's cloud sandbox and may not be ready immediately
-    /// after the formula is (re)written.
+    /// Reads back the computed result of a =PY() cell, polling until the Python code (which executes
+    /// asynchronously in Microsoft's cloud sandbox) finishes. Completion is detected deterministically
+    /// from Excel's calculation state plus a per-cell #BUSY! guard, so a converged result is never
+    /// confused with the in-flight #BUSY! placeholder. If the cloud backend is still busy at the
+    /// deadline, the result reports failure and asks the caller to retry or raise maxWaitSeconds.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Worksheet name</param>
     /// <param name="rangeAddress">Cell address containing the PY() formula</param>
-    /// <param name="maxWaitSeconds">Maximum seconds to poll for a non-transient result (default: 15)</param>
+    /// <param name="maxWaitSeconds">Maximum seconds to poll for the cloud result before giving up (default: 30). Returns as soon as the result is ready.</param>
     /// <exception cref="InvalidOperationException">If the range cannot be resolved</exception>
     [ServiceAction("get-result")]
     PythonInExcelResult GetResult(
         IExcelBatch batch,
         [RequiredParameter] string sheetName,
         [RequiredParameter] string rangeAddress,
-        int maxWaitSeconds = 15);
+        int maxWaitSeconds = 30);
 }

--- a/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
@@ -62,7 +62,7 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
     }
 
     /// <inheritdoc />
-    public PythonInExcelResult GetResult(IExcelBatch batch, string sheetName, string rangeAddress, int maxWaitSeconds = 15)
+    public PythonInExcelResult GetResult(IExcelBatch batch, string sheetName, string rangeAddress, int maxWaitSeconds = 30)
     {
         var result = new PythonInExcelResult
         {
@@ -94,24 +94,33 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                     return result;
                 }
 
-                // The Python code executes in a Microsoft-hosted cloud sandbox, not locally. There is
-                // no reliable "still computing" signal exposed via COM: Excel's local calculation
-                // engine considers itself done as soon as it dispatches the async call, so the cell
-                // shows a stale/default placeholder (e.g. plain "0", or even a transient error-shaped
-                // Value2) before the real cloud result ever arrives - and that placeholder can remain
-                // "stable" (identical across repeated reads) for a long time, indistinguishable from a
-                // genuinely converged result using only Value2/Text. A minimum settle window plus a
-                // longer stable-sample streak reduce (but cannot fully eliminate) false positives - this
-                // is a best-effort heuristic, not a guarantee. Classification below only trusts the
-                // final read once `stable` is true; if the deadline is reached without ever observing
-                // the required run of matching reads, GetResult reports failure and asks the caller to
-                // retry rather than guessing at an unconverged value.
-                // NOTE: Application.Wait() was tried as a message-pumping alternative to Thread.Sleep()
-                // (in case the cloud callback needs Excel's message queue pumped to be delivered) but it
-                // hung indefinitely in this non-visible automation context, so Thread.Sleep() is used.
-                const int MinSettleSeconds = 10;
-                const int RequiredStableSamples = 4;
-                const int PollIntervalMs = 2000;
+                // Completion detection uses Excel's calculation state plus a per-cell #BUSY! guard -
+                // NOT a value-stability guess.
+                //
+                // Ground truth (verified empirically against current Excel, both visible and headless):
+                // while the Microsoft-hosted cloud Python sandbox is still computing, the cell reads back
+                // as the #BUSY! placeholder (Range.Value2 == -2146826237) and Application.CalculationState
+                // is xlPending/xlCalculating. The moment the real result arrives, Value2 flips to the
+                // computed value (or an error code such as #PYTHON!) and CalculationState returns to
+                // xlDone. So the cell is "done" precisely when CalculationState == xlDone AND it no longer
+                // reads #BUSY!. This is deterministic and does not lock onto a stale placeholder the way
+                // the previous value-stability heuristic could.
+                //
+                // We deliberately do NOT call CalculateFullRebuild() on every poll: re-dispatching the
+                // async PY call repeatedly can keep the cell perpetually #BUSY! and prevent convergence.
+                // Instead we nudge calculation once (in case the workbook is in manual-calc mode) and then
+                // just observe. Thread.Sleep() is used to wait between reads - Application.Wait() was tried
+                // previously but hung indefinitely in the non-visible automation context.
+
+                // #BUSY! - the cloud Python call is still in flight (not a real error).
+                const int BusyErrorCode = -2146826237;
+                // XlCalculationState.xlDone (calculation complete).
+                const int XlDone = 0;
+                const int PollIntervalMs = 500;
+                // Consecutive non-busy reads that let us trust the result even if the workbook's
+                // application-level CalculationState is held pending by OTHER async cells (e.g. a Power
+                // Query or a second PY cell). This keeps convergence dependent primarily on THIS cell.
+                const int RequiredNonBusyReads = 3;
 
                 // Well-known Excel error code for #PYTHON! (Python code raised an error), used only to
                 // look up the canonical human-readable message via MapErrorCodeToMessage. Detection of
@@ -120,47 +129,53 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                 // a reliable discriminator on its own) - see the returnType-based classification below.
                 const int PythonErrorCode = -2146826233;
 
+                // Nudge calculation once so a manual-calc workbook actually dispatches the async PY call.
+                // Harmless if calculation is automatic or already running.
+                try
+                {
+                    ctx.App.Calculate();
+                }
+                catch (System.Runtime.InteropServices.COMException)
+                {
+                    // Application is busy calculating - the nudge is best-effort, so ignore and poll.
+                }
+
                 object? value = null;
                 string text = string.Empty;
-                object? previousValue = null;
-                int consecutiveMatches = 0;
-                bool stable = false;
+                int nonBusyReads = 0;
+                bool converged = false;
 
-                var startTime = DateTime.UtcNow;
-                var deadline = startTime.AddSeconds(Math.Max(MinSettleSeconds + 1, maxWaitSeconds));
+                var deadline = DateTime.UtcNow.AddSeconds(Math.Max(1, maxWaitSeconds));
                 do
                 {
-                    ctx.App.CalculateFullRebuild();
                     value = range.Value2;
                     text = range.Text?.ToString() ?? string.Empty;
+                    int calcState = (int)ctx.App.CalculationState;
 
-                    bool isTransient = Array.IndexOf(TransientMarkers, text) >= 0;
-                    // Match on Value2 only - range.Text has been observed to render inconsistently
-                    // (e.g. sometimes blank, sometimes a formatted error string) even while Value2
-                    // itself has already converged to a stable value/error code.
-                    bool matchesPrevious = previousValue != null && Equals(previousValue, value);
+                    bool cellBusy = (value is int busyCode && busyCode == BusyErrorCode)
+                        || Array.IndexOf(TransientMarkers, text) >= 0;
 
-                    consecutiveMatches = isTransient ? 0 : matchesPrevious ? consecutiveMatches + 1 : 1;
+                    nonBusyReads = cellBusy ? 0 : nonBusyReads + 1;
 
-                    bool minTimeElapsed = (DateTime.UtcNow - startTime).TotalSeconds >= MinSettleSeconds;
-                    if (!isTransient && consecutiveMatches >= RequiredStableSamples && minTimeElapsed)
+                    // Done when this cell is no longer #BUSY! and either the application has finished
+                    // calculating or the cell has read a settled (non-busy) value across several
+                    // consecutive polls (guards against unrelated pending async cells).
+                    if (!cellBusy && (calcState == XlDone || nonBusyReads >= RequiredNonBusyReads))
                     {
-                        stable = true;
+                        converged = true;
                         break;
                     }
 
-                    previousValue = value;
                     Thread.Sleep(PollIntervalMs);
                 }
                 while (DateTime.UtcNow < deadline);
 
-                if (!stable)
+                if (!converged)
                 {
-                    // Never observed the required run of matching reads - the last read cannot be
-                    // trusted as the converged Python result (it may be a stale/default placeholder,
-                    // or an in-flight transient error code). Report failure rather than guessing.
+                    // Still #BUSY! at the deadline - the cloud backend has not returned yet (often a
+                    // cold-start delay). Report rather than guessing at an unconverged placeholder.
                     result.Success = false;
-                    result.ErrorMessage = $"Python in Excel result did not stabilize within {maxWaitSeconds}s and may not reflect the completed cloud computation. Try get-result again, or increase maxWaitSeconds.";
+                    result.ErrorMessage = $"Python in Excel result did not finish within {maxWaitSeconds}s (the cell still reads as #BUSY!). The Microsoft-hosted Python backend may be under cold-start load - call get-result again, or increase maxWaitSeconds.";
                     return result;
                 }
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PythonInExcel/PythonInExcelCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PythonInExcel/PythonInExcelCommandsTests.cs
@@ -57,10 +57,11 @@ public class PythonInExcelCommandsTests : IClassFixture<PythonInExcelTestsFixtur
 
     /// <summary>
     /// Calls GetResult repeatedly until <paramref name="isAcceptable"/> is satisfied or the retry
-    /// budget is exhausted. Core's completion-detection heuristic is intentionally best-effort (see
-    /// PythonInExcelCommands.GetResult remarks) - there is no COM-level signal that can definitively
-    /// distinguish a converged cloud result from a stale placeholder, so a single read can flakily
-    /// under-wait. Retrying here mirrors the documented "call get-result again" guidance for callers.
+    /// budget is exhausted. Completion detection is now deterministic (CalculationState + a per-cell
+    /// #BUSY! guard - see PythonInExcelCommands.GetResult), so a single call normally converges; this
+    /// wrapper only adds defensive headroom for extreme cold-start delays that exceed the deadline.
+    /// The dedicated <see cref="SetFormula_ThenSingleGetResult_ConvergesWithoutRetry"/> test asserts
+    /// the no-retry path directly.
     /// </summary>
     private PythonInExcelResult GetResultWithRetry(
         IExcelBatch batch,
@@ -97,6 +98,37 @@ public class PythonInExcelCommandsTests : IClassFixture<PythonInExcelTestsFixtur
         var setResult = _rangeCommands.SetValues(batch, "Sheet1", sourceRange, values);
         Assert.True(setResult.Success, setResult.ErrorMessage);
         return sourceRange;
+    }
+
+    /// <summary>
+    /// Regression test for the completion-detection flakiness fix: a single GetResult call (no retry
+    /// loop) must reliably return the converged cloud value rather than a stale/#BUSY! placeholder.
+    /// Before the fix, GetResult used a value-stability heuristic that could return before the cloud
+    /// result arrived; it now waits deterministically on Application.CalculationState + a per-cell
+    /// #BUSY! guard, so one call is enough.
+    /// </summary>
+    [Fact]
+    public void SetFormula_ThenSingleGetResult_ConvergesWithoutRetry()
+    {
+        // Arrange
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string sourceRange = WriteSourceData(batch, startRow); // 5,15,25,35,45 => sum 125
+        string targetCell = $"D{startRow}";
+        string code = $"xl('{sourceRange}').sum()";
+
+        var setResult = _pythonCommands.SetFormula(batch, "Sheet1", targetCell, code, returnType: 0);
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+
+        // Act - a SINGLE GetResult call, deliberately NOT wrapped in GetResultWithRetry.
+        var getResult = _pythonCommands.GetResult(batch, "Sheet1", targetCell, DefaultMaxWaitSeconds);
+
+        // Assert - must be the real converged result, never a #BUSY! placeholder or premature read.
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.False(getResult.IsPythonError);
+        Assert.False(getResult.IsPythonObject);
+        Assert.NotNull(getResult.Value);
+        Assert.Equal(125d, Convert.ToDouble(getResult.Value, System.Globalization.CultureInfo.InvariantCulture));
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Problem

`pythoninexcel get-result` used a value-stability heuristic (4 identical `Value2` reads over ≥10s) to guess when the Microsoft-hosted cloud Python computation had finished. The code's own comments admitted it was "a best-effort heuristic, not a guarantee" — it could lock onto a stale `#BUSY!` placeholder and return the wrong value, which is why the tests wrapped it in a 3× retry loop.

## Root cause (diagnosed empirically)

Probing live Excel via COM (both visible and headless/daemon modes) showed a deterministic signal the old code wrongly assumed didn't exist:

- **While computing:** the cell reads `#BUSY!` (`Range.Value2 == -2146826237`) and `Application.CalculationState == xlPending`.
- **When done:** `Value2` flips to the real value (or an error code like `#PYTHON!`) and `CalculationState == xlDone`.

The old loop also called `CalculateFullRebuild()` on **every poll**, which can re-dispatch the async PY call and keep the cell perpetually `#BUSY!`.

## Fix

- Detect completion deterministically: done when `CalculationState == xlDone` **and** the cell no longer reads `#BUSY!` (with a small consecutive-non-busy fallback to guard against unrelated pending async cells).
- Remove the per-poll `CalculateFullRebuild()`; nudge calculation **once** (for manual-calc workbooks) then observe.
- Raise default `maxWaitSeconds` 15 → 30 to comfortably cover cold-start round-trips.
- Honest failure message when the cell is genuinely still `#BUSY!` at the deadline.

## Tests

- Added `SetFormula_ThenSingleGetResult_ConvergesWithoutRetry` — a **single** `get-result` call (no retry) that converges reliably (passes in ~10s cold start).
- Full `Feature=PythonInExcel` suite: **7/7 passing** (1m3s), including the preserved `#PYTHON!` error and Python-Object classification paths.

## Notes

CLI help and MCP tool schema/description regenerate from the interface, so the new default and updated docs propagate automatically. Changeset included (user-facing fix).