### PR TITLE
fix: correct FormatCondition.Borders index range in conditionalformat (#737)

### DIFF
--- a/.changeset/fix-conditionalformat-border-com-index.md
+++ b/.changeset/fix-conditionalformat-border-com-index.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Fix `conditionalformat add` throwing on `borderStyle`/`borderColor`** (#737). Writing border formatting on a conditional-format rule threw `COMException: Unable to set the LineStyle property of the Border class`. Root cause: `FormatCondition.Borders` is a 4-item collection indexed 1-4 (left/top/bottom/right), unlike `Range.Borders` which uses the `xlEdgeLeft`/`Top`/`Bottom`/`Right` constants (7-10) — writing (and reading) via those out-of-range indices silently returned an unbound placeholder that threw on write and reported blank values on read. Both the write path (`add`) and the read path (`list-rules`/`list-worksheet-rules`) now use the correct 1-4 indices, so border style and color round-trip correctly.

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
@@ -86,22 +86,27 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
                 if (!string.IsNullOrEmpty(borderStyle) || !string.IsNullOrEmpty(borderColor))
                 {
                     borders = formatCondition.Borders;
+                    // NOTE: FormatCondition.Borders is a 4-item collection indexed 1-4
+                    // (left/top/bottom/right), unlike Range.Borders which uses the
+                    // xlEdgeLeft(7)/xlEdgeTop(8)/xlEdgeBottom(9)/xlEdgeRight(10) constants.
+                    // Item(7-10) on FormatCondition.Borders returns an unbound placeholder
+                    // that can be read but throws COMException when its properties are set.
                     if (!string.IsNullOrEmpty(borderStyle))
                     {
                         var xlBorderStyle = FormattingHelpers.ParseBorderStyle(borderStyle);
                         // Apply to all four borders
-                        borders.Item(7).LineStyle = xlBorderStyle;  // xlEdgeLeft
-                        borders.Item(8).LineStyle = xlBorderStyle;  // xlEdgeTop
-                        borders.Item(9).LineStyle = xlBorderStyle;  // xlEdgeBottom
-                        borders.Item(10).LineStyle = xlBorderStyle; // xlEdgeRight
+                        borders.Item(1).LineStyle = xlBorderStyle; // left
+                        borders.Item(2).LineStyle = xlBorderStyle; // top
+                        borders.Item(3).LineStyle = xlBorderStyle; // bottom
+                        borders.Item(4).LineStyle = xlBorderStyle; // right
                     }
                     if (!string.IsNullOrEmpty(borderColor))
                     {
                         var color = FormattingHelpers.ParseColor(borderColor);
-                        borders.Item(7).Color = color;  // xlEdgeLeft
-                        borders.Item(8).Color = color;  // xlEdgeTop
-                        borders.Item(9).Color = color;  // xlEdgeBottom
-                        borders.Item(10).Color = color; // xlEdgeRight
+                        borders.Item(1).Color = color; // left
+                        borders.Item(2).Color = color; // top
+                        borders.Item(3).Color = color; // bottom
+                        borders.Item(4).Color = color; // right
                     }
                 }
 
@@ -319,7 +324,9 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
                 try
                 {
                     borders = fc.Borders;
-                    foreach (int edgeIndex in new[] { 7, 8, 9, 10 }) // left, top, bottom, right
+                    // NOTE: FormatCondition.Borders is a 4-item collection indexed 1-4
+                    // (left/top/bottom/right) - see write-side note in AddRule above.
+                    foreach (int edgeIndex in new[] { 1, 2, 3, 4 }) // left, top, bottom, right
                     {
                         edgeBorder = borders.Item(edgeIndex);
                         int lineStyle = Convert.ToInt32(edgeBorder.LineStyle, System.Globalization.CultureInfo.InvariantCulture);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/ConditionalFormat/ConditionalFormattingCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/ConditionalFormat/ConditionalFormattingCommandsTests.cs
@@ -139,6 +139,41 @@ public class ConditionalFormattingCommandsTests : IClassFixture<TempDirectoryFix
     }
 
     [Fact]
+    public void AddRule_WithBorderStyleAndColor_Succeeds()
+    {
+        // Regression test for #737: FormatCondition.Borders is a 4-item
+        // collection indexed 1-4, not the xlEdgeLeft(7)/Top(8)/Bottom(9)/Right(10)
+        // constants used for Range.Borders. Writing via those constants throws
+        // COMException: "Unable to set the LineStyle property of the Border class".
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        var result = _commands.AddRule(batch, "", "A1:A10", "cellValue", "greater", "100", null,
+            borderStyle: "continuous", borderColor: "#FF0000");
+
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public void ListRules_RuleWithBorderStyleAndColor_RoundTripsCorrectly()
+    {
+        // Regression test for #737 acceptance criterion (b): border style/color
+        // written via `add` must be correctly reported by `list-rules`.
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A10", "cellValue", "greater", "100", null,
+            borderStyle: "continuous", borderColor: "#FF0000");
+
+        var result = _commands.ListRules(batch, "", "A1:A10");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("continuous", rule.BorderStyle);
+        Assert.Equal("#FF0000", rule.BorderColor);
+    }
+
+    [Fact]
     public void ListRules_InvalidSheet_Throws()
     {
         var file = _fixture.CreateTestFile();


### PR DESCRIPTION
## Summary
Fixes #737 — conditionalformat add threw COMException: Unable to set the LineStyle property of the Border class whenever orderStyle/orderColor were supplied.

## Root cause
FormatCondition.Borders is a **4-item collection indexed 1-4** (left/top/bottom/right). This is different from Range.Borders, which uses the xlEdgeLeft(7)/xlEdgeTop(8)/xlEdgeBottom(9)/xlEdgeRight(10) constants. The existing code used those Range.Borders constants against FormatCondition.Borders:
- **Write path (AddRule)**: orders.Item(7).LineStyle = ... threw a COMException (the out-of-range index returns an unbound placeholder object that can be read but not written).
- **Read path (ListRules/ListWorksheetRules)**: the same out-of-range indices silently returned a blank LineStyle, so border formatting written through other means (e.g. Excel's UI) would not have round-tripped correctly either.

Root-caused via live COM repro against a real Excel instance, testing several hypotheses (ordering, Weight-first, Color-first, bulk vs. per-item) before confirming the index range was the actual issue.

## Fix
Both the write path and read path now use the correct 1-4 indices for FormatCondition.Borders.

## Tests (TDD)
Added two regression tests reproducing the exact COMException; verified RED against the un-fixed code (stashed the fix, confirmed both tests failed with the identical exception), then GREEN after the fix. Also added a round-trip test (dd → list-rules) confirming reported BorderStyle/BorderColor match what was written — issue's acceptance criterion (b).

Same-pattern search (acceptance criterion c): confirmed no other FormatCondition.Borders per-item writes exist in the codebase; the only other .Borders.Item(edge) usage is on Range.Borders (RangeCommands.Formatting.cs), which correctly supports the 7-10 constants and is unaffected.

All 10 tests in \Feature=ConditionalFormat\ pass; full local pre-commit hook (14 gates) passed.