### PR TITLE
Fix Python in Excel unavailable errors

### DIFF
--- a/.changeset/clear-python-availability.md
+++ b/.changeset/clear-python-availability.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Clear Python in Excel availability errors** (#753): `pythoninexcel set-formula` and `get-result` now explain when the current Excel session cannot use Python in Excel instead of reporting success or exposing a raw `#NAME?` worksheet error.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -466,11 +466,12 @@ Capture ranges or worksheets as PNG images using Excel's own rendering.
 Write and read `=PY()` formulas that run in Excel's cloud Python engine.
 
 **Operations:**
-- **Set Formula:** Write a `=PY("<code>", returnType)` formula via `Range.Formula2`. `returnType` 0 = "Excel Value" (a plain value/array), 1 = "Python Object" (a rich data type card, e.g. a DataFrame). Must always be passed explicitly — omitting it causes a `#NAME?` error.
-- **Get Result:** Read back the computed value, polling briefly since cloud execution is not instantaneous. **Best-effort:** Excel exposes no reliable "still computing" signal via COM, so a freshly written formula may read back as unconverged; if the poll doesn't stabilize in time, the call reports failure and asks the caller to retry rather than guessing at a stale value.
+- **Set Formula:** Write a `=PY("<code>", returnType)` formula via `Range.Formula2`. `returnType` 0 = "Excel Value" (a plain value/array), 1 = "Python Object" (a rich data type card, e.g. a DataFrame). Must always be passed explicitly. If Excel immediately evaluates the formula as `#NAME?`, the operation reports that Python in Excel is unavailable instead of claiming success.
+- **Get Result:** Read back the computed value, polling until Excel's calculation state and the cell's transient marker show that cloud execution has finished. If the deadline is reached, the operation reports the observed transient state rather than guessing at a stale value. A settled `#NAME?` on a `PY()` formula is reported as Python in Excel being unavailable.
 
 **Notes:**
 - **Requires:** a real Excel session signed into a licensed Microsoft 365 account with Python in Excel enabled, plus internet access — the Python code executes in a Microsoft-hosted cloud sandbox, not locally. Not available offline or with perpetual-license Excel.
+- **Unavailable vs. transient:** `#NAME?` means this Excel session cannot use Python in Excel. `#BUSY!`, `#CONNECT!`, and `#BLOCKED!` remain transient cloud states and keep their existing retry behavior.
 - **Data binding:** Reference live worksheet data inside the Python code with `xl("A1:A6")`, `xl("Sheet1!A1:A6")`, or a named range `xl("MyRange")` — works the same as if typed interactively.
 
 ---

--- a/skills/excel-mcp/references/gotchas.md
+++ b/skills/excel-mcp/references/gotchas.md
@@ -80,6 +80,12 @@ When you write formulas with `range(action: 'set-formulas')`, they don't automat
 3. range(action: 'get-values', ...)       → Read calculated results
 ```
 
+## Python in Excel Requires Microsoft 365 Entitlement
+
+`pythoninexcel` runs code in Microsoft's cloud sandbox. It requires a licensed Microsoft 365 account with Python in Excel enabled and internet access; perpetual-license Excel and offline sessions cannot run `=PY()` formulas.
+
+When Excel evaluates a `PY()` formula as `#NAME?`, both `set-formula` and `get-result` return a clear unavailable-feature error. Do not retry that condition as if calculation were pending. `#BUSY!`, `#CONNECT!`, and `#BLOCKED!` are transient cloud states and retain retry semantics.
+
 ## File Locking Across Sessions
 
 If multiple Excel sessions have the same workbook open, operations on one session can lock the file and timeout on other sessions (30-second timeout).

--- a/skills/shared/gotchas.md
+++ b/skills/shared/gotchas.md
@@ -80,6 +80,12 @@ When you write formulas with `range(action: 'set-formulas')`, they don't automat
 3. range(action: 'get-values', ...)       → Read calculated results
 ```
 
+## Python in Excel Requires Microsoft 365 Entitlement
+
+`pythoninexcel` runs code in Microsoft's cloud sandbox. It requires a licensed Microsoft 365 account with Python in Excel enabled and internet access; perpetual-license Excel and offline sessions cannot run `=PY()` formulas.
+
+When Excel evaluates a `PY()` formula as `#NAME?`, both `set-formula` and `get-result` return a clear unavailable-feature error. Do not retry that condition as if calculation were pending. `#BUSY!`, `#CONNECT!`, and `#BLOCKED!` are transient cloud states and retain retry semantics.
+
 ## File Locking Across Sessions
 
 If multiple Excel sessions have the same workbook open, operations on one session can lock the file and timeout on other sessions (30-second timeout).

--- a/src/ExcelMcp.Core/Commands/PythonInExcel/IPythonInExcelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PythonInExcel/IPythonInExcelCommands.cs
@@ -17,7 +17,9 @@ namespace Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
 /// deterministically from Excel's calculation state plus a per-cell #BUSY! guard, so a converged
 /// result is not confused with the in-flight #BUSY! placeholder. If the cloud backend is still busy
 /// at the deadline (e.g. a cold start), GET-RESULT reports that and asks the caller to retry or raise
-/// maxWaitSeconds rather than returning a placeholder.
+/// maxWaitSeconds rather than returning a placeholder. If Excel evaluates PY() as #NAME?, both
+/// actions report that Python in Excel is unavailable in the current session instead of returning
+/// the raw worksheet error.
 /// DATA BINDING: reference live worksheet data inside the Python code with xl("A1:A6"),
 /// xl("Sheet1!A1:A6"), or a named range xl("MyRange") — all work when the formula is authored via this
 /// tool, the same as if typed interactively. TIP: xl() returns a pandas DataFrame/Series (not a plain
@@ -26,12 +28,13 @@ namespace Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
 /// </summary>
 [ServiceCategory("pythoninexcel", "PythonInExcel")]
 [McpTool("pythoninexcel", Title = "Python in Excel Operations", Destructive = true, Category = "data",
-    Description = "Write and read Microsoft 365 \"Python in Excel\" =PY() formulas. Requires a licensed M365 account with Python in Excel enabled and internet access - Python code executes in Microsoft's cloud sandbox, not locally. SET-FORMULA writes '=PY(code, returnType)' via Range.Formula2 (returnType: 0=Excel Value, 1=Python Object; always pass it explicitly). GET-RESULT reads back the result, polling until the cloud round-trip completes (a fresh formula reads as #BUSY! while still computing); completion is detected deterministically from Excel's calculation state, so a real result is not confused with the #BUSY! placeholder. If the backend is still busy at the deadline (e.g. a cold start), GET-RESULT says so - call it again or raise maxWaitSeconds. Reference live worksheet data inside the Python code using xl(\"A1:A6\"), xl(\"Sheet1!A1:A6\"), or a named range xl(\"MyRange\") - this works reliably. TIP: xl() returns a DataFrame/Series, not a plain list, so prefer .sum()/.mean()/.max() methods over Python's builtin sum()/len().")]
+    Description = "Write and read Microsoft 365 \"Python in Excel\" =PY() formulas. Requires a licensed M365 account with Python in Excel enabled and internet access - Python code executes in Microsoft's cloud sandbox, not locally. SET-FORMULA writes '=PY(code, returnType)' via Range.Formula2 (returnType: 0=Excel Value, 1=Python Object; always pass it explicitly). GET-RESULT reads back the result, polling until the cloud round-trip completes (a fresh formula reads as #BUSY! while still computing); completion is detected deterministically from Excel's calculation state, so a real result is not confused with the #BUSY! placeholder. If Excel returns #NAME? for a PY() formula, both actions report that Python in Excel is unavailable in the current session. If the backend is still busy at the deadline (e.g. a cold start), GET-RESULT says so - call it again or raise maxWaitSeconds. Reference live worksheet data inside the Python code using xl(\"A1:A6\"), xl(\"Sheet1!A1:A6\"), or a named range xl(\"MyRange\") - this works reliably. TIP: xl() returns a DataFrame/Series, not a plain list, so prefer .sum()/.mean()/.max() methods over Python's builtin sum()/len().")]
 public interface IPythonInExcelCommands
 {
     /// <summary>
     /// Writes a =PY() formula to a cell/range via Range.Formula2. The Python code string is
-    /// automatically quote-escaped for embedding inside the Excel formula.
+    /// automatically quote-escaped for embedding inside the Excel formula. Returns failure with a
+    /// clear availability message if Excel immediately evaluates the formula as #NAME?.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Worksheet name</param>
@@ -53,6 +56,7 @@ public interface IPythonInExcelCommands
     /// from Excel's calculation state plus a per-cell #BUSY! guard, so a converged result is never
     /// confused with the in-flight #BUSY! placeholder. If the cloud backend is still busy at the
     /// deadline, the result reports failure and asks the caller to retry or raise maxWaitSeconds.
+    /// A #NAME? result on a PY() formula is reported as Python in Excel being unavailable.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Worksheet name</param>

--- a/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
@@ -35,6 +35,8 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic? range = null;
+            dynamic? cells = null;
+            dynamic? firstCell = null;
             try
             {
                 range = RangeHelpers.ResolveRange(ctx.Book, sheetName, rangeAddress, out string? specificError);
@@ -61,9 +63,11 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                     // #BUSY! for an enabled backend or #NAME? when PY() is unavailable.
                 }
 
-                object? value = range.Value2;
-                string displayedText = range.Text?.ToString() ?? string.Empty;
-                string storedFormula = range.Formula2?.ToString() ?? formula;
+                cells = range.Cells;
+                firstCell = cells.Item[1, 1];
+                object? value = firstCell.Value2;
+                string displayedText = firstCell.Text?.ToString() ?? string.Empty;
+                string storedFormula = firstCell.Formula2?.ToString() ?? formula;
                 if (IsPythonInExcelUnavailable(storedFormula, value, displayedText))
                 {
                     result.Success = false;
@@ -82,6 +86,8 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
             }
             finally
             {
+                ComUtilities.Release(ref firstCell);
+                ComUtilities.Release(ref cells);
                 ComUtilities.Release(ref range);
             }
         });

--- a/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
@@ -10,6 +10,12 @@ namespace Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
 /// </summary>
 public sealed class PythonInExcelCommands : IPythonInExcelCommands
 {
+    private const int NameErrorCode = -2146826259;
+    private const string PythonUnavailableErrorMessage =
+        "Python in Excel is not available in this Excel session. It requires a licensed Microsoft 365 account "
+        + "with the Python in Excel feature enabled and internet access; it is not available with perpetual-license "
+        + "Excel (2016/2019/2021/2024) or offline.";
+
     /// <summary>
     /// Transient result markers returned by Excel while the cloud Python sandbox is still
     /// computing/connecting - not real errors, just "not ready yet".
@@ -44,6 +50,26 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                 string formula = $"=PY(\"{escapedCode}\",{returnType})";
 
                 range.Formula2 = formula;
+
+                try
+                {
+                    range.Calculate();
+                }
+                catch (System.Runtime.InteropServices.COMException)
+                {
+                    // Excel may already be calculating asynchronously; the read below still reports
+                    // #BUSY! for an enabled backend or #NAME? when PY() is unavailable.
+                }
+
+                object? value = range.Value2;
+                string displayedText = range.Text?.ToString() ?? string.Empty;
+                string storedFormula = range.Formula2?.ToString() ?? formula;
+                if (IsPythonInExcelUnavailable(storedFormula, value, displayedText))
+                {
+                    result.Success = false;
+                    result.ErrorMessage = PythonUnavailableErrorMessage;
+                    return result;
+                }
 
                 result.Success = true;
                 result.Message = $"Set Python in Excel formula on '{range.Address}'. Use get-result to read the computed value once the cloud Python backend finishes.";
@@ -157,6 +183,13 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                     text = range.Text?.ToString() ?? string.Empty;
                     calcState = (int)ctx.App.CalculationState;
 
+                    if (IsPythonInExcelUnavailable(formula, value, text))
+                    {
+                        result.Success = false;
+                        result.ErrorMessage = PythonUnavailableErrorMessage;
+                        return result;
+                    }
+
                     int markerIndex = Array.IndexOf(TransientMarkers, text);
                     bool cellBusy = (value is int busyCode && busyCode == BusyErrorCode)
                         || markerIndex >= 0;
@@ -256,5 +289,21 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                 ComUtilities.Release(ref range);
             }
         });
+    }
+
+    /// <summary>
+    /// Identifies Excel's unavailable-function response without confusing unrelated #NAME? errors
+    /// or transient Python cloud markers with a missing Python in Excel capability.
+    /// </summary>
+    internal static bool IsPythonInExcelUnavailable(string formula, object? value, string displayedText)
+    {
+        string normalizedFormula = formula.TrimStart();
+        bool isTopLevelPythonFormula =
+            normalizedFormula.StartsWith("=PY(", StringComparison.OrdinalIgnoreCase)
+            || normalizedFormula.StartsWith("=_xlfn.PY(", StringComparison.OrdinalIgnoreCase);
+
+        return isTopLevelPythonFormula
+            && ((value is int errorCode && errorCode == NameErrorCode)
+                || string.Equals(displayedText, "#NAME?", StringComparison.Ordinal));
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PythonInExcel/PythonInExcelCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PythonInExcel/PythonInExcelCommandsTests.cs
@@ -131,6 +131,31 @@ public class PythonInExcelCommandsTests : IClassFixture<PythonInExcelTestsFixtur
         Assert.Equal(125d, Convert.ToDouble(getResult.Value, System.Globalization.CultureInfo.InvariantCulture));
     }
 
+    /// <summary>
+    /// Preserves support for writing one Python formula across a multi-cell target range while the
+    /// immediate availability check samples only the top-left cell.
+    /// </summary>
+    [Fact]
+    public void SetFormula_OnMultiCellRange_WritesEveryCell()
+    {
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string targetRange = $"D{startRow}:D{startRow + 1}";
+
+        var setResult = _pythonCommands.SetFormula(
+            batch,
+            "Sheet1",
+            targetRange,
+            "1 + 1",
+            returnType: 0);
+
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+
+        var formulaResult = _rangeCommands.GetFormulas(batch, "Sheet1", targetRange);
+        Assert.True(formulaResult.Success, formulaResult.ErrorMessage);
+        Assert.All(formulaResult.Formulas, row => Assert.StartsWith("=PY(", row[0], StringComparison.Ordinal));
+    }
+
     /// <inheritdoc/>
     [Fact]
     public void SetFormula_ThenGetResult_ComputesMeanOfWorksheetRange()

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PythonInExcel/PythonInExcelCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PythonInExcel/PythonInExcelCommandsTests.cs
@@ -238,6 +238,34 @@ public class PythonInExcelCommandsTests : IClassFixture<PythonInExcelTestsFixtur
         Assert.Contains("does not contain", getResult.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Verifies the classifier against the actual Value2 error emitted by the installed Excel
+    /// version for an unavailable worksheet function, rather than only a fabricated integer.
+    /// </summary>
+    [Fact]
+    public void UnavailableClassifier_UsesExcelNameErrorValue()
+    {
+        using var batch = BeginBatch();
+        int startRow = _fixture.GetUniqueRowBlockStart();
+        string targetCell = $"D{startRow}";
+
+        var setResult = _rangeCommands.SetFormulas(
+            batch,
+            "Sheet1",
+            targetCell,
+            [["=UNDEFINEDFUNCTION()"]]);
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+
+        var formulaResult = _rangeCommands.GetFormulas(batch, "Sheet1", targetCell);
+        Assert.True(formulaResult.Success, formulaResult.ErrorMessage);
+        object? nameErrorValue = formulaResult.Values[0][0];
+
+        Assert.True(PythonInExcelCommands.IsPythonInExcelUnavailable(
+            "=PY(\"1 + 1\",0)",
+            nameErrorValue,
+            string.Empty));
+    }
+
     /// <inheritdoc/>
     [Fact]
     public void SetFormula_WithEmptyCode_ThrowsArgumentException()

--- a/tests/ExcelMcp.Core.Tests/Unit/PythonInExcelAvailabilityClassificationTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/PythonInExcelAvailabilityClassificationTests.cs
@@ -1,0 +1,69 @@
+using Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
+
+/// <summary>
+/// Regression tests for issue #753: Excel reports an unavailable Python in Excel feature as
+/// a worksheet #NAME? error instead of throwing a COM exception.
+/// </summary>
+[Trait("Layer", "Core")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "PythonInExcel")]
+[Trait("Speed", "Fast")]
+[Trait("RequiresExcel", "false")]
+public sealed class PythonInExcelAvailabilityClassificationTests
+{
+    [Theory]
+    [InlineData("=PY(\"1 + 1\",0)")]
+    [InlineData("=_xlfn.PY(\"1 + 1\",0)")]
+    [InlineData("  =py(\"1 + 1\",0)  ")]
+    public void IsPythonInExcelUnavailable_NameErrorOnTopLevelPythonFormula_ReturnsTrue(string formula)
+    {
+        Assert.True(PythonInExcelCommands.IsPythonInExcelUnavailable(formula, -2146826259, "#NAME?"));
+    }
+
+    [Fact]
+    public void IsPythonInExcelUnavailable_NameErrorCodeWithoutRenderedText_ReturnsTrue()
+    {
+        Assert.True(PythonInExcelCommands.IsPythonInExcelUnavailable(
+            "=PY(\"1 + 1\",0)",
+            -2146826259,
+            string.Empty));
+    }
+
+    [Theory]
+    [InlineData("#BUSY!")]
+    [InlineData("#CONNECT!")]
+    [InlineData("#BLOCKED!")]
+    [InlineData("#PYTHON!")]
+    public void IsPythonInExcelUnavailable_NonNameMarker_ReturnsFalse(string displayedText)
+    {
+        Assert.False(PythonInExcelCommands.IsPythonInExcelUnavailable(
+            "=PY(\"1 + 1\",0)",
+            null,
+            displayedText));
+    }
+
+    [Theory]
+    [InlineData("=SUM(A1:A2)")]
+    [InlineData("=PYTHON(\"1 + 1\")")]
+    [InlineData("=SUM(PY(\"1 + 1\",0))")]
+    [InlineData("")]
+    public void IsPythonInExcelUnavailable_NameErrorOnNonTopLevelPythonFormula_ReturnsFalse(string formula)
+    {
+        Assert.False(PythonInExcelCommands.IsPythonInExcelUnavailable(formula, -2146826259, "#NAME?"));
+    }
+
+    [Theory]
+    [InlineData("#NAME")]
+    [InlineData("#NAME? ")]
+    [InlineData("")]
+    public void IsPythonInExcelUnavailable_NonCanonicalNameText_ReturnsFalse(string displayedText)
+    {
+        Assert.False(PythonInExcelCommands.IsPythonInExcelUnavailable(
+            "=PY(\"1 + 1\",0)",
+            null,
+            displayedText));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #753 by returning a clear unavailable-feature failure when Excel evaluates a genuine `PY()` formula as `#NAME?`.

- Detects unavailable Python in Excel from both `set-formula` and `get-result`
- Preserves retry semantics for `#BUSY!`, `#CONNECT!`, and `#BLOCKED!`
- Preserves Python runtime errors, object results, and successful values
- Keeps MCP Server and CLI behavior aligned through the shared Core command
- Updates tool descriptions, feature documentation, shared skill guidance, and release changeset

## Root cause

Excel stores `=PY(...)` formulas even when Python in Excel is unavailable, but evaluates them to the worksheet `#NAME?` error instead of throwing a COM exception. The Core command treated that value as a generic formula error, and `set-formula` reported success without checking the immediate result.

## Same-pattern search

The fix is scoped to top-level `=PY(...)` and `=_xlfn.PY(...)` formulas. Unrelated `#NAME?` errors and nested/lookalike formulas are not reclassified. Both MCP Server and CLI already dispatch through the same generated `ServiceRegistry` Core path, so no entry-point-specific duplication is required.

## Validation

- 15 focused classifier regression cases
- Real Excel `#NAME?` value verification
- Live entitled Python in Excel round-trip
- MCP tool discovery/schema tests
- CLI action validation tests
- Release build with 0 warnings/errors
- Full mandatory pre-commit suite, including CLI/MCP E2E, packaging, COM leak, success flag, coverage, documentation count, MCPB, VS Code extension, skills, plugin README, and dynamic-cast gates

## Compatibility

No API or parameter changes. Existing successful, transient, and Python runtime-error behavior is preserved.