### PR TITLE
fix: use PR + admin-merge instead of raw push for release changelog commit-back

### DIFF
--- a/.changeset/fix-release-changelog-admin-merge.md
+++ b/.changeset/fix-release-changelog-admin-merge.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Release automation: make the changelog commit-back reliable.** The post-release step that writes `CHANGELOG.md` back to `main` now opens a short-lived PR and merges it with an admin bypass, instead of pushing directly to `main`. A real release proved that GitHub can reject a raw `git push` to a ruleset-protected branch from inside a GitHub Actions runner even when the same admin PAT successfully bypasses the identical ruleset when used interactively — the admin-merge API path doesn't have that restriction.

--- a/.changeset/fix-release-changelog-admin-merge.md
+++ b/.changeset/fix-release-changelog-admin-merge.md
@@ -2,4 +2,4 @@
 "excelmcp": patch
 ---
 
-**Release automation: make the changelog commit-back reliable.** The post-release step that writes `CHANGELOG.md` back to `main` now opens a short-lived PR and merges it with an admin bypass, instead of pushing directly to `main`. A real release proved that GitHub can reject a raw `git push` to a ruleset-protected branch from inside a GitHub Actions runner even when the same admin PAT successfully bypasses the identical ruleset when used interactively — the admin-merge API path doesn't have that restriction.
+**Release automation: make the changelog commit-back reliable.** The post-release step that writes `CHANGELOG.md` back to `main` now opens a short-lived PR and merges it with an admin bypass, instead of pushing directly to `main`, fixing a case where the direct push was unexpectedly rejected.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -796,13 +796,24 @@ jobs:
     #
     # RELEASE_PAT is an admin Personal Access Token owned by the repo owner,
     # who IS a ruleset bypass actor (Repository admin role). It can therefore
-    # push this bookkeeping commit straight to main, bypassing branch
-    # protection -- no PR, nothing to get stuck.
+    # merge this bookkeeping PR straight into main, bypassing branch
+    # protection -- no stuck PR waiting on required checks.
+    #
+    # IMPORTANT: this pushes the commit to a side branch and merges it via
+    # `gh pr merge --admin`, rather than `git push HEAD:main` directly.
+    # A real release (2026-07-23, v1.10.1) proved that GitHub can reject a
+    # raw `git push` to a ruleset-protected branch from *inside* a GitHub
+    # Actions runner even when the same PAT, used interactively from a
+    # developer machine minutes earlier, successfully bypassed the identical
+    # ruleset ("Bypassed rule violations..."). The admin-merge API path does
+    # not have this Actions-runner restriction, and was verified working for
+    # the same PAT/ruleset combination as a manual recovery for that release.
     - name: Commit Changelog Update
       env:
         GH_TOKEN: ${{ secrets.RELEASE_PAT }}
       run: |
         VERSION=${{ env.VERSION }}
+        BRANCH="chore/changelog-v${VERSION}"
 
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -816,23 +827,31 @@ jobs:
         git commit -m "chore: update CHANGELOG.md for v${VERSION} release [skip ci]"
 
         if [ -z "${GH_TOKEN}" ]; then
-          echo "::error::RELEASE_PAT secret is not configured. Create an admin PAT with 'contents: write' and add it as the repo secret RELEASE_PAT so the changelog can be pushed to main."
+          echo "::error::RELEASE_PAT secret is not configured. Create an admin PAT with 'contents: write' and 'pull-requests: write' and add it as the repo secret RELEASE_PAT so the changelog can be committed to main."
           exit 1
         fi
 
-        # Push directly to main using the admin PAT. Retry with a rebase in
-        # case main advanced during the (long-running) release build.
+        # Push the commit to a side branch (never straight to main -- see
+        # note above), open a PR, then merge it with admin bypass so it
+        # doesn't get stuck on required status checks (the commit carries
+        # [skip ci], so no checks would ever run against it).
         REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-        for attempt in 1 2 3; do
-          if git push "$REMOTE" HEAD:main; then
-            echo "Pushed changelog update to main (attempt $attempt)."
-            exit 0
-          fi
-          echo "Push rejected (attempt $attempt); rebasing onto latest main and retrying..."
-          git fetch "$REMOTE" main
-          git rebase FETCH_HEAD || { echo "Rebase failed -- aborting."; git rebase --abort || true; exit 1; }
-        done
-        echo "Failed to push changelog update to main after 3 attempts."
+        git push "$REMOTE" "HEAD:refs/heads/${BRANCH}" --force
+
+        gh pr create \
+          --repo "${{ github.repository }}" \
+          --base main \
+          --head "$BRANCH" \
+          --title "chore: update CHANGELOG.md for v${VERSION} release" \
+          --body "Automated changelog commit-back for the v${VERSION} release. No code changes." \
+          --label skip-changelog
+
+        if gh pr merge "$BRANCH" --repo "${{ github.repository }}" --squash --admin --delete-branch; then
+          echo "Merged changelog update for v${VERSION} into main."
+          exit 0
+        fi
+
+        echo "::error::Failed to merge changelog PR for v${VERSION} into main. Branch '${BRANCH}' and its PR are left open for manual recovery."
         exit 1
       # Intentionally NOT continue-on-error: a silently swallowed failure here
       # is exactly what caused several past releases to be missing their

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -812,8 +812,11 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.RELEASE_PAT }}
       run: |
+        set -euo pipefail
+
         VERSION=${{ env.VERSION }}
         BRANCH="chore/changelog-v${VERSION}"
+        REPO="${{ github.repository }}"
 
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -835,24 +838,25 @@ jobs:
         # note above), open a PR, then merge it with admin bypass so it
         # doesn't get stuck on required status checks (the commit carries
         # [skip ci], so no checks would ever run against it).
-        REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+        REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
         git push "$REMOTE" "HEAD:refs/heads/${BRANCH}" --force
 
-        gh pr create \
-          --repo "${{ github.repository }}" \
-          --base main \
-          --head "$BRANCH" \
-          --title "chore: update CHANGELOG.md for v${VERSION} release" \
-          --body "Automated changelog commit-back for the v${VERSION} release. No code changes." \
-          --label skip-changelog
-
-        if gh pr merge "$BRANCH" --repo "${{ github.repository }}" --squash --admin --delete-branch; then
-          echo "Merged changelog update for v${VERSION} into main."
-          exit 0
+        # Idempotent: if a PR for this branch already exists (e.g. a rerun
+        # after a transient failure), reuse it instead of failing on create.
+        PR_URL=$(gh pr view "$BRANCH" --repo "$REPO" --json url --jq '.url' 2>/dev/null || true)
+        if [ -z "$PR_URL" ]; then
+          PR_URL=$(gh pr create \
+            --repo "$REPO" \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: update CHANGELOG.md for v${VERSION} release" \
+            --body "Automated changelog commit-back for the v${VERSION} release. No code changes." \
+            --label skip-changelog)
         fi
 
-        echo "::error::Failed to merge changelog PR for v${VERSION} into main. Branch '${BRANCH}' and its PR are left open for manual recovery."
-        exit 1
+        echo "Changelog PR: $PR_URL"
+        gh pr merge "$PR_URL" --repo "$REPO" --squash --admin --delete-branch
+        echo "Merged changelog update for v${VERSION} into main."
       # Intentionally NOT continue-on-error: a silently swallowed failure here
       # is exactly what caused several past releases to be missing their
       # changelog commit-back. Let it fail loudly so it gets noticed and fixed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -834,11 +834,18 @@ jobs:
           exit 1
         fi
 
+        # Rebase onto the latest main before publishing the side branch --
+        # the release build can run for a long time, so main may have
+        # advanced since checkout, which would otherwise make the PR
+        # unmergeable.
+        REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+        git fetch "$REMOTE" main
+        git rebase FETCH_HEAD
+
         # Push the commit to a side branch (never straight to main -- see
         # note above), open a PR, then merge it with admin bypass so it
         # doesn't get stuck on required status checks (the commit carries
         # [skip ci], so no checks would ever run against it).
-        REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
         git push "$REMOTE" "HEAD:refs/heads/${BRANCH}" --force
 
         # Idempotent: if a PR for this branch already exists (e.g. a rerun


### PR DESCRIPTION
## Problem
The v1.10.1 release's automated 'Commit Changelog Update' step failed to push CHANGELOG.md back to main: RELEASE_PAT (an admin PAT proven to bypass the main ruleset when used interactively from a developer machine) was rejected with GH013: Repository rule violations when the identical git push ran from inside the GitHub Actions runner.

## Fix
Instead of pushing straight to main, the step now:
1. Pushes the changelog commit to a short-lived chore/changelog-vX branch.
2. Opens a PR via gh pr create.
3. Merges it via gh pr merge --squash --admin --delete-branch.

The admin-merge API path doesn't have the Actions-runner push restriction, and was manually verified as a recovery for the v1.10.1 release (PR #741).

## Manual recovery already applied
main's CHANGELOG.md for v1.10.1 was already fixed via #741 using this exact same admin-merge mechanism.