### PR TITLE
Add visual conditional formatting rule details

### DIFF
--- a/.changeset/conditional-format-visual-rules.md
+++ b/.changeset/conditional-format-visual-rules.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": minor
+---
+
+**Conditional formatting: full support for visual rule types** (#743). `add-rule` can now create colorScale, dataBar, iconSet, top10, aboveAverage, timePeriod, uniqueValues and blanksCondition rules via discrete, LLM-friendly parameters (e.g. `colorScaleMinColor`, `dataBarDirection`, `iconSetId`, `rank`, `aboveBelow`, `datePeriod`). `list-rules` and `list-worksheet-rules` now report each visual rule's type-specific configuration — color-scale stops, data-bar settings, icon-set thresholds, top/bottom, above/below and date period — with colors as `#RRGGBB`, so visual rules can be fully inspected and round-tripped.

--- a/skills/excel-mcp/references/conditionalformat.md
+++ b/skills/excel-mcp/references/conditionalformat.md
@@ -7,6 +7,14 @@
 |------|-------------|------------|
 | `cell-value` | Format based on cell value comparison | operatorType + formula1 (+ formula2 for between) |
 | `expression` | Format based on formula result | formula only |
+| `color-scale` | 2- or 3-color gradient across the range | colorScaleMin/Mid/Max Type/Value/Color |
+| `data-bar` | In-cell bars proportional to value | dataBarColor, dataBarNegativeColor, dataBarDirection, dataBarShowValue, dataBarMin/Max Type/Value |
+| `icon-set` | Icons (arrows, traffic lights, etc.) per value band | iconSetId, iconSetReverse, iconSetShowIconOnly, iconThreshold1..4 Type/Value |
+| `top10` | Highlight top/bottom N (or percent) | rank, top10Percent, topBottom + formatting |
+| `above-average` | Highlight values above/below average | aboveBelow + formatting |
+| `time-period` | Highlight dates in a period | datePeriod + formatting |
+| `unique-values` | Highlight unique (or duplicate) values | formatting |
+| `blanks-condition` | Highlight blank cells | formatting |
 
 **Operators (for cell-value type)**:
 
@@ -30,6 +38,25 @@
 - `borderStyle`: Excel border style name
 - `borderColor`: Border color as `#RRGGBB` hex
 
+**Visual rule parameters** (used by the corresponding `ruleType`):
+
+- **color-scale**: `colorScaleMinType`/`colorScaleMidType`/`colorScaleMaxType`
+  (`minimum`, `maximum`, `number`, `percent`, `percentile`, `formula`), matching
+  `...Value` (when the type needs one) and `...Color` (`#RRGGBB`). Supplying any `mid*`
+  parameter creates a 3-color scale, otherwise a 2-color scale.
+- **data-bar**: `dataBarColor` (`#RRGGBB`), `dataBarNegativeColor`, `dataBarDirection`
+  (`context`, `leftToRight`, `rightToLeft`), `dataBarShowValue` (`true`/`false`),
+  `dataBarMinType`/`dataBarMaxType` (+ matching values).
+- **icon-set**: `iconSetId` (e.g. `3Arrows`, `3TrafficLights1`, `4Ratings`, `5Quarters`),
+  `iconSetReverse` (`true`/`false`), `iconSetShowIconOnly` (`true`/`false`),
+  `iconThreshold1Type..iconThreshold4Type` (+ matching `...Value`) for the editable bands.
+- **top10**: `rank` (count or percent), `top10Percent` (`true`/`false`),
+  `topBottom` (`top`/`bottom`), plus standard formatting options.
+- **above-average**: `aboveBelow` (`aboveAverage`, `belowAverage`, `aboveStdDev`,
+  `belowStdDev`, `equalAboveAverage`, `equalBelowAverage`), plus formatting options.
+- **time-period**: `datePeriod` (`today`, `yesterday`, `tomorrow`, `last7Days`,
+  `thisWeek`, `lastWeek`, `nextWeek`, `thisMonth`, `lastMonth`, `nextMonth`), plus formatting.
+
 **Actions**:
 
 | Action | Description |
@@ -45,8 +72,15 @@
 - Colors are returned as `#RRGGBB` hex strings, matching the `add-rule` input format.
 - Formatting fields (interiorColor, fontColor, fontBold/Italic, borderStyle/Color) are only
   present when the rule actually sets them.
-- Rule types that don't use an operator or basic formatting (e.g. colorScale, dataBar, iconSet)
-  return their `type` with null formatting fields.
+- Visual rule types return their type-specific configuration so they can be fully inspected
+  and round-tripped:
+  - `colorScale` → `colorScaleCriteria`: array of `{ type, value?, color }` stops.
+  - `dataBar` → `dataBar`: `{ fillColor, barColorNegative?, direction, showValue, minType, minValue?, maxType, maxValue? }`.
+  - `iconSet` → `iconSet`: `{ id, reverse, showIconOnly, criteria: [{ operator, value?, type, icon }] }`.
+  - `top10` → `top10`: `{ rank, percent, topBottom }`.
+  - `aboveAverage` → `aboveBelow`: e.g. `aboveAverage`, `belowAverage`, `aboveStdDev`.
+  - `timePeriod` → `datePeriod`: e.g. `today`, `last7Days`, `thisMonth`.
+  Each field is only present on its matching rule type.
 - Numeric `cell-value` formulas are returned in Excel's normalized form (e.g. `100` reads back
   as `=100`).
 
@@ -92,6 +126,48 @@
   "ruleType": "expression",
   "formula": "=$A1=\"Active\"",
   "interiorColor": "#90EE90"
+}
+```
+
+**3-color scale (red → yellow → green):**
+```json
+{
+  "action": "add-rule",
+  "rangeAddress": "A1:A100",
+  "ruleType": "color-scale",
+  "colorScaleMinType": "minimum",
+  "colorScaleMinColor": "#F8696B",
+  "colorScaleMidType": "percentile",
+  "colorScaleMidValue": "50",
+  "colorScaleMidColor": "#FFEB84",
+  "colorScaleMaxType": "maximum",
+  "colorScaleMaxColor": "#63BE7B"
+}
+```
+
+**Data bar with value shown:**
+```json
+{
+  "action": "add-rule",
+  "rangeAddress": "B1:B100",
+  "ruleType": "data-bar",
+  "dataBarColor": "#638EC6",
+  "dataBarDirection": "leftToRight",
+  "dataBarShowValue": true
+}
+```
+
+**3 traffic lights icon set:**
+```json
+{
+  "action": "add-rule",
+  "rangeAddress": "C1:C100",
+  "ruleType": "icon-set",
+  "iconSetId": "3TrafficLights1",
+  "iconThreshold1Type": "percent",
+  "iconThreshold1Value": "33",
+  "iconThreshold2Type": "percent",
+  "iconThreshold2Value": "67"
 }
 ```
 

--- a/skills/shared/conditionalformat.md
+++ b/skills/shared/conditionalformat.md
@@ -7,6 +7,14 @@
 |------|-------------|------------|
 | `cell-value` | Format based on cell value comparison | operatorType + formula1 (+ formula2 for between) |
 | `expression` | Format based on formula result | formula only |
+| `color-scale` | 2- or 3-color gradient across the range | colorScaleMin/Mid/Max Type/Value/Color |
+| `data-bar` | In-cell bars proportional to value | dataBarColor, dataBarNegativeColor, dataBarDirection, dataBarShowValue, dataBarMin/Max Type/Value |
+| `icon-set` | Icons (arrows, traffic lights, etc.) per value band | iconSetId, iconSetReverse, iconSetShowIconOnly, iconThreshold1..4 Type/Value |
+| `top10` | Highlight top/bottom N (or percent) | rank, top10Percent, topBottom + formatting |
+| `above-average` | Highlight values above/below average | aboveBelow + formatting |
+| `time-period` | Highlight dates in a period | datePeriod + formatting |
+| `unique-values` | Highlight unique (or duplicate) values | formatting |
+| `blanks-condition` | Highlight blank cells | formatting |
 
 **Operators (for cell-value type)**:
 
@@ -30,6 +38,25 @@
 - `borderStyle`: Excel border style name
 - `borderColor`: Border color as `#RRGGBB` hex
 
+**Visual rule parameters** (used by the corresponding `ruleType`):
+
+- **color-scale**: `colorScaleMinType`/`colorScaleMidType`/`colorScaleMaxType`
+  (`minimum`, `maximum`, `number`, `percent`, `percentile`, `formula`), matching
+  `...Value` (when the type needs one) and `...Color` (`#RRGGBB`). Supplying any `mid*`
+  parameter creates a 3-color scale, otherwise a 2-color scale.
+- **data-bar**: `dataBarColor` (`#RRGGBB`), `dataBarNegativeColor`, `dataBarDirection`
+  (`context`, `leftToRight`, `rightToLeft`), `dataBarShowValue` (`true`/`false`),
+  `dataBarMinType`/`dataBarMaxType` (+ matching values).
+- **icon-set**: `iconSetId` (e.g. `3Arrows`, `3TrafficLights1`, `4Ratings`, `5Quarters`),
+  `iconSetReverse` (`true`/`false`), `iconSetShowIconOnly` (`true`/`false`),
+  `iconThreshold1Type..iconThreshold4Type` (+ matching `...Value`) for the editable bands.
+- **top10**: `rank` (count or percent), `top10Percent` (`true`/`false`),
+  `topBottom` (`top`/`bottom`), plus standard formatting options.
+- **above-average**: `aboveBelow` (`aboveAverage`, `belowAverage`, `aboveStdDev`,
+  `belowStdDev`, `equalAboveAverage`, `equalBelowAverage`), plus formatting options.
+- **time-period**: `datePeriod` (`today`, `yesterday`, `tomorrow`, `last7Days`,
+  `thisWeek`, `lastWeek`, `nextWeek`, `thisMonth`, `lastMonth`, `nextMonth`), plus formatting.
+
 **Actions**:
 
 | Action | Description |
@@ -45,8 +72,15 @@
 - Colors are returned as `#RRGGBB` hex strings, matching the `add-rule` input format.
 - Formatting fields (interiorColor, fontColor, fontBold/Italic, borderStyle/Color) are only
   present when the rule actually sets them.
-- Rule types that don't use an operator or basic formatting (e.g. colorScale, dataBar, iconSet)
-  return their `type` with null formatting fields.
+- Visual rule types return their type-specific configuration so they can be fully inspected
+  and round-tripped:
+  - `colorScale` → `colorScaleCriteria`: array of `{ type, value?, color }` stops.
+  - `dataBar` → `dataBar`: `{ fillColor, barColorNegative?, direction, showValue, minType, minValue?, maxType, maxValue? }`.
+  - `iconSet` → `iconSet`: `{ id, reverse, showIconOnly, criteria: [{ operator, value?, type, icon }] }`.
+  - `top10` → `top10`: `{ rank, percent, topBottom }`.
+  - `aboveAverage` → `aboveBelow`: e.g. `aboveAverage`, `belowAverage`, `aboveStdDev`.
+  - `timePeriod` → `datePeriod`: e.g. `today`, `last7Days`, `thisMonth`.
+  Each field is only present on its matching rule type.
 - Numeric `cell-value` formulas are returned in Excel's normalized form (e.g. `100` reads back
   as `=100`).
 
@@ -92,6 +126,48 @@
   "ruleType": "expression",
   "formula": "=$A1=\"Active\"",
   "interiorColor": "#90EE90"
+}
+```
+
+**3-color scale (red → yellow → green):**
+```json
+{
+  "action": "add-rule",
+  "rangeAddress": "A1:A100",
+  "ruleType": "color-scale",
+  "colorScaleMinType": "minimum",
+  "colorScaleMinColor": "#F8696B",
+  "colorScaleMidType": "percentile",
+  "colorScaleMidValue": "50",
+  "colorScaleMidColor": "#FFEB84",
+  "colorScaleMaxType": "maximum",
+  "colorScaleMaxColor": "#63BE7B"
+}
+```
+
+**Data bar with value shown:**
+```json
+{
+  "action": "add-rule",
+  "rangeAddress": "B1:B100",
+  "ruleType": "data-bar",
+  "dataBarColor": "#638EC6",
+  "dataBarDirection": "leftToRight",
+  "dataBarShowValue": true
+}
+```
+
+**3 traffic lights icon set:**
+```json
+{
+  "action": "add-rule",
+  "rangeAddress": "C1:C100",
+  "ruleType": "icon-set",
+  "iconSetId": "3TrafficLights1",
+  "iconThreshold1Type": "percent",
+  "iconThreshold1Value": "33",
+  "iconThreshold2Type": "percent",
+  "iconThreshold2Value": "67"
 }
 ```
 

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.ReadVisualRules.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.ReadVisualRules.cs
@@ -1,0 +1,414 @@
+using System.Globalization;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.Core.Models;
+
+namespace Sbroenne.ExcelMcp.Core.Commands;
+
+/// <summary>
+/// Read-side helpers that extract type-specific configuration from visual conditional
+/// formatting rules (colorScale, dataBar, iconSet, top10, aboveAverage, timePeriod).
+/// Every COM read is guarded so unreadable properties degrade to null rather than throwing.
+/// </summary>
+public partial class ConditionalFormattingCommands
+{
+    private static List<ColorScaleCriterionInfo>? ReadColorScale(dynamic fc)
+    {
+        dynamic? criteria = null;
+        try
+        {
+            criteria = fc.ColorScaleCriteria;
+            int count = Convert.ToInt32(criteria.Count, CultureInfo.InvariantCulture);
+            var list = new List<ColorScaleCriterionInfo>();
+
+            for (int i = 1; i <= count; i++)
+            {
+                dynamic? criterion = null;
+                dynamic? formatColor = null;
+                try
+                {
+                    criterion = criteria.Item(i);
+                    var info = new ColorScaleCriterionInfo();
+
+                    int t = Convert.ToInt32(criterion.Type, CultureInfo.InvariantCulture);
+                    info.Type = ConditionValueTypeToString(t);
+
+                    if (ConditionValueTypeUsesValue(t))
+                        info.Value = ReadConditionValue(criterion);
+
+                    try
+                    {
+                        formatColor = criterion.FormatColor;
+                        info.Color = FormattingHelpers.ColorToHex(Convert.ToInt32(formatColor.Color, CultureInfo.InvariantCulture));
+                    }
+                    catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+                    list.Add(info);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref formatColor!);
+                    ComUtilities.Release(ref criterion!);
+                }
+            }
+
+            return list.Count > 0 ? list : null;
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
+        finally
+        {
+            ComUtilities.Release(ref criteria!);
+        }
+    }
+
+    private static DataBarInfo? ReadDataBar(dynamic fc)
+    {
+        try
+        {
+            var info = new DataBarInfo();
+
+            dynamic? barColor = null;
+            try
+            {
+                barColor = fc.BarColor;
+                info.FillColor = FormattingHelpers.ColorToHex(Convert.ToInt32(barColor.Color, CultureInfo.InvariantCulture));
+            }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+            finally { ComUtilities.Release(ref barColor!); }
+
+            // Negative bar color only meaningful when a custom color type is used.
+            dynamic? negativeFormat = null;
+            dynamic? negColor = null;
+            try
+            {
+                negativeFormat = fc.NegativeBarFormat;
+                int colorType = Convert.ToInt32(negativeFormat.ColorType, CultureInfo.InvariantCulture);
+                if (colorType == 0) // xlDataBarColor (explicit color, not "same as positive")
+                {
+                    negColor = negativeFormat.Color;
+                    info.BarColorNegative = FormattingHelpers.ColorToHex(Convert.ToInt32(negColor.Color, CultureInfo.InvariantCulture));
+                }
+            }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+            finally
+            {
+                ComUtilities.Release(ref negColor!);
+                ComUtilities.Release(ref negativeFormat!);
+            }
+
+            try { info.Direction = DataBarDirectionToString(Convert.ToInt32(fc.Direction, CultureInfo.InvariantCulture)); }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+            try { info.ShowValue = Convert.ToBoolean(fc.ShowValue, CultureInfo.InvariantCulture); }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+            ReadDataBarPoint(fc, info, isMin: true);
+            ReadDataBarPoint(fc, info, isMin: false);
+
+            return info;
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
+    }
+
+    private static void ReadDataBarPoint(dynamic fc, DataBarInfo info, bool isMin)
+    {
+        dynamic? point = null;
+        try
+        {
+            point = isMin ? fc.MinPoint : fc.MaxPoint;
+            int t = Convert.ToInt32(point.Type, CultureInfo.InvariantCulture);
+            string typeStr = ConditionValueTypeToString(t);
+            string? valueStr = ConditionValueTypeUsesValue(t) ? ReadConditionValue(point) : null;
+
+            if (isMin) { info.MinType = typeStr; info.MinValue = valueStr; }
+            else { info.MaxType = typeStr; info.MaxValue = valueStr; }
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { }
+        finally
+        {
+            ComUtilities.Release(ref point!);
+        }
+    }
+
+    private static IconSetInfo? ReadIconSet(dynamic fc)
+    {
+        try
+        {
+            var info = new IconSetInfo();
+
+            dynamic? iconSet = null;
+            try
+            {
+                iconSet = fc.IconSet;
+                info.Id = IconSetIdToString(Convert.ToInt32(iconSet.ID, CultureInfo.InvariantCulture));
+            }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+            finally { ComUtilities.Release(ref iconSet!); }
+
+            try { info.Reverse = Convert.ToBoolean(fc.ReverseOrder, CultureInfo.InvariantCulture); }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+            try { info.ShowIconOnly = Convert.ToBoolean(fc.ShowIconOnly, CultureInfo.InvariantCulture); }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+            dynamic? iconCriteria = null;
+            try
+            {
+                iconCriteria = fc.IconCriteria;
+                int count = Convert.ToInt32(iconCriteria.Count, CultureInfo.InvariantCulture);
+                var criteria = new List<IconCriterionInfo>();
+
+                for (int i = 1; i <= count; i++)
+                {
+                    dynamic? criterion = null;
+                    try
+                    {
+                        criterion = iconCriteria.Item(i);
+                        var c = new IconCriterionInfo();
+
+                        try { c.Operator = ConditionalFormattingOperatorToString(Convert.ToInt32(criterion.Operator, CultureInfo.InvariantCulture)); }
+                        catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+                        try
+                        {
+                            int t = Convert.ToInt32(criterion.Type, CultureInfo.InvariantCulture);
+                            c.Type = ConditionValueTypeToString(t);
+                        }
+                        catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+                        c.Value = ReadConditionValue(criterion);
+
+                        try { c.Icon = IconToString(Convert.ToInt32(criterion.Icon, CultureInfo.InvariantCulture)); }
+                        catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+                        criteria.Add(c);
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref criterion!);
+                    }
+                }
+
+                if (criteria.Count > 0)
+                    info.Criteria = criteria;
+            }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+            finally { ComUtilities.Release(ref iconCriteria!); }
+
+            return info;
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
+    }
+
+    private static Top10Info? ReadTop10(dynamic fc)
+    {
+        try
+        {
+            var info = new Top10Info();
+
+            try { info.Rank = Convert.ToInt32(fc.Rank, CultureInfo.InvariantCulture); }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+            try { info.Percent = Convert.ToBoolean(fc.Percent, CultureInfo.InvariantCulture); }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+            try { info.TopBottom = TopBottomToString(Convert.ToInt32(fc.TopBottom, CultureInfo.InvariantCulture)); }
+            catch (Exception ex) when (IsComOrBinderException(ex)) { }
+
+            return info;
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
+    }
+
+    private static string? ReadAboveBelow(dynamic fc)
+    {
+        try { return AboveBelowToString(Convert.ToInt32(fc.AboveBelow, CultureInfo.InvariantCulture)); }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
+    }
+
+    private static string? ReadTimePeriod(dynamic fc)
+    {
+        try { return TimePeriodToString(Convert.ToInt32(fc.DateOperator, CultureInfo.InvariantCulture)); }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
+    }
+
+    /// <summary>
+    /// Reads a ConditionValue/criterion <c>Value</c> and formats it as an invariant string.
+    /// Integral doubles are rendered without a trailing ".0". Returns null when unreadable.
+    /// </summary>
+    private static string? ReadConditionValue(dynamic owner)
+    {
+        try
+        {
+            object? value = owner.Value;
+            if (value == null)
+                return null;
+
+            if (value is double d)
+            {
+                return d == Math.Floor(d) && !double.IsInfinity(d)
+                    ? ((long)d).ToString(CultureInfo.InvariantCulture)
+                    : d.ToString(CultureInfo.InvariantCulture);
+            }
+
+            return Convert.ToString(value, CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return null; }
+    }
+
+    // === reverse mappings (int -> string) ===
+
+    private static string ConditionValueTypeToString(int type)
+    {
+        return type switch
+        {
+            -1 => "none",              // xlConditionValueNone
+            0 => "number",             // xlConditionValueNumber
+            1 => "minimum",            // xlConditionValueLowestValue
+            2 => "maximum",            // xlConditionValueHighestValue
+            3 => "percent",            // xlConditionValuePercent
+            4 => "percentile",         // xlConditionValuePercentile
+            5 => "formula",            // xlConditionValueFormula
+            6 => "automaticMinimum",   // xlConditionValueAutomaticMin
+            7 => "automaticMaximum",   // xlConditionValueAutomaticMax
+            _ => $"unknown({type})"
+        };
+    }
+
+    private static string DataBarDirectionToString(int direction)
+    {
+        return direction switch
+        {
+            -5002 => "context",       // xlContext (XlReadingOrder)
+            -5003 => "leftToRight",   // xlLTR
+            -5004 => "rightToLeft",   // xlRTL
+            _ => $"unknown({direction})"
+        };
+    }
+
+    private static string TopBottomToString(int topBottom)
+    {
+        return topBottom switch
+        {
+            0 => "bottom", // xlTop10Bottom
+            1 => "top",    // xlTop10Top
+            _ => $"unknown({topBottom})"
+        };
+    }
+
+    private static string AboveBelowToString(int aboveBelow)
+    {
+        return aboveBelow switch
+        {
+            0 => "aboveAverage",       // xlAboveAverage
+            1 => "aboveStdDev",        // xlAboveStdDev
+            2 => "belowAverage",       // xlBelowAverage
+            3 => "belowStdDev",        // xlBelowStdDev
+            4 => "equalAboveAverage",  // xlEqualAboveAverage
+            5 => "equalBelowAverage",  // xlEqualBelowAverage
+            _ => $"unknown({aboveBelow})"
+        };
+    }
+
+    private static string TimePeriodToString(int period)
+    {
+        return period switch
+        {
+            0 => "today",     // xlToday
+            1 => "yesterday", // xlYesterday
+            2 => "last7Days", // xlLast7Days
+            3 => "thisWeek",  // xlThisWeek
+            4 => "lastWeek",  // xlLastWeek
+            5 => "nextWeek",  // xlNextWeek
+            6 => "thisMonth", // xlThisMonth
+            7 => "lastMonth", // xlLastMonth
+            8 => "nextMonth", // xlNextMonth
+            9 => "tomorrow",  // xlTomorrow
+            _ => $"unknown({period})"
+        };
+    }
+
+    private static string IconSetIdToString(int id)
+    {
+        return id switch
+        {
+            1 => "3Arrows",          // xl3Arrows
+            2 => "3ArrowsGray",      // xl3ArrowsGray
+            3 => "3Flags",           // xl3Flags
+            4 => "3TrafficLights1",  // xl3TrafficLights1
+            5 => "3TrafficLights2",  // xl3TrafficLights2
+            6 => "3Signs",           // xl3Signs
+            7 => "3Symbols",         // xl3Symbols
+            8 => "4Arrows",          // xl4Arrows
+            9 => "4ArrowsGray",      // xl4ArrowsGray
+            10 => "4RedToBlack",     // xl4RedToBlack
+            11 => "4Ratings",        // xl4CRV
+            12 => "4TrafficLights",  // xl4TrafficLights
+            13 => "5Arrows",         // xl5Arrows
+            14 => "5ArrowsGray",     // xl5ArrowsGray
+            15 => "5Ratings",        // xl5CRV
+            16 => "5Quarters",       // xl5Quarters
+            _ => $"iconSet({id})"
+        };
+    }
+
+    private static string IconToString(int icon)
+    {
+        return icon switch
+        {
+            -1 => "noCellIcon",                    // xlIconNoCellIcon
+            1 => "greenUpArrow",                   // xlIconGreenUpArrow
+            2 => "yellowSideArrow",                // xlIconYellowSideArrow
+            3 => "redDownArrow",                   // xlIconRedDownArrow
+            4 => "grayUpArrow",                    // xlIconGrayUpArrow
+            5 => "graySideArrow",                  // xlIconGraySideArrow
+            6 => "grayDownArrow",                  // xlIconGrayDownArrow
+            7 => "greenFlag",                      // xlIconGreenFlag
+            8 => "yellowFlag",                     // xlIconYellowFlag
+            9 => "redFlag",                        // xlIconRedFlag
+            10 => "greenCircle",                   // xlIconGreenCircle
+            11 => "yellowCircle",                  // xlIconYellowCircle
+            12 => "redCircleWithBorder",           // xlIconRedCircleWithBorder
+            13 => "blackCircleWithBorder",         // xlIconBlackCircleWithBorder
+            14 => "greenTrafficLight",             // xlIconGreenTrafficLight
+            15 => "yellowTrafficLight",            // xlIconYellowTrafficLight
+            16 => "redTrafficLight",               // xlIconRedTrafficLight
+            17 => "yellowTriangle",                // xlIconYellowTriangle
+            18 => "redDiamond",                    // xlIconRedDiamond
+            19 => "greenCheckSymbol",              // xlIconGreenCheckSymbol
+            20 => "yellowExclamationSymbol",       // xlIconYellowExclamationSymbol
+            21 => "redCrossSymbol",                // xlIconRedCrossSymbol
+            22 => "greenCheck",                    // xlIconGreenCheck
+            23 => "yellowExclamation",             // xlIconYellowExclamation
+            24 => "redCross",                      // xlIconRedCross
+            25 => "yellowUpInclineArrow",          // xlIconYellowUpInclineArrow
+            26 => "yellowDownInclineArrow",        // xlIconYellowDownInclineArrow
+            27 => "grayUpInclineArrow",            // xlIconGrayUpInclineArrow
+            28 => "grayDownInclineArrow",          // xlIconGrayDownInclineArrow
+            29 => "redCircle",                     // xlIconRedCircle
+            30 => "pinkCircle",                    // xlIconPinkCircle
+            31 => "grayCircle",                    // xlIconGrayCircle
+            32 => "blackCircle",                   // xlIconBlackCircle
+            33 => "circleWithOneWhiteQuarter",     // xlIconCircleWithOneWhiteQuarter
+            34 => "circleWithTwoWhiteQuarters",    // xlIconCircleWithTwoWhiteQuarters
+            35 => "circleWithThreeWhiteQuarters",  // xlIconCircleWithThreeWhiteQuarters
+            36 => "whiteCircleAllWhiteQuarters",   // xlIconWhiteCircleAllWhiteQuarters
+            37 => "zeroBars",                      // xlIcon0Bars
+            38 => "oneBar",                        // xlIcon1Bar
+            39 => "twoBars",                       // xlIcon2Bars
+            40 => "threeBars",                     // xlIcon3Bars
+            41 => "fourBars",                      // xlIcon4Bars
+            42 => "goldStar",                      // xlIconGoldStar
+            43 => "halfGoldStar",                  // xlIconHalfGoldStar
+            44 => "silverStar",                    // xlIconSilverStar
+            45 => "greenUpTriangle",               // xlIconGreenUpTriangle
+            46 => "yellowDash",                    // xlIconYellowDash
+            47 => "redDownTriangle",               // xlIconRedDownTriangle
+            48 => "fourFilledBoxes",               // xlIcon4FilledBoxes
+            49 => "threeFilledBoxes",              // xlIcon3FilledBoxes
+            50 => "twoFilledBoxes",                // xlIcon2FilledBoxes
+            51 => "oneFilledBox",                  // xlIcon1FilledBox
+            52 => "zeroFilledBoxes",               // xlIcon0FilledBoxes
+            _ => $"icon({icon})"
+        };
+    }
+}

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.VisualRules.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.VisualRules.cs
@@ -1,0 +1,476 @@
+using System.Globalization;
+using Sbroenne.ExcelMcp.ComInterop;
+
+namespace Sbroenne.ExcelMcp.Core.Commands;
+
+/// <summary>
+/// Write-side helpers for creating visual conditional formatting rules
+/// (colorScale, dataBar, iconSet, top10, aboveAverage, uniqueValues, timePeriod).
+/// Each visual rule type requires a dedicated Excel COM Add* method rather than the
+/// generic FormatConditions.Add used by cellValue/expression rules.
+/// </summary>
+public partial class ConditionalFormattingCommands
+{
+    /// <summary>
+    /// Normalizes a rule-type string to a canonical lower-case key (kebab-case and
+    /// camelCase both accepted, e.g. "color-scale" and "colorScale" -> "colorscale").
+    /// </summary>
+    private static string NormalizeRuleType(string type) =>
+        (type ?? string.Empty).ToLowerInvariant().Replace("-", "");
+
+    // === colorScale ===
+
+    private static void AddColorScaleRule(
+        dynamic formatConditions,
+        string? minType, string? minValue, string? minColor,
+        string? midType, string? midValue, string? midColor,
+        string? maxType, string? maxValue, string? maxColor)
+    {
+        bool threeColor = !string.IsNullOrEmpty(midType)
+            || !string.IsNullOrEmpty(midValue)
+            || !string.IsNullOrEmpty(midColor);
+
+        dynamic? colorScale = null;
+        dynamic? criteria = null;
+        try
+        {
+            colorScale = formatConditions.AddColorScale(ColorScaleType: threeColor ? 3 : 2);
+            criteria = colorScale.ColorScaleCriteria;
+
+            // Criterion 1 = minimum stop.
+            SetColorScaleCriterion(criteria, 1, minType, minValue, minColor, defaultType: 1 /* lowest */);
+
+            if (threeColor)
+            {
+                SetColorScaleCriterion(criteria, 2, midType, midValue, midColor,
+                    defaultType: 4 /* percentile */, defaultValue: "50");
+                SetColorScaleCriterion(criteria, 3, maxType, maxValue, maxColor, defaultType: 2 /* highest */);
+            }
+            else
+            {
+                SetColorScaleCriterion(criteria, 2, maxType, maxValue, maxColor, defaultType: 2 /* highest */);
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref criteria!);
+            ComUtilities.Release(ref colorScale!);
+        }
+    }
+
+    private static void SetColorScaleCriterion(
+        dynamic criteria, int index,
+        string? type, string? value, string? color,
+        int defaultType, string? defaultValue = null)
+    {
+        dynamic? criterion = null;
+        dynamic? formatColor = null;
+        try
+        {
+            criterion = criteria.Item(index);
+
+            int t = string.IsNullOrEmpty(type) ? defaultType : ParseConditionValueType(type);
+            criterion.Type = t;
+
+            string? v = value ?? (string.IsNullOrEmpty(type) ? defaultValue : null);
+            if (ConditionValueTypeUsesValue(t) && !string.IsNullOrEmpty(v))
+            {
+                criterion.Value = ParseCriterionValue(v);
+            }
+
+            if (!string.IsNullOrEmpty(color))
+            {
+                formatColor = criterion.FormatColor;
+                formatColor.Color = FormattingHelpers.ParseColor(color);
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref formatColor!);
+            ComUtilities.Release(ref criterion!);
+        }
+    }
+
+    // === dataBar ===
+
+    private static void AddDataBarRule(
+        dynamic formatConditions,
+        string? fillColor, string? negativeColor, string? direction, bool? showValue,
+        string? minType, string? minValue, string? maxType, string? maxValue)
+    {
+        dynamic? dataBar = null;
+        try
+        {
+            dataBar = formatConditions.AddDatabar();
+
+            if (!string.IsNullOrEmpty(fillColor))
+            {
+                dynamic? barColor = null;
+                try
+                {
+                    barColor = dataBar.BarColor;
+                    barColor.Color = FormattingHelpers.ParseColor(fillColor);
+                }
+                finally { ComUtilities.Release(ref barColor!); }
+            }
+
+            if (!string.IsNullOrEmpty(negativeColor))
+            {
+                dynamic? negativeFormat = null;
+                dynamic? negColor = null;
+                try
+                {
+                    negativeFormat = dataBar.NegativeBarFormat;
+                    negativeFormat.ColorType = 0; // xlDataBarColor
+                    negColor = negativeFormat.Color;
+                    negColor.Color = FormattingHelpers.ParseColor(negativeColor);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref negColor!);
+                    ComUtilities.Release(ref negativeFormat!);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(direction))
+                dataBar.Direction = ParseDataBarDirection(direction);
+
+            if (showValue.HasValue)
+                dataBar.ShowValue = showValue.Value;
+
+            if (!string.IsNullOrEmpty(minType) || !string.IsNullOrEmpty(minValue))
+                ModifyConditionValue(dataBar, "MinPoint", minType, minValue);
+
+            if (!string.IsNullOrEmpty(maxType) || !string.IsNullOrEmpty(maxValue))
+                ModifyConditionValue(dataBar, "MaxPoint", maxType, maxValue);
+        }
+        finally
+        {
+            ComUtilities.Release(ref dataBar!);
+        }
+    }
+
+    private static void ModifyConditionValue(dynamic owner, string pointName, string? type, string? value)
+    {
+        dynamic? point = null;
+        try
+        {
+            point = pointName == "MinPoint" ? owner.MinPoint : owner.MaxPoint;
+            int t = string.IsNullOrEmpty(type)
+                ? (pointName == "MinPoint" ? 1 /* lowest */ : 2 /* highest */)
+                : ParseConditionValueType(type);
+
+            if (ConditionValueTypeUsesValue(t) && !string.IsNullOrEmpty(value))
+                point.Modify(t, ParseCriterionValue(value));
+            else
+                point.Modify(t);
+        }
+        finally
+        {
+            ComUtilities.Release(ref point!);
+        }
+    }
+
+    // === iconSet ===
+
+    private static void AddIconSetRule(
+        dynamic workbook,
+        dynamic formatConditions,
+        string? iconSetId,
+        bool? reverse,
+        bool? showIconOnly,
+        (string? Type, string? Value)[] thresholds)
+    {
+        dynamic? iconSetCondition = null;
+        dynamic? iconSets = null;
+        dynamic? iconSet = null;
+        dynamic? iconCriteria = null;
+        try
+        {
+            iconSetCondition = formatConditions.AddIconSetCondition();
+
+            if (!string.IsNullOrEmpty(iconSetId))
+            {
+                iconSets = workbook.IconSets;
+                iconSet = iconSets[ParseIconSetId(iconSetId)];
+                iconSetCondition.IconSet = iconSet;
+            }
+
+            if (reverse.HasValue)
+                iconSetCondition.ReverseOrder = reverse.Value;
+
+            if (showIconOnly.HasValue)
+                iconSetCondition.ShowIconOnly = showIconOnly.Value;
+
+            iconCriteria = iconSetCondition.IconCriteria;
+            int criteriaCount = Convert.ToInt32(iconCriteria.Count, CultureInfo.InvariantCulture);
+
+            // IconCriteria item 1 is the implicit lower bound; editable thresholds start at item 2.
+            for (int i = 0; i < thresholds.Length; i++)
+            {
+                var (tType, tValue) = thresholds[i];
+                if (string.IsNullOrEmpty(tType) && string.IsNullOrEmpty(tValue))
+                    continue;
+
+                int itemIndex = i + 2;
+                if (itemIndex > criteriaCount)
+                    break;
+
+                dynamic? criterion = null;
+                try
+                {
+                    criterion = iconCriteria.Item(itemIndex);
+                    if (!string.IsNullOrEmpty(tType))
+                        criterion.Type = ParseConditionValueType(tType);
+                    if (!string.IsNullOrEmpty(tValue))
+                        criterion.Value = ParseCriterionValue(tValue);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref criterion!);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref iconCriteria!);
+            ComUtilities.Release(ref iconSet!);
+            ComUtilities.Release(ref iconSets!);
+            ComUtilities.Release(ref iconSetCondition!);
+        }
+    }
+
+    // === top10 ===
+
+    private static void AddTop10Rule(
+        dynamic formatConditions,
+        int? rank, bool? percent, string? topBottom,
+        string? interiorColor, string? interiorPattern, string? fontColor,
+        bool? fontBold, bool? fontItalic, string? borderStyle, string? borderColor)
+    {
+        dynamic? fc = null;
+        try
+        {
+            fc = formatConditions.AddTop10();
+            if (rank.HasValue)
+                fc.Rank = rank.Value;
+            if (percent.HasValue)
+                fc.Percent = percent.Value;
+            if (!string.IsNullOrEmpty(topBottom))
+                fc.TopBottom = ParseTopBottom(topBottom);
+
+            ApplyRuleFormatting(fc, interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+        }
+        finally
+        {
+            ComUtilities.Release(ref fc!);
+        }
+    }
+
+    // === aboveAverage ===
+
+    private static void AddAboveAverageRule(
+        dynamic formatConditions,
+        string? aboveBelow,
+        string? interiorColor, string? interiorPattern, string? fontColor,
+        bool? fontBold, bool? fontItalic, string? borderStyle, string? borderColor)
+    {
+        dynamic? fc = null;
+        try
+        {
+            fc = formatConditions.AddAboveAverage();
+            if (!string.IsNullOrEmpty(aboveBelow))
+                fc.AboveBelow = ParseAboveBelow(aboveBelow);
+
+            ApplyRuleFormatting(fc, interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+        }
+        finally
+        {
+            ComUtilities.Release(ref fc!);
+        }
+    }
+
+    // === uniqueValues ===
+
+    private static void AddUniqueValuesRule(
+        dynamic formatConditions,
+        bool duplicate,
+        string? interiorColor, string? interiorPattern, string? fontColor,
+        bool? fontBold, bool? fontItalic, string? borderStyle, string? borderColor)
+    {
+        dynamic? fc = null;
+        try
+        {
+            fc = formatConditions.AddUniqueValues();
+            fc.DupeUnique = duplicate ? 1 /* xlDuplicate */ : 0 /* xlUnique */;
+
+            ApplyRuleFormatting(fc, interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+        }
+        finally
+        {
+            ComUtilities.Release(ref fc!);
+        }
+    }
+
+    // === timePeriod ===
+
+    private static void AddTimePeriodRule(
+        dynamic formatConditions,
+        string? datePeriod,
+        string? interiorColor, string? interiorPattern, string? fontColor,
+        bool? fontBold, bool? fontItalic, string? borderStyle, string? borderColor)
+    {
+        if (string.IsNullOrEmpty(datePeriod))
+            throw new ArgumentException("datePeriod is required for timePeriod rules (e.g. today, last7Days, thisMonth).");
+
+        dynamic? fc = null;
+        try
+        {
+            fc = formatConditions.Add(Type: 11 /* xlTimePeriod */, DateOperator: ParseTimePeriod(datePeriod));
+            ApplyRuleFormatting(fc, interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+        }
+        finally
+        {
+            ComUtilities.Release(ref fc!);
+        }
+    }
+
+    // === blanksCondition and other simple type-only rules ===
+
+    private static void AddSimpleRule(
+        dynamic formatConditions,
+        int xlType,
+        string? interiorColor, string? interiorPattern, string? fontColor,
+        bool? fontBold, bool? fontItalic, string? borderStyle, string? borderColor)
+    {
+        dynamic? fc = null;
+        try
+        {
+            fc = formatConditions.Add(Type: xlType);
+            ApplyRuleFormatting(fc, interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+        }
+        finally
+        {
+            ComUtilities.Release(ref fc!);
+        }
+    }
+
+    // === shared value helpers ===
+
+    /// <summary>
+    /// Whether a threshold type carries an associated value. Minimum/maximum/automatic
+    /// stops derive their value from the data, so no explicit value is set.
+    /// </summary>
+    private static bool ConditionValueTypeUsesValue(int conditionValueType) =>
+        conditionValueType is 0 /* number */ or 3 /* percent */ or 4 /* percentile */ or 5 /* formula */;
+
+    /// <summary>
+    /// Parses a threshold value: numeric strings become doubles; anything else (e.g. a
+    /// formula) is passed through as a string.
+    /// </summary>
+    private static object ParseCriterionValue(string value) =>
+        double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var d)
+            ? d
+            : value;
+
+    // === parse helpers (string -> Excel COM enum int) ===
+
+    private static int ParseConditionValueType(string type)
+    {
+        return type.ToLowerInvariant().Replace("-", "").Replace(" ", "") switch
+        {
+            "none" => -1,          // xlConditionValueNone
+            "number" or "num" => 0, // xlConditionValueNumber
+            "lowest" or "lowestvalue" or "minimum" or "min" => 1, // xlConditionValueLowestValue
+            "highest" or "highestvalue" or "maximum" or "max" => 2, // xlConditionValueHighestValue
+            "percent" => 3,        // xlConditionValuePercent
+            "percentile" => 4,     // xlConditionValuePercentile
+            "formula" => 5,        // xlConditionValueFormula
+            "automaticmin" or "automaticminimum" => 6, // xlConditionValueAutomaticMin
+            "automaticmax" or "automaticmaximum" => 7, // xlConditionValueAutomaticMax
+            _ => throw new ArgumentException(
+                $"Invalid threshold type: '{type}'. Valid values: number, minimum, maximum, percent, percentile, formula, automaticMinimum, automaticMaximum")
+        };
+    }
+
+    private static int ParseDataBarDirection(string direction)
+    {
+        return direction.ToLowerInvariant().Replace("-", "").Replace(" ", "") switch
+        {
+            "context" => -5002,      // xlContext (XlReadingOrder)
+            "lefttoright" or "ltr" => -5003, // xlLTR
+            "righttoleft" or "rtl" => -5004, // xlRTL
+            _ => throw new ArgumentException(
+                $"Invalid data bar direction: '{direction}'. Valid values: context, leftToRight, rightToLeft")
+        };
+    }
+
+    private static int ParseIconSetId(string iconSetId)
+    {
+        return iconSetId.ToLowerInvariant().Replace("-", "").Replace(" ", "") switch
+        {
+            "3arrows" => 1,          // xl3Arrows
+            "3arrowsgray" => 2,      // xl3ArrowsGray
+            "3flags" => 3,           // xl3Flags
+            "3trafficlights1" => 4,  // xl3TrafficLights1
+            "3trafficlights2" => 5,  // xl3TrafficLights2
+            "3signs" => 6,           // xl3Signs
+            "3symbols" => 7,         // xl3Symbols
+            "4arrows" => 8,          // xl4Arrows
+            "4arrowsgray" => 9,      // xl4ArrowsGray
+            "4redtoblack" => 10,     // xl4RedToBlack
+            "4crv" or "4ratings" => 11, // xl4CRV (Excel UI: "4 Ratings")
+            "4trafficlights" => 12,  // xl4TrafficLights
+            "5arrows" => 13,         // xl5Arrows
+            "5arrowsgray" => 14,     // xl5ArrowsGray
+            "5crv" or "5ratings" => 15, // xl5CRV (Excel UI: "5 Ratings")
+            "5quarters" => 16,       // xl5Quarters
+            _ => throw new ArgumentException(
+                $"Invalid icon set id: '{iconSetId}'. Valid values include: 3Arrows, 3ArrowsGray, 3Flags, 3TrafficLights1, 3TrafficLights2, 3Signs, 3Symbols, 4Arrows, 4ArrowsGray, 4RedToBlack, 4Ratings, 4TrafficLights, 5Arrows, 5ArrowsGray, 5Ratings, 5Quarters")
+        };
+    }
+
+    private static int ParseTopBottom(string topBottom)
+    {
+        return topBottom.ToLowerInvariant() switch
+        {
+            "bottom" => 0, // xlTop10Bottom
+            "top" => 1,    // xlTop10Top
+            _ => throw new ArgumentException($"Invalid topBottom value: '{topBottom}'. Valid values: top, bottom")
+        };
+    }
+
+    private static int ParseAboveBelow(string aboveBelow)
+    {
+        return aboveBelow.ToLowerInvariant().Replace("-", "").Replace(" ", "") switch
+        {
+            "aboveaverage" or "above" => 0,  // xlAboveAverage
+            "abovestddev" => 1,              // xlAboveStdDev
+            "belowaverage" or "below" => 2,  // xlBelowAverage
+            "belowstddev" => 3,              // xlBelowStdDev
+            "equalaboveaverage" => 4,        // xlEqualAboveAverage
+            "equalbelowaverage" => 5,        // xlEqualBelowAverage
+            _ => throw new ArgumentException(
+                $"Invalid aboveBelow value: '{aboveBelow}'. Valid values: aboveAverage, belowAverage, aboveStdDev, belowStdDev, equalAboveAverage, equalBelowAverage")
+        };
+    }
+
+    private static int ParseTimePeriod(string datePeriod)
+    {
+        return datePeriod.ToLowerInvariant().Replace("-", "").Replace(" ", "") switch
+        {
+            "today" => 0,      // xlToday
+            "yesterday" => 1,  // xlYesterday
+            "last7days" => 2,  // xlLast7Days
+            "thisweek" => 3,   // xlThisWeek
+            "lastweek" => 4,   // xlLastWeek
+            "nextweek" => 5,   // xlNextWeek
+            "thismonth" => 6,  // xlThisMonth
+            "lastmonth" => 7,  // xlLastMonth
+            "nextmonth" => 8,  // xlNextMonth
+            "tomorrow" => 9,   // xlTomorrow
+            _ => throw new ArgumentException(
+                $"Invalid datePeriod value: '{datePeriod}'. Valid values: today, yesterday, tomorrow, last7Days, thisWeek, lastWeek, nextWeek, thisMonth, lastMonth, nextMonth")
+        };
+    }
+}

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/ConditionalFormattingCommands.cs
@@ -24,105 +24,247 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
         bool? fontBold = null,
         bool? fontItalic = null,
         string? borderStyle = null,
-        string? borderColor = null)
+        string? borderColor = null,
+        string? colorScaleMinType = null,
+        string? colorScaleMinValue = null,
+        string? colorScaleMinColor = null,
+        string? colorScaleMidType = null,
+        string? colorScaleMidValue = null,
+        string? colorScaleMidColor = null,
+        string? colorScaleMaxType = null,
+        string? colorScaleMaxValue = null,
+        string? colorScaleMaxColor = null,
+        string? dataBarColor = null,
+        string? dataBarNegativeColor = null,
+        string? dataBarDirection = null,
+        bool? dataBarShowValue = null,
+        string? dataBarMinType = null,
+        string? dataBarMinValue = null,
+        string? dataBarMaxType = null,
+        string? dataBarMaxValue = null,
+        string? iconSetId = null,
+        bool? iconSetReverse = null,
+        bool? iconSetShowIconOnly = null,
+        string? iconThreshold1Type = null,
+        string? iconThreshold1Value = null,
+        string? iconThreshold2Type = null,
+        string? iconThreshold2Value = null,
+        string? iconThreshold3Type = null,
+        string? iconThreshold3Value = null,
+        string? iconThreshold4Type = null,
+        string? iconThreshold4Value = null,
+        int? rank = null,
+        bool? top10Percent = null,
+        string? topBottom = null,
+        string? aboveBelow = null,
+        string? datePeriod = null)
     {
         return batch.Execute((ctx, ct) =>
         {
             dynamic? sheet = null;
             dynamic? range = null;
             dynamic? formatConditions = null;
-            dynamic? formatCondition = null;
-            dynamic? interior = null;
-            dynamic? font = null;
-            dynamic? borders = null;
 
             try
             {
-                // Get sheet
                 sheet = string.IsNullOrEmpty(sheetName)
                     ? ctx.Book.ActiveSheet
                     : ctx.Book.Worksheets[sheetName];
 
-                // Get range
                 range = sheet.Range[rangeAddress];
-
-                // Get format conditions
                 formatConditions = range.FormatConditions;
 
-                // Parse rule type and operator
-                var xlType = ParseConditionalFormattingType(ruleType);
-                var xlOperator = ParseConditionalFormattingOperator(operatorType);
+                var normalizedType = NormalizeRuleType(ruleType);
 
-                // Add format condition
-                formatCondition = formatConditions.Add(
-                    Type: xlType,
-                    Operator: xlOperator,
-                    Formula1: formula1 ?? "",
-                    Formula2: formula2 ?? "");
-
-                // Apply Interior formatting
-                if (!string.IsNullOrEmpty(interiorColor) || !string.IsNullOrEmpty(interiorPattern))
+                switch (normalizedType)
                 {
-                    interior = formatCondition.Interior;
-                    if (!string.IsNullOrEmpty(interiorColor))
-                        interior.Color = FormattingHelpers.ParseColor(interiorColor);
-                    if (!string.IsNullOrEmpty(interiorPattern))
-                        interior.Pattern = ParseInteriorPattern(interiorPattern);
-                }
+                    case "cellvalue":
+                    case "expression":
+                        AddBasicRule(formatConditions, normalizedType, operatorType, formula1, formula2,
+                            interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+                        break;
 
-                // Apply Font formatting
-                if (!string.IsNullOrEmpty(fontColor) || fontBold.HasValue || fontItalic.HasValue)
-                {
-                    font = formatCondition.Font;
-                    if (!string.IsNullOrEmpty(fontColor))
-                        font.Color = FormattingHelpers.ParseColor(fontColor);
-                    if (fontBold.HasValue)
-                        font.Bold = fontBold.Value;
-                    if (fontItalic.HasValue)
-                        font.Italic = fontItalic.Value;
-                }
+                    case "colorscale":
+                        AddColorScaleRule(formatConditions,
+                            colorScaleMinType, colorScaleMinValue, colorScaleMinColor,
+                            colorScaleMidType, colorScaleMidValue, colorScaleMidColor,
+                            colorScaleMaxType, colorScaleMaxValue, colorScaleMaxColor);
+                        break;
 
-                // Apply Border formatting
-                if (!string.IsNullOrEmpty(borderStyle) || !string.IsNullOrEmpty(borderColor))
-                {
-                    borders = formatCondition.Borders;
-                    // NOTE: FormatCondition.Borders is a 4-item collection indexed 1-4
-                    // (left/top/bottom/right), unlike Range.Borders which uses the
-                    // xlEdgeLeft(7)/xlEdgeTop(8)/xlEdgeBottom(9)/xlEdgeRight(10) constants.
-                    // Item(7-10) on FormatCondition.Borders returns an unbound placeholder
-                    // that can be read but throws COMException when its properties are set.
-                    if (!string.IsNullOrEmpty(borderStyle))
-                    {
-                        var xlBorderStyle = FormattingHelpers.ParseBorderStyle(borderStyle);
-                        // Apply to all four borders
-                        borders.Item(1).LineStyle = xlBorderStyle; // left
-                        borders.Item(2).LineStyle = xlBorderStyle; // top
-                        borders.Item(3).LineStyle = xlBorderStyle; // bottom
-                        borders.Item(4).LineStyle = xlBorderStyle; // right
-                    }
-                    if (!string.IsNullOrEmpty(borderColor))
-                    {
-                        var color = FormattingHelpers.ParseColor(borderColor);
-                        borders.Item(1).Color = color; // left
-                        borders.Item(2).Color = color; // top
-                        borders.Item(3).Color = color; // bottom
-                        borders.Item(4).Color = color; // right
-                    }
+                    case "databar":
+                        AddDataBarRule(formatConditions,
+                            dataBarColor, dataBarNegativeColor, dataBarDirection, dataBarShowValue,
+                            dataBarMinType, dataBarMinValue, dataBarMaxType, dataBarMaxValue);
+                        break;
+
+                    case "iconset":
+                        AddIconSetRule(ctx.Book, formatConditions,
+                            iconSetId, iconSetReverse, iconSetShowIconOnly,
+                            new[]
+                            {
+                                (iconThreshold1Type, iconThreshold1Value),
+                                (iconThreshold2Type, iconThreshold2Value),
+                                (iconThreshold3Type, iconThreshold3Value),
+                                (iconThreshold4Type, iconThreshold4Value)
+                            });
+                        break;
+
+                    case "top10":
+                        AddTop10Rule(formatConditions, rank, top10Percent, topBottom,
+                            interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+                        break;
+
+                    case "aboveaverage":
+                        AddAboveAverageRule(formatConditions, aboveBelow,
+                            interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+                        break;
+
+                    case "uniquevalues":
+                        AddUniqueValuesRule(formatConditions, false,
+                            interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+                        break;
+
+                    case "timeperiod":
+                        AddTimePeriodRule(formatConditions, datePeriod,
+                            interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+                        break;
+
+                    case "blankscondition":
+                        AddSimpleRule(formatConditions, 10 /* xlBlanksCondition */,
+                            interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+                        break;
+
+                    default:
+                        throw new ArgumentException(
+                            $"Invalid conditional formatting type: '{ruleType}'. " +
+                            "Valid values: cellValue, expression, colorScale, dataBar, top10, iconSet, uniqueValues, blanksCondition, timePeriod, aboveAverage");
                 }
 
                 return new OperationResult { Success = true, FilePath = batch.WorkbookPath }; // Dummy return for batch.Execute
             }
             finally
             {
-                ComUtilities.Release(ref borders!);
-                ComUtilities.Release(ref font!);
-                ComUtilities.Release(ref interior!);
-                ComUtilities.Release(ref formatCondition!);
                 ComUtilities.Release(ref formatConditions!);
                 ComUtilities.Release(ref range!);
                 ComUtilities.Release(ref sheet!);
             }
         });
+    }
+
+    /// <summary>
+    /// Adds a basic (cellValue/expression) rule and applies interior/font/border formatting.
+    /// </summary>
+    private static void AddBasicRule(
+        dynamic formatConditions,
+        string normalizedType,
+        string? operatorType,
+        string? formula1,
+        string? formula2,
+        string? interiorColor,
+        string? interiorPattern,
+        string? fontColor,
+        bool? fontBold,
+        bool? fontItalic,
+        string? borderStyle,
+        string? borderColor)
+    {
+        dynamic? formatCondition = null;
+
+        try
+        {
+            var xlType = normalizedType == "expression" ? 2 : 1;
+            var xlOperator = ParseConditionalFormattingOperator(operatorType);
+
+            formatCondition = formatConditions.Add(
+                Type: xlType,
+                Operator: xlOperator,
+                Formula1: formula1 ?? "",
+                Formula2: formula2 ?? "");
+
+            ApplyRuleFormatting(formatCondition,
+                interiorColor, interiorPattern, fontColor, fontBold, fontItalic, borderStyle, borderColor);
+        }
+        finally
+        {
+            ComUtilities.Release(ref formatCondition!);
+        }
+    }
+
+    /// <summary>
+    /// Applies interior/font/border formatting to a format condition. Shared by rule types
+    /// that support cell formatting (cellValue, expression, top10, aboveAverage, timePeriod, etc.).
+    /// </summary>
+    private static void ApplyRuleFormatting(
+        dynamic formatCondition,
+        string? interiorColor,
+        string? interiorPattern,
+        string? fontColor,
+        bool? fontBold,
+        bool? fontItalic,
+        string? borderStyle,
+        string? borderColor)
+    {
+        dynamic? interior = null;
+        dynamic? font = null;
+        dynamic? borders = null;
+
+        try
+        {
+            // Apply Interior formatting
+            if (!string.IsNullOrEmpty(interiorColor) || !string.IsNullOrEmpty(interiorPattern))
+            {
+                interior = formatCondition.Interior;
+                if (!string.IsNullOrEmpty(interiorColor))
+                    interior.Color = FormattingHelpers.ParseColor(interiorColor);
+                if (!string.IsNullOrEmpty(interiorPattern))
+                    interior.Pattern = ParseInteriorPattern(interiorPattern);
+            }
+
+            // Apply Font formatting
+            if (!string.IsNullOrEmpty(fontColor) || fontBold.HasValue || fontItalic.HasValue)
+            {
+                font = formatCondition.Font;
+                if (!string.IsNullOrEmpty(fontColor))
+                    font.Color = FormattingHelpers.ParseColor(fontColor);
+                if (fontBold.HasValue)
+                    font.Bold = fontBold.Value;
+                if (fontItalic.HasValue)
+                    font.Italic = fontItalic.Value;
+            }
+
+            // Apply Border formatting
+            if (!string.IsNullOrEmpty(borderStyle) || !string.IsNullOrEmpty(borderColor))
+            {
+                borders = formatCondition.Borders;
+                // NOTE: FormatCondition.Borders is a 4-item collection indexed 1-4
+                // (left/top/bottom/right), unlike Range.Borders which uses the
+                // xlEdgeLeft(7)/xlEdgeTop(8)/xlEdgeBottom(9)/xlEdgeRight(10) constants.
+                // Item(7-10) on FormatCondition.Borders returns an unbound placeholder
+                // that can be read but throws COMException when its properties are set.
+                if (!string.IsNullOrEmpty(borderStyle))
+                {
+                    var xlBorderStyle = FormattingHelpers.ParseBorderStyle(borderStyle);
+                    borders.Item(1).LineStyle = xlBorderStyle; // left
+                    borders.Item(2).LineStyle = xlBorderStyle; // top
+                    borders.Item(3).LineStyle = xlBorderStyle; // bottom
+                    borders.Item(4).LineStyle = xlBorderStyle; // right
+                }
+                if (!string.IsNullOrEmpty(borderColor))
+                {
+                    var color = FormattingHelpers.ParseColor(borderColor);
+                    borders.Item(1).Color = color; // left
+                    borders.Item(2).Color = color; // top
+                    borders.Item(3).Color = color; // bottom
+                    borders.Item(4).Color = color; // right
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref borders!);
+            ComUtilities.Release(ref font!);
+            ComUtilities.Release(ref interior!);
+        }
     }
 
     /// <inheritdoc />
@@ -271,9 +413,10 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
             {
                 fc = formatConditions.Item(i);
 
+                int typeNum = ReadRuleTypeInt(fc);
                 var rule = new ConditionalFormatRuleInfo
                 {
-                    Type = ReadRuleType(fc)
+                    Type = typeNum >= 0 ? ConditionalFormattingTypeToString(typeNum) : "unknown"
                 };
 
                 rule.Operator = ReadRuleOperator(fc);
@@ -343,6 +486,17 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
                 }
                 catch (Exception ex) when (IsComOrBinderException(ex)) { }
 
+                // Type-specific configuration (visual rule types).
+                switch (typeNum)
+                {
+                    case 3: rule.ColorScaleCriteria = ReadColorScale(fc); break;   // xlColorScale
+                    case 4: rule.DataBar = ReadDataBar(fc); break;                 // xlDatabar
+                    case 5: rule.Top10 = ReadTop10(fc); break;                     // xlTop10
+                    case 6: rule.IconSet = ReadIconSet(fc); break;                 // xlIconSet
+                    case 11: rule.DatePeriod = ReadTimePeriod(fc); break;          // xlTimePeriod
+                    case 12: rule.AboveBelow = ReadAboveBelow(fc); break;          // xlAboveAverageCondition
+                }
+
                 rules.Add(rule);
             }
             finally
@@ -359,10 +513,10 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
         return rules;
     }
 
-    private static string ReadRuleType(dynamic fc)
+    private static int ReadRuleTypeInt(dynamic fc)
     {
-        try { return ConditionalFormattingTypeToString(Convert.ToInt32(fc.Type, System.Globalization.CultureInfo.InvariantCulture)); }
-        catch (Exception ex) when (IsComOrBinderException(ex)) { return "unknown"; }
+        try { return Convert.ToInt32(fc.Type, System.Globalization.CultureInfo.InvariantCulture); }
+        catch (Exception ex) when (IsComOrBinderException(ex)) { return -1; }
     }
 
     private static string? ReadRuleOperator(dynamic fc)
@@ -429,34 +583,6 @@ public partial class ConditionalFormattingCommands : IConditionalFormattingComma
         ex is Microsoft.CSharp.RuntimeBinder.RuntimeBinderException
         or System.Runtime.InteropServices.COMException
         or System.InvalidCastException;
-
-    private static int ParseConditionalFormattingType(string type)
-    {
-        return type.ToLowerInvariant() switch
-        {
-            "cellvalue" => 1, // xlCellValue
-            "cell-value" => 1, // xlCellValue (kebab-case alias)
-            "expression" => 2, // xlExpression
-            "colorscale" => 3, // xlColorScale
-            "color-scale" => 3, // xlColorScale (kebab-case alias)
-            "databar" => 4, // xlDatabar
-            "data-bar" => 4, // xlDatabar (kebab-case alias)
-            "top10" => 5, // xlTop10
-            "iconset" => 6, // xlIconSet
-            "icon-set" => 6, // xlIconSet (kebab-case alias)
-            "uniquevalues" => 8, // xlUniqueValues
-            "unique-values" => 8, // xlUniqueValues (kebab-case alias)
-            "blankscondition" => 10, // xlBlanksCondition
-            "blanks-condition" => 10, // xlBlanksCondition (kebab-case alias)
-            "timeperiod" => 11, // xlTimePeriod
-            "time-period" => 11, // xlTimePeriod (kebab-case alias)
-            "aboveaverage" => 12, // xlAboveAverageCondition
-            "above-average" => 12, // xlAboveAverageCondition (kebab-case alias)
-            _ => throw new ArgumentException(
-                $"Invalid conditional formatting type: '{type}'. " +
-                "Valid values: cellValue, expression, colorScale, dataBar, top10, iconSet, uniqueValues, blanksCondition, timePeriod, aboveAverage")
-        };
-    }
 
     private static int ParseConditionalFormattingOperator(string? operatorType)
     {

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/IConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/IConditionalFormattingCommands.cs
@@ -6,20 +6,36 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 
 /// <summary>
 /// Conditional formatting - visual rules based on cell values.
-/// TYPES: cellValue (requires operatorType+formula1), expression (formula only). Both camelCase and kebab-case accepted.
+/// TYPES: cellValue (requires operatorType+formula1), expression (formula only),
+/// colorScale, dataBar, iconSet, top10, aboveAverage, timePeriod, uniqueValues, blanksCondition.
+/// Both camelCase and kebab-case accepted.
 /// FORMAT: interiorColor/fontColor as #RRGGBB, fontBold/Italic, borderStyle/Color.
+/// Visual rule types use dedicated parameters on add-rule and return their type-specific
+/// configuration from list-rules / list-worksheet-rules.
 ///
 /// OPERATORS: equal, notEqual, greater, less, greaterEqual, lessEqual, between, notBetween.
 /// For 'between' and 'notBetween', both formula1 and formula2 are required.
 /// </summary>
 [ServiceCategory("conditionalformat", "ConditionalFormat")]
 [McpTool("conditionalformat", Title = "Conditional Formatting", Destructive = true, Category = "structure",
-    Description = "Conditional formatting - visual rules based on cell values. TYPES: cellValue (accepts both camelCase and kebab-case, e.g. cell-value), expression. For cellValue: requires operatorType + formula1. FORMAT: interiorColor/fontColor as #RRGGBB hex, fontBold/fontItalic booleans, borderStyle/borderColor.")]
+    Description = "Conditional formatting - visual rules based on cell values. TYPES: cellValue, expression, colorScale, dataBar, iconSet, top10, aboveAverage, timePeriod, uniqueValues, blanksCondition (accepts both camelCase and kebab-case). For cellValue: requires operatorType + formula1. Visual types use dedicated add-rule parameters and list-rules returns their type-specific config (colorScaleCriteria, dataBar, iconSet, top10, aboveBelow, datePeriod). FORMAT: interiorColor/fontColor as #RRGGBB hex, fontBold/fontItalic booleans, borderStyle/borderColor.")]
 public interface IConditionalFormattingCommands
 {
     /// <summary>
-    /// Adds conditional formatting rule to range with full format control
-    /// Excel COM: Range.FormatConditions.Add(), FormatCondition.Interior/Font/Borders
+    /// Adds a conditional formatting rule to a range.
+    /// Excel COM: Range.FormatConditions.Add / AddColorScale / AddDatabar /
+    /// AddIconSetCondition / AddTop10 / AddAboveAverage / AddUniqueValues.
+    ///
+    /// Basic rules (cellValue, expression) use operatorType/formula1/formula2 plus the
+    /// interior/font/border format parameters. Visual rules use their own dedicated
+    /// parameters (all optional; only the ones matching ruleType are read):
+    /// - colorScale: colorScaleMin/Mid/Max Type/Value/Color (supply a mid stop for a 3-color scale)
+    /// - dataBar: dataBarColor, dataBarNegativeColor, dataBarDirection, dataBarShowValue,
+    ///   dataBarMin/Max Type/Value
+    /// - iconSet: iconSetId, iconSetReverse, iconSetShowIconOnly, iconThreshold1..4 Type/Value
+    /// - top10: rank, top10Percent, topBottom
+    /// - aboveAverage: aboveBelow
+    /// - timePeriod: datePeriod
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Sheet name (empty for active sheet)</param>
@@ -35,6 +51,39 @@ public interface IConditionalFormattingCommands
     /// <param name="fontItalic">Italic font</param>
     /// <param name="borderStyle">Border style: none, continuous, dash, dot, etc.</param>
     /// <param name="borderColor">Border color (#RRGGBB or color index)</param>
+    /// <param name="colorScaleMinType">colorScale minimum stop type: minimum, number, percent, percentile, formula</param>
+    /// <param name="colorScaleMinValue">colorScale minimum stop value (for number/percent/percentile/formula)</param>
+    /// <param name="colorScaleMinColor">colorScale minimum stop color (#RRGGBB)</param>
+    /// <param name="colorScaleMidType">colorScale midpoint stop type (supply to create a 3-color scale)</param>
+    /// <param name="colorScaleMidValue">colorScale midpoint stop value</param>
+    /// <param name="colorScaleMidColor">colorScale midpoint stop color (#RRGGBB)</param>
+    /// <param name="colorScaleMaxType">colorScale maximum stop type: maximum, number, percent, percentile, formula</param>
+    /// <param name="colorScaleMaxValue">colorScale maximum stop value</param>
+    /// <param name="colorScaleMaxColor">colorScale maximum stop color (#RRGGBB)</param>
+    /// <param name="dataBarColor">dataBar fill color (#RRGGBB)</param>
+    /// <param name="dataBarNegativeColor">dataBar negative-value bar color (#RRGGBB)</param>
+    /// <param name="dataBarDirection">dataBar fill direction: context, leftToRight, rightToLeft</param>
+    /// <param name="dataBarShowValue">dataBar show the cell value alongside the bar</param>
+    /// <param name="dataBarMinType">dataBar minimum point type: automaticMinimum, minimum, number, percent, percentile, formula</param>
+    /// <param name="dataBarMinValue">dataBar minimum point value</param>
+    /// <param name="dataBarMaxType">dataBar maximum point type: automaticMaximum, maximum, number, percent, percentile, formula</param>
+    /// <param name="dataBarMaxValue">dataBar maximum point value</param>
+    /// <param name="iconSetId">iconSet id: 3Arrows, 3TrafficLights1, 4Ratings, 5Quarters, etc.</param>
+    /// <param name="iconSetReverse">iconSet reverse icon order</param>
+    /// <param name="iconSetShowIconOnly">iconSet show only the icon (hide the value)</param>
+    /// <param name="iconThreshold1Type">iconSet threshold 1 type: percent, number, percentile, formula</param>
+    /// <param name="iconThreshold1Value">iconSet threshold 1 value</param>
+    /// <param name="iconThreshold2Type">iconSet threshold 2 type</param>
+    /// <param name="iconThreshold2Value">iconSet threshold 2 value</param>
+    /// <param name="iconThreshold3Type">iconSet threshold 3 type</param>
+    /// <param name="iconThreshold3Value">iconSet threshold 3 value</param>
+    /// <param name="iconThreshold4Type">iconSet threshold 4 type</param>
+    /// <param name="iconThreshold4Value">iconSet threshold 4 value</param>
+    /// <param name="rank">top10 rank (number of values, or percent when top10Percent is true)</param>
+    /// <param name="top10Percent">top10 treat rank as a percentage</param>
+    /// <param name="topBottom">top10 direction: top or bottom</param>
+    /// <param name="aboveBelow">aboveAverage selector: aboveAverage, belowAverage, aboveStdDev, belowStdDev, equalAboveAverage, equalBelowAverage</param>
+    /// <param name="datePeriod">timePeriod period: today, yesterday, tomorrow, last7Days, thisWeek, lastWeek, nextWeek, thisMonth, lastMonth, nextMonth</param>
     /// <exception cref="InvalidOperationException">Sheet or range not found</exception>
     /// <exception cref="ArgumentException">Invalid rule type, operator, color, or format value</exception>
     [ServiceAction("add-rule")]
@@ -52,7 +101,40 @@ public interface IConditionalFormattingCommands
         [FromString("fontBold")] bool? fontBold = null,
         [FromString("fontItalic")] bool? fontItalic = null,
         [FromString("borderStyle")] string? borderStyle = null,
-        [FromString("borderColor")] string? borderColor = null);
+        [FromString("borderColor")] string? borderColor = null,
+        [FromString("colorScaleMinType")] string? colorScaleMinType = null,
+        [FromString("colorScaleMinValue")] string? colorScaleMinValue = null,
+        [FromString("colorScaleMinColor")] string? colorScaleMinColor = null,
+        [FromString("colorScaleMidType")] string? colorScaleMidType = null,
+        [FromString("colorScaleMidValue")] string? colorScaleMidValue = null,
+        [FromString("colorScaleMidColor")] string? colorScaleMidColor = null,
+        [FromString("colorScaleMaxType")] string? colorScaleMaxType = null,
+        [FromString("colorScaleMaxValue")] string? colorScaleMaxValue = null,
+        [FromString("colorScaleMaxColor")] string? colorScaleMaxColor = null,
+        [FromString("dataBarColor")] string? dataBarColor = null,
+        [FromString("dataBarNegativeColor")] string? dataBarNegativeColor = null,
+        [FromString("dataBarDirection")] string? dataBarDirection = null,
+        [FromString("dataBarShowValue")] bool? dataBarShowValue = null,
+        [FromString("dataBarMinType")] string? dataBarMinType = null,
+        [FromString("dataBarMinValue")] string? dataBarMinValue = null,
+        [FromString("dataBarMaxType")] string? dataBarMaxType = null,
+        [FromString("dataBarMaxValue")] string? dataBarMaxValue = null,
+        [FromString("iconSetId")] string? iconSetId = null,
+        [FromString("iconSetReverse")] bool? iconSetReverse = null,
+        [FromString("iconSetShowIconOnly")] bool? iconSetShowIconOnly = null,
+        [FromString("iconThreshold1Type")] string? iconThreshold1Type = null,
+        [FromString("iconThreshold1Value")] string? iconThreshold1Value = null,
+        [FromString("iconThreshold2Type")] string? iconThreshold2Type = null,
+        [FromString("iconThreshold2Value")] string? iconThreshold2Value = null,
+        [FromString("iconThreshold3Type")] string? iconThreshold3Type = null,
+        [FromString("iconThreshold3Value")] string? iconThreshold3Value = null,
+        [FromString("iconThreshold4Type")] string? iconThreshold4Type = null,
+        [FromString("iconThreshold4Value")] string? iconThreshold4Value = null,
+        [FromString("rank")] int? rank = null,
+        [FromString("top10Percent")] bool? top10Percent = null,
+        [FromString("topBottom")] string? topBottom = null,
+        [FromString("aboveBelow")] string? aboveBelow = null,
+        [FromString("datePeriod")] string? datePeriod = null);
 
     /// <summary>
     /// Removes all conditional formatting from range
@@ -73,8 +155,10 @@ public interface IConditionalFormattingCommands
     /// Excel COM: Range.FormatConditions enumeration.
     /// Returns rule type, operator, formulas, applies-to range, priority, and formatting
     /// (interior/font/borders). Colors are returned as #RRGGBB hex strings. Rules are returned
-    /// in priority order. Rule types that do not use an operator or formatting (e.g. colorScale,
-    /// dataBar, iconSet) return only their type with null formatting fields.
+    /// in priority order. Visual rule types also return their type-specific configuration:
+    /// colorScale -> colorScaleCriteria, dataBar -> dataBar, iconSet -> iconSet,
+    /// top10 -> top10, aboveAverage -> aboveBelow, timePeriod -> datePeriod. Each field is only
+    /// present on its matching rule type.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Sheet name (empty for active sheet)</param>

--- a/src/ExcelMcp.Core/Models/ConditionalFormatTypes.cs
+++ b/src/ExcelMcp.Core/Models/ConditionalFormatTypes.cs
@@ -117,4 +117,164 @@ public class ConditionalFormatRuleInfo
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? BorderColor { get; set; }
+
+    /// <summary>
+    /// Color-scale criteria (2 or 3 stops), populated for <c>colorScale</c> rules.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<ColorScaleCriterionInfo>? ColorScaleCriteria { get; set; }
+
+    /// <summary>
+    /// Data-bar configuration, populated for <c>dataBar</c> rules.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DataBarInfo? DataBar { get; set; }
+
+    /// <summary>
+    /// Icon-set configuration, populated for <c>iconSet</c> rules.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IconSetInfo? IconSet { get; set; }
+
+    /// <summary>
+    /// Top/bottom configuration, populated for <c>top10</c> rules.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Top10Info? Top10 { get; set; }
+
+    /// <summary>
+    /// Above/below average selector (e.g. aboveAverage, belowAverage, aboveStdDev),
+    /// populated for <c>aboveAverage</c> rules.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AboveBelow { get; set; }
+
+    /// <summary>
+    /// Date period (e.g. today, yesterday, last7Days, thisMonth),
+    /// populated for <c>timePeriod</c> rules.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DatePeriod { get; set; }
+}
+
+/// <summary>
+/// A single color-scale stop (minimum, midpoint or maximum).
+/// </summary>
+public class ColorScaleCriterionInfo
+{
+    /// <summary>
+    /// Threshold type (e.g. minimum, maximum, number, percent, percentile, formula).
+    /// </summary>
+    public string Type { get; set; } = "";
+
+    /// <summary>
+    /// Threshold value, when the type requires one (null for minimum/maximum/automatic).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Value { get; set; }
+
+    /// <summary>
+    /// Stop color as #RRGGBB.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Color { get; set; }
+}
+
+/// <summary>
+/// Data-bar configuration read from a <c>dataBar</c> rule.
+/// </summary>
+public class DataBarInfo
+{
+    /// <summary>Bar fill color as #RRGGBB.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FillColor { get; set; }
+
+    /// <summary>Negative-value bar color as #RRGGBB, when a custom negative color is set.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BarColorNegative { get; set; }
+
+    /// <summary>Fill direction (context, leftToRight, rightToLeft).</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Direction { get; set; }
+
+    /// <summary>Whether the cell value is shown alongside the bar.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ShowValue { get; set; }
+
+    /// <summary>Minimum-point threshold type.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MinType { get; set; }
+
+    /// <summary>Minimum-point threshold value, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MinValue { get; set; }
+
+    /// <summary>Maximum-point threshold type.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MaxType { get; set; }
+
+    /// <summary>Maximum-point threshold value, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MaxValue { get; set; }
+}
+
+/// <summary>
+/// Icon-set configuration read from an <c>iconSet</c> rule.
+/// </summary>
+public class IconSetInfo
+{
+    /// <summary>Icon-set id (e.g. 3Arrows, 3TrafficLights1, 5Quarters).</summary>
+    public string Id { get; set; } = "";
+
+    /// <summary>Whether the icon order is reversed.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Reverse { get; set; }
+
+    /// <summary>Whether only the icon (not the value) is shown.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ShowIconOnly { get; set; }
+
+    /// <summary>Icon threshold criteria, in ascending order.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<IconCriterionInfo>? Criteria { get; set; }
+}
+
+/// <summary>
+/// A single icon-set threshold criterion.
+/// </summary>
+public class IconCriterionInfo
+{
+    /// <summary>Comparison operator (greater, greaterEqual).</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Operator { get; set; }
+
+    /// <summary>Threshold value, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Value { get; set; }
+
+    /// <summary>Threshold type (number, percent, percentile, formula).</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Type { get; set; }
+
+    /// <summary>Icon name for this criterion (e.g. greenUpArrow), when readable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Icon { get; set; }
+}
+
+/// <summary>
+/// Top/bottom configuration read from a <c>top10</c> rule.
+/// </summary>
+public class Top10Info
+{
+    /// <summary>Number of values (or percent) to highlight.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Rank { get; set; }
+
+    /// <summary>Whether <see cref="Rank"/> is a percentage rather than a count.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Percent { get; set; }
+
+    /// <summary>Whether the rule highlights the top or bottom values.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TopBottom { get; set; }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/ConditionalFormat/ConditionalFormattingCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/ConditionalFormat/ConditionalFormattingCommandsTests.cs
@@ -192,4 +192,194 @@ public class ConditionalFormattingCommandsTests : IClassFixture<TempDirectoryFix
         Assert.ThrowsAny<Exception>(() =>
             _commands.ListRules(batch, "", "NotARange!!"));
     }
+
+    // === Issue #743: visual rule types expose type-specific configuration ===
+
+    [Fact]
+    public void AddRule_ColorScale_RoundTrips()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "colorScale", null, null, null,
+            colorScaleMinType: "minimum", colorScaleMinColor: "#F8696B",
+            colorScaleMidType: "percentile", colorScaleMidValue: "50", colorScaleMidColor: "#FFEB84",
+            colorScaleMaxType: "maximum", colorScaleMaxColor: "#63BE7B");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("colorScale", rule.Type);
+        Assert.NotNull(rule.ColorScaleCriteria);
+        Assert.Equal(3, rule.ColorScaleCriteria!.Count);
+        Assert.Equal("minimum", rule.ColorScaleCriteria[0].Type);
+        Assert.Equal("#F8696B", rule.ColorScaleCriteria[0].Color);
+        Assert.Equal("percentile", rule.ColorScaleCriteria[1].Type);
+        Assert.Equal("50", rule.ColorScaleCriteria[1].Value);
+        Assert.Equal("#FFEB84", rule.ColorScaleCriteria[1].Color);
+        Assert.Equal("maximum", rule.ColorScaleCriteria[2].Type);
+        Assert.Equal("#63BE7B", rule.ColorScaleCriteria[2].Color);
+        // Visual rules must not carry cellValue-only fields.
+        Assert.Null(rule.DataBar);
+        Assert.Null(rule.IconSet);
+    }
+
+    [Fact]
+    public void AddRule_DataBar_RoundTrips()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "dataBar", null, null, null,
+            dataBarColor: "#638EC6", dataBarDirection: "leftToRight", dataBarShowValue: true,
+            dataBarMinType: "minimum", dataBarMaxType: "maximum");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("dataBar", rule.Type);
+        Assert.NotNull(rule.DataBar);
+        Assert.Equal("#638EC6", rule.DataBar!.FillColor);
+        Assert.Equal("leftToRight", rule.DataBar.Direction);
+        Assert.True(rule.DataBar.ShowValue);
+        Assert.Equal("minimum", rule.DataBar.MinType);
+        Assert.Equal("maximum", rule.DataBar.MaxType);
+        Assert.Null(rule.ColorScaleCriteria);
+    }
+
+    [Fact]
+    public void AddRule_IconSet_RoundTrips()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "iconSet", null, null, null,
+            iconSetId: "3TrafficLights1", iconSetReverse: false, iconSetShowIconOnly: false,
+            iconThreshold1Type: "percent", iconThreshold1Value: "33",
+            iconThreshold2Type: "percent", iconThreshold2Value: "67");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("iconSet", rule.Type);
+        Assert.NotNull(rule.IconSet);
+        Assert.Equal("3TrafficLights1", rule.IconSet!.Id);
+        Assert.False(rule.IconSet.Reverse);
+        Assert.False(rule.IconSet.ShowIconOnly);
+        Assert.NotNull(rule.IconSet.Criteria);
+        Assert.True(rule.IconSet.Criteria!.Count >= 2);
+        Assert.Null(rule.DataBar);
+    }
+
+    [Fact]
+    public void AddRule_Top10_RoundTrips()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "top10", null, null, null,
+            rank: 10, top10Percent: false, topBottom: "top",
+            interiorColor: "#FFC7CE");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("top10", rule.Type);
+        Assert.NotNull(rule.Top10);
+        Assert.Equal(10, rule.Top10!.Rank);
+        Assert.False(rule.Top10.Percent);
+        Assert.Equal("top", rule.Top10.TopBottom);
+        Assert.Equal("#FFC7CE", rule.InteriorColor);
+    }
+
+    [Fact]
+    public void AddRule_AboveAverage_RoundTrips()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "aboveAverage", null, null, null,
+            aboveBelow: "belowAverage", interiorColor: "#FFEB9C");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("aboveAverage", rule.Type);
+        Assert.Equal("belowAverage", rule.AboveBelow);
+        Assert.Equal("#FFEB9C", rule.InteriorColor);
+    }
+
+    [Fact]
+    public void AddRule_TimePeriod_RoundTrips()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "timePeriod", null, null, null,
+            datePeriod: "last7Days", interiorColor: "#C6EFCE");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("timePeriod", rule.Type);
+        Assert.Equal("last7Days", rule.DatePeriod);
+        Assert.Equal("#C6EFCE", rule.InteriorColor);
+    }
+
+    [Fact]
+    public void ListRules_MixedRuleTypes_EachHasOnlyItsFields()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "cellValue", "greater", "100", null,
+            interiorColor: "#FFFF00");
+        _commands.AddRule(batch, "", "A1:A41", "colorScale", null, null, null,
+            colorScaleMinType: "minimum", colorScaleMinColor: "#F8696B",
+            colorScaleMaxType: "maximum", colorScaleMaxColor: "#63BE7B");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Rules.Count);
+
+        var cellValue = result.Rules.Single(r => r.Type == "cellValue");
+        Assert.Null(cellValue.ColorScaleCriteria);
+        Assert.Null(cellValue.DataBar);
+        Assert.Null(cellValue.IconSet);
+        Assert.Null(cellValue.Top10);
+
+        var colorScale = result.Rules.Single(r => r.Type == "colorScale");
+        Assert.NotNull(colorScale.ColorScaleCriteria);
+        Assert.Null(colorScale.Operator);
+        Assert.Null(colorScale.DataBar);
+    }
+
+    [Fact]
+    public void ListRules_CellValueRule_HasNoVisualFields()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(file);
+
+        _commands.AddRule(batch, "", "A1:A41", "cellValue", "between", "10", "20",
+            interiorColor: "#FFFF00");
+
+        var result = _commands.ListRules(batch, "", "A1:A41");
+
+        Assert.True(result.Success);
+        var rule = Assert.Single(result.Rules);
+        Assert.Equal("cellValue", rule.Type);
+        Assert.Null(rule.ColorScaleCriteria);
+        Assert.Null(rule.DataBar);
+        Assert.Null(rule.IconSet);
+        Assert.Null(rule.Top10);
+        Assert.Null(rule.AboveBelow);
+        Assert.Null(rule.DatePeriod);
+    }
 }


### PR DESCRIPTION
## Summary
- expose type-specific details for visual conditional formatting rules in list responses
- support creating visual rules through add-rule with flat parameters
- add round-trip integration tests and docs updates