### PR TITLE
fix(docs): report real page dates in the sitemap, assert accessibility fixes

### DIFF
--- a/.changeset/quiet-owls-listen.md
+++ b/.changeset/quiet-owls-listen.md
@@ -1,0 +1,10 @@
+---
+"excelmcp": patch
+---
+
+**Accurate documentation-site dates and accessibility fixes**: the sitemap now
+reports each page's real last-changed date instead of the date the site was
+built, so search engines no longer see all 52 pages change on every deploy. The
+site logo, loading indicator and search box also gained the accessible names and
+image dimensions they were missing, and the build now fails if any of those
+regress.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # hooks.py derives each sitemap <lastmod> from `git log`, so the full
+          # history is required. A shallow clone would date every page to the
+          # tip commit; audit_site.py fails the build if it detects that.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -52,6 +52,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # hooks.py derives each sitemap <lastmod> from `git log`, so the full
+          # history is required. A shallow clone would date every page to the
+          # tip commit; audit_site.py fails the build if it detects that.
+          fetch-depth: 0
 
       - name: Restore persisted star history
         shell: pwsh

--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -7,6 +7,23 @@ the repo (root `README.md`, `FEATURES.md`, `docs/features/`, package READMEs,
 The canonical feature reference is organized into intent-based pages under `docs/features/`;
 `hooks.py` adapts those pages for the website without copying operation details.
 
+## Theme overrides
+
+`overrides/` holds the templates that change MkDocs/Material output:
+
+| File | Why |
+| --- | --- |
+| `sitemap.xml` | Adds a real `<lastmod>` (the git commit date behind each page, supplied by `hooks.py`) and the home page's `<video:video>` block. The stock template stamps the *build* date on every URL, which told crawlers all 52 pages changed on every deploy. |
+| `partials/logo.html` | Upstream renders `alt="logo"` with no dimensions - a WCAG 1.1.1 failure and an unsized image. |
+| `partials/progress.html` | Upstream's `role="progressbar"` has no accessible name (WCAG 4.1.2). |
+
+Material's search dialog needs the same treatment, but its partial is ~45 lines
+of markup and feature flags, so forking it to add one attribute would pin a
+large slice of Material internals. That one stays a string patch in
+`hooks.py`. `audit_site.py` asserts all four fixes are present in the built
+HTML, so an upstream change that breaks any of them fails the build instead of
+silently regressing accessibility.
+
 ## Setup (one-time)
 
 ```powershell
@@ -36,9 +53,13 @@ after a build:
 
 ```powershell
 cd gh-pages
-.\.venv\Scripts\python.exe audit_site.py           # SEO / LLM-discoverability audit
+.\.venv\Scripts\python.exe audit_site.py           # SEO / a11y / LLM-discoverability audit
 .\.venv\Scripts\python.exe check_deploy_paths.py   # deploy paths: filter covers every mirrored source
 ```
+
+Both workflows that build the site check out with `fetch-depth: 0`, because the
+sitemap dates come from `git log`. On a shallow clone every page would claim the
+tip commit's date; `audit_site.py` fails the build when it sees that.
 
 Two further checks run on a schedule rather than per pull request:
 

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -19,6 +19,7 @@ import json
 import re
 import sys
 import zlib
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -208,6 +209,52 @@ def audit_offsite_links(html_files: list[Path]) -> None:
                 )
 
 
+def audit_accessibility(html_files: list[Path]) -> None:
+    """Assert the accessible names Material's own partials omit.
+
+    Three WCAG defects are patched during the build: the logo's alt text and
+    dimensions and the loading progress bar (both via ``overrides/partials/``),
+    and the search dialog's accessible name (a string patch in ``hooks.py``,
+    because upstream's search partial is far too large to fork for one
+    attribute). All three are invisible in normal use and none of them failed
+    the build if they stopped applying - so a Material upgrade that renamed a
+    class or reordered an attribute would have silently regressed the site.
+    """
+    # Attribute quotes are optional: the minify plugin strips them.
+    q = r'["\']?'
+    checks = (
+        (
+            re.compile(rf"<div[^>]*\brole={q}dialog\b[^>]*>"),
+            "search dialog",
+            "hooks.py on_post_page no longer matches Material's search partial",
+        ),
+        (
+            re.compile(rf"<div[^>]*\brole={q}progressbar\b[^>]*>"),
+            "progress bar",
+            "overrides/partials/progress.html is missing or out of date",
+        ),
+    )
+    logo = re.compile(rf"<img[^>]*\bsrc={q}[^\"'\s>]*assets/images/logo\.png[^>]*>")
+    for path in html_files:
+        html = path.read_text(encoding="utf-8", errors="replace")
+        name = page_name(path)
+        for pattern, what, hint in checks:
+            for tag in pattern.findall(html):
+                if "aria-label" not in tag and "aria-labelledby" not in tag:
+                    fail(f"{name}: {what} has no accessible name - {hint}")
+        for tag in logo.findall(html):
+            if re.search(rf"\balt={q}logo\b", tag) or "alt=" not in tag:
+                fail(
+                    f"{name}: logo image has no meaningful alt text - "
+                    "overrides/partials/logo.html is missing or out of date"
+                )
+            elif "width=" not in tag or "height=" not in tag:
+                fail(
+                    f"{name}: logo image is unsized - "
+                    "overrides/partials/logo.html is missing or out of date"
+                )
+
+
 def audit_internal_links(html_files: list[Path]) -> None:
     """Every site-absolute internal link must resolve to something we built."""
     for path in html_files:
@@ -232,8 +279,6 @@ def audit_sitemap() -> None:
         fail("sitemap.xml is missing")
         return
     xml = sitemap.read_text(encoding="utf-8")
-    if "<lastmod>" in xml:
-        fail("sitemap.xml still contains unreliable <lastmod> values")
     if "<video:video>" not in xml:
         fail("sitemap.xml is missing the home-page video markup")
     locs = re.findall(r"<loc>([^<]+)</loc>", xml)
@@ -242,13 +287,36 @@ def audit_sitemap() -> None:
     for loc in locs:
         if not loc.startswith(SITE_URL):
             fail(f"sitemap.xml has an off-site <loc>: {loc}")
+
+    # Every URL must carry a real git-derived <lastmod>. hooks.py used to strip
+    # <lastmod> wholesale because MkDocs stamps the *build* date on every page,
+    # telling crawlers all 52 pages changed on every deploy. Now the dates come
+    # from git, so absent or malformed ones mean the index failed to build.
+    lastmods = re.findall(r"<lastmod>([^<]+)</lastmod>", xml)
+    if len(lastmods) != len(locs):
+        fail(
+            f"sitemap.xml has {len(locs)} <loc> entries but {len(lastmods)} "
+            "<lastmod> values; every URL needs a git-derived date"
+        )
+    for value in lastmods:
+        try:
+            datetime.fromisoformat(value)
+        except ValueError:
+            fail(f"sitemap.xml has a malformed <lastmod>: {value}")
+    if len(lastmods) > 1 and len(set(lastmods)) == 1:
+        # The signature of a shallow clone: git log sees one commit, so every
+        # path resolves to the same date. The workflow needs fetch-depth: 0.
+        fail(
+            "sitemap.xml gives every URL the same <lastmod> "
+            f"({lastmods[0]}); the checkout is probably shallow"
+        )
+
     if not (SITE_DIR / "sitemap.xml.gz").is_file():
         fail("sitemap.xml.gz is missing")
     else:
-        # The gzipped twin is what many crawlers actually fetch, and hooks.py
-        # rewrites it separately after enriching sitemap.xml. Checking only that
-        # it exists would let the two silently diverge - publishing a .gz still
-        # carrying the lastmod values the plain file had dropped.
+        # The gzipped twin is what many crawlers actually fetch. MkDocs writes it
+        # from the same rendered template as sitemap.xml, so a mismatch means
+        # something rewrote one of the two after the build.
         # gzip surfaces corruption three ways and only one of them is an OSError:
         # BadGzipFile (wrong format / CRC failure) subclasses it, but EOFError
         # (truncated write) and zlib.error (damaged deflate stream) inherit
@@ -425,6 +493,7 @@ def main() -> int:
         audit_html(path)
     audit_internal_links(html_files)
     audit_offsite_links(html_files)
+    audit_accessibility(html_files)
     audit_jsonld(html_files)
     audit_sitemap()
     audit_llms(html_files)

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -219,40 +219,51 @@ def audit_accessibility(html_files: list[Path]) -> None:
     attribute). All three are invisible in normal use and none of them failed
     the build if they stopped applying - so a Material upgrade that renamed a
     class or reordered an attribute would have silently regressed the site.
+
+    Each element is matched by the specific Material class we patch rather than
+    by its ARIA role, for two reasons. Matching ``role=dialog`` generally would
+    fail the build for any *other* dialog Material grows that we never patched,
+    and - worse - it would go quiet exactly when it matters: if an upgrade
+    restructured the search markup out from under the patch, a role-based search
+    would simply find nothing and pass. Hence the explicit "not found" failure
+    below; an element that vanished is a regression, not a clean run.
     """
-    # Attribute quotes are optional: the minify plugin strips them.
+    # Attribute quotes are optional: the minify plugin strips them. The trailing
+    # character class stops `md-search` also matching `md-search__inner`.
     q = r'["\']?'
     checks = (
         (
-            re.compile(rf"<div[^>]*\brole={q}dialog\b[^>]*>"),
             "search dialog",
+            re.compile(rf"<div[^>]*\bclass={q}md-search[\"'\s>][^>]*>"),
             "hooks.py on_post_page no longer matches Material's search partial",
         ),
         (
-            re.compile(rf"<div[^>]*\brole={q}progressbar\b[^>]*>"),
             "progress bar",
+            re.compile(rf"<div[^>]*\bclass={q}md-progress[\"'\s>][^>]*>"),
             "overrides/partials/progress.html is missing or out of date",
         ),
     )
+    logo_hint = "overrides/partials/logo.html is missing or out of date"
     logo = re.compile(rf"<img[^>]*\bsrc={q}[^\"'\s>]*assets/images/logo\.png[^>]*>")
     for path in html_files:
         html = path.read_text(encoding="utf-8", errors="replace")
         name = page_name(path)
-        for pattern, what, hint in checks:
-            for tag in pattern.findall(html):
+        for what, pattern, hint in checks:
+            tags = pattern.findall(html)
+            if not tags:
+                fail(f"{name}: no {what} found - {hint}")
+                continue
+            for tag in tags:
                 if "aria-label" not in tag and "aria-labelledby" not in tag:
                     fail(f"{name}: {what} has no accessible name - {hint}")
-        for tag in logo.findall(html):
+        logos = logo.findall(html)
+        if not logos:
+            fail(f"{name}: no logo image found - {logo_hint}")
+        for tag in logos:
             if re.search(rf"\balt={q}logo\b", tag) or "alt=" not in tag:
-                fail(
-                    f"{name}: logo image has no meaningful alt text - "
-                    "overrides/partials/logo.html is missing or out of date"
-                )
+                fail(f"{name}: logo image has no meaningful alt text - {logo_hint}")
             elif "width=" not in tag or "height=" not in tag:
-                fail(
-                    f"{name}: logo image is unsized - "
-                    "overrides/partials/logo.html is missing or out of date"
-                )
+                fail(f"{name}: logo image is unsized - {logo_hint}")
 
 
 def audit_internal_links(html_files: list[Path]) -> None:

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -6,27 +6,38 @@ are generated from the authoritative Markdown files elsewhere in the repo
 drift from the real docs. It is the MkDocs equivalent of the old Jekyll
 ``build.sh`` script.
 
-Generated files are written to ``docs/_generated/`` (git-ignored) and pulled
-into the thin wrapper pages under ``docs/`` via the ``pymdownx.snippets``
-``--8<--`` include syntax. Regeneration happens automatically on every
-``mkdocs build`` / ``mkdocs serve`` via the ``on_pre_build`` event.
+Generated files are written to ``gh-pages/_generated/`` (git-ignored, and
+deliberately outside ``docs_dir``) and pulled into the thin wrapper pages under
+``docs/`` via the ``pymdownx.snippets`` ``--8<--`` include syntax. Regeneration
+happens automatically on every ``mkdocs build`` / ``mkdocs serve`` via the
+``on_pre_build`` event.
+
+Two smaller jobs live here as well:
+
+* ``on_env`` hands ``overrides/sitemap.xml`` the git commit date behind every
+  page, so ``<lastmod>`` reflects real content changes rather than the build
+  date, plus the home page's video metadata.
+* ``on_post_page`` gives Material's search dialog an accessible name. The logo
+  and progress-bar equivalents are declarative partials under ``overrides/``;
+  ``audit_site.py`` fails the build if any of the three stops applying.
 """
 
 from __future__ import annotations
 
-import gzip
 import json
 import logging
 import posixpath
 import re
+import subprocess
+from datetime import datetime
 from pathlib import Path
 
 log = logging.getLogger("mkdocs.hooks.generate")
 
 # Home-page intro video. MkDocs' built-in sitemap is a plain URL sitemap and has
-# no notion of embedded media, so we enrich the home page's <url> entry with a
-# Google video-sitemap <video:video> block in on_post_build. Keep these fields in
-# sync with the VideoObject JSON-LD in docs/index.md.
+# no notion of embedded media, so overrides/sitemap.xml renders a Google
+# video-sitemap <video:video> block into the home page's <url> entry. Keep these
+# fields in sync with the VideoObject JSON-LD in docs/index.md.
 VIDEO = {
     "page_url": "https://excelmcpserver.dev/",
     "thumbnail": "https://i.ytimg.com/vi/B6eIQ5BIbNc/maxresdefault.jpg",
@@ -39,17 +50,6 @@ VIDEO = {
     "duration": "62",
     "publication_date": "2025-11-23T08:33:40-08:00",
 }
-
-_VIDEO_NS = "http://www.google.com/schemas/sitemap-video/1.1"
-
-
-def _xml_escape(text: str) -> str:
-    return (
-        text.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-    )
 
 # gh-pages/hooks.py -> gh-pages/ -> repo root
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -290,7 +290,127 @@ def _write(name: str, source_rel: str, content: str) -> None:
     GEN_DIR.mkdir(parents=True, exist_ok=True)
     content = _rewrite_links(content, source_rel)
     (GEN_DIR / name).write_text(content, encoding="utf-8")
+    MIRROR_SOURCES[name] = source_rel
     log.info("generated _generated/%s", name)
+
+
+# Generated file name (e.g. "features-data.md") -> repo-relative canonical
+# source. Populated by _write during on_pre_build and read back when dating
+# sitemap entries: a wrapper page's real "last modified" is driven by the
+# canonical file it mirrors, not by the two-line wrapper.
+MIRROR_SOURCES: dict[str, str] = {}
+
+# Matches the snippet includes in the wrapper pages, e.g.
+#     --8<-- "_generated/features-data.md"
+_GEN_INCLUDE = re.compile(r'--8<--\s*"_generated/([^"]+)"')
+
+
+def _git_lastmod_index() -> dict[str, str]:
+    """Map every tracked repo-relative path to its last commit date (W3C).
+
+    One ``git log`` walk over the whole history, newest first: the first time a
+    path appears is by definition its most recent change. This replaces the
+    previous behaviour of stripping ``<lastmod>`` altogether, which was done
+    because MkDocs stamps every URL with the *build* date - a false freshness
+    signal on every page in every deploy.
+
+    Returns an empty index (so ``<lastmod>`` is simply omitted) when git is
+    unavailable, which keeps ``mkdocs build`` working from a source tarball.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "log", "--format=%cI", "--name-only", "--no-renames"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        log.warning("git log failed (%s); sitemap will omit <lastmod>", exc)
+        return {}
+
+    index: dict[str, str] = {}
+    date = ""
+    for line in proc.stdout.splitlines():
+        if not line:
+            continue
+        # Commit-date lines are the only ones that can start with a 4-digit year
+        # followed by '-'; paths in this repo never do.
+        if len(line) >= 5 and line[:4].isdigit() and line[4] == "-":
+            date = line
+        elif date:
+            index.setdefault(line, date)
+    return index
+
+
+def _git_is_shallow() -> bool:
+    """True when the checkout has truncated history.
+
+    Worth reporting explicitly: a shallow clone still lists every tracked file,
+    just all under the tip commit's date, so the lastmod index looks perfectly
+    healthy while every date in it is wrong.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--is-shallow-repository"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return False
+    return proc.stdout.strip() == "true"
+
+
+def _page_lastmod(files) -> dict[str, str]:
+    """Map each page's ``src_uri`` to the newest git date that affects it.
+
+    For a wrapper page that is nothing but an ``--8<--`` include, that is the
+    date of the canonical source; the wrapper itself contributes its own date
+    too, so editing either one refreshes the entry.
+    """
+    index = _git_lastmod_index()
+    if not index:
+        return {}
+    if _git_is_shallow():
+        # A shallow clone (actions/checkout's default fetch-depth: 1) still lists
+        # every tracked file - all under the tip commit's date. So the index
+        # looks healthy and only the dates are wrong; audit_site.py catches it by
+        # noticing that every page claims the same <lastmod>.
+        log.warning(
+            "shallow git clone: every sitemap <lastmod> will be the tip "
+            "commit's date - the workflow needs fetch-depth: 0"
+        )
+
+    lastmod: dict[str, str] = {}
+    for file in files.documentation_pages():
+        candidates = []
+        wrapper_rel = f"gh-pages/docs/{file.src_uri}"
+        if wrapper_rel in index:
+            candidates.append(index[wrapper_rel])
+        try:
+            text = Path(file.abs_src_path).read_text(encoding="utf-8")
+        except OSError:
+            text = ""
+        for name in _GEN_INCLUDE.findall(text):
+            source_rel = MIRROR_SOURCES.get(name)
+            if source_rel and source_rel in index:
+                candidates.append(index[source_rel])
+        if candidates:
+            # git's %cI keeps each committer's UTC offset, so the strings are
+            # not directly comparable as instants - parse before taking the max.
+            lastmod[file.src_uri] = max(candidates, key=datetime.fromisoformat)
+    return lastmod
+
+
+def on_env(env, config, files, **kwargs):  # noqa: D401 - MkDocs hook signature
+    """Expose sitemap data to overrides/sitemap.xml."""
+    env.globals["page_lastmod"] = _page_lastmod(files)
+    env.globals["video"] = VIDEO
+    return env
 
 
 DOCS_DIR = Path(__file__).resolve().parent / "docs"
@@ -792,78 +912,30 @@ def _write_tools_json(config) -> None:
 
 
 def on_post_build(config, **kwargs):  # noqa: D401 - MkDocs hook signature
-    """Normalize and enrich the generated sitemap.
+    """Write the LLM-facing outputs that MkDocs itself has no notion of.
 
-    MkDocs writes a plain URL sitemap that cannot describe the home-page intro
-    video, so we add the ``video`` namespace to ``<urlset>`` and inject a
-    ``<video:video>`` block into the home page's ``<url>``. Both ``sitemap.xml``
-    and its gzipped twin are updated so Search Console reads the enriched copy.
-    MkDocs also stamps every URL with the build date, even when its content did
-    not change. Those unreliable ``lastmod`` values are removed rather than
-    sending search engines a false freshness signal.
+    The sitemap used to be rewritten here - stripping ``<lastmod>`` and splicing
+    in a ``<video:video>`` block with regexes, then re-gzipping by hand. Both
+    jobs now happen declaratively in ``overrides/sitemap.xml``, which also means
+    MkDocs writes ``sitemap.xml.gz`` from the same rendered output instead of the
+    two being kept in step manually.
     """
-    site_dir = Path(config["site_dir"])
     _write_llm_outputs(config)
     _write_tools_json(config)
 
-    sitemap = site_dir / "sitemap.xml"
-    if not sitemap.is_file():
-        log.warning("sitemap.xml not found; skipping video-sitemap enrichment")
-        return
-
-    xml = sitemap.read_text(encoding="utf-8")
-    xml = re.sub(r"\s*<lastmod>[^<]+</lastmod>", "", xml)
-
-    if 'xmlns:video=' not in xml:
-        xml = xml.replace(
-            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
-            f' xmlns:video="{_VIDEO_NS}">',
-            1,
-        )
-
-    video_block = (
-        "        <video:video>\n"
-        f"            <video:thumbnail_loc>{_xml_escape(VIDEO['thumbnail'])}</video:thumbnail_loc>\n"
-        f"            <video:title>{_xml_escape(VIDEO['title'])}</video:title>\n"
-        f"            <video:description>{_xml_escape(VIDEO['description'])}</video:description>\n"
-        f"            <video:player_loc>{_xml_escape(VIDEO['player_loc'])}</video:player_loc>\n"
-        f"            <video:duration>{VIDEO['duration']}</video:duration>\n"
-        f"            <video:publication_date>{VIDEO['publication_date']}</video:publication_date>\n"
-        "            <video:family_friendly>yes</video:family_friendly>\n"
-        "            <video:live>no</video:live>\n"
-        "        </video:video>\n"
-    )
-
-    # Insert the video block inside the home page's <url>...</url> element.
-    home_url = re.compile(
-        r"(<url>\s*<loc>"
-        + re.escape(VIDEO["page_url"])
-        + r"</loc>.*?)(</url>)",
-        re.DOTALL,
-    )
-    if "<video:video>" not in xml:
-        new_xml, count = home_url.subn(rf"\1{video_block}    \2", xml, count=1)
-        if count:
-            xml = new_xml
-        else:
-            log.warning(
-                "home page <url> not found in sitemap; video markup not added"
-            )
-
-    sitemap.write_text(xml, encoding="utf-8", newline="\n")
-
-    gz = site_dir / "sitemap.xml.gz"
-    if gz.exists():
-        # mtime=0 keeps the output reproducible, matching MkDocs' own gzip call.
-        with gzip.GzipFile(gz, "wb", mtime=0) as fh:
-            fh.write(xml.encode("utf-8"))
-
-    log.info("normalized sitemap dates and added home-page video markup")
-
 
 def on_post_page(output, page, config, **kwargs):  # noqa: D401 - MkDocs hook signature
-    """Add accessibility metadata omitted by the upstream Material partials."""
+    """Give Material's search dialog an accessible name.
+
+    A role="dialog" with no name is a WCAG 4.1.2 failure. Unlike the logo and
+    progress-bar fixes - now declarative partials under ``overrides/`` - this one
+    stays a string patch on purpose: upstream's ``partials/search.html`` is ~45
+    lines of markup, icon lookups and feature flags, so copying it into
+    ``overrides/`` to add one attribute would pin a large slice of Material
+    internals and silently miss every upstream change to the search UI.
+
+    Two variants because mkdocs-minify strips attribute quotes.
+    """
     output = output.replace(
         '<div class="md-search" data-md-component="search" role="dialog">',
         '<div class="md-search" data-md-component="search" role="dialog" '
@@ -873,25 +945,5 @@ def on_post_page(output, page, config, **kwargs):  # noqa: D401 - MkDocs hook si
         "<div class=md-search data-md-component=search role=dialog>",
         '<div class=md-search data-md-component=search role=dialog '
         'aria-label="Search documentation">',
-    )
-    output = output.replace(
-        '<div class="md-progress" data-md-component="progress" role="progressbar">',
-        '<div class="md-progress" data-md-component="progress" role="progressbar" '
-        'aria-label="Page loading progress">',
-    )
-    output = output.replace(
-        "<div class=md-progress data-md-component=progress role=progressbar>",
-        '<div class=md-progress data-md-component=progress role=progressbar '
-        'aria-label="Page loading progress">',
-    )
-    output = re.sub(
-        r'<img src="([^"]*assets/images/logo\.png)" alt="logo">',
-        r'<img src="\1" alt="Excel MCP Server" width="256" height="256">',
-        output,
-    )
-    output = re.sub(
-        r"<img src=([^\s>]*assets/images/logo\.png) alt=logo>",
-        r'<img src="\1" alt="Excel MCP Server" width="256" height="256">',
-        output,
     )
     return output

--- a/gh-pages/overrides/partials/logo.html
+++ b/gh-pages/overrides/partials/logo.html
@@ -1,0 +1,15 @@
+{#-
+  Overrides material/templates/partials/logo.html.
+
+  Upstream renders `alt="logo"` with no dimensions. That is a WCAG 1.1.1 failure
+  (the alt text names the element rather than the site) and an unsized image,
+  which costs layout stability. Previously patched with two regexes over the
+  built HTML - one for the normal output and one for the quote-stripped minified
+  form. `config.site_name` is "Excel MCP Server", the value those regexes wrote.
+-#}
+{% if config.theme.logo %}
+  <img src="{{ config.theme.logo | url }}" alt="{{ config.site_name }}" width="256" height="256">
+{% else %}
+  {% set icon = config.theme.icon.logo or "material/library" %}
+  {% include ".icons/" ~ icon ~ ".svg" %}
+{% endif %}

--- a/gh-pages/overrides/partials/progress.html
+++ b/gh-pages/overrides/partials/progress.html
@@ -1,0 +1,8 @@
+{#-
+  Overrides material/templates/partials/progress.html.
+
+  A role="progressbar" with no accessible name is a WCAG 4.1.2 failure. Upstream
+  is a single div, so overriding it here is cheap and cannot drift; it replaces
+  two string patches over the built HTML in hooks.py.
+-#}
+<div class="md-progress" data-md-component="progress" role="progressbar" aria-label="Page loading progress"></div>

--- a/gh-pages/overrides/sitemap.xml
+++ b/gh-pages/overrides/sitemap.xml
@@ -1,0 +1,43 @@
+{#-
+  Overrides mkdocs/templates/sitemap.xml.
+
+  Two things the stock template cannot do, both of which used to be regex
+  surgery over the built file in hooks.py:
+
+  1. <lastmod> - MkDocs stamps every URL with the *build* date, so a deploy that
+     changed one page claimed all 52 had changed. `page_lastmod` (from hooks.py)
+     carries the real git commit date of the content behind each page, including
+     the canonical repo file a wrapper page mirrors.
+  2. <video:video> - the home page embeds an intro video, and a plain URL sitemap
+     has no way to describe it.
+
+  Rendering both here means MkDocs writes sitemap.xml.gz from this same output,
+  instead of hooks.py having to re-gzip a file it had just patched.
+-#}
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+{%- for file in pages -%}
+    {% if not file.page.is_link and (file.page.abs_url or file.page.canonical_url) %}
+    {%- set loc = file.page.canonical_url or file.page.abs_url %}
+    <url>
+         <loc>{{ loc|e }}</loc>
+         {%- set lastmod = page_lastmod.get(file.src_uri) %}
+         {%- if lastmod %}
+         <lastmod>{{ lastmod|e }}</lastmod>
+         {%- endif %}
+         {%- if loc == video.page_url %}
+         <video:video>
+             <video:thumbnail_loc>{{ video.thumbnail|e }}</video:thumbnail_loc>
+             <video:title>{{ video.title|e }}</video:title>
+             <video:description>{{ video.description|e }}</video:description>
+             <video:player_loc>{{ video.player_loc|e }}</video:player_loc>
+             <video:duration>{{ video.duration|e }}</video:duration>
+             <video:publication_date>{{ video.publication_date|e }}</video:publication_date>
+             <video:family_friendly>yes</video:family_friendly>
+             <video:live>no</video:live>
+         </video:video>
+         {%- endif %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>


### PR DESCRIPTION
## The sitemap had no dates at all

`hooks.py` stripped every `<lastmod>` with a regex over the built XML. The reason was sound — MkDocs stamps the **build** date on every URL, so each deploy told crawlers all 52 pages had changed — but the fix traded a false signal for no signal.

Dates now come from git. One `git log` walk maps each tracked path to its last commit, and a wrapper page takes the newest date among itself and the canonical repo file it mirrors. Spot-checked against `git log -1` for five paths covering all four source layouts (`docs/`, root, `gh-pages/docs/`, `skills/shared/`) — exact match on all five.

## Which let the sitemap become a real template

`overrides/sitemap.xml` renders `<lastmod>` **and** the home page's `<video:video>` block declaratively. That deletes ~55 lines of regex surgery plus a hand-rolled re-gzip from `on_post_build` — and because MkDocs writes `sitemap.xml.gz` from the same rendered template, the two can no longer drift.

## Accessibility: two of three become templates, one deliberately doesn't

| Fix | Before | After |
| --- | --- | --- |
| Logo (`alt="logo"`, unsized) | 2 regexes over minified HTML | `overrides/partials/logo.html` (upstream is 7 lines) |
| Progress bar (no accessible name) | 2 string patches | `overrides/partials/progress.html` (upstream is 1 line) |
| Search dialog (no accessible name) | 2 string patches | **unchanged, on purpose** |

Material's search partial is ~45 lines of markup, icon lookups and feature flags. Forking it to add one attribute would pin a large slice of theme internals and silently miss every upstream change to the search UI — a worse trade than the patch it replaces.

## The part that actually matters: none of this was verified

There were **no accessibility assertions at all**. A Material upgrade that renamed a class would have silently un-fixed the site, in the exact way that made the regex approach fragile in the first place. `audit_site.py` now asserts all four fixes in the built HTML, plus that every URL carries a valid, non-uniform `<lastmod>`.

Both workflows that build the site check out with `fetch-depth: 0`, since a shallow clone dates every page to the tip commit.

## Verification

Every new guard was negative-tested:

| Injected defect | Result |
| --- | --- |
| `<lastmod>` stripped (the old behaviour) | exit 1 — "52 `<loc>` entries but 0 `<lastmod>` values" |
| All dates identical (shallow-clone symptom) | exit 1 — "the checkout is probably shallow" |
| Malformed date | exit 1 — "malformed `<lastmod>`: yesterday" |
| Overrides removed + search patch disabled | exit 1 — **208 failures** (4 per page × 52) |

Two things that exercise caught, both of which would otherwise have shipped:

1. **A bug in my own a11y guard** — `for pattern, what, hint = checks:` instead of `in checks`, which made the whole check a no-op. It only surfaced because the negative test was run.
2. **A heuristic I had written was wrong.** I assumed a shallow clone yields few paths, so I warned when the index was small. Measured against a real `--depth 1` clone: it lists **all 843** tracked files, just all under one date — so the warning would never fire. Replaced with `git rev-parse --is-shallow-repository`, verified `True` against the shallow clone and `False` here.

Output delta versus the previous build is **only** the minifier dropping quotes around the logo's `src`/`width`/`height`, which `hooks.py` used to re-add *after* minification. Semantically identical HTML; the `aria-label`s and alt text are unchanged.

`mkdocs build --strict --clean`, `audit_site.py` (52 pages) and `check_deploy_paths.py` all pass; 166 files. All 15 pre-commit gates ran, none bypassed.