### PR TITLE
ci: use STAR_HISTORY_TOKEN secret for star history chart

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -47,7 +47,10 @@ jobs:
       - name: Generate star history chart
         shell: pwsh
         env:
-          STAR_HISTORY_TOKEN: ${{ github.token }}
+          # The default GITHUB_TOKEN can no longer read the timestamp-enriched
+          # stargazers endpoint (403 as of 2026). Configure a fine-grained PAT with
+          # `metadata: read` as the STAR_HISTORY_TOKEN secret to refresh the chart.
+          STAR_HISTORY_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN || github.token }}
         run: >
           ./scripts/Update-StarHistory.ps1
           -Repository '${{ github.repository }}'


### PR DESCRIPTION
## Problem

The scheduled **Deploy GitHub Pages** workflow was failing at the *Generate star history chart* step with a `403`:

> You do not have permission to view the stargazers of this repository

GitHub no longer lets the built-in Actions `GITHUB_TOKEN` read the timestamp-enriched stargazers endpoint (`Accept: application/vnd.github.star+json`), which the star-history script relies on. Verified: the default token returns `403`, while a fine-grained PAT with `metadata: read` returns `200` with `starred_at` values.

## Fix

`deploy-gh-pages.yml` now sources the token from an optional `STAR_HISTORY_TOKEN` secret, falling back to `github.token` when unset:

```yaml
STAR_HISTORY_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN || github.token }}
```

The `STAR_HISTORY_TOKEN` secret (fine-grained PAT, `metadata: read` on this repo) has been configured, so scheduled runs will refresh the chart again.

## Scope

- One-line workflow change plus an explanatory comment. No script or committed-SVG changes.
- CI/docs-only — no changeset (labeled `skip-changelog`).
