### PR TITLE
fix(docs): repair broken NuGet.org package links without regressing the site

### DIFF
--- a/.changeset/brave-cups-repeat.md
+++ b/.changeset/brave-cups-repeat.md
@@ -1,0 +1,7 @@
+---
+"excelmcp": patch
+---
+
+**Fixed broken documentation links on NuGet.org** — the MCP Server and CLI package pages linked to the installation guides, feature reference, and privacy policy using relative paths. NuGet.org resolves those against the package itself rather than the repository, so every one of them returned a 404 for anyone reading the package page. They now point at absolute repository URLs and work from NuGet.org, GitHub, and inside the shipped skill packages alike.
+
+The documentation site is unaffected: those links still resolve to the site's own pages, and a new audit check fails the build if a published page ever starts sending readers to GitHub for content the site hosts itself.

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -26,6 +26,11 @@ SITE_DIR = Path(__file__).resolve().parent / "_site"
 MKDOCS_YML = Path(__file__).resolve().parent / "mkdocs.yml"
 SITE_URL = "https://excelmcpserver.dev/"
 
+# Imported rather than duplicated: this is the same mapping hooks.py uses to
+# rewrite links, so the audit cannot drift away from what the build produces.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from hooks import SITE_PAGE_MAP as SOURCE_TO_SITE  # noqa: E402
+
 # Google truncates around these lengths; well outside them is a real problem.
 TITLE_MAX = 70
 DESCRIPTION_MIN = 50
@@ -174,6 +179,33 @@ def audit_html(path: Path) -> None:
     # Markdown alternate must be advertised and must exist.
     if 'type="text/markdown"' not in html and "type=text/markdown" not in html:
         fail(f"{name}: no <link rel=alternate type=text/markdown>")
+
+
+def audit_offsite_links(html_files: list[Path]) -> None:
+    """No page may link out to GitHub for content we publish ourselves.
+
+    Canonical sources that are also rendered outside GitHub (the NuGet package
+    READMEs) spell their links out as absolute GitHub URLs, because NuGet.org
+    resolves relative links against the package root and they 404. hooks.py maps
+    those back to the published page. If that mapping is missed - a new absolute
+    link, or a page added without a SITE_PAGE_MAP entry - the site silently
+    starts sending readers to GitHub instead of its own page, losing both the
+    reader and the internal link equity.
+    """
+    # Quotes are optional: the minify plugin strips them from attribute values.
+    pattern = re.compile(
+        r'href=["\']?https://github\.com/sbroenne/mcp-server-excel/(?:blob|tree)/main/([^"\'\s>#]+)'
+    )
+    for path in html_files:
+        html = path.read_text(encoding="utf-8", errors="replace")
+        name = page_name(path)
+        for target in pattern.findall(html):
+            mapped = SOURCE_TO_SITE.get(target.rstrip("/"))
+            if mapped is not None:
+                fail(
+                    f"{name}: links to GitHub for {target}, which is published at "
+                    f"{mapped} - add the mapping in hooks.py instead"
+                )
 
 
 def audit_internal_links(html_files: list[Path]) -> None:
@@ -392,6 +424,7 @@ def main() -> int:
     for path in html_files:
         audit_html(path)
     audit_internal_links(html_files)
+    audit_offsite_links(html_files)
     audit_jsonld(html_files)
     audit_sitemap()
     audit_llms(html_files)

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -162,16 +162,35 @@ SITE_PAGE_MAP.update(
 
 
 def _rewrite_links(text: str, source_rel: str) -> str:
-    """Resolve repo-relative links in pulled-in content so they work on the site.
+    """Resolve links in pulled-in content so they work on the site.
 
-    Links that point at a page we publish are rewritten to that page's URL;
-    everything else that resolves inside the repo is rewritten to an absolute
-    GitHub URL. External links, anchors and site-absolute links are left alone.
+    Two cases:
+
+    - Repo-relative links: rewritten to the published page when we publish one,
+      otherwise to an absolute GitHub URL.
+    - Absolute GitHub URLs into this repo: rewritten *back* to the published
+      page when we publish one. Sources that are also rendered outside GitHub -
+      the NuGet package READMEs - have to spell links out absolutely, because
+      NuGet.org resolves relative links against the package root and they 404.
+      Without this the website would link out to GitHub for pages it publishes
+      itself.
+
+    External links, anchors and site-absolute links are left alone.
     """
     source_dir = posixpath.dirname(source_rel)
 
     def repl(match: re.Match) -> str:
         label, url = match.group(1), match.group(2)
+
+        for prefix in (GITHUB_BLOB, GITHUB_TREE):
+            if url.startswith(prefix):
+                remainder = url[len(prefix) :]
+                target, _, anchor = remainder.partition("#")
+                anchor = f"#{anchor}" if anchor else ""
+                if target.rstrip("/") in SITE_PAGE_MAP:
+                    return f"[{label}]({SITE_PAGE_MAP[target.rstrip('/')]}{anchor})"
+                return match.group(0)
+
         if url.startswith(("http://", "https://", "#", "/", "mailto:", "<")):
             return match.group(0)
 

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -38,7 +38,7 @@ Also perfect for RPA workflows, CI/CD pipelines, batch processing, and automated
 dotnet tool install --global Sbroenne.ExcelMcp.CLI
 ```
 
-📖 **[Full Installation Guide](../../docs/INSTALLATION-CLI.md)** - PATH setup, GitHub Copilot plugin, updating, uninstalling, and troubleshooting
+📖 **[Full Installation Guide](https://github.com/sbroenne/mcp-server-excel/blob/main/docs/INSTALLATION-CLI.md)** - PATH setup, GitHub Copilot plugin, updating, uninstalling, and troubleshooting
 
 📚 **CLI usage guide:** See the session workflow, troubleshooting, advanced usage, and CI/CD examples below.
 
@@ -52,7 +52,7 @@ ExcelMcp.CLI provides **326 operations** across 31 feature command categories in
 
 Drives the **actual Excel application** via COM — not a file-format parser — so live operations (Power Query refresh, recalculation, DAX evaluation, VBA execution) run for real and existing workbooks stay intact.
 
-📚 **[Complete Feature Reference →](../../FEATURES.md)** - Full documentation with all operations, grouped by category
+📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Full documentation with all operations, grouped by category
 
 ---
 
@@ -61,7 +61,7 @@ Drives the **actual Excel application** via COM — not a file-format parser —
 - **Windows OS** (Windows 10/11 or Server 2016+) + **Microsoft Excel 2016 or later** — COM interop is Windows-specific and requires Excel to be installed
 - **.NET 10 Runtime** only if using the NuGet .NET tool install path (not required for the standalone exe)
 
-📖 **[Full System Requirements & Optional Components](../../docs/INSTALLATION-CLI.md)** - including DAX/MSOLAP prerequisites
+📖 **[Full System Requirements & Optional Components](https://github.com/sbroenne/mcp-server-excel/blob/main/docs/INSTALLATION-CLI.md)** - including DAX/MSOLAP prerequisites
 
 ---
 
@@ -176,7 +176,7 @@ These tests open actual workbooks, issue `session open/list/close`, and call `ex
 
 ## 🤝 Related Tools
 
-- **[MCP Server](../ExcelMcp.McpServer/README.md)** - For conversational AI (Claude Desktop, VS Code Chat) — distributed as `mcp-excel.exe`
+- **[MCP Server](https://github.com/sbroenne/mcp-server-excel/blob/main/src/ExcelMcp.McpServer/README.md)** - For conversational AI (Claude Desktop, VS Code Chat) — distributed as `mcp-excel.exe`
 - **[VS Code Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)** - One-click Excel automation in VS Code
 - **Issues & Discussions**: [GitHub](https://github.com/sbroenne/mcp-server-excel)
 - **Full docs**: [excelmcpserver.dev](https://excelmcpserver.dev/)
@@ -185,7 +185,7 @@ These tests open actual workbooks, issue `session open/list/close`, and call `ex
 
 ## 📄 License
 
-MIT License - see [LICENSE](../../LICENSE) for details.
+MIT License - see [LICENSE](https://github.com/sbroenne/mcp-server-excel/blob/main/LICENSE) for details.
 
 ---
 

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -57,15 +57,15 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 - ✅ Windsurf
 - ✅ Any MCP-compatible client
 
-📖 **Detailed setup instructions:** [MCP Server Installation Guide](../../docs/INSTALLATION-MCP-SERVER.md)
+📖 **Detailed setup instructions:** [MCP Server Installation Guide](https://github.com/sbroenne/mcp-server-excel/blob/main/docs/INSTALLATION-MCP-SERVER.md)
 
-🎯 **Quick config examples:** [examples/mcp-configs/](../../examples/mcp-configs/)
+🎯 **Quick config examples:** [examples/mcp-configs/](https://github.com/sbroenne/mcp-server-excel/tree/main/examples/mcp-configs)
 
 ## 🛠️ What You Can Do
 
 **31 specialized tools with 326 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
 
-📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 326 operations, grouped by category
+📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 326 operations, grouped by category
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT
@@ -99,11 +99,11 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 ## 📋 Additional Resources
 
 - **[GitHub Repository](https://github.com/sbroenne/mcp-server-excel)** - Source code, issues, discussions
-- **[MCP Server Installation Guide](../../docs/INSTALLATION-MCP-SERVER.md)** - Detailed setup for all platforms
+- **[MCP Server Installation Guide](https://github.com/sbroenne/mcp-server-excel/blob/main/docs/INSTALLATION-MCP-SERVER.md)** - Detailed setup for all platforms
 - **[VS Code Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)** - One-click installation
-- **[CLI Documentation](../ExcelMcp.CLI/README.md)** - Comprehensive commands for RPA and CI/CD automation
+- **[CLI Documentation](https://github.com/sbroenne/mcp-server-excel/blob/main/src/ExcelMcp.CLI/README.md)** - Comprehensive commands for RPA and CI/CD automation
 
 **License:** MIT  
-**Privacy:** [PRIVACY.md](../../PRIVACY.md)
+**Privacy:** [PRIVACY.md](https://github.com/sbroenne/mcp-server-excel/blob/main/PRIVACY.md)
 **Platform:** Windows only (requires Excel 2016+)  
 **Support:** [GitHub Issues](https://github.com/sbroenne/mcp-server-excel/issues)


### PR DESCRIPTION
## The bug

`src/ExcelMcp.McpServer/README.md` and `src/ExcelMcp.CLI/README.md` are shipped as the **NuGet package descriptions**, and both linked to sibling documentation with relative paths:

```
[Full Installation Guide](../../docs/INSTALLATION-CLI.md)
[Complete Feature Reference →](../../FEATURES.md)
[PRIVACY.md](../../PRIVACY.md)
```

NuGet.org resolves relative links against the **package root**, not the repository, and doesn't serve packed files as web documents — so all **11** of these 404 for anyone reading the package page. Microsoft's own guidance is to use absolute repository URLs in package READMEs.

## Why it wasn't a one-line fix

The website publishes most of those targets itself (`/features/`, `/installation-cli/`, `/privacy/`, `/mcp-server/`). Absolutising the links naively would have made excelmcpserver.dev **link out to GitHub for its own pages** — losing the reader and the internal link equity.

So `_rewrite_links` now also maps absolute GitHub URLs **back** to the published page. Canonical sources spell links out absolutely (correct on GitHub, NuGet.org, and inside the shipped skill packages), and the site rewrites the ones it publishes.

**Result: the built site is byte-identical across all 166 files.** The fix is invisible to the website and only changes what NuGet.org readers get.

## Regression guard

New `audit_offsite_links` check in `audit_site.py` fails the build if any published page links to GitHub for a path in `SITE_PAGE_MAP`. It imports the map from `hooks.py` rather than duplicating it, so the two can't drift.

**Negative-tested:** disabling the reverse mapping produces 9 failures and exit 1. That test also caught a bug in the check itself — it required quoted `href` values, but the minify plugin strips attribute quotes, so the first version silently passed against a genuinely broken site.

## What I did *not* do, and why

The plan was to first move "website-only" docs to be canonical under `gh-pages/docs/` to shrink the mirroring in `hooks.py`. **I measured, and the premise was wrong** — there are essentially no website-only pages:

| Doc | Real inbound repo link |
| --- | --- |
| `docs/guides/*` (all 6) | `FEATURES.md`, browsed on GitHub |
| `docs/ARCHITECTURE.md` | root `README.md` |
| `docs/INSTALLATION-{MCP-SERVER,CLI}.md` | `src/*/README.md` → **ships to NuGet** |
| `docs/USE-CASES.md` | all four `docs/features/*` pages |
| `docs/CONTRIBUTING.md` | GitHub convention |

Every candidate is genuinely dual-purpose, so moving any of them trades a website win for broken GitHub/NuGet browsing. That also means the mirroring in `hooks.py` is **more justified than I claimed** — link rewriting is load-bearing, and a transform needs somewhere to write its output. I'll report the revised picture rather than pursue the teardown on a false premise.

## Verification

- Site **byte-identical**, 166 files (SHA-256 per file)
- `audit_site.py` clean, 52 pages; negative test exits 1
- `check_deploy_paths.py` passes
- All 15 pre-commit gates run, none bypassed

Changeset included (user-visible fix).