### PR TITLE
fix(plugins): preserve quoted arguments and survive an unreachable release API

### DIFF
--- a/.changeset/plugin-bootstrap-p0-fixes.md
+++ b/.changeset/plugin-bootstrap-p0-fixes.md
@@ -1,0 +1,23 @@
+---
+"excelmcp": patch
+---
+
+**Copilot plugins: arguments with quotes now survive, and a cached runtime keeps
+working offline.** Two defects made the published `excel-cli` and `excel-mcp`
+plugins fail in normal use.
+
+Every documented inline JSON example — `--values '[["Name","Amount"]]'` — was
+silently corrupted to `[[Name,Amount]]` when invoked through the plugin's own
+wrapper or the generated `excelcli` PATH shim, because Windows PowerShell rebuilds
+the command line for native executables and drops embedded double quotes. The
+wrapper now builds the command line itself using the standard MSVCRT quoting rules
+and hands it to the process verbatim, and the `.cmd` shim resolves the executable
+first so `%*` is passed through untouched.
+
+Separately, the bootstrap aborted whenever the GitHub release API was unreachable —
+even with the correct runtime already downloaded and extracted — so a rate limit or
+an offline machine stopped the MCP server from starting at all. A failed update
+check now falls back to the cached runtime and warns on stderr, and an
+already-extracted runtime is resolved before any download is considered, so
+reclaiming the cached `.zip` no longer requires the network. With nothing usable
+cached, the failure stays loud.

--- a/.github/plugins/excel-cli/bin/download.ps1
+++ b/.github/plugins/excel-cli/bin/download.ps1
@@ -32,6 +32,15 @@ function Write-Status {
     }
 }
 
+function Write-StatusError {
+    param([string]$Message)
+
+    # Always stderr. Stdout carries the -PassThru binary path, and for the MCP plugin it is the
+    # MCP stdio transport, so diagnostics must never be written there. This is intentionally not
+    # gated on -Quiet: -Quiet suppresses progress chatter, not warnings.
+    [Console]::Error.WriteLine($Message)
+}
+
 function Ensure-Directory {
     param([Parameter(Mandatory = $true)][string]$Path)
 
@@ -137,11 +146,25 @@ function Resolve-BinaryPath {
 function Ensure-LatestRuntime {
     param([Parameter(Mandatory = $true)]$State)
 
-    $downloadZipPath = Join-Path $DownloadsDir $State.assetName
-    $releaseDir = Join-Path $ReleasesDir $State.latestVersion
-
     Ensure-Directory -Path $DownloadsDir
     Ensure-Directory -Path $ReleasesDir
+
+    # Fast path: an already-extracted runtime matching the resolved release is usable as-is.
+    # This is checked before any download so that a warm cache never needs the network, even
+    # when the cached .zip has been removed by a disk cleanup tool.
+    if (-not $Force -and $State.cachedReleaseTag -eq $State.latestTag) {
+        $cachedBinary = Resolve-BinaryPath -State $State
+        if (-not [string]::IsNullOrWhiteSpace($cachedBinary) -and (Test-Path $cachedBinary)) {
+            return $cachedBinary
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($State.assetName) -or [string]::IsNullOrWhiteSpace($State.assetUrl)) {
+        throw "excel-cli must download the runtime but has no release metadata available. Check your network connection and try again.`nRelease page: $ReleasePageUrl"
+    }
+
+    $downloadZipPath = Join-Path $DownloadsDir $State.assetName
+    $releaseDir = Join-Path $ReleasesDir $State.latestVersion
 
     $downloadRequired = $Force -or -not (Test-Path $downloadZipPath) -or $State.cachedReleaseTag -ne $State.latestTag
     if ($downloadRequired) {
@@ -149,11 +172,6 @@ function Ensure-LatestRuntime {
         Invoke-WebRequest -Uri $State.assetUrl -OutFile $downloadZipPath
     } else {
         Write-Status "[excel-cli] Reusing cached package $($State.assetName)." "DarkGray"
-    }
-
-    $binaryPath = Resolve-BinaryPath -State $State
-    if (-not $Force -and $State.cachedReleaseTag -eq $State.latestTag -and -not [string]::IsNullOrWhiteSpace($binaryPath) -and (Test-Path $binaryPath)) {
-        return $binaryPath
     }
 
     if (Test-Path $releaseDir) {
@@ -184,14 +202,32 @@ $state = Get-State
 $sessionNeedsFreshnessCheck = $Force -or [string]::IsNullOrWhiteSpace($state.checkedSessionId) -or $state.checkedSessionId -ne $SessionId
 
 if ($sessionNeedsFreshnessCheck) {
-    $latest = Get-LatestReleaseMetadata
-    $state.checkedSessionId = $SessionId
-    $state.checkedAtUtc = [DateTime]::UtcNow.ToString("o")
-    $state.latestTag = $latest.Tag
-    $state.latestVersion = $latest.Version
-    $state.assetName = $latest.AssetName
-    $state.assetUrl = $latest.AssetUrl
-    Save-State -State $state
+    try {
+        $latest = Get-LatestReleaseMetadata
+        $state.checkedSessionId = $SessionId
+        $state.checkedAtUtc = [DateTime]::UtcNow.ToString("o")
+        $state.latestTag = $latest.Tag
+        $state.latestVersion = $latest.Version
+        $state.assetName = $latest.AssetName
+        $state.assetUrl = $latest.AssetUrl
+        Save-State -State $state
+    } catch {
+        # A failed update check must not take down a working installation. If a usable runtime
+        # is already cached, degrade to it instead of aborting.
+        $cachedBinary = Resolve-BinaryPath -State $state
+        if ([string]::IsNullOrWhiteSpace($cachedBinary) -or -not (Test-Path $cachedBinary)) {
+            throw
+        }
+
+        Write-StatusError "[excel-cli] Could not check for updates: $($_.Exception.Message)"
+        Write-StatusError "[excel-cli] Continuing with the cached runtime $($state.latestTag)."
+
+        # Record the attempt so that every command in this session does not retry a failing
+        # endpoint. The next Copilot session checks again.
+        $state.checkedSessionId = $SessionId
+        $state.checkedAtUtc = [DateTime]::UtcNow.ToString("o")
+        Save-State -State $state
+    }
 } else {
     Write-Status "[excel-cli] Freshness already checked for this Copilot session." "DarkGray"
 }

--- a/.github/plugins/excel-cli/bin/start-cli.ps1
+++ b/.github/plugins/excel-cli/bin/start-cli.ps1
@@ -7,6 +7,50 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+# Windows PowerShell rebuilds a command line when it invokes a native executable, and its
+# built-in quoting drops embedded double quotes. That silently corrupts JSON arguments such as
+# --values '[["Name","Amount"]]', which is the most common excelcli invocation. Build the command
+# line ourselves using the standard MSVCRT quoting rules and hand it to the process verbatim.
+function ConvertTo-NativeArgument {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    if ($Value.Length -gt 0 -and $Value -notmatch '[ \t\n\v"]') {
+        return $Value
+    }
+
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.Append('"')
+
+    $index = 0
+    while ($index -lt $Value.Length) {
+        $backslashes = 0
+        while ($index -lt $Value.Length -and $Value[$index] -eq '\') {
+            $index++
+            $backslashes++
+        }
+
+        if ($index -eq $Value.Length) {
+            # Trailing backslashes must be doubled so they do not escape the closing quote.
+            [void]$builder.Append('\' * ($backslashes * 2))
+            break
+        }
+
+        if ($Value[$index] -eq '"') {
+            # Escape the quote and double the backslashes that precede it.
+            [void]$builder.Append('\' * ($backslashes * 2 + 1))
+            [void]$builder.Append('"')
+        } else {
+            [void]$builder.Append('\' * $backslashes)
+            [void]$builder.Append($Value[$index])
+        }
+
+        $index++
+    }
+
+    [void]$builder.Append('"')
+    return $builder.ToString()
+}
+
 $downloadScript = Join-Path $PSScriptRoot "download.ps1"
 $binaryPath = & $downloadScript -PassThru -Quiet
 
@@ -14,5 +58,16 @@ if ([string]::IsNullOrWhiteSpace($binaryPath) -or -not (Test-Path $binaryPath)) 
     throw "excel-cli bootstrap did not resolve a usable excelcli.exe runtime."
 }
 
-& $binaryPath @PassthroughArgs
-exit $LASTEXITCODE
+if ($null -eq $PassthroughArgs) {
+    $PassthroughArgs = @()
+}
+
+$startInfo = New-Object System.Diagnostics.ProcessStartInfo
+$startInfo.FileName = $binaryPath
+$startInfo.Arguments = (($PassthroughArgs | ForEach-Object { ConvertTo-NativeArgument -Value $_ }) -join ' ')
+# Inherit this process's stdin/stdout/stderr so interactive and piped usage keep working.
+$startInfo.UseShellExecute = $false
+
+$process = [System.Diagnostics.Process]::Start($startInfo)
+$process.WaitForExit()
+exit $process.ExitCode

--- a/.github/plugins/excel-cli/com.github.copilot/bin/install-global.ps1
+++ b/.github/plugins/excel-cli/com.github.copilot/bin/install-global.ps1
@@ -21,6 +21,11 @@ if (-not (Test-Path $WrapperPath)) {
     exit 1
 }
 
+if (-not (Test-Path $DownloadScriptPath)) {
+    Write-Error "❌ Plugin bootstrap script not found at $DownloadScriptPath"
+    exit 1
+}
+
 if (-not (Test-Path $CopilotBinDir)) {
     Write-Host "[Install] Creating $CopilotBinDir ..." -ForegroundColor Yellow
     New-Item -ItemType Directory -Path $CopilotBinDir -Force | Out-Null

--- a/.github/plugins/excel-cli/com.github.copilot/bin/install-global.ps1
+++ b/.github/plugins/excel-cli/com.github.copilot/bin/install-global.ps1
@@ -6,6 +6,7 @@ $ErrorActionPreference = "Stop"
 
 $PluginDir = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $WrapperPath = Join-Path $PluginDir "bin\start-cli.ps1"
+$DownloadScriptPath = Join-Path $PluginDir "bin\download.ps1"
 $CopilotDir = Join-Path $env:USERPROFILE ".copilot"
 $CopilotBinDir = Join-Path $CopilotDir "bin"
 $ShimCmdPath = Join-Path $CopilotBinDir "excelcli.cmd"
@@ -25,10 +26,20 @@ if (-not (Test-Path $CopilotBinDir)) {
     New-Item -ItemType Directory -Path $CopilotBinDir -Force | Out-Null
 }
 
-$escapedWrapperPath = $WrapperPath.Replace('"', '""')
+$escapedDownloadPath = $DownloadScriptPath.Replace('"', '""')
+# Resolve the runtime first, then invoke it with cmd's verbatim %*. Routing arguments through
+# "powershell -File" would strip embedded double quotes and corrupt JSON arguments such as
+# --values '[["Name","Amount"]]', so the executable is called directly instead.
 $cmdShim = @"
 @echo off
-powershell -ExecutionPolicy Bypass -File "$escapedWrapperPath" %*
+setlocal
+set "EXCELCLI_EXE="
+for /f "usebackq delims=" %%i in (``powershell -NoProfile -ExecutionPolicy Bypass -File "$escapedDownloadPath" -PassThru -Quiet``) do set "EXCELCLI_EXE=%%i"
+if not defined EXCELCLI_EXE (
+    echo excel-cli bootstrap did not resolve a usable excelcli.exe runtime. 1>&2
+    exit /b 1
+)
+"%EXCELCLI_EXE%" %*
 exit /b %ERRORLEVEL%
 "@
 

--- a/.github/plugins/excel-mcp/bin/download.ps1
+++ b/.github/plugins/excel-mcp/bin/download.ps1
@@ -32,6 +32,15 @@ function Write-Status {
     }
 }
 
+function Write-StatusError {
+    param([string]$Message)
+
+    # Always stderr. Stdout carries the -PassThru binary path, and for the MCP plugin it is the
+    # MCP stdio transport, so diagnostics must never be written there. This is intentionally not
+    # gated on -Quiet: -Quiet suppresses progress chatter, not warnings.
+    [Console]::Error.WriteLine($Message)
+}
+
 function Ensure-Directory {
     param([Parameter(Mandatory = $true)][string]$Path)
 
@@ -137,11 +146,25 @@ function Resolve-BinaryPath {
 function Ensure-LatestRuntime {
     param([Parameter(Mandatory = $true)]$State)
 
-    $downloadZipPath = Join-Path $DownloadsDir $State.assetName
-    $releaseDir = Join-Path $ReleasesDir $State.latestVersion
-
     Ensure-Directory -Path $DownloadsDir
     Ensure-Directory -Path $ReleasesDir
+
+    # Fast path: an already-extracted runtime matching the resolved release is usable as-is.
+    # This is checked before any download so that a warm cache never needs the network, even
+    # when the cached .zip has been removed by a disk cleanup tool.
+    if (-not $Force -and $State.cachedReleaseTag -eq $State.latestTag) {
+        $cachedBinary = Resolve-BinaryPath -State $State
+        if (-not [string]::IsNullOrWhiteSpace($cachedBinary) -and (Test-Path $cachedBinary)) {
+            return $cachedBinary
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($State.assetName) -or [string]::IsNullOrWhiteSpace($State.assetUrl)) {
+        throw "excel-mcp must download the runtime but has no release metadata available. Check your network connection and try again.`nRelease page: $ReleasePageUrl"
+    }
+
+    $downloadZipPath = Join-Path $DownloadsDir $State.assetName
+    $releaseDir = Join-Path $ReleasesDir $State.latestVersion
 
     $downloadRequired = $Force -or -not (Test-Path $downloadZipPath) -or $State.cachedReleaseTag -ne $State.latestTag
     if ($downloadRequired) {
@@ -149,11 +172,6 @@ function Ensure-LatestRuntime {
         Invoke-WebRequest -Uri $State.assetUrl -OutFile $downloadZipPath
     } else {
         Write-Status "[excel-mcp] Reusing cached package $($State.assetName)." "DarkGray"
-    }
-
-    $binaryPath = Resolve-BinaryPath -State $State
-    if (-not $Force -and $State.cachedReleaseTag -eq $State.latestTag -and -not [string]::IsNullOrWhiteSpace($binaryPath) -and (Test-Path $binaryPath)) {
-        return $binaryPath
     }
 
     if (Test-Path $releaseDir) {
@@ -184,14 +202,32 @@ $state = Get-State
 $sessionNeedsFreshnessCheck = $Force -or [string]::IsNullOrWhiteSpace($state.checkedSessionId) -or $state.checkedSessionId -ne $SessionId
 
 if ($sessionNeedsFreshnessCheck) {
-    $latest = Get-LatestReleaseMetadata
-    $state.checkedSessionId = $SessionId
-    $state.checkedAtUtc = [DateTime]::UtcNow.ToString("o")
-    $state.latestTag = $latest.Tag
-    $state.latestVersion = $latest.Version
-    $state.assetName = $latest.AssetName
-    $state.assetUrl = $latest.AssetUrl
-    Save-State -State $state
+    try {
+        $latest = Get-LatestReleaseMetadata
+        $state.checkedSessionId = $SessionId
+        $state.checkedAtUtc = [DateTime]::UtcNow.ToString("o")
+        $state.latestTag = $latest.Tag
+        $state.latestVersion = $latest.Version
+        $state.assetName = $latest.AssetName
+        $state.assetUrl = $latest.AssetUrl
+        Save-State -State $state
+    } catch {
+        # A failed update check must not take down a working installation. If a usable runtime
+        # is already cached, degrade to it instead of aborting.
+        $cachedBinary = Resolve-BinaryPath -State $state
+        if ([string]::IsNullOrWhiteSpace($cachedBinary) -or -not (Test-Path $cachedBinary)) {
+            throw
+        }
+
+        Write-StatusError "[excel-mcp] Could not check for updates: $($_.Exception.Message)"
+        Write-StatusError "[excel-mcp] Continuing with the cached runtime $($state.latestTag)."
+
+        # Record the attempt so that every command in this session does not retry a failing
+        # endpoint. The next Copilot session checks again.
+        $state.checkedSessionId = $SessionId
+        $state.checkedAtUtc = [DateTime]::UtcNow.ToString("o")
+        Save-State -State $state
+    }
 } else {
     Write-Status "[excel-mcp] Freshness already checked for this Copilot session." "DarkGray"
 }

--- a/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -640,6 +643,370 @@ public sealed class PluginBootstrapBuildTests
         }
     }
 
+    [Theory]
+    [InlineData("excel-cli", "excelcli.exe", "ExcelMcp-CLI-{0}-windows.zip")]
+    [InlineData("excel-mcp", "mcp-excel.exe", "ExcelMcp-MCP-Server-{0}-windows.zip")]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_ApiUnavailableWithWarmCache_FallsBackToCachedRuntime(
+        string pluginName,
+        string executableName,
+        string assetNameFormat)
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox($"download-offline-fallback-{pluginName}");
+        try
+        {
+            var userProfile = Path.Combine(sandbox, "user");
+            Directory.CreateDirectory(userProfile);
+
+            var harnessPath = CreateDownloadHarnessScript(sandbox);
+            var version = "1.2.3";
+            var tag = $"v{version}";
+            var assetName = string.Format(CultureInfo.InvariantCulture, assetNameFormat, version);
+
+            var firstResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", tag,
+                    "-AssetName", assetName,
+                    "-Mode", "success"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-a",
+                    ["OS"] = "Windows_NT"
+                });
+
+            Assert.Equal(0, firstResult.ExitCode);
+            ResetMockCalls(userProfile);
+
+            // A brand new Copilot session re-runs the freshness check, and that check now fails.
+            var offlineResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", tag,
+                    "-AssetName", assetName,
+                    "-Mode", "api-fail",
+                    "-QuietMode"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-b",
+                    ["OS"] = "Windows_NT"
+                });
+
+            Assert.Equal(0, offlineResult.ExitCode);
+            Assert.EndsWith(executableName, offlineResult.Stdout.Trim(), StringComparison.OrdinalIgnoreCase);
+
+            // The warning must never reach stdout: it carries the resolved path, and for the MCP
+            // plugin it is also the MCP stdio transport.
+            Assert.Contains("Could not check for updates", offlineResult.Stderr, StringComparison.Ordinal);
+            Assert.DoesNotContain("Could not check for updates", offlineResult.Stdout, StringComparison.Ordinal);
+
+            // Falling back must not re-download anything.
+            Assert.Equal(0, ReadMockCallCount(userProfile, "web"));
+            Assert.Equal(0, ReadMockCallCount(userProfile, "expand"));
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Theory]
+    [InlineData("excel-cli", "excelcli.exe", "ExcelMcp-CLI-{0}-windows.zip")]
+    [InlineData("excel-mcp", "mcp-excel.exe", "ExcelMcp-MCP-Server-{0}-windows.zip")]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_CachedArchiveRemoved_ReusesExtractedRuntimeWithoutDownloading(
+        string pluginName,
+        string executableName,
+        string assetNameFormat)
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox($"download-archive-removed-{pluginName}");
+        try
+        {
+            var userProfile = Path.Combine(sandbox, "user");
+            Directory.CreateDirectory(userProfile);
+
+            var harnessPath = CreateDownloadHarnessScript(sandbox);
+            var version = "1.2.3";
+            var tag = $"v{version}";
+            var assetName = string.Format(CultureInfo.InvariantCulture, assetNameFormat, version);
+
+            var firstResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", tag,
+                    "-AssetName", assetName,
+                    "-Mode", "success"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-a",
+                    ["OS"] = "Windows_NT"
+                });
+
+            Assert.Equal(0, firstResult.ExitCode);
+
+            // Simulate a disk cleanup tool reclaiming the cached archive while the extracted
+            // runtime stays in place.
+            var downloadsDir = Path.Combine(
+                userProfile,
+                ".copilot",
+                "plugin-runtime",
+                "mcp-server-excel",
+                pluginName,
+                "downloads");
+            Assert.True(Directory.Exists(downloadsDir), $"Expected cached downloads at {downloadsDir}");
+            Directory.Delete(downloadsDir, recursive: true);
+
+            ResetMockCalls(userProfile);
+
+            var secondResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", tag,
+                    "-AssetName", assetName,
+                    "-Mode", "success",
+                    "-QuietMode"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-b",
+                    ["OS"] = "Windows_NT"
+                });
+
+            Assert.Equal(0, secondResult.ExitCode);
+            Assert.EndsWith(executableName, secondResult.Stdout.Trim(), StringComparison.OrdinalIgnoreCase);
+
+            // The already-extracted runtime matches the resolved release, so nothing is fetched
+            // or re-extracted just because the archive is gone.
+            Assert.Equal(0, ReadMockCallCount(userProfile, "web"));
+            Assert.Equal(0, ReadMockCallCount(userProfile, "expand"));
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Theory]
+    [InlineData("excel-cli", "excelcli.exe", "ExcelMcp-CLI-{0}-windows.zip", "Failed to resolve the latest excelcli release.")]
+    [InlineData("excel-mcp", "mcp-excel.exe", "ExcelMcp-MCP-Server-{0}-windows.zip", "Failed to resolve the latest ExcelMcp MCP server release.")]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_ApiUnavailableWithoutCache_FailsWithClearError(
+        string pluginName,
+        string executableName,
+        string assetNameFormat,
+        string expectedErrorPrefix)
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox($"download-offline-cold-{pluginName}");
+        try
+        {
+            var userProfile = Path.Combine(sandbox, "user");
+            Directory.CreateDirectory(userProfile);
+
+            var harnessPath = CreateDownloadHarnessScript(sandbox);
+            var version = "1.2.3";
+            var tag = $"v{version}";
+            var assetName = string.Format(CultureInfo.InvariantCulture, assetNameFormat, version);
+
+            var result = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", tag,
+                    "-AssetName", assetName,
+                    "-Mode", "api-fail"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-a",
+                    ["OS"] = "Windows_NT"
+                });
+
+            // With no cached runtime to fall back to there is nothing to degrade to, so the
+            // failure must stay loud rather than emitting an unusable path.
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Contains(expectedErrorPrefix, result.CombinedOutput, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public void DownloadBootstrapScripts_AreStructurallyIdenticalAcrossPlugins()
+    {
+        // The two bootstrap scripts are maintained as copies that differ only by plugin-specific
+        // names. Normalizing those tokens must make them byte-identical, so a fix applied to one
+        // copy and forgotten in the other fails here instead of shipping.
+        var cli = File.ReadAllText(GetPluginScriptPath("excel-cli", "download.ps1"));
+        var mcp = File.ReadAllText(GetPluginScriptPath("excel-mcp", "download.ps1"));
+
+        Assert.Equal(NormalizeBootstrapScript(cli), NormalizeBootstrapScript(mcp));
+    }
+
+    private static string NormalizeBootstrapScript(string text)
+        => text
+            .Replace("the latest excelcli release.", "the latest RUNTIME release.", StringComparison.Ordinal)
+            .Replace("the latest ExcelMcp MCP server release.", "the latest RUNTIME release.", StringComparison.Ordinal)
+            .Replace("✅ excelcli runtime ready.", "✅ RUNTIME ready.", StringComparison.Ordinal)
+            .Replace("✅ ExcelMcp MCP runtime ready.", "✅ RUNTIME ready.", StringComparison.Ordinal)
+            .Replace("ExcelMcp-CLI-", "ASSET-", StringComparison.Ordinal)
+            .Replace("ExcelMcp-MCP-Server-", "ASSET-", StringComparison.Ordinal)
+            .Replace("excelcli.exe", "RUNTIME.exe", StringComparison.Ordinal)
+            .Replace("mcp-excel.exe", "RUNTIME.exe", StringComparison.Ordinal)
+            .Replace("excel-cli", "PLUGIN", StringComparison.Ordinal)
+            .Replace("excel-mcp", "PLUGIN", StringComparison.Ordinal);
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task StartCliWrapper_EscapesArgumentsSoTheyRoundTripThroughWin32Parsing()
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox("start-cli-argument-fidelity");
+        try
+        {
+            var harnessPath = Path.Combine(sandbox, "escape-harness.ps1");
+            File.WriteAllText(harnessPath, """
+                [CmdletBinding()]
+                param([Parameter(Mandatory = $true)][string]$ScriptPath)
+
+                $ErrorActionPreference = "Stop"
+
+                $tokens = $null
+                $errors = $null
+                $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$errors)
+                if ($errors.Count -gt 0) {
+                    throw "Parse errors in $ScriptPath"
+                }
+
+                $definition = $ast.Find(
+                    {
+                        param($node)
+                        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                        $node.Name -eq 'ConvertTo-NativeArgument'
+                    },
+                    $true)
+
+                if ($null -eq $definition) {
+                    throw "ConvertTo-NativeArgument was not found in $ScriptPath"
+                }
+
+                . ([scriptblock]::Create($definition.Extent.Text))
+
+                $cases = @(
+                    '[["Name","Amount"],["Widget",1500]]'
+                    'plain'
+                    'has space'
+                    'trailing\'
+                    'embedded\\backslash'
+                    'quote"inside'
+                    'backslash\"quote'
+                    ''
+                    'C:\reports\Q1 results.xlsx'
+                    '{"nested":{"value":"a b"}}'
+                )
+
+                $encoded = foreach ($case in $cases) { ConvertTo-NativeArgument -Value $case }
+                Write-Output ($encoded -join ' ')
+                """);
+
+            var result = await RunPowerShellFileAsync(
+                harnessPath,
+                ["-ScriptPath", GetPluginScriptPath("excel-cli", "start-cli.ps1")]);
+
+            Assert.Equal(0, result.ExitCode);
+
+            var commandLine = result.Stdout.Trim();
+            Assert.NotEmpty(commandLine);
+
+            string[] expected =
+            [
+                """[["Name","Amount"],["Widget",1500]]""",
+                "plain",
+                "has space",
+                @"trailing\",
+                @"embedded\\backslash",
+                """quote"inside""",
+                """backslash\"quote""",
+                string.Empty,
+                @"C:\reports\Q1 results.xlsx",
+                """{"nested":{"value":"a b"}}"""
+            ];
+
+            // CommandLineToArgvW is the parser the CRT and .NET use to split a process command
+            // line, so round-tripping through it proves the child sees the original arguments.
+            var parsed = SplitCommandLine($"excelcli.exe {commandLine}").Skip(1).ToArray();
+
+            Assert.Equal(expected, parsed);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static string[] SplitCommandLine(string commandLine)
+    {
+        var argv = CommandLineToArgvW(commandLine, out var count);
+        if (argv == IntPtr.Zero)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        try
+        {
+            var results = new string[count];
+            for (var i = 0; i < count; i++)
+            {
+                var itemPtr = Marshal.ReadIntPtr(argv, i * IntPtr.Size);
+                results[i] = Marshal.PtrToStringUni(itemPtr) ?? string.Empty;
+            }
+
+            return results;
+        }
+        finally
+        {
+            LocalFree(argv);
+        }
+    }
+
+    [DllImport("shell32.dll", EntryPoint = "CommandLineToArgvW", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CommandLineToArgvW(string lpCmdLine, out int pNumArgs);
+
+    [DllImport("kernel32.dll", EntryPoint = "LocalFree", SetLastError = true)]
+    private static extern IntPtr LocalFree(IntPtr hMem);
+
     private static void AssertBootstrapAssetSet(string pluginRoot, params string[] relativePaths)
     {
         foreach (var relativePath in relativePaths)
@@ -867,7 +1234,9 @@ public sealed class PluginBootstrapBuildTests
                 [string]$AssetName,
 
                 [Parameter(Mandatory = $true)]
-                [string]$Mode
+                [string]$Mode,
+
+                [switch]$QuietMode
             )
 
             $ErrorActionPreference = "Stop"
@@ -960,7 +1329,11 @@ public sealed class PluginBootstrapBuildTests
             }
 
             $env:OS = "Windows_NT"
-            & $ScriptPath -PassThru
+            if ($QuietMode) {
+                & $ScriptPath -PassThru -Quiet
+            } else {
+                & $ScriptPath -PassThru
+            }
             """);
 
         return harnessPath;

--- a/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
@@ -888,6 +888,61 @@ public sealed class PluginBootstrapBuildTests
     [Fact]
     [Trait("Category", "Integration")]
     [Trait("Feature", "PluginBootstrap")]
+    public async Task InstallGlobal_WhenDownloadScriptMissing_FailsBeforeWritingShims()
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        // The generated .cmd shim resolves the runtime by invoking bin\download.ps1, so the
+        // installer depends on that script existing. Without an explicit guard it would happily
+        // write shims that only fail later, at first use, with an opaque error. Validating the
+        // dependency up front has to happen *before* any shim or PATH mutation, which is what
+        // this test pins: a missing download.ps1 must abort with nothing written.
+        var sandbox = CreateSandbox("install-global-missing-download");
+        try
+        {
+            var pluginDir = Path.Combine(sandbox, "excel-cli");
+            var pluginBinDir = Path.Combine(pluginDir, "bin");
+            var installerDir = Path.Combine(pluginDir, "com.github.copilot", "bin");
+            Directory.CreateDirectory(pluginBinDir);
+            Directory.CreateDirectory(installerDir);
+
+            // The wrapper is present; only download.ps1 is absent. That isolates the new guard
+            // from the pre-existing wrapper check, so this test cannot pass for the wrong reason.
+            File.WriteAllText(Path.Combine(pluginBinDir, "start-cli.ps1"), "exit 0");
+
+            var installerPath = Path.Combine(installerDir, "install-global.ps1");
+            File.Copy(
+                Path.Combine(RepoRoot, ".github", "plugins", "excel-cli", "com.github.copilot", "bin", "install-global.ps1"),
+                installerPath);
+
+            // Redirect the profile so a regression that proceeds past the guard writes its shims
+            // into the sandbox instead of the real ~/.copilot/bin.
+            var fakeHome = Path.Combine(sandbox, "home");
+            Directory.CreateDirectory(fakeHome);
+
+            var result = await RunPowerShellFileAsync(
+                installerPath,
+                [],
+                new Dictionary<string, string> { ["USERPROFILE"] = fakeHome });
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Contains("download.ps1", result.Stderr, StringComparison.OrdinalIgnoreCase);
+
+            // Failing "cleanly" means no partial install: no shim directory, and no shims.
+            var shimDir = Path.Combine(fakeHome, ".copilot", "bin");
+            Assert.False(
+                Directory.Exists(shimDir),
+                $"Installer created {shimDir} despite the missing bootstrap script.");
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
     public async Task StartCliWrapper_EscapesArgumentsSoTheyRoundTripThroughWin32Parsing()
     {
         Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");


### PR DESCRIPTION
Fixes two defects found while exercising the published `excel-cli` / `excel-mcp` plugins v1.10.7 end to end. Both reproduce on a stock install; neither is fixable in `mcp-server-excel-plugins`, whose `plugins/` tree is regenerated from the templates in this repo on every release.

## 1. Quoted arguments were destroyed in transit

Every documented inline JSON example fails through the plugin's own entry point:

| Path | `--values '[["Name","Amount"]]'` |
|---|---|
| `excelcli.exe` directly | works |
| via `bin\start-cli.ps1` | **fails** — arrives as `[[Name,Amount]]` |
| via the generated `excelcli` PATH shim | **fails** identically |

Windows PowerShell rebuilds the command line when it invokes a native executable and drops embedded double quotes, so escaping at the call site cannot help. `start-cli.ps1` now builds the command line itself using the standard MSVCRT quoting rules and hands it to `ProcessStartInfo` verbatim. `UseShellExecute=false` with no redirection means the child inherits stdin/stdout/stderr, so interactive and piped use are unchanged, and the exit code still propagates.

There was a **second, independent mangling layer**: the generated `.cmd` shim used `powershell -File wrapper.ps1 %*`, and `-File` argument parsing strips quotes before the wrapper ever runs. Fixing the wrapper alone leaves the shim broken. The shim now resolves the executable up front via `download.ps1 -PassThru -Quiet` and invokes it directly, so cmd forwards `%*` untouched. The `.ps1` shim needs no change — PowerShell-to-PowerShell passes objects rather than a serialized command line.

A/B through `excelcli diag echo`:

```
before: [[Name,Amount],[Widget,1500]]
after:  [["Name","Amount"],["Widget",1500]]
```

## 2. Bootstrap hard-failed offline despite a valid cached runtime

`Get-LatestReleaseMetadata` threw with no `catch`, and the freshness check re-runs in every new Copilot session. With 1.10.7 fully downloaded and extracted and the API unreachable, the bootstrap exited 1 — so a rate limit (60 req/hr per IP, shared behind corporate NAT) or an offline machine stopped the MCP server from starting at all.

A failed update check now degrades to the cached runtime and warns on **stderr**. That channel matters: stdout carries the resolved path for `-PassThru` and, for `excel-mcp`, *is* the MCP stdio transport, so a warning there would corrupt the protocol. The attempt is recorded so one dead endpoint isn't retried by every command in the session. With no usable cached runtime the failure stays loud and still points at the release page.

### Ordering bug found while fixing the above

`$downloadRequired` was computed and the download executed *before* `Resolve-BinaryPath`, which made the early return unreachable. So when the cached `.zip` was absent but the extracted runtime was present, valid and tag-matched, the script still tried to re-download and hard-failed offline — any disk-cleanup tool that reclaimed `downloads/` bricked the plugin. Resolution now happens first and short-circuits.

## Tests

New coverage in `PluginBootstrapBuildTests.cs`, using the existing stubbed-release-API harness:

- warm cache + unreachable API → exit 0, path on stdout, warning on stderr, no re-download
- cached archive deleted + extracted runtime intact → exit 0 with zero network calls (the ordering regression)
- cold cache + unreachable API → still fails loudly
- argument fidelity, round-tripped through `CommandLineToArgvW` — the same parser the CRT uses to split a process command line, which keeps the assertion independent of whichever PowerShell version runs the tests
- a normalize-and-compare parity test over the two `download.ps1` copies

Each new test was confirmed to **fail** against the unfixed script before being kept. 42/42 green in `ExcelMcp.SkillGeneration.Tests`.

## Deliberately out of scope

- `start-mcp.ps1` shares the wrapper pattern but never receives arguments, so the bug cannot manifest there. Not worth perturbing the MCP stdio handshake in a fix release.
- The two `download.ps1` copies are still maintained as near-duplicates; the parity test guards them until they can be generated from one template (`scripts/Build-Plugins.ps1` already does token substitution).
- P1 robustness work — version pinning/compatibility bounds, verifying the resolved binary's real version, zip integrity and checksums, atomic extraction, `GITHUB_TOKEN` auth, and a time-based staleness window for `"standalone"` installs (which today never re-check, so PATH users are pinned to their first download).