### PR TITLE
docs: guard against silently-dropped front matter, split out an FAQ page

### DIFF
--- a/docs/INSTALLATION-CLI.md
+++ b/docs/INSTALLATION-CLI.md
@@ -214,7 +214,7 @@ dotnet tool uninstall --global Sbroenne.ExcelMcp.CLI
 
 ## Getting Help
 
-- **Troubleshooting:** [Troubleshooting & FAQ](https://excelmcpserver.dev/troubleshooting/)
+- **Troubleshooting:** [Troubleshooting](https://excelmcpserver.dev/troubleshooting/) · [FAQ](https://excelmcpserver.dev/faq/)
 - **Documentation:** [GitHub Repository](https://github.com/sbroenne/mcp-server-excel)
 - **Issues:** [GitHub Issues](https://github.com/sbroenne/mcp-server-excel/issues)
 - **Contributing:** [Contributing Guide](CONTRIBUTING.md)

--- a/docs/INSTALLATION-MCP-SERVER.md
+++ b/docs/INSTALLATION-MCP-SERVER.md
@@ -387,7 +387,7 @@ dotnet tool uninstall --global Sbroenne.ExcelMcp.McpServer
 
 ## Getting Help
 
-- **Troubleshooting:** [Troubleshooting & FAQ](https://excelmcpserver.dev/troubleshooting/)
+- **Troubleshooting:** [Troubleshooting](https://excelmcpserver.dev/troubleshooting/) · [FAQ](https://excelmcpserver.dev/faq/)
 - **Documentation:** [GitHub Repository](https://github.com/sbroenne/mcp-server-excel)
 - **Issues:** [GitHub Issues](https://github.com/sbroenne/mcp-server-excel/issues)
 - **Contributing:** [Contributing Guide](CONTRIBUTING.md)

--- a/gh-pages/.gitignore
+++ b/gh-pages/.gitignore
@@ -4,6 +4,9 @@ _site/
 # Generated documentation pages (produced by hooks.py from canonical repo docs)
 docs/_generated/
 
+# Star-history chart: produced by the deploy workflow before mkdocs runs, never committed
+docs/assets/images/star-history.svg
+
 # Python
 __pycache__/
 .venv/

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 SITE_DIR = Path(__file__).resolve().parent / "_site"
+MKDOCS_YML = Path(__file__).resolve().parent / "mkdocs.yml"
 SITE_URL = "https://excelmcpserver.dev/"
 
 # Google truncates around these lengths; well outside them is a real problem.
@@ -27,8 +28,59 @@ TITLE_MAX = 70
 DESCRIPTION_MIN = 50
 DESCRIPTION_MAX = 200
 
+# The home page legitimately renders site_description; every other page must not.
+HOMEPAGE = "index.html"
+
+# Remote status badges: their pixel dimensions are not knowable at build time, and
+# the URL may carry no file extension at all (e.g. img.shields.io/...?style=flat),
+# so they are matched on host rather than on the path.
+BADGE_HOSTS = ("img.shields.io", "cdn.jsdelivr.net", "vsmarketplacebadges.dev", "badgen.net")
+
+# Material emits the theme logo from its own header partial and sizes it via CSS;
+# it cannot carry width/height without overriding that partial.
+THEME_LOGO_SUFFIXES = ("/logo.png", "/icon.png")
+
 failures: list[str] = []
 checked = 0
+
+
+def _site_description() -> str:
+    """Read ``site_description`` out of mkdocs.yml.
+
+    Parsed rather than hardcoded on purpose: a copy of the string here would stop
+    matching the moment someone rewords mkdocs.yml, and the fallback check below
+    would then pass forever while guarding nothing - a silent failure inside a
+    detector whose whole job is catching silent failures.
+
+    A full ``yaml.safe_load`` is not an option because mkdocs.yml carries custom
+    ``!!python/name:`` tags, so only this one key is parsed. Plain, quoted and
+    ``>``/``|`` block scalar forms are all handled.
+    """
+    lines = MKDOCS_YML.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        match = re.match(r"^site_description:\s*(.*?)\s*$", line)
+        if not match:
+            continue
+        value = match.group(1)
+        if value[:1] in (">", "|"):
+            block: list[str] = []
+            for follow in lines[index + 1 :]:
+                if not follow.strip():
+                    block.append("")
+                    continue
+                if not follow[:1].isspace():
+                    break
+                block.append(follow.strip())
+            value = " ".join(x for x in block if x)
+        else:
+            value = value.strip("'\"")
+        return " ".join(value.split())
+
+    print("ERROR: could not find site_description in mkdocs.yml", file=sys.stderr)
+    sys.exit(2)
+
+
+SITE_DESCRIPTION = _site_description()
 
 
 def fail(message: str) -> None:
@@ -65,11 +117,25 @@ def audit_html(path: Path) -> None:
     if not description:
         fail(f"{name}: no meta description")
     else:
+        text = " ".join(description.group(1).split())
         length = len(description.group(1).strip())
         if not DESCRIPTION_MIN <= length <= DESCRIPTION_MAX:
             fail(
                 f"{name}: meta description is {length} chars "
                 f"(want {DESCRIPTION_MIN}-{DESCRIPTION_MAX})"
+            )
+        # Material falls back to site_description whenever a page has no usable
+        # per-page description, and MkDocs reports nothing when that happens.
+        # Two ways to trigger it, both silent: a double quote inside an unquoted
+        # `description:` value terminates the rendered content="..." attribute
+        # early, and an unquoted YAML scalar containing ": " makes the whole
+        # front-matter block unparseable - dropping title, description and
+        # keywords together.
+        if name != HOMEPAGE and text == SITE_DESCRIPTION:
+            fail(
+                f"{name}: meta description fell back to site_description - this "
+                f"page's YAML front matter did not apply (check the description "
+                f'value for a double quote or an unquoted ": ")'
             )
 
     for prop in ("og:title", "og:description", "og:image", "og:url", "og:type"):
@@ -85,13 +151,19 @@ def audit_html(path: Path) -> None:
         fail(f"{name}: found {h1_count} <h1> elements (want exactly 1)")
 
     # Raster content images need explicit dimensions to avoid layout shift.
-    # SVG badges carry intrinsic dimensions in the file itself, so they are exempt.
-    svg_hosts = ("img.shields.io", "cdn.jsdelivr.net")
+    # SVGs carry intrinsic dimensions in the file itself, remote badges have no
+    # build-time dimensions (and often no file extension either, so they are
+    # matched on host), and the theme logo is emitted by Material's own partials.
     for img in re.findall(r"<img\b[^>]*>", html):
         src_match = re.search(r'src=["\']?([^"\'\s>]+)', img)
         src = src_match.group(1) if src_match else ""
-        is_svg = src.split("?")[0].endswith(".svg") or any(h in src for h in svg_hosts)
-        if "data:image" in img or is_svg:
+        parts = urlsplit(src)
+        exempt = (
+            parts.netloc in BADGE_HOSTS
+            or parts.path.endswith(".svg")
+            or parts.path.endswith(THEME_LOGO_SUFFIXES)
+        )
+        if "data:image" in img or exempt:
             continue
         if "width=" not in img or "height=" not in img:
             fail(f"{name}: <img> without width/height: {src or img[:60]}")
@@ -227,12 +299,53 @@ def audit_robots() -> None:
 
 
 def audit_faq() -> None:
-    path = SITE_DIR / "troubleshooting" / "index.html"
-    if not path.is_file():
-        fail("troubleshooting page is missing")
+    """The FAQ page must carry parseable FAQPage structured data.
+
+    The JSON-LD is derived from the page's own ``###`` question headings by
+    hooks.py, so a parser regression shows up as too few questions rather than
+    as a build failure.
+    """
+    faq = SITE_DIR / "faq" / "index.html"
+    if not faq.is_file():
+        fail("FAQ page is missing")
         return
-    if "FAQPage" not in path.read_text(encoding="utf-8"):
-        fail("troubleshooting page has no FAQPage structured data")
+    html = faq.read_text(encoding="utf-8")
+    blocks = re.findall(
+        r'<script type=["\']?application/ld\+json["\']?>(.*?)</script>', html, re.DOTALL
+    )
+    faq_blocks = []
+    for block in blocks:
+        try:
+            data = json.loads(block)
+        except json.JSONDecodeError:
+            continue  # audit_jsonld reports the parse error itself
+        if data.get("@type") == "FAQPage":
+            faq_blocks.append(data)
+    if not faq_blocks:
+        fail("faq/index.html: no FAQPage structured data")
+    elif len(faq_blocks[0].get("mainEntity", [])) < 5:
+        fail(
+            f"faq/index.html: FAQPage has only "
+            f"{len(faq_blocks[0].get('mainEntity', []))} questions - parser regression?"
+        )
+
+    if not (SITE_DIR / "troubleshooting" / "index.html").is_file():
+        fail("troubleshooting page is missing")
+
+
+def audit_jsonld(html_files: list[Path]) -> None:
+    """Every JSON-LD block must actually parse, or search engines ignore it."""
+    for path in html_files:
+        html = path.read_text(encoding="utf-8", errors="replace")
+        for block in re.findall(
+            r'<script type=["\']?application/ld\+json["\']?>(.*?)</script>',
+            html,
+            re.DOTALL,
+        ):
+            try:
+                json.loads(block)
+            except json.JSONDecodeError as exc:
+                fail(f"{page_name(path)}: invalid JSON-LD: {exc}")
 
 
 def main() -> int:
@@ -243,6 +356,8 @@ def main() -> int:
     html_files = sorted(
         p
         for p in SITE_DIR.rglob("*.html")
+        # 404.html is not an indexable page: MkDocs renders it with no canonical
+        # URL and no page metadata, so every metadata check would fire on it.
         if p.name != "404.html" and "assets" not in p.relative_to(SITE_DIR).parts
     )
     if not html_files:
@@ -252,6 +367,7 @@ def main() -> int:
     for path in html_files:
         audit_html(path)
     audit_internal_links(html_files)
+    audit_jsonld(html_files)
     audit_sitemap()
     audit_llms(html_files)
     audit_tools_json()

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -17,6 +17,7 @@ import gzip
 import json
 import re
 import sys
+import zlib
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -215,12 +216,23 @@ def audit_sitemap() -> None:
         # rewrites it separately after enriching sitemap.xml. Checking only that
         # it exists would let the two silently diverge - publishing a .gz still
         # carrying the lastmod values the plain file had dropped.
+        # gzip surfaces corruption three ways and only one of them is an OSError:
+        # BadGzipFile (wrong format / CRC failure) subclasses it, but EOFError
+        # (truncated write) and zlib.error (damaged deflate stream) inherit
+        # straight from Exception. Catching OSError alone would let the two most
+        # likely real-world cases escape as a traceback, burying every other
+        # finding this audit produced. The type name is included because
+        # "EOFError" says truncated write, where "BadGzipFile" says wrong format.
         try:
             with gzip.open(SITE_DIR / "sitemap.xml.gz", "rt", encoding="utf-8") as fh:
                 if fh.read() != xml:
                     fail("sitemap.xml.gz does not match sitemap.xml")
-        except OSError as exc:
-            fail(f"sitemap.xml.gz could not be read: {exc}")
+        except (OSError, EOFError, zlib.error) as exc:
+            kind = type(exc).__qualname__
+            if type(exc).__module__ != "builtins":
+                # zlib.error's bare name is just "error", which says nothing.
+                kind = f"{type(exc).__module__}.{kind}"
+            fail(f"sitemap.xml.gz could not be read: {kind}: {exc}")
 
 
 def audit_llms(html_files: list[Path]) -> None:

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -13,6 +13,7 @@ pre-commit fast path stays fast.
 
 from __future__ import annotations
 
+import gzip
 import json
 import re
 import sys
@@ -209,6 +210,17 @@ def audit_sitemap() -> None:
             fail(f"sitemap.xml has an off-site <loc>: {loc}")
     if not (SITE_DIR / "sitemap.xml.gz").is_file():
         fail("sitemap.xml.gz is missing")
+    else:
+        # The gzipped twin is what many crawlers actually fetch, and hooks.py
+        # rewrites it separately after enriching sitemap.xml. Checking only that
+        # it exists would let the two silently diverge - publishing a .gz still
+        # carrying the lastmod values the plain file had dropped.
+        try:
+            with gzip.open(SITE_DIR / "sitemap.xml.gz", "rt", encoding="utf-8") as fh:
+                if fh.read() != xml:
+                    fail("sitemap.xml.gz does not match sitemap.xml")
+        except OSError as exc:
+            fail(f"sitemap.xml.gz could not be read: {exc}")
 
 
 def audit_llms(html_files: list[Path]) -> None:

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -118,7 +118,7 @@ def audit_html(path: Path) -> None:
         fail(f"{name}: no meta description")
     else:
         text = " ".join(description.group(1).split())
-        length = len(description.group(1).strip())
+        length = len(text)
         if not DESCRIPTION_MIN <= length <= DESCRIPTION_MAX:
             fail(
                 f"{name}: meta description is {length} chars "

--- a/gh-pages/docs/faq.md
+++ b/gh-pages/docs/faq.md
@@ -1,0 +1,84 @@
+---
+title: Frequently Asked Questions
+description: >-
+  Answers to common questions about Excel MCP Server - Windows and Excel
+  requirements, CLI vs. MCP Server, workbook safety, cost, and privacy.
+keywords: "Excel MCP FAQ, does Excel MCP need Excel installed, Excel MCP Windows only, Excel MCP vs openpyxl, Excel MCP CLI or MCP Server, is Excel MCP free"
+---
+
+# Frequently Asked Questions
+
+<!--
+  Every `###` heading on this page is parsed by gh-pages/hooks.py into FAQPage
+  JSON-LD (see `_faq_jsonld`). The structured data is derived from this visible
+  content, so there is nothing to keep in sync by hand - just write the
+  questions here. Headings rather than collapsible admonitions are used
+  deliberately: they give each answer a stable anchor that can be deep-linked
+  from another page or straight from a search result.
+-->
+
+Hitting an actual error rather than a question? See
+[Troubleshooting](troubleshooting.md).
+
+## Getting started
+
+### Do I need to know how Excel automation works to use this?
+
+No. You talk to your AI assistant in plain language ("build a PivotTable of
+sales by product and chart it") and it drives Excel for you. The
+[feature reference](features.md) is there when you want to see everything that's
+possible - you don't need to memorize it.
+
+### CLI or MCP Server - which should I install?
+
+Both expose the **same 326 operations**. Use the **MCP Server** for
+conversational AI (Claude Desktop, VS Code Chat); use the **CLI** (`excelcli`)
+for coding agents and scripting, where it uses ~64% fewer tokens. You can
+install both. See [Installation](installation.md).
+
+### Which AI assistants does it work with?
+
+Any client that speaks the Model Context Protocol - GitHub Copilot in VS Code,
+Claude Desktop, Claude Code, Cursor, and others. Coding agents that can run
+shell commands can use the CLI directly instead. See
+[MCP Server installation](installation-mcp-server.md).
+
+## Requirements and platform
+
+### Does it require Microsoft Excel to be installed?
+
+Yes. Excel MCP Server drives the **real Excel application** through its COM API,
+so it's **Windows-only** and needs **Excel 2016 or later** installed locally. It
+is not a file-format parser and does not run on macOS or Linux.
+
+### Why drive real Excel instead of parsing the file?
+
+Because Excel itself is the only thing that fully understands its own file
+format. Recalculation, Power Query evaluation, the Data Model, PivotTable
+caches, and chart rendering all live in the application, not in the `.xlsx`
+container. See
+[Excel automation vs. file parsers](guides/excel-automation-vs-file-parsers.md)
+for the full comparison with tools like openpyxl and pandas.
+
+### Will it damage my existing workbooks?
+
+No. Excel itself opens and saves the file, so formulas, PivotTables, charts,
+macros, the Data Model, and formatting are all preserved. Other tools that
+rewrite the `.xlsx` file directly can silently drop those; here Excel does the
+work.
+
+## Cost, privacy and support
+
+### Does it cost anything or send my data anywhere?
+
+Excel MCP Server is free and open source (MIT). It runs locally against your own
+Excel. A few opt-in features reach the internet (remote M/DAX formatting, and
+Python in Excel, which runs in Microsoft's cloud). See
+[Privacy](privacy.md) for details.
+
+### Where do I report a bug or ask for a feature?
+
+On [GitHub Issues](https://github.com/sbroenne/mcp-server-excel/issues). If
+something is failing rather than missing, check
+[Troubleshooting](troubleshooting.md) first - most first-time failures are one
+of a handful of known setup issues.

--- a/gh-pages/docs/troubleshooting.md
+++ b/gh-pages/docs/troubleshooting.md
@@ -1,46 +1,17 @@
 ---
-title: Troubleshooting & FAQ
+title: Troubleshooting
 description: >-
-  Fixes for the most common Excel MCP Server issues — Excel must be closed,
+  Fixes for the most common Excel MCP Server issues - Excel must be closed,
   VBA trust, DAX/MSOLAP setup, PATH problems, and protected workbooks.
 keywords: "Excel MCP troubleshooting, VBA trust, MSOLAP DAX, workbook locked, mcp-excel not recognized, IRM AIP Excel"
 ---
 
-# Troubleshooting & FAQ
+# Troubleshooting
 
-Hitting a snag? Most first-time issues fall into one of the cases below. If none
-of these help, open a [GitHub issue](https://github.com/sbroenne/mcp-server-excel/issues).
-
-## Frequently asked questions
-
-??? question "Do I need to know how Excel automation works to use this?"
-    No. You talk to your AI assistant in plain language ("build a PivotTable of
-    sales by product and chart it") and it drives Excel for you. The
-    [feature reference](features.md) is there when you want to see everything
-    that's possible — you don't need to memorize it.
-
-??? question "Does it require Microsoft Excel to be installed?"
-    Yes. Excel MCP Server drives the **real Excel application** through its COM
-    API, so it's **Windows-only** and needs **Excel 2016 or later** installed
-    locally. It is not a file-format parser and does not run on macOS or Linux.
-
-??? question "Will it damage my existing workbooks?"
-    No. Excel itself opens and saves the file, so formulas, PivotTables, charts,
-    macros, the Data Model, and formatting are all preserved. Other tools that
-    rewrite the `.xlsx` file directly can silently drop those; here Excel does
-    the work.
-
-??? question "CLI or MCP Server — which should I install?"
-    Both expose the **same 326 operations**. Use the **MCP Server** for
-    conversational AI (Claude Desktop, VS Code Chat); use the **CLI**
-    (`excelcli`) for coding agents and scripting, where it uses ~64% fewer
-    tokens. You can install both. See [Installation](installation.md).
-
-??? question "Does it cost anything or send my data anywhere?"
-    Excel MCP Server is free and open source (MIT). It runs locally against your
-    own Excel. A few opt-in features reach the internet (remote M/DAX
-    formatting, and Python in Excel, which runs in Microsoft's cloud). See
-    [Privacy](privacy.md) for details.
+Hitting a snag? Most first-time issues fall into one of the cases below. For
+general questions about what the tool is and what it needs, see the
+[FAQ](faq.md). If none of these help, open a
+[GitHub issue](https://github.com/sbroenne/mcp-server-excel/issues).
 
 ## Common issues
 
@@ -121,6 +92,7 @@ winget install OpenJS.NodeJS.LTS
 
 ## Still stuck?
 
+- **General questions:** [FAQ](faq.md)
 - **Task guides:** [Refresh Power Query](guides/refresh-power-query.md) · [PivotTables](guides/automate-pivottables.md) · [DAX & the Data Model](guides/query-data-model-with-dax.md) · [VBA macros](guides/run-vba-macros.md)
 - **Installation details:** [MCP Server](installation-mcp-server.md) · [CLI](installation-cli.md)
 - **How it works:** [Architecture](architecture.md)

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -325,41 +325,86 @@ def on_page_markdown(markdown, page, config, **kwargs):  # noqa: D401 - MkDocs h
     return markdown
 
 
-_FAQ_QUESTION = re.compile(r'^\?{3}\+?\s+question\s+"([^"]+)"\s*$')
+_FAQ_ADMONITION = re.compile(r'^\?{3}\+?\s+question\s+"([^"]+)"\s*$')
+_FAQ_HEADING = re.compile(r"^###\s+(.+?)\s*$")
+_FAQ_MIN_ENTITIES = 3
 
 
 def _faq_jsonld(markdown: str) -> str:
-    """Build FAQPage JSON-LD from ``??? question "..."`` admonitions.
+    """Build FAQPage JSON-LD from a page's own question blocks.
 
-    Derived from the page body rather than maintained separately, so the
-    structured data and the visible FAQ cannot diverge.
+    Two source forms are recognised:
+
+    * ``### Some question?`` headings - preferred, because each answer keeps a
+      stable anchor that can be deep-linked from another page or straight from a
+      search result, and shows up in the page table of contents.
+    * ``??? question "..."`` collapsible admonitions, which have no anchor at
+      all, kept so a page written either way still works.
+
+    Either way the structured data is derived from the page body rather than
+    maintained separately, so the two cannot diverge.
     """
     items: list[tuple[str, list[str]]] = []
     current: list[str] | None = None
+    indented = False
 
     for line in markdown.splitlines():
-        match = _FAQ_QUESTION.match(line)
-        if match:
+        admonition = _FAQ_ADMONITION.match(line)
+        if admonition:
             current = []
-            items.append((match.group(1), current))
+            indented = True
+            items.append((admonition.group(1), current))
             continue
+
+        heading = _FAQ_HEADING.match(line)
+        if heading:
+            text = heading.group(1).strip()
+            if text.endswith("?"):
+                current = []
+                indented = False
+                items.append((text, current))
+            else:
+                current = None
+            continue
+
         if current is None:
             continue
+
+        # A heading of any level ends a heading-sourced answer.
+        if not indented and line.startswith("#"):
+            current = None
+            continue
+
         if not line.strip():
             current.append("")
-        elif line.startswith((" ", "\t")):
-            current.append(line.strip())
-        else:
+        elif indented and not line.startswith((" ", "\t")):
             current = None
+        else:
+            current.append(line.strip())
 
     entities = []
     for question, answer_lines in items:
-        answer = " ".join(x for x in answer_lines if x).strip()
+        # Fenced code blocks and table rows are useful on the page but pure noise
+        # inside a structured answer, so they are dropped here.
+        prose: list[str] = []
+        in_fence = False
+        for raw in answer_lines:
+            if raw.startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence or raw.startswith("|"):
+                continue
+            # Strip the list marker only where it starts a line, so a dash used
+            # mid-sentence survives into the structured answer.
+            prose.append(re.sub(r"^[-*+]\s+", "", raw))
+
+        answer = " ".join(x for x in prose if x).strip()
         if not answer:
             continue
         # Strip inline Markdown so the structured answer is plain prose.
         answer = _MD_LINK.sub(r"\1", answer)
         answer = re.sub(r"[*_`]+", "", answer)
+        answer = re.sub(r"\s{2,}", " ", answer).strip()
         entities.append(
             {
                 "@type": "Question",
@@ -368,7 +413,9 @@ def _faq_jsonld(markdown: str) -> str:
             }
         )
 
-    if not entities:
+    # A page with one or two question-shaped headings is a guide that happens to
+    # ask a question, not an FAQ; emitting FAQPage there is a false signal.
+    if len(entities) < _FAQ_MIN_ENTITIES:
         return ""
 
     return json.dumps(

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -131,7 +131,8 @@ nav:
   - Resources:
     - Examples & use cases: use-cases.md
     - Agent Skills: skills.md
-    - Troubleshooting & FAQ: troubleshooting.md
+    - FAQ: faq.md
+    - Troubleshooting: troubleshooting.md
     - Architecture: architecture.md
     - Changelog: changelog.md
     - Contributing: contributing.md


### PR DESCRIPTION
Ported from the sibling repo `sbroenne/mcp-server-powerpoint#48`, which surfaced these while adapting this repo's docs-site tooling. All six items in that port were evaluated here; four applied, one was already handled, one did not exist in this repo.

## 1. Guard against silently-dropped YAML front matter

There are two ways a page's front matter is discarded without MkDocs saying a word:

- A **double quote** inside an unquoted `description:` value terminates the rendered `content="..."` attribute early, truncating the meta description.
- An unquoted YAML scalar containing **`: `** (colon-space) makes the *entire* front-matter block unparseable, so `title`, `description` **and** `keywords` are all dropped at once and the page silently falls back to `site_description`.

`audit_site.py` now fails when any page other than the home page renders `site_description` verbatim.

`site_description` is **parsed out of `mkdocs.yml`** rather than copied into the auditor. A hardcoded copy would stop matching the moment someone rewords the value, and the guard would then pass forever while checking nothing — a silent failure inside a detector whose whole purpose is catching silent failures. A full `yaml.safe_load` is not possible (`mkdocs.yml` carries `!!python/name:` tags), so only that one key is parsed; plain, quoted and `>`/`|` block-scalar forms are handled, and a missing key exits non-zero rather than degrading to a no-op.

**Negative-tested both failure modes** by temporarily breaking `installation-cli.md`:

| Injected fault | `mkdocs build --strict` | `audit_site.py` |
|---|---|---|
| `description: Install: the Excel CLI…` | passes silently | ✅ `meta description fell back to site_description - this page's YAML front matter did not apply` |
| `description: Install the "Excel" CLI…` | passes silently | ✅ `meta description is 11 chars (want 50-200)` |

Both reverted; the site is clean today, so this is a regression guard rather than a fix.

## 2. False-positive fixes in `audit_site.py`

- **Badge images matched on host, not on the path.** The old `src.split("?")[0].endswith(".svg") or any(h in src for h in svg_hosts)` was a substring test. Now `urlsplit(src).netloc` is compared against a badge-host allowlist and `urlsplit(src).path` is used for the extension test, so extensionless shields.io URLs with query strings are recognised properly.
- **Theme logo exempted.** Material emits it from its own header partial and sizes it via CSS; it cannot carry `width`/`height` without overriding that partial.
- **`404.html`** was already excluded here — added the comment explaining why so it does not get "cleaned up" later.

Also added: every JSON-LD block must parse, and the FAQ page must carry `FAQPage` data with a plausible number of questions (guards the parser below).

## 3. Star-history placeholder — **not needed here, skipped**

Verified before porting. This repo references the chart by **absolute URL** (`https://excelmcpserver.dev/assets/images/star-history.svg`), so MkDocs never validates it and `mkdocs build --strict` passes on a clean checkout. The trap does not exist. Added only the `.gitignore` entry so the CI-generated file cannot be committed by accident.

## 4. FAQ JSON-LD accepts `###` headings

`_faq_jsonld()` parsed only `??? question "..."` admonitions. Collapsible admonitions have **no stable anchor**, so individual answers cannot be deep-linked, do not appear in the page contents, and search engines cannot jump a reader to one answer. Both forms are now accepted, with headings preferred; a heading-sourced answer ends at the next heading of any level.

Added beyond the source port: **at least three questions are required** before `FAQPage` is emitted. One generated guide page has a single question-shaped `###` heading, and a one-question `FAQPage` on a task guide is a false signal rather than an FAQ.

## 5. Cleaner structured answers

Fenced code blocks and table rows are dropped from `acceptedAnswer.text` — useful on the page, pure noise in structured data — and runs of whitespace are collapsed.

List markers are stripped **only at line start** (before the lines are joined), rather than with a regex over the joined string as in the source port. The joined-string form also ate dashes used mid-sentence; worth flowing back to PowerPoint.

## 6. Standalone `/faq/` page

`/faq/` previously 404'd and the Q&A lived inside the troubleshooting page. It is now its own page using `###` headings, which is what makes items 4 and 5 meaningful, earns the `FAQPage` rich result, and matches question-shaped queries.

The split is clean and nothing is duplicated: question-shaped Q&A moved to `/faq/`, diagnostic and procedural material stayed in `/troubleshooting/` (retitled from "Troubleshooting & FAQ"), and the two cross-link. Added to the nav, which also feeds `llms.txt`. The FAQ gained three new entries that had no home before (AI-client compatibility, why real Excel rather than a file parser, where to report bugs), giving eight structured questions.

## 7. Sitemap parity check (added during review, from the same cross-repo diff)

`hooks.py` rewrites `sitemap.xml.gz` separately after stripping `lastmod` and injecting the video markup, but the audit only checked that the `.gz` **exists**. Nothing verified the two agree, so they could silently diverge and publish a gzipped sitemap still carrying the `lastmod` values the plain file had dropped — and the gzipped copy is what many crawlers actually fetch.

Negative-tested in both directions:

| Injected fault | Result |
|---|---|
| `<lastmod>` added to `sitemap.xml` only | ✅ both the lastmod check and the parity check fire |
| Stale `.gz` written beside a **correct** `sitemap.xml` | ✅ parity check fires alone — the lastmod and existence checks both pass |

The second row is the blind spot: without parity, that state ships silently.
### Corrupt-archive handling

`gzip` reports corruption three ways and only one is an `OSError`. Measured over 400 single-byte corruptions of a valid archive rather than assumed:

| Failure mode | Exception | Subclasses `OSError`? |
|---|---|---|
| Wrong format / CRC failure | `gzip.BadGzipFile` | yes (395/400) |
| Damaged deflate stream | `zlib.error` | **no** (5/400) |
| Truncated write | `EOFError` | **no** |
| Empty file | *none* — reads as `""` | falls through to the mismatch check |

All now produce a clean audit failure instead of a traceback that would bury every other finding. The exception type is reported module-qualified, because `zlib.error`'s bare name is just `error`.
## Validation

- `python -m mkdocs build --strict --clean` — clean
- `python audit_site.py` — passes, 52 pages, 0 issues
- Negative test for item 1 — fires on both fault forms, then reverted and re-verified clean
- `scripts\check-doc-counts.ps1` — passes, 31 tools / 326 operations
- Full pre-commit suite — all gates passed (docs-only fast path; no compiled surface changed)
- `dotnet build -c Release` — 0 warnings, 0 errors

## Changeset

Labelled `skip-changelog` per `.changeset/README.md`: this is a docs and docs-tooling change with no user-visible change to the MCP Server, CLI, VS Code Extension, or MCPB.


