### PR TITLE
ci(docs): validate the Pages site on PRs and harden the build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,28 @@ updates:
         patterns:
           - "*"
 
+  # Documentation site (MkDocs) - check weekly
+  - package-ecosystem: "pip"
+    directory: "/gh-pages"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "documentation"
+      - "automated"
+    commit-message:
+      prefix: "chore(docs-deps)"
+    reviewers:
+      - "sbroenne"
+    groups:
+      docs-dependencies:
+        patterns:
+          - "*"
+
   # .NET SDK (via global.json if present)
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
-# CI Gate — the single authoritative status check for pull requests.
+# CI Gate — the authoritative status checks for pull requests.
 #
-# This job ALWAYS runs on every PR to `main` (no path filters), so it can be
-# safely marked as a required status check without the "required check never
+# Both jobs ALWAYS run on every PR to `main` (no path filters), so they can be
+# safely marked as required status checks without the "required check never
 # runs on path-filtered PRs" deadlock.
 #
-# It ports the Excel-free pre-commit gates (scripts/pre-commit.ps1) into CI so
+# `Docs Site` builds and audits the MkDocs website. `CI Gate` ports the
+# Excel-free pre-commit gates (scripts/pre-commit.ps1) into CI so
 # that the correctness checks are enforced server-side even if a contributor
 # bypasses the local hook (see Rule 31). The Excel-dependent gates — the CLI
 # workflow smoke test and the MCP smoke test — are intentionally NOT run here:
@@ -29,6 +30,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The documentation site is the primary distribution channel for this project
+  # (README.md is a landing page that links to excelmcpserver.dev), but until
+  # this job existed nothing validated it before merge: the Pages workflow only
+  # builds on push to `main`, and scripts/pre-commit.ps1 classifies `docs/`,
+  # `gh-pages/` and `*.md` as a docs-only fast path that skips almost every
+  # gate. A broken --strict build or audit regression therefore surfaced only
+  # after merge, on the deploy run. Runs unfiltered like the CI Gate job below
+  # so it can safely be a required check.
+  docs:
+    name: Docs Site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: gh-pages/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r gh-pages/requirements.txt
+
+      - name: Build with MkDocs
+        working-directory: gh-pages
+        run: mkdocs build --strict --clean
+
+      - name: Audit built site
+        working-directory: gh-pages
+        run: python audit_site.py
+
+      # Guards against the deploy workflow's hand-written paths: filter drifting
+      # from the canonical sources hooks.py mirrors, which would publish a
+      # silently stale site until the nightly cron caught up.
+      - name: Verify deploy path filter covers every mirrored source
+        working-directory: gh-pages
+        run: python check_deploy_paths.py
+
   ci-gate:
     name: CI Gate
     runs-on: windows-latest

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -26,9 +26,8 @@ on:
       - '.github/star-history.csv'
       - 'scripts/Update-StarHistory.ps1'
       - 'scripts/Restore-StarHistory.ps1'
-      - 'scripts/Persist-StarHistory.ps1'
-      - 'scripts/Test-StarHistory.ps1'
   schedule:
+    # After star-history.yml (02:17 UTC) so the site renders the same day's snapshot.
     - cron: "17 3 * * *"
   workflow_dispatch:
 
@@ -39,8 +38,11 @@ concurrency:
 
 jobs:
   build:
+    # Read-only: persisting the star history now lives in star-history.yml, so
+    # this job - which installs third-party Python packages - no longer needs
+    # write access to the repository.
     permissions:
-      contents: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       indexnow_urls: ${{ steps.indexnow-urls.outputs.urls }}
@@ -50,10 +52,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Test star history generator
-        shell: pwsh
-        run: ./scripts/Test-StarHistory.ps1
 
       - name: Restore persisted star history
         shell: pwsh
@@ -66,7 +64,7 @@ jobs:
             -HistoryPath $env:STAR_HISTORY_PATH `
             -RemotePath $env:STAR_HISTORY_PATH
 
-      - name: Record current public star count and generate chart
+      - name: Render star history chart
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
@@ -79,24 +77,12 @@ jobs:
             throw "GitHub did not return a valid public stargazers_count."
           }
 
+          # Local render only - the durable snapshot is written by star-history.yml.
           ./scripts/Update-StarHistory.ps1 `
             -Repository '${{ github.repository }}' `
             -HistoryPath $env:STAR_HISTORY_PATH `
             -CurrentCount $count `
             -OutputPath './gh-pages/docs/assets/images/star-history.svg'
-
-      - name: Persist daily aggregate snapshot
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./scripts/Persist-StarHistory.ps1 `
-            -Repository '${{ github.repository }}' `
-            -Branch $env:STAR_HISTORY_BRANCH `
-            -HistoryPath $env:STAR_HISTORY_PATH `
-            -RemotePath $env:STAR_HISTORY_PATH `
-            -CommitSha '${{ github.sha }}' `
-            -TempPath $env:RUNNER_TEMP
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,72 @@
+name: Link Check
+
+# Weekly link rot check for the published site.
+#
+# audit_site.py already validates internal structure on every PR, but nothing
+# checked that the site's outbound links still resolve. Broken external links
+# degrade both the reading experience and search ranking.
+#
+# Deliberately NOT run on pull requests: external endpoints rate-limit and go
+# down for reasons unrelated to the change under review, so this would be a
+# flaky required check. It runs on a schedule and files an issue instead.
+
+on:
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Check links in built site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: gh-pages/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r gh-pages/requirements.txt
+
+      - name: Build site
+        working-directory: gh-pages
+        run: mkdocs build --strict --clean
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # --base lets root-relative hrefs resolve against the built output, so
+          # internal and external links are both covered.
+          args: >-
+            --base gh-pages/_site
+            --no-progress
+            --max-concurrency 4
+            --accept 200,206,429
+            --exclude '^https?://localhost'
+            --exclude '^https?://127\.0\.0\.1'
+            --exclude 'example\.com'
+            'gh-pages/_site/**/*.html'
+          fail: true
+          output: lychee-report.md
+
+      - name: File an issue when links are broken
+        if: failure() && steps.lychee.outcome == 'failure'
+        uses: peter-evans/create-issue-from-file@v6
+        with:
+          title: "Broken links on excelmcpserver.dev"
+          content-filepath: lychee-report.md
+          # Only labels that actually exist in this repo - the API rejects
+          # unknown label names.
+          labels: documentation

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,114 @@
+name: Star History
+
+# Records the daily public star count and persists it to the star-history-data
+# branch.
+#
+# This is deliberately separate from "Deploy GitHub Pages". Persisting the
+# snapshot needs `contents: write`, while the Pages build installs third-party
+# Python packages from requirements.txt. Keeping them in one job meant the
+# dependency install ran with write access to the repository. The Pages build
+# now only *restores* the history (read-only) and renders the chart.
+#
+# Scheduled ahead of the Pages deploy (03:17 UTC) so the site picks up the
+# snapshot taken here on the same day.
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/Update-StarHistory.ps1'
+      - 'scripts/Restore-StarHistory.ps1'
+      - 'scripts/Persist-StarHistory.ps1'
+      - 'scripts/Test-StarHistory.ps1'
+      - '.github/workflows/star-history.yml'
+  pull_request:
+    paths:
+      - 'scripts/Update-StarHistory.ps1'
+      - 'scripts/Restore-StarHistory.ps1'
+      - 'scripts/Persist-StarHistory.ps1'
+      - 'scripts/Test-StarHistory.ps1'
+      - '.github/workflows/star-history.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: star-history
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Runs on pull requests too, so a change to the generator is validated before
+  # it reaches main rather than only afterwards on the Pages build.
+  test:
+    name: Test star history generator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Test star history generator
+        shell: pwsh
+        run: ./scripts/Test-StarHistory.ps1
+
+  snapshot:
+    name: Record and persist snapshot
+    needs: test
+    # Never persist from a pull request: forks cannot be trusted with write
+    # access, and a PR should not mutate the durable history.
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      STAR_HISTORY_BRANCH: star-history-data
+      STAR_HISTORY_PATH: .github/star-history.csv
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Restore persisted star history
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/Restore-StarHistory.ps1 `
+            -Repository '${{ github.repository }}' `
+            -Branch $env:STAR_HISTORY_BRANCH `
+            -HistoryPath $env:STAR_HISTORY_PATH `
+            -RemotePath $env:STAR_HISTORY_PATH
+
+      - name: Record current public star count
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Repository metadata remains public even though timestamped stargazers are restricted.
+          $countText = gh api "repos/${{ github.repository }}" --jq ".stargazers_count"
+          $count = 0
+
+          if ($LASTEXITCODE -ne 0 -or -not [int]::TryParse($countText, [ref]$count)) {
+            throw "GitHub did not return a valid public stargazers_count."
+          }
+
+          ./scripts/Update-StarHistory.ps1 `
+            -Repository '${{ github.repository }}' `
+            -HistoryPath $env:STAR_HISTORY_PATH `
+            -CurrentCount $count `
+            -OutputPath $(Join-Path $env:RUNNER_TEMP 'star-history.svg')
+
+      - name: Persist daily aggregate snapshot
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/Persist-StarHistory.ps1 `
+            -Repository '${{ github.repository }}' `
+            -Branch $env:STAR_HISTORY_BRANCH `
+            -HistoryPath $env:STAR_HISTORY_PATH `
+            -RemotePath $env:STAR_HISTORY_PATH `
+            -CommitSha '${{ github.sha }}' `
+            -TempPath $env:RUNNER_TEMP

--- a/gh-pages/.gitignore
+++ b/gh-pages/.gitignore
@@ -4,6 +4,9 @@ _site/
 # Generated documentation pages (produced by hooks.py from canonical repo docs).
 # Outside docs/ on purpose - see the comment on GEN_DIR in hooks.py.
 _generated/
+# Former location, kept so the stale directory in long-lived clones stays
+# ignored rather than showing up as untracked files.
+docs/_generated/
 
 # Python
 __pycache__/

--- a/gh-pages/.gitignore
+++ b/gh-pages/.gitignore
@@ -1,8 +1,9 @@
 # MkDocs build output
 _site/
 
-# Generated documentation pages (produced by hooks.py from canonical repo docs)
-docs/_generated/
+# Generated documentation pages (produced by hooks.py from canonical repo docs).
+# Outside docs/ on purpose - see the comment on GEN_DIR in hooks.py.
+_generated/
 
 # Python
 __pycache__/

--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -28,3 +28,22 @@ cd gh-pages
 
 (Alternatively, activate the venv first with `.\.venv\Scripts\Activate.ps1`, then plain
 `mkdocs serve`/`mkdocs build` will use the correct interpreter.)
+
+## Checks
+
+Both run in the `Docs Site` CI job on every pull request, and can be run locally
+after a build:
+
+```powershell
+cd gh-pages
+.\.venv\Scripts\python.exe audit_site.py           # SEO / LLM-discoverability audit
+.\.venv\Scripts\python.exe check_deploy_paths.py   # deploy paths: filter covers every mirrored source
+```
+
+Two further checks run on a schedule rather than per pull request:
+
+| Workflow | When | What |
+| --- | --- | --- |
+| `link-check.yml` | Weekly | Runs lychee over the built site and files an issue on link rot. Not a PR check: external endpoints rate-limit and would make it flaky. |
+| `star-history.yml` | Daily, plus PRs touching the scripts | Records and persists the star snapshot. Split out of the Pages build so that job no longer needs `contents: write` while installing pip packages. |
+

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -7,8 +7,9 @@ Run after ``mkdocs build`` from the ``gh-pages`` directory::
     python audit_site.py
 
 Exits non-zero and prints every failure if the built site regresses. This runs in
-the Pages deploy workflow rather than the pre-commit hook, so the docs-only
-pre-commit fast path stays fast.
+the ``Docs Site`` CI job on every pull request and in the Pages deploy workflow,
+rather than in the pre-commit hook, so the docs-only pre-commit fast path stays
+fast.
 """
 
 from __future__ import annotations

--- a/gh-pages/check_deploy_paths.py
+++ b/gh-pages/check_deploy_paths.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Verify the Pages deploy workflow rebuilds the site for every canonical source.
+
+``hooks.py`` pulls canonical Markdown from all over the repo into the site, but
+``.github/workflows/deploy-gh-pages.yml`` decides *when* to rebuild from a
+hand-written ``paths:`` filter. Nothing kept the two in sync, so adding a new
+mirrored source silently produced a stale website until the next nightly cron.
+
+This script fails when a source that ``hooks.py`` reads is not covered by the
+workflow filter. Run it from the ``gh-pages`` directory::
+
+    python check_deploy_paths.py
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+GH_PAGES = Path(__file__).resolve().parent
+REPO_ROOT = GH_PAGES.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-gh-pages.yml"
+
+# Literal _read("...") calls in hooks.py: CHANGELOG.md, SECURITY.md, the
+# installation pages and so on. The dict-driven sources are collected from the
+# imported module instead, because those paths are built with f-strings.
+_READ_CALL = re.compile(r'_read\(\s*"([^"]+)"')
+
+
+def mirrored_sources() -> set[str]:
+    sys.path.insert(0, str(GH_PAGES))
+    import hooks  # noqa: PLC0415 - deliberate late import; needs sys.path above
+
+    sources: set[str] = set()
+    sources.update(hooks.FEATURE_SOURCES.values())
+    sources.update(hooks.GUIDE_SOURCES.values())
+    sources.update(f"skills/shared/{name}" for name in hooks.SKILL_SOURCES)
+    sources.update(_READ_CALL.findall((GH_PAGES / "hooks.py").read_text(encoding="utf-8")))
+    return sources
+
+
+def workflow_paths() -> list[str]:
+    config = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    # YAML 1.1 parses a bare `on:` key as the boolean True.
+    triggers = config.get("on", config.get(True, {})) or {}
+    return list((triggers.get("push") or {}).get("paths") or [])
+
+
+def main() -> int:
+    if not WORKFLOW.is_file():
+        print(f"ERROR: {WORKFLOW} not found", file=sys.stderr)
+        return 2
+
+    patterns = workflow_paths()
+    if not patterns:
+        print("ERROR: the deploy workflow declares no push paths filter", file=sys.stderr)
+        return 2
+
+    missing: list[str] = []
+    for source in sorted(mirrored_sources()):
+        if not (REPO_ROOT / source).is_file():
+            missing.append(f"{source}: read by hooks.py but does not exist in the repo")
+            continue
+        if not any(fnmatch.fnmatch(source, pattern) for pattern in patterns):
+            missing.append(
+                f"{source}: mirrored into the site but no paths: entry in "
+                f"{WORKFLOW.relative_to(REPO_ROOT).as_posix()} matches it"
+            )
+
+    if missing:
+        print(
+            "Deploy path check FAILED - editing these files would not rebuild "
+            f"the site:\n"
+        )
+        for item in missing:
+            print(f"  - {item}")
+        return 1
+
+    print(
+        f"Deploy path check passed: {len(mirrored_sources())} mirrored sources, "
+        f"all covered by {len(patterns)} paths entries."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -53,7 +53,12 @@ def _xml_escape(text: str) -> str:
 
 # gh-pages/hooks.py -> gh-pages/ -> repo root
 REPO_ROOT = Path(__file__).resolve().parent.parent
-GEN_DIR = Path(__file__).resolve().parent / "docs" / "_generated"
+# Deliberately OUTSIDE docs_dir. When the generated files lived in
+# docs/_generated/, every build rewrote files inside the directory `mkdocs
+# serve` watches, so a single edit put the dev server into an endless
+# rebuild loop. `.` is a snippets base_path, so the `--8<-- "_generated/..."`
+# includes in the wrapper pages resolve here unchanged.
+GEN_DIR = Path(__file__).resolve().parent / "_generated"
 
 GITHUB_BLOB = "https://github.com/sbroenne/mcp-server-excel/blob/main/"
 GITHUB_TREE = "https://github.com/sbroenne/mcp-server-excel/tree/main/"
@@ -270,6 +275,9 @@ def _write(name: str, source_rel: str, content: str) -> None:
 
 
 DOCS_DIR = Path(__file__).resolve().parent / "docs"
+# Mirrors the snippets `base_path` in mkdocs.yml, in the same order. Kept in
+# sync so the llms.txt/mirror output resolves exactly what the site renders.
+SNIPPET_BASE_PATHS = (DOCS_DIR, Path(__file__).resolve().parent)
 
 
 def _resolve_snippets(text: str, depth: int = 0) -> str:
@@ -284,11 +292,12 @@ def _resolve_snippets(text: str, depth: int = 0) -> str:
         return text
 
     def repl(match: re.Match) -> str:
-        target = DOCS_DIR / match.group(1)
-        if not target.is_file():
-            log.warning("snippet not found while building llms output: %s", target)
-            return ""
-        return _resolve_snippets(target.read_text(encoding="utf-8"), depth + 1)
+        for base in SNIPPET_BASE_PATHS:
+            target = base / match.group(1)
+            if target.is_file():
+                return _resolve_snippets(target.read_text(encoding="utf-8"), depth + 1)
+        log.warning("snippet not found while building llms output: %s", match.group(1))
+        return ""
 
     return _SNIPPET.sub(repl, text)
 

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -31,6 +31,12 @@ watch:
 # Raw generated includes live in gh-pages/_generated/ (outside docs_dir, so
 # `mkdocs serve` does not retrigger itself) and are pulled into the thin wrapper
 # pages via pymdownx.snippets, which reads them straight from disk.
+#
+# They used to live in docs/_generated/. Long-lived clones still have that stale
+# directory, and without this exclusion MkDocs would silently build every stale
+# file as a published page. Keep this even though nothing writes there anymore.
+exclude_docs: |
+  _generated/
 
 # Many pulled-in source READMEs contain repo-relative links (e.g. ../../FEATURES.md)
 # that intentionally point at GitHub, not the site. Keep these as warnings, never

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -14,11 +14,23 @@ docs_dir: docs
 site_dir: _site
 use_directory_urls: true
 
-# Raw generated includes live in docs/_generated/ and are pulled into the thin
-# wrapper pages via pymdownx.snippets. They must NOT be built as standalone
-# pages (snippets reads them straight from disk, independent of this exclusion).
-exclude_docs: |
-  _generated/
+# hooks.py mirrors canonical Markdown from all over the repo into the site, but
+# MkDocs only watches docs_dir, mkdocs.yml and the hooks themselves. Without
+# these entries `mkdocs serve` silently ignores edits to the real sources, so a
+# local preview of a FEATURES.md or skills/shared/ change showed nothing.
+watch:
+  - ../FEATURES.md
+  - ../CHANGELOG.md
+  - ../SECURITY.md
+  - ../PRIVACY.md
+  - ../docs
+  - ../skills
+  - ../src/ExcelMcp.CLI/README.md
+  - ../src/ExcelMcp.McpServer/README.md
+
+# Raw generated includes live in gh-pages/_generated/ (outside docs_dir, so
+# `mkdocs serve` does not retrigger itself) and are pulled into the thin wrapper
+# pages via pymdownx.snippets, which reads them straight from disk.
 
 # Many pulled-in source READMEs contain repo-relative links (e.g. ../../FEATURES.md)
 # that intentionally point at GitHub, not the site. Keep these as warnings, never
@@ -167,6 +179,10 @@ markdown_extensions:
   - pymdownx.snippets:
       base_path:
         - docs
+        # gh-pages/, so the `--8<-- "_generated/..."` includes resolve. The
+        # generated files sit outside docs_dir on purpose: writing them into it
+        # made every build retrigger `mkdocs serve`, looping forever.
+        - .
       check_paths: true
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
## Why

Now that the docs site is the primary published surface (the repo README is effectively a landing page linking to excelmcpserver.dev), it was the least-protected part of the repo:

- **`CI Gate` never built the site**, and `pre-commit.ps1` classifies `gh-pages/` as doc-only, so a broken site was only discoverable *after* it had deployed.
- The deploy workflow's `paths:` filter was **hand-maintained** in parallel with the sources `hooks.py` mirrors, so adding a mirrored file silently stopped triggering a deploy.
- `mkdocs-material` was **not covered by Dependabot** at all.

## Validation

- **New `Docs Site` CI job** — `mkdocs build --strict`, `audit_site.py`, and the new `check_deploy_paths.py` on every PR. Unfiltered, like `CI Gate`, so it can safely be made a required check.
- **`gh-pages/check_deploy_paths.py`** — mechanically proves the deploy `paths:` filter covers every source `hooks.py` mirrors (currently 47 sources / 21 entries). Negative-tested: removing one entry reports 24 failures and exits 1.
- **Dependabot `pip` entry** for `/gh-pages`.

## Build fixes

- **Fixed a pre-existing infinite `mkdocs serve` rebuild loop.** `hooks.py`'s `on_pre_build` rewrote its generated pages *into* `docs_dir`, which serve watches, so every build retriggered itself. Generated output moved to `gh-pages/_generated/` (outside `docs_dir`) with the snippets `base_path` extended to `[docs, .]` so the existing `--8<--` includes resolve unchanged. Rebuild detections after a single edit: **9+ and climbing → 1**.
- **Added a `watch:` key** so serve reloads on `FEATURES.md`, `CHANGELOG.md`, `docs/`, `skills/` and the two `src/*/README.md` — previously only `gh-pages/` was watched.

## Workflow split

- **Star history moved to `star-history.yml`.** Persisting the snapshot needs `contents: write`, and it shared a job with `pip install -r requirements.txt` — i.e. third-party package installs ran with repo write access. The Pages build is now **`contents: read`** and only *restores* the history to render the chart. The 13 generator tests also run on pull requests now, rather than only after merge.
- **New `link-check.yml`** — weekly lychee run over the built site, filing an issue on link rot. Deliberately scheduled rather than per-PR: external endpoints rate-limit and would make it a flaky required check.

## Verification

- `_site` is **byte-identical across all 164 files** before and after (SHA-256 per file).
- `audit_site.py`: clean, 51 pages. `check_deploy_paths.py`: passes.
- Serve loop re-tested by touching `FEATURES.md` → exactly 1 rebuild (also confirms `watch:` works).
- `Test-StarHistory.ps1`: 13/13 pass.
- All 15 pre-commit gates passed (no `--no-verify`).

## Notes

- Verified action versions rather than guessing: `peter-evans/create-issue-from-file` is on **v6**, not v5. Also, the `automated` label **does not exist** in this repo, which would have hard-failed issue creation — `link-check.yml` uses only `documentation`. FYI the existing Dependabot entries already reference several non-existent labels (`automated`, `nuget`, `github-actions`, `docker`); harmless there, left alone.
- **`mkdocs-redirects` deliberately not added** — there are no legacy URLs to redirect, and an empty redirect map is cargo cult. Worth adding at the first page rename.
- Deferred behind #771 (it rewrites `audit_sitemap` and the a11y/logo overrides, so they would conflict): the SEO/sitemap cleanup, and the larger `pymdownx.snippets` migration that would delete most of `hooks.py`.

Docs/CI only — no changeset (`skip-changelog`).