### PR TITLE
fix(mcp-server): drop noisy HttpClient telemetry metrics

### DIFF
--- a/.changeset/reduce-mcp-telemetry-noise.md
+++ b/.changeset/reduce-mcp-telemetry-noise.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Reduced MCP Server telemetry noise and cost.** The MCP Server no longer reports the .NET runtime's built-in HTTP-client connection-pool metrics (`http.client.open_connections`, `http.client.active_requests`, `http.client.connection.duration`, `http.client.request.time_in_queue`, `http.client.request.duration`) to Application Insights. These were emitted automatically by the telemetry SDK regardless of actual traffic and accounted for the large majority of telemetry ingestion volume, without providing any useful signal for this tool.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,9 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="3.1.2" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <!-- Test-only: verifies dropped-metric View configuration in ExcelMcp.McpServer.Tests -->
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.16.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
+using OpenTelemetry.Metrics;
 using Sbroenne.ExcelMcp.McpServer.Telemetry;
 
 namespace Sbroenne.ExcelMcp.McpServer;
@@ -349,8 +350,43 @@ public class Program
 
         builder.Services.AddApplicationInsightsTelemetryWorkerService(aiOptions);
 
+        // AddApplicationInsightsTelemetryWorkerService() unconditionally subscribes to the .NET 8+
+        // built-in "System.Net.Http" meter (via UseApplicationInsightsTelemetry -> AddHttpClientMetrics),
+        // with no opt-out exposed on ApplicationInsightsServiceOptions. ExcelMcp.McpServer makes at most
+        // one lightweight HttpClient call per process (NuGetVersionChecker), so these connection-pool
+        // gauges/histograms are pure noise - they were driving ~96% of billed AppMetrics ingestion.
+        // ConfigureOpenTelemetryMeterProvider appends to the same MeterProviderBuilder already
+        // registered above, so this reliably drops the instruments regardless of registration order.
+        builder.Services.ConfigureOpenTelemetryMeterProvider(ConfigureDroppedHttpClientMetrics);
+
         // Application Insights 3.x no longer exposes the classic telemetry initializer abstraction.
         // ExcelMcpTelemetry enriches each telemetry item with user/session/version context before sending.
+    }
+
+    /// <summary>
+    /// Names of the noisy .NET built-in HttpClient meter instruments that ExcelMcp.McpServer never
+    /// consumes. See <see cref="ConfigureTelemetry"/> for why these must be dropped explicitly.
+    /// </summary>
+    internal static readonly string[] DroppedHttpClientMetricNames =
+    [
+        "http.client.open_connections",
+        "http.client.active_requests",
+        "http.client.connection.duration",
+        "http.client.request.time_in_queue",
+        "http.client.request.duration",
+    ];
+
+    /// <summary>
+    /// Adds metric Views that drop the noisy HttpClient instruments before export/aggregation.
+    /// Exposed internally (rather than inlined) so it can be exercised directly in unit tests
+    /// without needing a full Application Insights host pipeline.
+    /// </summary>
+    internal static void ConfigureDroppedHttpClientMetrics(MeterProviderBuilder metrics)
+    {
+        foreach (var name in DroppedHttpClientMetricNames)
+        {
+            metrics.AddView(name, MetricStreamConfiguration.Drop);
+        }
     }
 
     /// <summary>

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -367,7 +367,7 @@ public class Program
     /// Names of the noisy .NET built-in HttpClient meter instruments that ExcelMcp.McpServer never
     /// consumes. See <see cref="ConfigureTelemetry"/> for why these must be dropped explicitly.
     /// </summary>
-    internal static readonly string[] DroppedHttpClientMetricNames =
+    private static readonly string[] DroppedHttpClientMetricNames =
     [
         "http.client.open_connections",
         "http.client.active_requests",

--- a/tests/ExcelMcp.McpServer.Tests/ExcelMcp.McpServer.Tests.csproj
+++ b/tests/ExcelMcp.McpServer.Tests/ExcelMcp.McpServer.Tests.csproj
@@ -23,6 +23,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!-- Test-only: verifies OpenTelemetry metric View drop configuration for noisy HttpClient meters -->
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ProgramTelemetryMetricsTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ProgramTelemetryMetricsTests.cs
@@ -52,7 +52,8 @@ public sealed class ProgramTelemetryMetricsTests
         timeInQueue.Record(7.8);
         keptMetric.Add(1);
 
-        provider.ForceFlush();
+        var flushed = provider.ForceFlush();
+        Assert.True(flushed, "ForceFlush should succeed; a false result would make the metric assertions below misleading.");
 
         var exportedNames = exportedMetrics.Select(m => m.Name).ToList();
 

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ProgramTelemetryMetricsTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ProgramTelemetryMetricsTests.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics.Metrics;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
+
+/// <summary>
+/// Verifies that the noisy .NET built-in "System.Net.Http" meter instruments
+/// (http.client.open_connections, http.client.active_requests, etc.) are dropped
+/// from the OpenTelemetry metrics pipeline before export.
+///
+/// Background: Microsoft.ApplicationInsights.WorkerService 3.x unconditionally calls
+/// meterProviderBuilder.AddMeter("System.Net.Http") with no opt-out via
+/// ApplicationInsightsServiceOptions. Since ExcelMcp.McpServer makes at most one
+/// lightweight HttpClient call per process (NuGetVersionChecker), these connection-pool
+/// gauges/histograms were driving ~96% of billed Application Insights ingestion.
+/// </summary>
+[Trait("Layer", "McpServer")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "Telemetry")]
+[Trait("Speed", "Fast")]
+public sealed class ProgramTelemetryMetricsTests
+{
+    [Fact]
+    public void ConfigureDroppedHttpClientMetrics_DropsAllNoisyHttpClientInstruments()
+    {
+        using var meter = new Meter(nameof(ConfigureDroppedHttpClientMetrics_DropsAllNoisyHttpClientInstruments));
+
+        var openConnections = meter.CreateUpDownCounter<long>("http.client.open_connections");
+        var activeRequests = meter.CreateUpDownCounter<long>("http.client.active_requests");
+        var requestDuration = meter.CreateHistogram<double>("http.client.request.duration");
+        var connectionDuration = meter.CreateHistogram<double>("http.client.connection.duration");
+        var timeInQueue = meter.CreateHistogram<double>("http.client.request.time_in_queue");
+        var keptMetric = meter.CreateCounter<long>("tool.invocations");
+
+        var exportedMetrics = new List<Metric>();
+
+        var builder = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name);
+
+        Program.ConfigureDroppedHttpClientMetrics(builder);
+
+        using var provider = builder
+            .AddInMemoryExporter(exportedMetrics)
+            .Build();
+
+        openConnections.Add(1);
+        activeRequests.Add(1);
+        requestDuration.Record(12.3);
+        connectionDuration.Record(45.6);
+        timeInQueue.Record(7.8);
+        keptMetric.Add(1);
+
+        provider.ForceFlush();
+
+        var exportedNames = exportedMetrics.Select(m => m.Name).ToList();
+
+        Assert.DoesNotContain("http.client.open_connections", exportedNames);
+        Assert.DoesNotContain("http.client.active_requests", exportedNames);
+        Assert.DoesNotContain("http.client.request.duration", exportedNames);
+        Assert.DoesNotContain("http.client.connection.duration", exportedNames);
+        Assert.DoesNotContain("http.client.request.time_in_queue", exportedNames);
+        Assert.Contains("tool.invocations", exportedNames);
+    }
+}


### PR DESCRIPTION
## Problem

Investigation into elevated Azure telemetry costs found that `AppMetrics` accounted for ~96% of Application Insights ingestion volume in the workspace backing the MCP Server's telemetry. Nearly all of it came from five .NET built-in HttpClient meter instruments:

- `http.client.open_connections`
- `http.client.active_requests`
- `http.client.connection.duration`
- `http.client.request.time_in_queue`
- `http.client.request.duration`

## Root cause

`Microsoft.ApplicationInsights.WorkerService` 3.x unconditionally subscribes to the .NET 8+ built-in `System.Net.Http` meter (`UseApplicationInsightsTelemetry()` -> `AddHttpClientMetrics()` -> `meterProviderBuilder.AddMeter("System.Net.Http")`), with no opt-out exposed via `ApplicationInsightsServiceOptions`. The existing `EnableDependencyTrackingTelemetryModule = false` setting only disables the classic dependency-tracking module, not this OpenTelemetry meter subscription.

ExcelMcp.McpServer makes at most one lightweight `HttpClient` call per process (`NuGetVersionChecker`, checking GitHub releases), so these connection-pool gauges/histograms provide no useful signal and were pure noise.

## Fix

Adds OpenTelemetry metric Views (`MetricStreamConfiguration.Drop`) for the five noisy instruments via `services.ConfigureOpenTelemetryMeterProvider(...)`, which appends configuration to the same `MeterProviderBuilder` already registered by `AddApplicationInsightsTelemetryWorkerService`. No new production package references were needed (OpenTelemetry packages already flow in transitively).

## Testing

- New unit test (`ProgramTelemetryMetricsTests`) builds a real `MeterProviderBuilder` with an in-memory exporter, applies `Program.ConfigureDroppedHttpClientMetrics`, records measurements on all 5 target instruments plus one unrelated "kept" metric, and asserts only the kept metric is exported. Written first (RED via missing method), then implemented (GREEN).
- Full local pre-commit hook suite passed (COM leak check, coverage/naming audit, Release build, doc counts, CLI workflow smoke test, MCP Server smoke test, CLI/MCP Server release deliverables, VS Code extension packaging, MCPB bundle, agent skills package, plugin README validation, dynamic-cast audit).

## Changeset

Added `.changeset/reduce-mcp-telemetry-noise.md` (patch).
