### PR TITLE
Fix missing star history restore exit code

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -20,6 +20,7 @@ on:
       - '.github/workflows/deploy-gh-pages.yml'
       - '.github/star-history.csv'
       - 'scripts/Update-StarHistory.ps1'
+      - 'scripts/Restore-StarHistory.ps1'
       - 'scripts/Persist-StarHistory.ps1'
       - 'scripts/Test-StarHistory.ps1'
   schedule:
@@ -54,23 +55,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $apiPath = "repos/${{ github.repository }}/contents/$env:STAR_HISTORY_PATH" +
-            "?ref=$env:STAR_HISTORY_BRANCH"
-          $response = & gh api $apiPath 2>&1
-          $responseText = $response -join "`n"
-
-          if ($LASTEXITCODE -eq 0) {
-            $state = $responseText | ConvertFrom-Json
-            $content = [Convert]::FromBase64String(($state.content -replace "\s", ""))
-            [IO.File]::WriteAllBytes($env:STAR_HISTORY_PATH, $content)
-            Write-Host "Restored aggregate snapshots from $env:STAR_HISTORY_BRANCH."
-          }
-          elseif ($responseText -match "HTTP 404") {
-            Write-Host "No persisted branch exists yet; using the exact aggregate bootstrap."
-          }
-          else {
-            throw "Unable to restore persisted star history: $responseText"
-          }
+          ./scripts/Restore-StarHistory.ps1 `
+            -Repository '${{ github.repository }}' `
+            -Branch $env:STAR_HISTORY_BRANCH `
+            -HistoryPath $env:STAR_HISTORY_PATH `
+            -RemotePath $env:STAR_HISTORY_PATH
 
       - name: Record current public star count and generate chart
         shell: pwsh

--- a/docs/STAR-HISTORY.md
+++ b/docs/STAR-HISTORY.md
@@ -14,9 +14,12 @@ against the repository's public `stargazers_count`.
 
 Scheduled builds do not query the restricted timestamped stargazers REST
 endpoint. They read the exact current `stargazers_count` from public repository
-metadata using the workflow's `GITHUB_TOKEN`, append or replace that UTC day's
-aggregate snapshot, and persist the CSV on the `star-history-data` branch. Count
-decreases are retained so unstars are represented rather than hidden.
+metadata using the workflow's `GITHUB_TOKEN`. Before recording the count, the
+workflow restores the CSV from `star-history-data`; an expected missing branch
+or file uses the committed aggregate bootstrap, while other API failures stop
+the deployment. It then appends or replaces that UTC day's aggregate snapshot
+and persists the CSV on the data branch. Count decreases are retained so
+unstars are represented rather than hidden.
 
 The dedicated data branch keeps daily state durable without granting a personal
 access token or write access to `main`. The Pages site continues to deploy from

--- a/scripts/Restore-StarHistory.ps1
+++ b/scripts/Restore-StarHistory.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+    Restores durable aggregate star history from the GitHub Contents API.
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[^/]+/[^/]+$")]
+    [string]$Repository,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Branch,
+
+    [Parameter(Mandatory = $true)]
+    [string]$HistoryPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RemotePath,
+
+    [scriptblock]$ApiInvoker = {
+        param([string[]]$Arguments)
+
+        $output = & gh @Arguments 2>&1
+        return [pscustomobject]@{
+            ExitCode = $LASTEXITCODE
+            Output = @($output)
+        }
+    }
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-GitHubApi {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    $result = & $ApiInvoker -Arguments $Arguments
+    if ($null -eq $result -or
+        $null -eq $result.PSObject.Properties["ExitCode"] -or
+        $null -eq $result.PSObject.Properties["Output"]) {
+        throw "The GitHub API invoker returned an invalid result."
+    }
+
+    return $result
+}
+
+$resolvedHistoryPath = [IO.Path]::GetFullPath($HistoryPath)
+if (-not (Test-Path -LiteralPath $resolvedHistoryPath -PathType Leaf)) {
+    throw "Star-history bootstrap file '$resolvedHistoryPath' does not exist."
+}
+
+$contentApi = "repos/$Repository/contents/$RemotePath" + "?ref=$Branch"
+$contentResult = Invoke-GitHubApi -Arguments @("api", $contentApi)
+$responseText = @($contentResult.Output) -join "`n"
+
+if ($contentResult.ExitCode -eq 0) {
+    $state = $responseText | ConvertFrom-Json
+    $content = [Convert]::FromBase64String(($state.content -replace "\s", ""))
+    [IO.File]::WriteAllBytes($resolvedHistoryPath, $content)
+    $global:LASTEXITCODE = 0
+    Write-Host "Restored aggregate snapshots from $Branch."
+    return
+}
+
+if ($responseText -match "HTTP 404") {
+    # GitHub Actions propagates the last native exit code even when this expected 404 is handled.
+    $global:LASTEXITCODE = 0
+    Write-Host "No persisted branch or aggregate file exists yet; using the exact aggregate bootstrap."
+    return
+}
+
+throw "Unable to restore persisted star history: $responseText"

--- a/scripts/Restore-StarHistory.ps1
+++ b/scripts/Restore-StarHistory.ps1
@@ -56,6 +56,12 @@ $responseText = @($contentResult.Output) -join "`n"
 
 if ($contentResult.ExitCode -eq 0) {
     $state = $responseText | ConvertFrom-Json
+    if ($null -eq $state -or
+        $null -eq $state.PSObject.Properties["content"] -or
+        [string]::IsNullOrWhiteSpace([string]$state.content)) {
+        throw "GitHub did not return a file content payload for persisted star history."
+    }
+
     $content = [Convert]::FromBase64String(($state.content -replace "\s", ""))
     [IO.File]::WriteAllBytes($resolvedHistoryPath, $content)
     $global:LASTEXITCODE = 0

--- a/scripts/Test-StarHistory.ps1
+++ b/scripts/Test-StarHistory.ps1
@@ -248,6 +248,25 @@ date,count
     }
     $testsRun++
 
+    $historyPath = New-HistoryFile -Name "restore-invalid-response.csv" -Content @"
+date,count
+2026-01-01,1
+"@
+    $invalidRestoreInvoker = {
+        param([string[]]$Arguments)
+
+        return [pscustomobject]@{ ExitCode = 0; Output = @("{}") }
+    }
+    Assert-Throws -ExpectedMessage "did not return a file content payload" -Action {
+        & $restoreScriptPath `
+            -Repository "owner/repository" `
+            -Branch "star-history-data" `
+            -HistoryPath $historyPath `
+            -RemotePath ".github/star-history.csv" `
+            -ApiInvoker $invalidRestoreInvoker
+    }
+    $testsRun++
+
     $historyPath = New-HistoryFile -Name "persist-existing.csv" -Content @"
 date,count
 2026-01-01,1

--- a/scripts/Test-StarHistory.ps1
+++ b/scripts/Test-StarHistory.ps1
@@ -6,6 +6,7 @@
 $ErrorActionPreference = "Stop"
 
 $scriptPath = Join-Path $PSScriptRoot "Update-StarHistory.ps1"
+$restoreScriptPath = Join-Path $PSScriptRoot "Restore-StarHistory.ps1"
 $persistScriptPath = Join-Path $PSScriptRoot "Persist-StarHistory.ps1"
 $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "excelmcp-star-history-tests-$([Guid]::NewGuid().ToString('N'))"
 $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
@@ -171,6 +172,79 @@ date,count
     Assert-Throws -ExpectedMessage "does not contain any aggregate rows" -Action {
         Invoke-StarHistory -HistoryPath $historyPath -OutputPath (Join-Path $testRoot "empty.svg") `
             -WithoutSnapshot
+    }
+    $testsRun++
+
+    $historyPath = New-HistoryFile -Name "restore-missing.csv" -Content @"
+date,count
+2026-01-01,1
+"@
+    $missingRestoreInvoker = {
+        param([string[]]$Arguments)
+
+        $request = $Arguments -join " "
+        if ($request -eq "api repos/owner/repository/contents/.github/star-history.csv?ref=star-history-data") {
+            return [pscustomobject]@{ ExitCode = 1; Output = @("gh: Not Found (HTTP 404)") }
+        }
+
+        throw "Unexpected gh invocation: $request"
+    }
+    $global:LASTEXITCODE = 23
+    & $restoreScriptPath `
+        -Repository "owner/repository" `
+        -Branch "star-history-data" `
+        -HistoryPath $historyPath `
+        -RemotePath ".github/star-history.csv" `
+        -ApiInvoker $missingRestoreInvoker
+    Assert-True -Condition ($global:LASTEXITCODE -eq 0) `
+        -Message "A missing persisted aggregate left a stale non-zero native exit code."
+    Assert-True -Condition ([IO.File]::ReadAllText($historyPath) -like "*2026-01-01,1*") `
+        -Message "A missing persisted aggregate changed the bootstrap history."
+    $testsRun++
+
+    $historyPath = New-HistoryFile -Name "restore-existing.csv" -Content @"
+date,count
+2026-01-01,1
+"@
+    $restoredText = "date,count`n2026-01-01,1`n2026-01-02,2`n"
+    $restoredContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($restoredText))
+    $existingRestoreInvoker = {
+        param([string[]]$Arguments)
+
+        $request = $Arguments -join " "
+        if ($request -eq "api repos/owner/repository/contents/.github/star-history.csv?ref=star-history-data") {
+            $body = @{ content = $restoredContent } | ConvertTo-Json -Compress
+            return [pscustomobject]@{ ExitCode = 0; Output = @($body) }
+        }
+
+        throw "Unexpected gh invocation: $request"
+    }
+    & $restoreScriptPath `
+        -Repository "owner/repository" `
+        -Branch "star-history-data" `
+        -HistoryPath $historyPath `
+        -RemotePath ".github/star-history.csv" `
+        -ApiInvoker $existingRestoreInvoker
+    Assert-True -Condition ([IO.File]::ReadAllText($historyPath) -eq $restoredText) `
+        -Message "The persisted aggregate was not restored over the bootstrap history."
+    $testsRun++
+
+    $historyPath = New-HistoryFile -Name "restore-error.csv" -Content @"
+date,count
+2026-01-01,1
+"@
+    $failedRestoreInvoker = {
+        param([string[]]$Arguments)
+
+        return [pscustomobject]@{ ExitCode = 1; Output = @("gh: API rate limit exceeded (HTTP 403)") }
+    }
+    Assert-Throws -ExpectedMessage "Unable to restore persisted star history" -Action {
+        & $restoreScriptPath `
+            -Repository "owner/repository" `
+            -Branch "star-history-data" `
+            -HistoryPath $historyPath `
+            -RemotePath ".github/star-history.csv" `
+            -ApiInvoker $failedRestoreInvoker
     }
     $testsRun++
 

--- a/scripts/pre-commit.ps1
+++ b/scripts/pre-commit.ps1
@@ -92,7 +92,7 @@ function Stop-DotNetBuildServers {
 # changes, including edits to the gh-pages documentation website and its star-history
 # generation workflow. These files do not affect the shipped Excel binaries. Cheap
 # source-level guards still run for every commit.
-$docOnlyPattern = '(\.md$)|(^\.changeset/)|(^docs/)|(^gh-pages/)|(^\.github/(ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE))|(^\.github/workflows/deploy-gh-pages\.yml$)|(^scripts/(pre-commit|(Update|Persist|Test)-StarHistory)\.ps1$)'
+$docOnlyPattern = '(\.md$)|(^\.changeset/)|(^docs/)|(^gh-pages/)|(^\.github/(ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE))|(^\.github/workflows/deploy-gh-pages\.yml$)|(^scripts/(pre-commit|(Update|Restore|Persist|Test)-StarHistory)\.ps1$)'
 $stagedFiles = git diff --cached --name-only 2>&1 | Where-Object { $_ }
 $codeChangedFiles = $stagedFiles | Where-Object { $_ -notmatch $docOnlyPattern }
 $hasCodeChanges = @($codeChangedFiles).Count -gt 0


### PR DESCRIPTION
## Summary
Fix the first Pages deployment after #762 by treating an expected missing star-history branch or file as a successful bootstrap restore. Unexpected GitHub API errors still fail explicitly, and the workflow retains its existing repository-scoped `contents: write` permission.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that causes existing functionality to stop working as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Maintenance (dependency updates, code cleanup, etc.)

## Related Issues
Follow-up to #762.
Failed deployment: https://github.com/sbroenne/mcp-server-excel/actions/runs/31719978204

## Changeset
- [ ] Added a changeset (`npx changeset`) describing this change for end users — see `.changeset/README.md`
- [x] Not applicable (docs/tests/CI/dependency-only) — added `skip-changelog` label instead

## Changes Made
- Extracted restore behavior into `Restore-StarHistory.ps1` with an injectable GitHub API invoker.
- Reset the native process exit status only for the expected HTTP 404 bootstrap path; all other API failures throw.
- Validate successful API responses contain a non-empty file payload before decoding or replacing the bootstrap.
- Added regression coverage for missing state, successful restore, invalid payloads, and unexpected API failures.
- Included the new Pages-only script in workflow triggers and the pre-commit docs-only classification.

## Testing Performed
- [ ] Ran `& .\scripts\Test-E2E.ps1` locally and confirmed it completed with no failures or unresolved issues
- [x] Ran the relevant focused regression tests and recorded the exact command and result below
- [ ] Tested manually with various Excel files
- [ ] Verified Excel process cleanup (no excel.exe remains after 5 seconds)
- [x] Tested error conditions (missing branch/file, invalid success payload, and unexpected API failure)
- [x] All existing star-history commands still work
- [ ] VBA script execution tested (if applicable)
- [ ] XLSM file format validation tested (if applicable)
- [ ] VBA trust setup tested (if applicable)
- [ ] Build produces zero warnings

## Test Commands
```powershell
pwsh -NoLogo -NoProfile -File ./scripts/Test-StarHistory.ps1 # 13 passed
# Parsed all four star-history scripts plus pre-commit.ps1 with the PowerShell parser
actionlint .github/workflows/deploy-gh-pages.yml # v1.7.12
Set-Location gh-pages
mkdocs build --strict --clean
```

## Core Commands Coverage Checklist ⚠️

**Does this PR add or modify Core Commands methods?** [ ] Yes [x] No

**Coverage Impact**: No Core Commands changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [ ] Code builds with zero warnings
- [x] Appropriate error handling added
- [ ] Updated help text (if adding new commands)
- [ ] Updated README.md (if needed)
- [ ] Follows Excel COM best practices from copilot-instructions.md
- [ ] Uses batch API with proper disposal (`using var batch` or `await using var batch`)
- [ ] Properly handles 1-based Excel indexing
- [ ] Escapes user input with `.EscapeMarkup()`
- [x] Returns consistent exit codes (0 = expected bootstrap/success, 1+ = unexpected error)

## Additional Notes
The normal pre-commit hook passed. Compiled-product, packaging, and Excel E2E gates were skipped by the repository's existing Pages-only classification because this PR does not change MCP server or CLI code.