### PR TITLE
docs: pin changelog preamble to top and fix release tooling that sank it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+All notable changes to ExcelMcp will be documented in this file.
+
+This changelog covers all components:
+
+- **MCP Server** - Model Context Protocol server for AI assistants
+- **CLI** - Command-line interface for scripting and coding agents
+- **VS Code Extension** - One-click installation with bundled MCP Server
+- **MCPB** - Claude Desktop bundle for one-click installation
+
+Entries are short and end-user-facing. Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses [Semantic Versioning](https://semver.org/). Starting with this file, entries are compiled automatically from [changesets](.changeset/README.md) at release time — see [Release Strategy](docs/RELEASE-STRATEGY.md#changelog-generation) for how to add one.
+
 ## [1.10.2] - 2026-07-26
 
 ### Minor Changes
@@ -69,21 +80,6 @@
 ### Patch Changes
 
 - [#699](https://github.com/sbroenne/mcp-server-excel/pull/699) [`0e1c4eb`](https://github.com/sbroenne/mcp-server-excel/commit/0e1c4eb773185cfe164cadadb3ad3d23839417ec) Thanks [@sbroenne](https://github.com/sbroenne)! - **Changelog generation now uses changesets** (#698): Each PR adds a small, human-written note describing what changed for users, and these notes are compiled automatically into `CHANGELOG.md` and the GitHub Release notes when a new version ships. This replaces the old manual process, which had let several releases' worth of changes sit mislabeled as "Unreleased" for months. The changelog itself has also been cleaned up — the mislabeled entries were consolidated and condensed into clearer, less technical summaries.
-
-All notable changes to ExcelMcp will be documented in this file.
-
-This changelog covers all components:
-
-- **MCP Server** - Model Context Protocol server for AI assistants
-- **CLI** - Command-line interface for scripting and coding agents
-- **VS Code Extension** - One-click installation with bundled MCP Server
-- **MCPB** - Claude Desktop bundle for one-click installation
-
-Entries are short and end-user-facing. Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses [Semantic Versioning](https://semver.org/). Starting with this file, entries are compiled automatically from [changesets](.changeset/README.md) at release time — see [Release Strategy](docs/RELEASE-STRATEGY.md#changelog-generation) for how to add one.
-
-## [Unreleased]
-
-_No pending changes. New entries are added automatically from [changesets](.changeset/README.md) when a release is cut — see [Release Strategy](docs/RELEASE-STRATEGY.md#changelog-generation)._
 
 ## [1.9.0] - 2026-07-08
 

--- a/scripts/Build-Changelog.ps1
+++ b/scripts/Build-Changelog.ps1
@@ -143,9 +143,31 @@ if ($headerIdx -ge $newSectionLines.Count -or $newSectionLines[$headerIdx] -notm
 $newSectionLines[$headerIdx] = "## [$Version] - $Date"
 $newSection = ($newSectionLines -join "`n").Trim()
 
-# --- Step 5: reassemble CHANGELOG.md: title + normalized new section + untouched body.
-$beforeBodyTrimmed = $beforeBody.TrimStart("`r", "`n")
-$finalContent = "$titleLine`n`n$newSection`n`n$beforeBodyTrimmed".TrimEnd() + "`n"
+# --- Step 5: reassemble CHANGELOG.md as: title + preamble + new section + prior
+# versions. The preamble is any prose between the title and the first `## [` version
+# heading. Inserting the new section *after* the preamble — rather than immediately
+# after the title line — keeps the preamble pinned at the top. Inserting after the
+# title (the previous behavior) pushed the preamble one release further down every
+# time, which is how it eventually ended up buried among old version entries.
+$beforeBodyLines = $beforeBody -split "`n"
+$firstVersionIdx = -1
+for ($i = 0; $i -lt $beforeBodyLines.Count; $i++) {
+    if ($beforeBodyLines[$i] -match '^##\s+\[') { $firstVersionIdx = $i; break }
+}
+if ($firstVersionIdx -le 0) {
+    # No preamble (body starts at, or before, the first version heading).
+    $preambleBlock = ''
+    $priorVersions = $beforeBody.Trim("`r", "`n")
+}
+else {
+    $preambleBlock = (($beforeBodyLines[0..($firstVersionIdx - 1)]) -join "`n").Trim("`r", "`n")
+    $priorVersions = (($beforeBodyLines[$firstVersionIdx..($beforeBodyLines.Count - 1)]) -join "`n").Trim("`r", "`n")
+}
+$sections = @($titleLine)
+if (-not [string]::IsNullOrWhiteSpace($preambleBlock)) { $sections += $preambleBlock }
+$sections += $newSection
+if (-not [string]::IsNullOrWhiteSpace($priorVersions)) { $sections += $priorVersions }
+$finalContent = ($sections -join "`n`n").TrimEnd() + "`n"
 Set-Content -LiteralPath $changelogPath -Value $finalContent -NoNewline
 
 # --- Step 6: keep package.json's bookkeeping version in exact sync with the real


### PR DESCRIPTION
## Summary

Fixes a long-standing structural drift in `CHANGELOG.md` and the root cause in the release tooling that produced it.

**Symptom:** the intro preamble ("All notable changes to ExcelMcp…", the component list, the "Entries are short…" note) had drifted down into the middle of the `## [1.9.1]` section, and a stray `## [Unreleased]` ("_No pending changes_") block was wedged between 1.9.1 and 1.9.0.

**Root cause:** `scripts/Build-Changelog.ps1` (Step 5) reassembled the file as `title + newSection + body`, i.e. it inserted each new release *between the `# Changelog` title and the preamble*. Every release pushed the preamble one version further down, until it ended up buried among old entries.

## Changes

- **`CHANGELOG.md`** — move the preamble back directly under the `# Changelog` title; remove the vestigial `## [Unreleased]` block (pending changes are tracked as `.changeset/*.md` fragments, not an Unreleased section).
- **`scripts/Build-Changelog.ps1`** — split the existing body into the preamble (prose before the first `## [` heading) and the prior versions, then reassemble as `title + preamble + newSection + priorVersions`. The new release now lands **below** the preamble and **above** the previous latest version, so the preamble stays pinned at the top permanently.

## Validation

- Simulated a release run (Steps 3+5) against the restructured file: preamble stays on top, new `## [X.Y.Z]` inserts directly beneath it and above the previous latest version.
- Full 14-gate pre-commit suite passed locally (Release build, COM-leak, success-flag, coverage, MCP/Core, doc-counts, dynamic-cast, packaging, CLI/MCP smoke).

No product/runtime behavior change (release infrastructure + changelog docs only) → `skip-changelog`.