### PR TITLE
Add list-rules and list-worksheet-rules to conditionalformat (#730)

### DIFF
--- a/.changeset/conditionalformat-list-rules.md
+++ b/.changeset/conditionalformat-list-rules.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": minor
+---
+
+**Read existing conditional formatting rules** (#730): the `conditionalformat` tool now supports `list-rules` (per range) and `list-worksheet-rules` (entire sheet). Both return each rule's type, operator, formulas, applies-to range, priority, and formatting (interior/font/borders) with colors as `#RRGGBB` hex strings, in priority order — enabling round-trip safety, debugging, migration, and audit workflows before modifying or clearing rules.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -191,7 +191,7 @@ Pre-commit runs `scripts/pre-commit.ps1` which blocks commits if any check fails
 | 4 | MCP-Core Implementation | `check-mcp-core-implementations.ps1` | All enum actions have Core method implementations |
 | 5 | Success Flag | `check-success-flag.ps1` | Rule 0: Never `Success=true` with `ErrorMessage` |
 | 6 | Release Solution Build | `dotnet build Sbroenne.ExcelMcp.sln -c Release` | Refreshes Release binaries and generated skill outputs used by packaging |
-| 6b | Documentation Count Validation | `check-doc-counts.ps1` | All user-facing docs report the code-derived tool/operation counts (26 tools / 232 operations) |
+| 6b | Documentation Count Validation | `check-doc-counts.ps1` | All user-facing docs report the code-derived tool/operation counts (26 tools / 234 operations) |
 | 7 | CLI Workflow Test | `Test-CliWorkflow.ps1` | E2E CLI workflow smoke test |
 | 8 | MCP Smoke Test | `dotnet test --filter "...SmokeTest..."` | All MCP tools functional |
 | 9 | CLI Release Deliverables | `dotnet pack` + `dotnet publish` + ZIP | Local CLI NuGet + standalone ZIP match release shapes |

--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -64,7 +64,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## What You Can Do
 
-**18 command categories with 232 operations** for comprehensive Excel automation:
+**18 command categories with 234 operations** for comprehensive Excel automation:
 
 - **Power Query** (12 ops) — Create, update, refresh queries; M code management
 - **Data Model/DAX** (19 ops) — Measures, relationships, EVALUATE queries

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -53,7 +53,7 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ## What You Can Do
 
-**26 specialized tools with 232 operations** for comprehensive Excel automation:
+**26 specialized tools with 234 operations** for comprehensive Excel automation:
 
 ### Core Operations
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # ExcelMcp - Complete Feature Reference
 
-**26 specialized tools with 232 operations for comprehensive Excel automation**
+**26 specialized tools with 234 operations for comprehensive Excel automation**
 
 ---
 
@@ -439,13 +439,15 @@ Add interactive slicers to filter PivotTables and Excel Tables visually.
 
 ---
 
-## 🌈 Conditional Formatting (2 operations)
+## 🌈 Conditional Formatting (4 operations)
 
 Apply rule-based formatting that highlights cells based on their values.
 
 **Operations:**
 - **Add Rule:** Create a conditional formatting rule — cell value comparison (>, <, =, etc.), expression-based formula (custom DAX/Excel formula), or color scale/data bar/icon set
 - **Clear Rules:** Remove formatting from ranges
+- **List Rules:** Read existing conditional formatting rules for a range — returns rule type, operator, formulas, applies-to range, priority, and formatting (interior/font/borders) with colors as #RRGGBB hex
+- **List Worksheet Rules:** Read all conditional formatting rules across an entire worksheet, each with its applies-to range, in priority order
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Automate Excel with AI** — A Model Context Protocol (MCP) server for comprehensive Excel automation through conversational AI.
 
-**MCP Server for Excel** enables AI assistants (GitHub Copilot, Claude, ChatGPT) to automate Excel through natural language commands. Automate Power Query, DAX measures, VBA macros, PivotTables, Charts, formatting, and data transformations (26 tools with 232 operations).
+**MCP Server for Excel** enables AI assistants (GitHub Copilot, Claude, ChatGPT) to automate Excel through natural language commands. Automate Power Query, DAX measures, VBA macros, PivotTables, Charts, formatting, and data transformations (26 tools with 234 operations).
 
 **⚡ Powered by the real Excel engine** — ExcelMcp drives the actual Excel application through its official COM API, so it does what file-parser tools can't: run live operations (refresh Power Query, recalculate, refresh PivotTables and the Data Model, evaluate DAX, run VBA and Python `=PY()`) and edit your existing workbooks with every formula, PivotTable, chart, macro and format left intact.
 
@@ -32,7 +32,7 @@
 
 ## 🎯 What You Can Do
 
-**26 specialized tools with 232 operations:**
+**26 specialized tools with 234 operations:**
 
 - 🔄 **Power Query** (1 tool, 12 ops) - Atomic workflows, M code management, load destinations
 - 📊 **Data Model/DAX** (2 tools, 19 ops) - Measures, relationships, model structure
@@ -51,7 +51,7 @@
 - 📸 **Screenshot** (1 tool, 2 ops) - Capture ranges/sheets as PNG for LLM visual verification
 - 🪧 **Window Management** (1 tool, 9 ops) - Show/hide Excel, arrange, position, status bar feedback
 
-📚 **[Complete Feature Reference →](FEATURES.md)** - Detailed documentation of all 232 operations
+📚 **[Complete Feature Reference →](FEATURES.md)** - Detailed documentation of all 234 operations
 
 
 ## 💬 Example Prompts

--- a/docs/COPILOT-PLUGIN-DISTRIBUTION.md
+++ b/docs/COPILOT-PLUGIN-DISTRIBUTION.md
@@ -6,7 +6,7 @@ This document outlines how the Excel MCP Server and Excel CLI are distributed as
 
 ExcelMcp is published as **two complementary plugins** in the GitHub Copilot plugin marketplace:
 
-- **`excel-mcp`** — MCP Server with 26 tools (232 operations) for conversational AI (Claude Desktop, Copilot chat)
+- **`excel-mcp`** — MCP Server with 26 tools (234 operations) for conversational AI (Claude Desktop, Copilot chat)
 - **`excel-cli`** — CLI-only skill for coding agents (token-efficient, `--help` discoverable)
 
 Both plugins are maintained in a separate published repository and auto-synced from this source repo.
@@ -63,7 +63,7 @@ copilot plugin install excel-cli@mcp-server-excel-plugins
 
 ### Excel MCP Plugin
 
-Provides the full MCP Server with 26 tools (232 operations) for conversational AI:
+Provides the full MCP Server with 26 tools (234 operations) for conversational AI:
 
 ```powershell
 copilot plugin install excel-mcp@mcp-server-excel-plugins

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,6 +1,6 @@
 ---
 title: Complete Feature Reference
-description: 26 specialized tools with 232 operations for comprehensive Excel automation — Power Query, DAX, VBA, charts, PivotTables and more.
+description: 26 specialized tools with 234 operations for comprehensive Excel automation — Power Query, DAX, VBA, charts, PivotTables and more.
 keywords: "Excel MCP features, Power Query automation, DAX measures, VBA macros, Excel tools, MCP operations"
 ---
 

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -129,7 +129,7 @@ hide:
 
 </div>
 
-[See all 26 tools and 232 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 26 tools and 234 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 

--- a/gh-pages/docs/troubleshooting.md
+++ b/gh-pages/docs/troubleshooting.md
@@ -31,7 +31,7 @@ of these help, open a [GitHub issue](https://github.com/sbroenne/mcp-server-exce
     the work.
 
 ??? question "CLI or MCP Server — which should I install?"
-    Both expose the **same 232 operations**. Use the **MCP Server** for
+    Both expose the **same 234 operations**. Use the **MCP Server** for
     conversational AI (Claude Desktop, VS Code Chat); use the **CLI**
     (`excelcli`) for coding agents and scripting, where it uses ~64% fewer
     tokens. You can install both. See [Installation](installation.md).

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -13,7 +13,7 @@ Excel MCP Server lets you automate Excel through conversation with Claude:
 - **Automate** - VBA macros, batch operations, data refresh
 - **Agent Mode** - Say "show me Excel" and watch AI work in real-time, side-by-side with Claude
 
-**26 tools with 232 operations** for comprehensive Excel automation.
+**26 tools with 234 operations** for comprehensive Excel automation.
 
 ## Requirements
 

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 # Excel MCP Server Skill
 
-Provides 232 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
+Provides 234 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
 
 ## Workflow Checklist
 

--- a/skills/excel-mcp/references/conditionalformat.md
+++ b/skills/excel-mcp/references/conditionalformat.md
@@ -36,6 +36,19 @@
 |--------|-------------|
 | `add-rule` | Add conditional formatting rule to range |
 | `clear-rules` | Remove all conditional formatting from range |
+| `list-rules` | Read existing rules for a range (type, operator, formulas, applies-to, priority, formatting) |
+| `list-worksheet-rules` | Read all rules across an entire worksheet, each with its applies-to range |
+
+**Reading rules (`list-rules` / `list-worksheet-rules`)**:
+
+- Rules are returned in priority order.
+- Colors are returned as `#RRGGBB` hex strings, matching the `add-rule` input format.
+- Formatting fields (interiorColor, fontColor, fontBold/Italic, borderStyle/Color) are only
+  present when the rule actually sets them.
+- Rule types that don't use an operator or basic formatting (e.g. colorScale, dataBar, iconSet)
+  return their `type` with null formatting fields.
+- Numeric `cell-value` formulas are returned in Excel's normalized form (e.g. `100` reads back
+  as `=100`).
 
 **Formula Notes**:
 
@@ -95,6 +108,12 @@ excelcli conditionalformat add-rule --session <id> --sheet-name "Data" --range-a
 
 # Clear all rules from range
 excelcli conditionalformat clear-rules --session <id> --sheet-name "Data" --range-address "A1:E100"
+
+# List rules for a range
+excelcli conditionalformat list-rules --session <id> --sheet-name "Data" --range-address "A1:E100"
+
+# List all rules on a worksheet
+excelcli conditionalformat list-worksheet-rules --session <id> --sheet-name "Data"
 ```
 
 **Common Mistakes**:

--- a/skills/shared/conditionalformat.md
+++ b/skills/shared/conditionalformat.md
@@ -36,6 +36,19 @@
 |--------|-------------|
 | `add-rule` | Add conditional formatting rule to range |
 | `clear-rules` | Remove all conditional formatting from range |
+| `list-rules` | Read existing rules for a range (type, operator, formulas, applies-to, priority, formatting) |
+| `list-worksheet-rules` | Read all rules across an entire worksheet, each with its applies-to range |
+
+**Reading rules (`list-rules` / `list-worksheet-rules`)**:
+
+- Rules are returned in priority order.
+- Colors are returned as `#RRGGBB` hex strings, matching the `add-rule` input format.
+- Formatting fields (interiorColor, fontColor, fontBold/Italic, borderStyle/Color) are only
+  present when the rule actually sets them.
+- Rule types that don't use an operator or basic formatting (e.g. colorScale, dataBar, iconSet)
+  return their `type` with null formatting fields.
+- Numeric `cell-value` formulas are returned in Excel's normalized form (e.g. `100` reads back
+  as `=100`).
 
 **Formula Notes**:
 
@@ -95,6 +108,12 @@ excelcli conditionalformat add-rule --session <id> --sheet-name "Data" --range-a
 
 # Clear all rules from range
 excelcli conditionalformat clear-rules --session <id> --sheet-name "Data" --range-address "A1:E100"
+
+# List rules for a range
+excelcli conditionalformat list-rules --session <id> --sheet-name "Data" --range-address "A1:E100"
+
+# List all rules on a worksheet
+excelcli conditionalformat list-worksheet-rules --session <id> --sheet-name "Data"
 ```
 
 **Common Mistakes**:

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides 18 command categories with 232 operations matching the MCP Server — the same capabilities, just packaged as 18 CLI command categories instead of the MCP Server's 26 tools. It uses **64% fewer tokens** than the MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 26 tool schemas into context.
+The CLI provides 18 command categories with 234 operations matching the MCP Server — the same capabilities, just packaged as 18 CLI command categories instead of the MCP Server's 26 tools. It uses **64% fewer tokens** than the MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 26 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|
@@ -48,7 +48,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## 📋 What You Can Do
 
-ExcelMcp.CLI provides **232 operations** across 18 command categories: Power Query, Data Model/DAX, PivotTables, Excel Tables, Charts, VBA, Ranges, Worksheets, Connections, Named Ranges, Conditional Formatting, Slicers, Calculation Mode, Python in Excel, Screenshot, File & Session, and Window Management.
+ExcelMcp.CLI provides **234 operations** across 18 command categories: Power Query, Data Model/DAX, PivotTables, Excel Tables, Charts, VBA, Ranges, Worksheets, Connections, Named Ranges, Conditional Formatting, Slicers, Calculation Mode, Python in Excel, Screenshot, File & Session, and Window Management.
 
 Drives the **actual Excel application** via COM — not a file-format parser — so live operations (Power Query refresh, recalculation, DAX evaluation, VBA execution) run for real and existing workbooks stay intact.
 

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
@@ -313,17 +313,25 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
                 }
                 catch (Exception ex) when (IsComOrBinderException(ex)) { }
 
-                // Borders (read the left edge border as representative)
+                // Borders: scan all four edges and use the first that has a
+                // style (rules typically apply borders uniformly, but external
+                // rules may set only some edges).
                 try
                 {
                     borders = fc.Borders;
-                    edgeBorder = borders.Item(7); // xlEdgeLeft
-                    int lineStyle = Convert.ToInt32(edgeBorder.LineStyle, System.Globalization.CultureInfo.InvariantCulture);
-                    if (lineStyle != -4142) // xlLineStyleNone
+                    foreach (int edgeIndex in new[] { 7, 8, 9, 10 }) // left, top, bottom, right
                     {
-                        rule.BorderStyle = BorderStyleToString(lineStyle) ?? lineStyle.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                        try { rule.BorderColor = FormattingHelpers.ColorToHex(Convert.ToInt32(edgeBorder.Color, System.Globalization.CultureInfo.InvariantCulture)); }
-                        catch (Exception ex) when (IsComOrBinderException(ex)) { }
+                        edgeBorder = borders.Item(edgeIndex);
+                        int lineStyle = Convert.ToInt32(edgeBorder.LineStyle, System.Globalization.CultureInfo.InvariantCulture);
+                        if (lineStyle != -4142) // xlLineStyleNone
+                        {
+                            rule.BorderStyle = BorderStyleToString(lineStyle) ?? lineStyle.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                            try { rule.BorderColor = FormattingHelpers.ColorToHex(Convert.ToInt32(edgeBorder.Color, System.Globalization.CultureInfo.InvariantCulture)); }
+                            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+                            ComUtilities.Release(ref edgeBorder!);
+                            break;
+                        }
+                        ComUtilities.Release(ref edgeBorder!);
                     }
                 }
                 catch (Exception ex) when (IsComOrBinderException(ex)) { }

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
@@ -157,7 +157,262 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
         });
     }
 
+    /// <inheritdoc />
+    public ConditionalFormatListResult ListRules(
+        IExcelBatch batch,
+        string sheetName,
+        string rangeAddress)
+    {
+        var result = new ConditionalFormatListResult
+        {
+            FilePath = batch.WorkbookPath,
+            SheetName = sheetName,
+            RangeAddress = rangeAddress
+        };
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            dynamic? range = null;
+            dynamic? formatConditions = null;
+
+            try
+            {
+                sheet = string.IsNullOrEmpty(sheetName)
+                    ? ctx.Book.ActiveSheet
+                    : ctx.Book.Worksheets[sheetName];
+
+                range = sheet.Range[rangeAddress];
+                formatConditions = range.FormatConditions;
+
+                result.SheetName = sheet.Name;
+                result.Rules = ReadFormatConditions(formatConditions);
+                result.Success = true;
+
+                return result;
+            }
+            finally
+            {
+                ComUtilities.Release(ref formatConditions!);
+                ComUtilities.Release(ref range!);
+                ComUtilities.Release(ref sheet!);
+            }
+        });
+    }
+
+    /// <inheritdoc />
+    public ConditionalFormatListResult ListWorksheetRules(
+        IExcelBatch batch,
+        string sheetName)
+    {
+        var result = new ConditionalFormatListResult
+        {
+            FilePath = batch.WorkbookPath,
+            SheetName = sheetName,
+            RangeAddress = null
+        };
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            dynamic? cells = null;
+            dynamic? formatConditions = null;
+
+            try
+            {
+                sheet = string.IsNullOrEmpty(sheetName)
+                    ? ctx.Book.ActiveSheet
+                    : ctx.Book.Worksheets[sheetName];
+
+                cells = sheet.Cells;
+                formatConditions = cells.FormatConditions;
+
+                result.SheetName = sheet.Name;
+                result.Rules = ReadFormatConditions(formatConditions);
+                result.Success = true;
+
+                return result;
+            }
+            finally
+            {
+                ComUtilities.Release(ref formatConditions!);
+                ComUtilities.Release(ref cells!);
+                ComUtilities.Release(ref sheet!);
+            }
+        });
+    }
+
     // === HELPER METHODS ===
+
+    /// <summary>
+    /// Reads a FormatConditions collection into a list of rule descriptors.
+    /// Each optional COM property read is guarded so unsupported rule types degrade gracefully.
+    /// </summary>
+    private static List<ConditionalFormatRuleInfo> ReadFormatConditions(dynamic formatConditions)
+    {
+        var rules = new List<ConditionalFormatRuleInfo>();
+
+        int count = formatConditions.Count;
+        for (int i = 1; i <= count; i++)
+        {
+            dynamic? fc = null;
+            dynamic? appliesTo = null;
+            dynamic? interior = null;
+            dynamic? font = null;
+            dynamic? borders = null;
+            dynamic? edgeBorder = null;
+
+            try
+            {
+                fc = formatConditions.Item(i);
+
+                var rule = new ConditionalFormatRuleInfo
+                {
+                    Type = ReadRuleType(fc)
+                };
+
+                rule.Operator = ReadRuleOperator(fc);
+                rule.Formula1 = ReadRuleString(fc, "Formula1");
+                rule.Formula2 = ReadRuleString(fc, "Formula2");
+                rule.Priority = ReadRuleInt(fc, "Priority");
+                rule.StopIfTrue = ReadRuleBool(fc, "StopIfTrue");
+
+                try
+                {
+                    appliesTo = fc.AppliesTo;
+                    rule.AppliesTo = appliesTo?.Address;
+                }
+                catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+                // Interior (fill)
+                try
+                {
+                    interior = fc.Interior;
+                    int colorIndex = interior.ColorIndex;
+                    if (colorIndex != -4142) // xlColorIndexNone
+                    {
+                        rule.InteriorColor = FormattingHelpers.ColorToHex((int)interior.Color);
+                        try { rule.InteriorPattern = (int)interior.Pattern; }
+                        catch (Exception ex) when (IsComOrBinderException(ex)) { }
+                    }
+                }
+                catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+                // Font
+                try
+                {
+                    font = fc.Font;
+                    int fontColorIndex = font.ColorIndex;
+                    if (fontColorIndex != -4105 && fontColorIndex != -4142) // not Automatic/None
+                    {
+                        try { rule.FontColor = FormattingHelpers.ColorToHex((int)font.Color); }
+                        catch (Exception ex) when (IsComOrBinderException(ex)) { }
+                    }
+                    rule.FontBold = ReadRuleBool(font, "Bold");
+                    rule.FontItalic = ReadRuleBool(font, "Italic");
+                }
+                catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+                // Borders (read the left edge border as representative)
+                try
+                {
+                    borders = fc.Borders;
+                    edgeBorder = borders.Item(7); // xlEdgeLeft
+                    int lineStyle = edgeBorder.LineStyle;
+                    if (lineStyle != -4142) // xlLineStyleNone
+                    {
+                        rule.BorderStyle = BorderStyleToString(lineStyle) ?? lineStyle.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                        try { rule.BorderColor = FormattingHelpers.ColorToHex((int)edgeBorder.Color); }
+                        catch (Exception ex) when (IsComOrBinderException(ex)) { }
+                    }
+                }
+                catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+                rules.Add(rule);
+            }
+            finally
+            {
+                ComUtilities.Release(ref edgeBorder!);
+                ComUtilities.Release(ref borders!);
+                ComUtilities.Release(ref font!);
+                ComUtilities.Release(ref interior!);
+                ComUtilities.Release(ref appliesTo!);
+                ComUtilities.Release(ref fc!);
+            }
+        }
+
+        return rules;
+    }
+
+    private static string ReadRuleType(dynamic fc)
+    {
+        try { return ConditionalFormattingTypeToString((int)fc.Type); }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return "unknown"; }
+    }
+
+    private static string? ReadRuleOperator(dynamic fc)
+    {
+        try { return ConditionalFormattingOperatorToString((int)fc.Operator); }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
+    }
+
+    private static string? ReadRuleString(dynamic fc, string property)
+    {
+        try
+        {
+            string? value = property switch
+            {
+                "Formula1" => fc.Formula1,
+                "Formula2" => fc.Formula2,
+                _ => null
+            };
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex))
+        {
+            return null;
+        }
+    }
+
+    private static int? ReadRuleInt(dynamic fc, string property)
+    {
+        try
+        {
+            var value = property switch
+            {
+                "Priority" => (object)fc.Priority,
+                _ => null
+            };
+            return value == null ? null : (int?)Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex))
+        {
+            return null;
+        }
+    }
+
+    private static bool? ReadRuleBool(dynamic obj, string property)
+    {
+        try
+        {
+            var value = property switch
+            {
+                "StopIfTrue" => (object?)obj.StopIfTrue,
+                "Bold" => obj.Bold,
+                "Italic" => obj.Italic,
+                _ => null
+            };
+            return value == null ? null : (bool?)Convert.ToBoolean(value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex))
+        {
+            return null;
+        }
+    }
+
+    private static bool IsComOrBinderException(Exception ex) =>
+        ex is Microsoft.CSharp.RuntimeBinder.RuntimeBinderException
+        or System.Runtime.InteropServices.COMException;
 
     private static int ParseConditionalFormattingType(string type)
     {
@@ -233,6 +488,59 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
             "gray75" => 10, // xlPatternGray75
             "gray25" => 11, // xlPatternGray25
             _ => throw new ArgumentException($"Unknown interior pattern: {pattern}. Use pattern constant or: none, solid, gray50, gray75, gray25")
+        };
+    }
+
+    // === REVERSE MAPPINGS (int -> string) for reading existing rules ===
+
+    private static string ConditionalFormattingTypeToString(int type)
+    {
+        return type switch
+        {
+            1 => "cellValue", // xlCellValue
+            2 => "expression", // xlExpression
+            3 => "colorScale", // xlColorScale
+            4 => "dataBar", // xlDatabar
+            5 => "top10", // xlTop10
+            6 => "iconSet", // xlIconSet
+            8 => "uniqueValues", // xlUniqueValues
+            10 => "blanksCondition", // xlBlanksCondition
+            11 => "timePeriod", // xlTimePeriod
+            12 => "aboveAverage", // xlAboveAverageCondition
+            _ => $"unknown({type})"
+        };
+    }
+
+    private static string? ConditionalFormattingOperatorToString(int operatorType)
+    {
+        return operatorType switch
+        {
+            0 => null, // xlNoOperator (rule type does not use an operator)
+            1 => "between", // xlBetween
+            2 => "notBetween", // xlNotBetween
+            3 => "equal", // xlEqual
+            4 => "notEqual", // xlNotEqual
+            5 => "greater", // xlGreater
+            6 => "less", // xlLess
+            7 => "greaterEqual", // xlGreaterEqual
+            8 => "lessEqual", // xlLessEqual
+            _ => null
+        };
+    }
+
+    private static string? BorderStyleToString(int lineStyle)
+    {
+        return lineStyle switch
+        {
+            -4142 => "none", // xlLineStyleNone
+            1 => "continuous", // xlContinuous
+            -4115 => "dash", // xlDash
+            4 => "dashDot", // xlDashDot
+            5 => "dashDotDot", // xlDashDotDot
+            -4118 => "dot", // xlDot
+            -4119 => "double", // xlDouble
+            13 => "slantDashDot", // xlSlantDashDot
+            _ => null
         };
     }
 }

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
@@ -289,7 +289,7 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
                 {
                     interior = fc.Interior;
                     int colorIndex = Convert.ToInt32(interior.ColorIndex, System.Globalization.CultureInfo.InvariantCulture);
-                    if (colorIndex != -4142) // xlColorIndexNone
+                    if (colorIndex != -4142 && colorIndex != -4105) // not None/Automatic
                     {
                         rule.InteriorColor = FormattingHelpers.ColorToHex(Convert.ToInt32(interior.Color, System.Globalization.CultureInfo.InvariantCulture));
                         try { rule.InteriorPattern = Convert.ToInt32(interior.Pattern, System.Globalization.CultureInfo.InvariantCulture); }

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
@@ -346,13 +346,13 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
 
     private static string ReadRuleType(dynamic fc)
     {
-        try { return ConditionalFormattingTypeToString((int)fc.Type); }
+        try { return ConditionalFormattingTypeToString(Convert.ToInt32(fc.Type, System.Globalization.CultureInfo.InvariantCulture)); }
         catch (Exception ex) when (IsComOrBinderException(ex)) { return "unknown"; }
     }
 
     private static string? ReadRuleOperator(dynamic fc)
     {
-        try { return ConditionalFormattingOperatorToString((int)fc.Operator); }
+        try { return ConditionalFormattingOperatorToString(Convert.ToInt32(fc.Operator, System.Globalization.CultureInfo.InvariantCulture)); }
         catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
     }
 

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
@@ -288,11 +288,11 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
                 try
                 {
                     interior = fc.Interior;
-                    int colorIndex = interior.ColorIndex;
+                    int colorIndex = Convert.ToInt32(interior.ColorIndex, System.Globalization.CultureInfo.InvariantCulture);
                     if (colorIndex != -4142) // xlColorIndexNone
                     {
-                        rule.InteriorColor = FormattingHelpers.ColorToHex((int)interior.Color);
-                        try { rule.InteriorPattern = (int)interior.Pattern; }
+                        rule.InteriorColor = FormattingHelpers.ColorToHex(Convert.ToInt32(interior.Color, System.Globalization.CultureInfo.InvariantCulture));
+                        try { rule.InteriorPattern = Convert.ToInt32(interior.Pattern, System.Globalization.CultureInfo.InvariantCulture); }
                         catch (Exception ex) when (IsComOrBinderException(ex)) { }
                     }
                 }
@@ -302,10 +302,10 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
                 try
                 {
                     font = fc.Font;
-                    int fontColorIndex = font.ColorIndex;
+                    int fontColorIndex = Convert.ToInt32(font.ColorIndex, System.Globalization.CultureInfo.InvariantCulture);
                     if (fontColorIndex != -4105 && fontColorIndex != -4142) // not Automatic/None
                     {
-                        try { rule.FontColor = FormattingHelpers.ColorToHex((int)font.Color); }
+                        try { rule.FontColor = FormattingHelpers.ColorToHex(Convert.ToInt32(font.Color, System.Globalization.CultureInfo.InvariantCulture)); }
                         catch (Exception ex) when (IsComOrBinderException(ex)) { }
                     }
                     rule.FontBold = ReadRuleBool(font, "Bold");
@@ -318,11 +318,11 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
                 {
                     borders = fc.Borders;
                     edgeBorder = borders.Item(7); // xlEdgeLeft
-                    int lineStyle = edgeBorder.LineStyle;
+                    int lineStyle = Convert.ToInt32(edgeBorder.LineStyle, System.Globalization.CultureInfo.InvariantCulture);
                     if (lineStyle != -4142) // xlLineStyleNone
                     {
                         rule.BorderStyle = BorderStyleToString(lineStyle) ?? lineStyle.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                        try { rule.BorderColor = FormattingHelpers.ColorToHex((int)edgeBorder.Color); }
+                        try { rule.BorderColor = FormattingHelpers.ColorToHex(Convert.ToInt32(edgeBorder.Color, System.Globalization.CultureInfo.InvariantCulture)); }
                         catch (Exception ex) when (IsComOrBinderException(ex)) { }
                     }
                 }
@@ -412,7 +412,8 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
 
     private static bool IsComOrBinderException(Exception ex) =>
         ex is Microsoft.CSharp.RuntimeBinder.RuntimeBinderException
-        or System.Runtime.InteropServices.COMException;
+        or System.Runtime.InteropServices.COMException
+        or System.InvalidCastException;
 
     private static int ParseConditionalFormattingType(string type)
     {

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
@@ -252,7 +252,7 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
     {
         var rules = new List<ConditionalFormatRuleInfo>();
 
-        int count = formatConditions.Count;
+        int count = Convert.ToInt32(formatConditions.Count, System.Globalization.CultureInfo.InvariantCulture);
         for (int i = 1; i <= count; i++)
         {
             dynamic? fc = null;

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/IConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/IConditionalFormattingCommands.cs
@@ -67,6 +67,38 @@ public interface IConditionalFormattingCommands
         IExcelBatch batch,
         [RequiredParameter, FromString("sheetName")] string sheetName,
         [RequiredParameter, FromString("rangeAddress")] string rangeAddress);
+
+    /// <summary>
+    /// Lists existing conditional formatting rules for a range.
+    /// Excel COM: Range.FormatConditions enumeration.
+    /// Returns rule type, operator, formulas, applies-to range, priority, and formatting
+    /// (interior/font/borders). Colors are returned as #RRGGBB hex strings. Rules are returned
+    /// in priority order. Rule types that do not use an operator or formatting (e.g. colorScale,
+    /// dataBar, iconSet) return only their type with null formatting fields.
+    /// </summary>
+    /// <param name="batch">Excel batch session</param>
+    /// <param name="sheetName">Sheet name (empty for active sheet)</param>
+    /// <param name="rangeAddress">Range address to read rules from (e.g., A1:G41)</param>
+    /// <exception cref="InvalidOperationException">Sheet or range not found</exception>
+    [ServiceAction("list-rules")]
+    ConditionalFormatListResult ListRules(
+        IExcelBatch batch,
+        [RequiredParameter, FromString("sheetName")] string sheetName,
+        [RequiredParameter, FromString("rangeAddress")] string rangeAddress);
+
+    /// <summary>
+    /// Lists all conditional formatting rules on an entire worksheet.
+    /// Excel COM: Worksheet.Cells.FormatConditions enumeration.
+    /// Each rule includes its applies-to range so rules can be grouped by range. Colors are
+    /// returned as #RRGGBB hex strings and rules are returned in priority order.
+    /// </summary>
+    /// <param name="batch">Excel batch session</param>
+    /// <param name="sheetName">Sheet name (empty for active sheet)</param>
+    /// <exception cref="InvalidOperationException">Sheet not found</exception>
+    [ServiceAction("list-worksheet-rules")]
+    ConditionalFormatListResult ListWorksheetRules(
+        IExcelBatch batch,
+        [RequiredParameter, FromString("sheetName")] string sheetName);
 }
 
 

--- a/src/ExcelMcp.Core/Commands/FormattingHelpers.cs
+++ b/src/ExcelMcp.Core/Commands/FormattingHelpers.cs
@@ -31,6 +31,21 @@ internal static class FormattingHelpers
     }
 
     /// <summary>
+    /// Converts an Excel RGB integer color value to a #RRGGBB hex string.
+    /// Excel stores colors as BGR (blue is the high byte), so this reverses
+    /// <see cref="ParseColor"/>.
+    /// </summary>
+    /// <param name="excelColor">Excel RGB integer value (BGR ordering)</param>
+    /// <returns>Color in #RRGGBB format</returns>
+    public static string ColorToHex(int excelColor)
+    {
+        var r = excelColor & 0xFF;
+        var g = (excelColor >> 8) & 0xFF;
+        var b = (excelColor >> 16) & 0xFF;
+        return $"#{r:X2}{g:X2}{b:X2}";
+    }
+
+    /// <summary>
     /// Parses a border style string to Excel constant.
     /// </summary>
     /// <param name="style">Border style name</param>

--- a/src/ExcelMcp.Core/Models/ConditionalFormatListResult.cs
+++ b/src/ExcelMcp.Core/Models/ConditionalFormatListResult.cs
@@ -1,0 +1,118 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result for listing existing conditional formatting rules from a range or worksheet.
+/// </summary>
+public class ConditionalFormatListResult : ResultBase
+{
+    /// <summary>
+    /// Worksheet the rules were read from.
+    /// </summary>
+    public string SheetName { get; set; } = "";
+
+    /// <summary>
+    /// Range the rules were read from. Null when the whole worksheet was scanned.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RangeAddress { get; set; }
+
+    /// <summary>
+    /// Conditional formatting rules in priority order.
+    /// </summary>
+    public List<ConditionalFormatRuleInfo> Rules { get; set; } = [];
+}
+
+/// <summary>
+/// Describes a single conditional formatting rule read from Excel.
+/// Formatting properties are only populated when the rule actually sets them.
+/// </summary>
+public class ConditionalFormatRuleInfo
+{
+    /// <summary>
+    /// Rule type (e.g. cellValue, expression, colorScale, dataBar, top10, iconSet,
+    /// uniqueValues, blanksCondition, timePeriod, aboveAverage).
+    /// </summary>
+    public string Type { get; set; } = "";
+
+    /// <summary>
+    /// Comparison operator (e.g. equal, greater, between). Null when the rule type
+    /// does not use an operator (e.g. expression, colorScale).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Operator { get; set; }
+
+    /// <summary>
+    /// First formula/value for the condition.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Formula1 { get; set; }
+
+    /// <summary>
+    /// Second formula/value (used by between/notBetween).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Formula2 { get; set; }
+
+    /// <summary>
+    /// Range the rule applies to (absolute address, e.g. $A$1:$A$41).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AppliesTo { get; set; }
+
+    /// <summary>
+    /// Priority of the rule within the collection (1-based, lower = higher priority).
+    /// Null when the rule type does not expose a priority.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Priority { get; set; }
+
+    /// <summary>
+    /// Whether rule evaluation stops if this rule is true.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? StopIfTrue { get; set; }
+
+    /// <summary>
+    /// Interior (fill) color as #RRGGBB, when set.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? InteriorColor { get; set; }
+
+    /// <summary>
+    /// Interior pattern constant, when set.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? InteriorPattern { get; set; }
+
+    /// <summary>
+    /// Font color as #RRGGBB, when set.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FontColor { get; set; }
+
+    /// <summary>
+    /// Font bold state, when set (null = not specified / mixed).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? FontBold { get; set; }
+
+    /// <summary>
+    /// Font italic state, when set (null = not specified / mixed).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? FontItalic { get; set; }
+
+    /// <summary>
+    /// Border style name, when set (applied to edge borders).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BorderStyle { get; set; }
+
+    /// <summary>
+    /// Border color as #RRGGBB, when set.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BorderColor { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/ConditionalFormatTypes.cs
+++ b/src/ExcelMcp.Core/Models/ConditionalFormatTypes.cs
@@ -105,15 +105,15 @@ public class ConditionalFormatRuleInfo
     public bool? FontItalic { get; set; }
 
     /// <summary>
-    /// Border style name, when set. Sourced from the left edge border
-    /// (xlEdgeLeft), which is read as representative of the rule's border.
+    /// Border style name, when set. Read by scanning the edge borders
+    /// (left, top, bottom, right) and using the first one that has a style.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? BorderStyle { get; set; }
 
     /// <summary>
-    /// Border color as #RRGGBB, when set. Sourced from the left edge border
-    /// (xlEdgeLeft), matching <see cref="BorderStyle"/>.
+    /// Border color as #RRGGBB, when set. Read from the same edge border as
+    /// <see cref="BorderStyle"/> (the first edge that has a style).
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? BorderColor { get; set; }

--- a/src/ExcelMcp.Core/Models/ConditionalFormatTypes.cs
+++ b/src/ExcelMcp.Core/Models/ConditionalFormatTypes.cs
@@ -105,13 +105,15 @@ public class ConditionalFormatRuleInfo
     public bool? FontItalic { get; set; }
 
     /// <summary>
-    /// Border style name, when set (applied to edge borders).
+    /// Border style name, when set. Sourced from the left edge border
+    /// (xlEdgeLeft), which is read as representative of the rule's border.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? BorderStyle { get; set; }
 
     /// <summary>
-    /// Border color as #RRGGBB, when set.
+    /// Border color as #RRGGBB, when set. Sourced from the left edge border
+    /// (xlEdgeLeft), matching <see cref="BorderStyle"/>.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? BorderColor { get; set; }

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -63,9 +63,9 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**26 specialized tools with 232 operations** covering Power Query, Data Model/DAX, PivotTables, Excel Tables, Charts, VBA, Ranges, Worksheets, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
+**26 specialized tools with 234 operations** covering Power Query, Data Model/DAX, PivotTables, Excel Tables, Charts, VBA, Ranges, Worksheets, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
 
-📚 **[Complete Feature Reference →](https://excelmcpserver.dev/features/)** - Detailed documentation of all 232 operations, grouped by category
+📚 **[Complete Feature Reference →](https://excelmcpserver.dev/features/)** - Detailed documentation of all 234 operations, grouped by category
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/ConditionalFormat/ConditionalFormattingCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/ConditionalFormat/ConditionalFormattingCommandsTests.cs
@@ -97,9 +97,10 @@ public class ConditionalFormattingCommandsTests : IClassFixture<TempDirectoryFix
 
         Assert.True(result.Success);
         Assert.Equal(2, result.Rules.Count);
-        // Priority values, when present, should be ascending in collection order.
+        // cellValue rules always carry a priority, so every rule must expose one.
+        Assert.All(result.Rules, r => Assert.True(r.Priority.HasValue));
+        // Priorities should be in ascending collection order.
         var priorities = result.Rules
-            .Where(r => r.Priority.HasValue)
             .Select(r => r.Priority!.Value)
             .ToList();
         var sorted = priorities.OrderBy(p => p).ToList();

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/ConditionalFormat/ConditionalFormattingCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/ConditionalFormat/ConditionalFormattingCommandsTests.cs
@@ -1,0 +1,159 @@
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.ConditionalFormat;
+
+/// <summary>
+/// Integration tests for ConditionalFormattingCommands read operations
+/// (list-rules / list-worksheet-rules). Exercises real Excel COM automation.
+/// </summary>
+[Trait("Layer", "Core")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Feature", "ConditionalFormat")]
+[Trait("RequiresExcel", "true")]
+public class ConditionalFormattingCommandsTests : IClassFixture<TempDirectoryFixture>
+{
+    private readonly ConditionalFormattingCommands _commands;
+    private readonly TempDirectoryFixture _fixture;
+
+    /// <summary>
+    /// Initializes a new instance of the test class.
+    /// </summary>
+    public ConditionalFormattingCommandsTests(TempDirectoryFixture fixture)
+    {
+        _commands = new ConditionalFormattingCommands();
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void ListRules_NoRules_ReturnsEmptyList()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        var result = _commands.ListRules(batch, "", "A1:D10");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Rules);
+        Assert.Empty(result.Rules);
+    }
+
+    [Fact]
+    public void ListRules_SingleCellValueRule_ReturnsRuleWithDetails()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "cellValue", "greater", "100", null,
+            interiorColor: "#FFFF00");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("cellValue", rule.Type);
+        Assert.Equal("greater", rule.Operator);
+        // Excel normalizes numeric Formula1 to a leading-'=' form ("=100").
+        Assert.Equal("=100", rule.Formula1);
+        Assert.Equal("#FFFF00", rule.InteriorColor);
+        Assert.False(string.IsNullOrEmpty(rule.AppliesTo));
+    }
+
+    [Fact]
+    public void ListRules_ExpressionRuleWithFontFormatting_ReturnsFontDetails()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:G41", "expression", null, "=$G1>1000", null,
+            interiorColor: "#FF0000", fontColor: "#FFFFFF", fontBold: true);
+
+        var result = _commands.ListRules(batch, "", "A1:G41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("expression", rule.Type);
+        Assert.Equal("=$G1>1000", rule.Formula1);
+        Assert.Equal("#FF0000", rule.InteriorColor);
+        Assert.Equal("#FFFFFF", rule.FontColor);
+        Assert.True(rule.FontBold);
+    }
+
+    [Fact]
+    public void ListRules_MultipleRules_ReturnsAllInPriorityOrder()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "cellValue", "greater", "100", null,
+            interiorColor: "#FFFF00");
+        _commands.AddRule(batch, "", "A1:A41", "cellValue", "less", "0", null,
+            interiorColor: "#00FF00");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Rules.Count);
+        // Priority values, when present, should be ascending in collection order.
+        var priorities = result.Rules
+            .Where(r => r.Priority.HasValue)
+            .Select(r => r.Priority!.Value)
+            .ToList();
+        var sorted = priorities.OrderBy(p => p).ToList();
+        Assert.Equal(sorted, priorities);
+    }
+
+    [Fact]
+    public void ListWorksheetRules_AggregatesRulesAcrossRanges()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A10", "cellValue", "greater", "5", null,
+            interiorColor: "#FFFF00");
+        _commands.AddRule(batch, "", "C1:C10", "cellValue", "less", "5", null,
+            interiorColor: "#00FF00");
+
+        var result = _commands.ListWorksheetRules(batch, "");
+
+        Assert.True(result.Success);
+        Assert.Null(result.RangeAddress);
+        Assert.True(result.Rules.Count >= 2);
+        Assert.All(result.Rules, r => Assert.False(string.IsNullOrEmpty(r.AppliesTo)));
+    }
+
+    [Fact]
+    public void ListWorksheetRules_NoRules_ReturnsEmptyList()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        var result = _commands.ListWorksheetRules(batch, "");
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Rules);
+    }
+
+    [Fact]
+    public void ListRules_InvalidSheet_Throws()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        Assert.ThrowsAny<Exception>(() =>
+            _commands.ListRules(batch, "NonExistentSheet", "A1:D10"));
+    }
+
+    [Fact]
+    public void ListRules_InvalidRange_Throws()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        Assert.ThrowsAny<Exception>(() =>
+            _commands.ListRules(batch, "", "NotARange!!"));
+    }
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -19,7 +19,7 @@ Other tools (openpyxl-based MCP servers and Agent Skills, including Anthropic's 
 
 ## Key features
 
-The Excel MCP Server (excel-mcp) provides **26 specialized tools with 232 operations** for comprehensive Excel automation:
+The Excel MCP Server (excel-mcp) provides **26 specialized tools with 234 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query & M code** - Create, edit and optimize M code. Import from files, databases and APIs. Refresh queries and manage load destinations.
 - 🧮 **Power Pivot & DAX** - Build Data Models, create DAX measures and manage table relationships. Full Power Pivot automation.
@@ -31,7 +31,7 @@ The Excel MCP Server (excel-mcp) provides **26 specialized tools with 232 operat
 - 🐍 **Python in Excel** - Write and run `=PY()` formulas that execute in Excel's cloud Python engine — process worksheet data with pandas, NumPy and more, from your AI assistant.
 - 🧪 **LLM-tested quality** - Tool behavior validated with real LLM workflows using [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering), so AI assistants reliably understand and use every operation.
 
-📚 **[See all 26 tools and 232 operations →](https://excelmcpserver.dev/features/)**
+📚 **[See all 26 tools and 234 operations →](https://excelmcpserver.dev/features/)**
 
 ### Agent Skills (Bundled)
 


### PR DESCRIPTION
## Summary

Closes #730. Adds two read actions to the `conditionalformat` tool so existing conditional formatting rules can be inspected — previously only `add-rule` and `clear-rules` were available.

- **`list-rules`** — reads rules for a range (`Range.FormatConditions`)
- **`list-worksheet-rules`** — reads all rules on a sheet (`Worksheet.Cells.FormatConditions`)

Both return each rule''s type, operator, formulas, applies-to range, priority, `stopIfTrue`, and formatting (interior/font/borders), with colors as `#RRGGBB` hex strings, in priority order. MCP + CLI parity is generated automatically from `IConditionalFormattingCommands`.

## Changes

- **New models**: `ConditionalFormatListResult` + `ConditionalFormatRuleInfo` (all formatting fields nullable — only populated when the rule sets them).
- **Helpers**: `FormattingHelpers.ColorToHex` (reverse of `ParseColor`), plus reverse int→string mappers for rule type, operator, and border style.
- **Commands**: `ListRules` / `ListWorksheetRules` on the interface + implementations, using the existing `dynamic?` + `finally`/`ComUtilities.Release` COM pattern. Color-scale/data-bar/icon-set rules degrade gracefully (type only, null formatting).
- **Docs**: FEATURES.md (Conditional Formatting 2 → 4 ops; total 232 → 234), README/plugin/gh-pages docs, and `skills/shared/conditionalformat.md`.
- **Changeset**: `.changeset/conditionalformat-list-rules.md` (minor).

## Tests

New `ConditionalFormattingCommandsTests` — 8 real-Excel integration tests, all passing: no rules (empty range + empty sheet), single cellValue rule, expression rule with font+interior, multiple rules in priority order, worksheet-scope aggregation, invalid sheet/range error paths.

## Acceptance criteria

- [x] `list-rules` action added (MCP + CLI parity)
- [x] Returns rule type, operator, formulas, applies-to range, and formatting
- [x] Supports both per-range and per-worksheet scoping
- [x] Colors returned as `#RRGGBB` hex strings
- [x] Rules returned in priority order
- [x] CLI: `list-rules` and `list-worksheet-rules` commands added
- [x] Tests for success and edge cases (no rules, invalid range, empty sheet)

## Notes

Excel normalizes numeric `cell-value` formulas, so `100` reads back as `=100`. The raw Excel value is returned intentionally — stripping the leading `=` would corrupt expression rules like `=$G1>1000`.

All 14 pre-commit gates pass locally.