### PR TITLE
Fix formula COMException 0x800A03EC by falling back Formula2→Formula

### DIFF
--- a/src/ExcelMcp.ComInterop/ComUtilities.cs
+++ b/src/ExcelMcp.ComInterop/ComUtilities.cs
@@ -383,6 +383,45 @@ public static class ComUtilities
         }
     }
 
+
+    /// <summary>
+    /// HRESULT for Excel "application-defined or object-defined error".
+    /// Common when Formula2 is unavailable (Excel 2019 / some locales) or the call is rejected.
+    /// </summary>
+    public const int ExcelObjectDefinedError = unchecked((int)0x800A03EC);
+
+    /// <summary>
+    /// Reads formulas preferring Formula2 (dynamic-array aware), falling back to Formula
+    /// when Formula2 throws 0x800A03EC — typical on Excel 2019 32-bit / non-en-US builds
+    /// where VBA Range.Formula still works (see GitHub issue #750).
+    /// </summary>
+    public static object GetRangeFormulas(dynamic range)
+    {
+        try
+        {
+            return range.Formula2;
+        }
+        catch (COMException ex) when (ex.HResult == ExcelObjectDefinedError)
+        {
+            return range.Formula;
+        }
+    }
+
+    /// <summary>
+    /// Writes formulas preferring Formula2, falling back to Formula on 0x800A03EC (issue #750).
+    /// </summary>
+    public static void SetRangeFormulas(dynamic range, object formulas)
+    {
+        try
+        {
+            range.Formula2 = formulas;
+        }
+        catch (COMException ex) when (ex.HResult == ExcelObjectDefinedError)
+        {
+            range.Formula = formulas;
+        }
+    }
+
     [DllImport("kernel32.dll")]
     private static extern void Sleep(uint dwMilliseconds);
 

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
@@ -39,10 +39,10 @@ public partial class RangeCommands
                 int startRow = Convert.ToInt32(range.Row);
                 int startColumn = Convert.ToInt32(range.Column);
 
-                // Get formulas and values - handle single cell case
-                // Use Formula2 (modern) instead of Formula (legacy) to avoid implicit intersection (@)
-                // operator being injected in Excel Table cells. Formula2 respects dynamic array semantics.
-                object formulaOrArray = range.Formula2;
+                // Get formulas and values - handle single cell case.
+                // Prefer Formula2 (dynamic arrays); fall back to Formula on Excel builds that
+                // reject Formula2 with 0x800A03EC (Excel 2019 / some locales — issue #750).
+                object formulaOrArray = ComUtilities.GetRangeFormulas(range);
                 object valueOrArray = range.Value2;
 
                 if (formulaOrArray is object[,] formulas && valueOrArray is object[,] values)
@@ -228,10 +228,8 @@ public partial class RangeCommands
                         }
                     }
 
-                    // Use Formula2 (modern) instead of Formula (legacy) to prevent Excel from
-                    // injecting the @ implicit intersection operator in table cells, which causes
-                    // #FIELD! errors with custom functions that return entity cards.
-                    range.Formula2 = arrayFormulas;
+                    // Prefer Formula2; fall back to Formula when Formula2 is unavailable (issue #750).
+                    ComUtilities.SetRangeFormulas(range, arrayFormulas);
                 }
 
                 result.Success = true;


### PR DESCRIPTION
## Summary
- `range get-formulas` / `set-formulas` used `Range.Formula2` only.
- On Excel 2019 (32-bit) / some locales, `Formula2` throws `COMException 0x800A03EC` even though `Range.Formula` works (see #750).
- Add `ComUtilities.GetRangeFormulas` / `SetRangeFormulas` that try `Formula2` then fall back to `Formula`.

## Test plan
- [ ] On Excel 2019 de-DE: `set-values` A1:A2, `set-formulas` A3=`=A1+A2`, `get-formulas` A1:A3 succeed
- [ ] On Microsoft 365: Formula2 path still used when available (no regression on dynamic-array tables)
- [ ] Values / format / worksheet tools unchanged

Closes #750