### PR TITLE
fix(docs): derive the MCP help banner counts, stamp skill VERSIONs, and fix misleading skill rules

### DIFF
--- a/.changeset/plugin-docs-accuracy.md
+++ b/.changeset/plugin-docs-accuracy.md
@@ -6,13 +6,19 @@
 server's `--help` banner claimed "22 tools with 195+ operations" while the server
 actually registers 31 tools with 326 operations. The repo already derives those
 numbers from code and enforces them across 16 documents on every commit; the banner
-was simply not one of them, so it drifted unnoticed. It is now correct and covered by
-that guard.
+was simply not one of them, so it drifted unnoticed.
+
+Rather than correcting the literal, the banner now *derives* both numbers by
+reflecting over the live `[McpServerTool]` registration, so it can no longer disagree
+with the server's own `tools/list` response. The doc-count guard was extended to fail
+if anyone reintroduces a hard-coded count there — including a count that happens to be
+correct on the day it is written.
 
 The `excel-cli` plugin shipped without the `VERSION` file its `excel-mcp` counterpart
 carries, because the build never passed a version through for the CLI skill and only
 rewrote a `VERSION` that already existed instead of creating one. Both plugins now
-get a stamped `VERSION`.
+get a stamped `VERSION`, and the build fails if any packaged skill is missing one or
+carries the wrong version.
 
 Two skill instructions were misleading in ways that produce visibly wrong output. The
 number-format table showed rendered results as though separators were fixed, but

--- a/.changeset/plugin-docs-accuracy.md
+++ b/.changeset/plugin-docs-accuracy.md
@@ -1,0 +1,28 @@
+---
+"excelmcp": patch
+---
+
+**Accurate plugin documentation and a VERSION file for the CLI plugin.** The MCP
+server's `--help` banner claimed "22 tools with 195+ operations" while the server
+actually registers 31 tools with 326 operations. The repo already derives those
+numbers from code and enforces them across 16 documents on every commit; the banner
+was simply not one of them, so it drifted unnoticed. It is now correct and covered by
+that guard.
+
+The `excel-cli` plugin shipped without the `VERSION` file its `excel-mcp` counterpart
+carries, because the build never passed a version through for the CLI skill and only
+rewrote a `VERSION` that already existed instead of creating one. Both plugins now
+get a stamped `VERSION`.
+
+Two skill instructions were misleading in ways that produce visibly wrong output. The
+number-format table showed rendered results as though separators were fixed, but
+Excel renders them per the user's Windows regional settings — `$#,##0.00` shows
+`$1.234,56` on a German machine — so the skill now explains that format codes are
+written in US notation while the rendering is locale-dependent, and warns against
+"fixing" the code. The formatting workflow also stopped at applying a number format,
+which leaves date and currency columns showing `#####` because formatted values are
+wider than the raw ones; auto-fitting columns is now a required step.
+
+Finally, the CLI skill assumed `excelcli` was on PATH while the plugin's global shim
+is explicitly opt-in, so an agent following the skill hit command-not-found. The
+preconditions now state the requirement plainly and give the ways to satisfy it.

--- a/scripts/Build-Plugins.ps1
+++ b/scripts/Build-Plugins.ps1
@@ -118,12 +118,27 @@ function Copy-AgentSkill {
 
 function Assert-AgentSkill {
     param(
-        [string]$SkillDir
+        [string]$SkillDir,
+        [string]$ExpectedVersion
     )
 
     $skillPath = Join-Path $SkillDir "SKILL.md"
     if (-not (Test-Path $skillPath -PathType Leaf)) {
         throw "Agent Skill is missing SKILL.md: $SkillDir"
+    }
+
+    # Every packaged skill must carry a VERSION stamped with the version the plugin was built at.
+    # excel-cli previously shipped with no VERSION at all, and nothing failed the build.
+    if ($ExpectedVersion) {
+        $versionPath = Join-Path $SkillDir "VERSION"
+        if (-not (Test-Path $versionPath -PathType Leaf)) {
+            throw "Agent Skill is missing VERSION: $SkillDir"
+        }
+
+        $skillVersion = (Get-Content $versionPath -Raw).Trim()
+        if ($skillVersion -ne $ExpectedVersion) {
+            throw "$versionPath has version '$skillVersion' but expected '$ExpectedVersion'."
+        }
     }
 
     $lines = @(Get-Content $skillPath)
@@ -230,7 +245,7 @@ function Assert-AgentPluginPackage {
     $skillsRoot = Join-Path $PluginDir "skills"
     if (Test-Path $skillsRoot) {
         Get-ChildItem -Path $skillsRoot -Directory | ForEach-Object {
-            Assert-AgentSkill -SkillDir $_.FullName
+            Assert-AgentSkill -SkillDir $_.FullName -ExpectedVersion $ExpectedVersion
         }
     }
 

--- a/scripts/Build-Plugins.ps1
+++ b/scripts/Build-Plugins.ps1
@@ -107,8 +107,11 @@ function Copy-AgentSkill {
     New-Item -ItemType Directory -Path (Split-Path -Parent $DestinationDir) -Force | Out-Null
     Copy-Item -Path $SourceDir -Destination $DestinationDir -Recurse -Force
 
+    # Write the VERSION file unconditionally. Guarding on Test-Path only *updated* a VERSION that
+    # the canonical skill already carried, so excel-cli - whose source skill has none - shipped
+    # without one while excel-mcp shipped with one.
     $skillVersionPath = Join-Path $DestinationDir "VERSION"
-    if ($Version -and (Test-Path $skillVersionPath)) {
+    if ($Version) {
         Set-Content -Path $skillVersionPath -Value $Version -Encoding UTF8 -NoNewline
     }
 }
@@ -340,7 +343,7 @@ Set-Content -Path (Join-Path $OutputCli "version.txt") -Value $Version -Encoding
 Write-Host "  Synchronizing complete excel-cli skill directory..." -ForegroundColor Cyan
 $SourceSkillCli = Join-Path $SkillsDir "excel-cli"
 $DestSkillCli = Join-Path $OutputCli "skills\excel-cli"
-Copy-AgentSkill -SourceDir $SourceSkillCli -DestinationDir $DestSkillCli
+Copy-AgentSkill -SourceDir $SourceSkillCli -DestinationDir $DestSkillCli -Version $Version
 
 Assert-AgentPluginPackage -PluginName "excel-cli" -PluginDir $OutputCli -ExpectedVersion $Version
 Write-Host "✅ excel-cli plugin built" -ForegroundColor Green

--- a/scripts/check-doc-counts.ps1
+++ b/scripts/check-doc-counts.ps1
@@ -171,6 +171,9 @@ $checks = @(
     @{ File = ".github\plugins\excel-mcp\README.md";    Pattern = '(?<t>\d+) specialized tools with (?<o>\d+) operations' }
     @{ File = ".github\plugins\excel-cli\README.md";    Pattern = 'command categories with (?<o>\d+) operations' }
     @{ File = "skills\excel-mcp\SKILL.md";              Pattern = 'Provides (?<o>\d+) Excel operations' }
+    # The --help banner is the first thing a user sees when the server will not start, and it
+    # drifted to "22 tools with 195+ operations" because nothing checked it.
+    @{ File = "src\ExcelMcp.McpServer\Program.cs";      Pattern = 'Provides (?<t>\d+) tools with (?<o>\d+) operations' }
 )
 
 foreach ($check in $checks) {

--- a/scripts/check-doc-counts.ps1
+++ b/scripts/check-doc-counts.ps1
@@ -171,9 +171,6 @@ $checks = @(
     @{ File = ".github\plugins\excel-mcp\README.md";    Pattern = '(?<t>\d+) specialized tools with (?<o>\d+) operations' }
     @{ File = ".github\plugins\excel-cli\README.md";    Pattern = 'command categories with (?<o>\d+) operations' }
     @{ File = "skills\excel-mcp\SKILL.md";              Pattern = 'Provides (?<o>\d+) Excel operations' }
-    # The --help banner is the first thing a user sees when the server will not start, and it
-    # drifted to "22 tools with 195+ operations" because nothing checked it.
-    @{ File = "src\ExcelMcp.McpServer\Program.cs";      Pattern = 'Provides (?<t>\d+) tools with (?<o>\d+) operations' }
 )
 
 foreach ($check in $checks) {
@@ -195,6 +192,31 @@ foreach ($check in $checks) {
         if ($m.Groups['o'].Success -and [int]$m.Groups['o'].Value -ne $canonicalOps) {
             Add-Failure ("$($check.File): operation count is {0} but should be {1} -> `"{2}`"" -f $m.Groups['o'].Value, $canonicalOps, $m.Value.Trim())
         }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 5b. The --help banner must stay derived, not restated
+# ---------------------------------------------------------------------------
+# The banner is the first thing a user sees when the server will not start, and it silently
+# drifted to "22 tools with 195+ operations" while the real surface was 31/326 -- because nothing
+# checked it. It is now interpolated from McpToolSurface, which reflects over the live
+# [McpServerTool] registration. Rather than validating a literal here (there no longer is one),
+# this fails if anyone reintroduces one.
+$helpBannerFile = "src\ExcelMcp.McpServer\Program.cs"
+$helpBannerPath = Join-Path $rootDir $helpBannerFile
+if (-not (Test-Path $helpBannerPath)) {
+    Add-Failure "Expected source file not found: $helpBannerFile"
+} else {
+    $helpBannerContent = Get-Content $helpBannerPath -Raw
+
+    $hardCoded = [regex]::Matches($helpBannerContent, 'Provides\s+\d+\s+tools\s+with\s+\d+\+?\s+operations')
+    foreach ($m in $hardCoded) {
+        Add-Failure ("{0}: the --help banner restates the counts as a literal -> `"{1}`". Interpolate McpToolSurface.ToolCount / McpToolSurface.OperationCount instead so it cannot drift." -f $helpBannerFile, $m.Value.Trim())
+    }
+
+    if ($helpBannerContent -notmatch 'Provides \{McpToolSurface\.ToolCount\} tools with \{McpToolSurface\.OperationCount\} operations') {
+        Add-Failure "${helpBannerFile}: the --help banner no longer derives its counts from McpToolSurface (was it reworded or removed?)."
     }
 }
 

--- a/skills/excel-cli/SKILL.md
+++ b/skills/excel-cli/SKILL.md
@@ -17,8 +17,16 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
 
 - Windows host with Microsoft Excel installed (2016+)
 - Uses COM interop — does NOT work on macOS or Linux
-- GitHub Copilot `excel-cli` plugin auto-downloads the latest Windows runtime on first use
-- Direct skill-only installs require `excelcli.exe` on PATH
+- **Every command below invokes `excelcli` directly, so it must resolve on PATH.**
+  Installing the `excel-cli` plugin does *not* put it there — the global shim is opt-in. Run
+  `com.github.copilot\bin\install-global.ps1` from the installed plugin folder once (it writes
+  `excelcli.cmd` / `excelcli.ps1` into `~\.copilot\bin` and adds that to your user PATH), or
+  install the runtime independently via the standalone release zip or
+  `dotnet tool install --global Sbroenne.ExcelMcp.CLI`.
+  If `excelcli` is not found, report that and stop — do not guess at a path.
+- The runtime itself is downloaded and cached on first use under
+  `~\.copilot\plugin-runtime\mcp-server-excel\excel-cli`, so only the first invocation needs
+  network access
 
 ## Workflow Checklist
 

--- a/skills/excel-cli/references/behavioral-rules.md
+++ b/skills/excel-cli/references/behavioral-rules.md
@@ -107,8 +107,8 @@ Always apply number formats after setting values. Without formatting:
 
 **Common format codes (US locale, auto-translated):**
 
-| Data Type | Format Code | Result |
-|-----------|-------------|--------|
+| Data Type | Format Code | Result (en-US) |
+|-----------|-------------|----------------|
 | USD | `$#,##0.00` | $1,234.56 |
 | EUR | `€#,##0.00` | €1,234.56 |
 | Number | `#,##0.00` | 1,234.56 |
@@ -116,11 +116,18 @@ Always apply number formats after setting values. Without formatting:
 | Date (ISO) | `yyyy-mm-dd` | 2025-01-22 |
 | Date (US) | `mm/dd/yyyy` | 01/22/2025 |
 
+**Rendered output is locale-dependent.** The `Result` column assumes en-US regional settings. Excel
+interprets `,` and `.` in a format code according to the user's locale, so `$#,##0.00` displays as
+`$1,234.56` on en-US but `$1.234,56` on de-DE — same code, different separators. Always write the US
+form (it is auto-translated), never promise a literal rendering, and never "correct" a format code
+because a screenshot shows swapped separators.
+
 **Workflow:**
 ```
 1. range set-values (data is now in cells)
 2. range set-number-format (apply format to range)
-3. range_format auto-fit-columns (when content would clip at default width)
+3. range_format auto-fit-columns (widen columns to fit — formatted dates and
+   long numbers render as ##### at the default column width)
 ```
 
 ### Format Tabular Data as Excel Tables

--- a/skills/excel-cli/references/dashboard.md
+++ b/skills/excel-cli/references/dashboard.md
@@ -9,9 +9,10 @@ Every report or dashboard should follow this sequence:
 ```
 1. Structure data → Excel Tables (never plain ranges)
 2. Format values → Number formats by data type
-3. Add visuals → Charts with explicit positioning
-4. Verify layout → Screenshot to confirm no overlaps
-5. Save and close → Persist changes
+3. Fit columns → auto-fit so nothing renders as #####
+4. Add visuals → Charts with explicit positioning
+5. Verify layout → Screenshot to confirm no overlaps
+6. Save and close → Persist changes
 ```
 
 ## Step 1: Structure Data as Excel Tables
@@ -34,8 +35,8 @@ table(create, tableName='SalesData', rangeAddress='A1:D20')
 
 **Apply number formats AFTER setting values — not before:**
 
-| Data Type | Format Code | Result |
-|-----------|-------------|--------|
+| Data Type | Format Code | Result (en-US) |
+|-----------|-------------|----------------|
 | Currency (USD) | `$#,##0.00` | $1,234.56 |
 | Currency (EUR) | `€#,##0.00` | €1,234.56 |
 | Percentage | `0.0%` | 12.3% |
@@ -45,7 +46,26 @@ table(create, tableName='SalesData', rangeAddress='A1:D20')
 
 **Always use US format codes** — Excel translates automatically to the user's locale.
 
-## Step 3: Position Charts with No Overlaps
+**Rendered output is locale-dependent.** The `Result` column assumes en-US regional settings. Excel
+interprets `,` and `.` in a format code according to the user's locale, so `$#,##0.00` displays as
+`$1,234.56` on en-US but `$1.234,56` on de-DE. Same code, different separators — this is correct
+behaviour, not a formatting bug. Never promise a literal rendering when reporting back to the user.
+
+## Step 3: Fit Columns to Content
+
+**Number formats make cells WIDER, so auto-fit immediately after formatting:**
+
+```
+range_format(action: 'auto-fit-columns', sheetName: 'Sales', rangeAddress: 'A:F')
+```
+
+A date formatted as `yyyy-mm-dd` or a currency value formatted as `$#,##0.00` does not fit the
+default column width, so Excel renders the cell as `#####`. A screenshot taken before auto-fit will
+show those columns as unreadable hash marks. Auto-fit before Step 5, not after.
+
+Use `range_format auto-fit-rows` as well when any cell has `wrapText` enabled.
+
+## Step 4: Position Charts with No Overlaps
 
 **Charts have automatic collision detection and three positioning modes:**
 
@@ -81,13 +101,14 @@ All chart operations automatically warn about overlaps. If a result includes an 
 - Keep chart sizes consistent (same row/column span)
 - **Always check result messages** for overlap warnings
 
-## Step 4: Verify with Screenshot
+## Step 5: Verify with Screenshot
 
 **Always take a screenshot after creating charts or complex layouts:**
 
 ```
 screenshot(capture, rangeAddress='A1:M50')
 → Confirm: no overlaps, professional spacing, readable labels
+→ Confirm: no column renders as ##### (if it does, go back to Step 3 and auto-fit)
 → If issues found: chart(fit-to-range) to reposition, then screenshot again
 ```
 
@@ -124,7 +145,7 @@ Sheet "Detail":
 
 - [ ] Data in Excel Tables (not plain ranges)
 - [ ] Number formats applied (currency, dates, percentages)
-- [ ] Column widths appropriate for content
+- [ ] `range_format auto-fit-columns` run after formatting (no `#####` cells)
 - [ ] Chart titles are descriptive
 - [ ] Chart axis labels formatted (currency, percentages)
 - [ ] No chart overlaps with data or other charts

--- a/skills/excel-cli/references/range.md
+++ b/skills/excel-cli/references/range.md
@@ -93,8 +93,8 @@ range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
 
 ## Format Codes
 
-| Type | Code | Example |
-|------|------|---------|
+| Type | Code | Example (en-US) |
+|------|------|-----------------|
 | Number | `#,##0.00` | 1,234.56 |
 | Dollar | `$#,##0.00` | $1,234.56 |
 | Euro | `€#,##0.00` | €1,234.56 |
@@ -109,6 +109,16 @@ range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
 | Text | `@` | (as-is) |
 
 All format codes are auto-translated to the user's locale. Use US codes (d/m/y for dates, . for decimal, , for thousands).
+
+**The `Example` column assumes en-US regional settings — rendering is locale-dependent.** Excel
+interprets the `,` and `.` in a format code according to the user's locale, and the same is true of
+the `d`/`m`/`y` date codes. So `$#,##0.00` displays as `$1,234.56` on en-US but `$1.234,56` on de-DE,
+and `mm/dd/yyyy` follows the locale's date separator. This is correct behaviour, not a bug — do not
+rewrite a format code because a screenshot shows swapped separators, and do not tell the user a
+literal rendering without accounting for their regional settings.
+
+After applying a number format, run `range_format auto-fit-columns` — formatted values are wider
+than raw ones and will render as `#####` at the default column width.
 
 ## Actions
 

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -74,11 +74,20 @@ Always apply number formats after setting values:
 | Percent | `0.00%` | 15.00% |
 | Date (ISO) | `yyyy-mm-dd` | 2025-01-22 |
 
+Write format codes in US notation (`,` grouping, `.` decimal) regardless of the machine's
+locale — Excel translates them. The **rendered** separators follow the user's Windows regional
+settings, so `$#,##0.00` shows `$1.234,56` on a German system. Don't "fix" that by swapping the
+separators in the format code; it would break on every other locale.
+
 **Workflow:**
 ```
 1. range set-values (data is now in cells)
 2. range set-number-format (apply format)
+3. range_format auto-fit-columns (formatted values are wider than raw ones)
 ```
+
+Step 3 is not optional. A column sized for `45678` is too narrow once that value renders as
+`2025-01-22` or `$1,234.56`, and Excel displays `#####` instead of the number.
 
 ### Rule 4: Use Excel Tables (Not Plain Ranges)
 

--- a/skills/excel-mcp/references/behavioral-rules.md
+++ b/skills/excel-mcp/references/behavioral-rules.md
@@ -105,8 +105,8 @@ Always apply number formats after setting values. Without formatting:
 
 **Common format codes (US locale, auto-translated):**
 
-| Data Type | Format Code | Result |
-|-----------|-------------|--------|
+| Data Type | Format Code | Result (en-US) |
+|-----------|-------------|----------------|
 | USD | `$#,##0.00` | $1,234.56 |
 | EUR | `€#,##0.00` | €1,234.56 |
 | Number | `#,##0.00` | 1,234.56 |
@@ -114,11 +114,18 @@ Always apply number formats after setting values. Without formatting:
 | Date (ISO) | `yyyy-mm-dd` | 2025-01-22 |
 | Date (US) | `mm/dd/yyyy` | 01/22/2025 |
 
+**Rendered output is locale-dependent.** The `Result` column assumes en-US regional settings. Excel
+interprets `,` and `.` in a format code according to the user's locale, so `$#,##0.00` displays as
+`$1,234.56` on en-US but `$1.234,56` on de-DE — same code, different separators. Always write the US
+form (it is auto-translated), never promise a literal rendering, and never "correct" a format code
+because a screenshot shows swapped separators.
+
 **Workflow:**
 ```
 1. range set-values (data is now in cells)
 2. range set-number-format (apply format to range)
-3. range_format auto-fit-columns (when content would clip at default width)
+3. range_format auto-fit-columns (widen columns to fit — formatted dates and
+   long numbers render as ##### at the default column width)
 ```
 
 ### Format Tabular Data as Excel Tables

--- a/skills/excel-mcp/references/dashboard.md
+++ b/skills/excel-mcp/references/dashboard.md
@@ -7,9 +7,10 @@ Every report or dashboard should follow this sequence:
 ```
 1. Structure data → Excel Tables (never plain ranges)
 2. Format values → Number formats by data type
-3. Add visuals → Charts with explicit positioning
-4. Verify layout → Screenshot to confirm no overlaps
-5. Save and close → Persist changes
+3. Fit columns → auto-fit so nothing renders as #####
+4. Add visuals → Charts with explicit positioning
+5. Verify layout → Screenshot to confirm no overlaps
+6. Save and close → Persist changes
 ```
 
 ## Step 1: Structure Data as Excel Tables
@@ -32,8 +33,8 @@ table(create, tableName='SalesData', rangeAddress='A1:D20')
 
 **Apply number formats AFTER setting values — not before:**
 
-| Data Type | Format Code | Result |
-|-----------|-------------|--------|
+| Data Type | Format Code | Result (en-US) |
+|-----------|-------------|----------------|
 | Currency (USD) | `$#,##0.00` | $1,234.56 |
 | Currency (EUR) | `€#,##0.00` | €1,234.56 |
 | Percentage | `0.0%` | 12.3% |
@@ -43,7 +44,26 @@ table(create, tableName='SalesData', rangeAddress='A1:D20')
 
 **Always use US format codes** — Excel translates automatically to the user's locale.
 
-## Step 3: Position Charts with No Overlaps
+**Rendered output is locale-dependent.** The `Result` column assumes en-US regional settings. Excel
+interprets `,` and `.` in a format code according to the user's locale, so `$#,##0.00` displays as
+`$1,234.56` on en-US but `$1.234,56` on de-DE. Same code, different separators — this is correct
+behaviour, not a formatting bug. Never promise a literal rendering when reporting back to the user.
+
+## Step 3: Fit Columns to Content
+
+**Number formats make cells WIDER, so auto-fit immediately after formatting:**
+
+```
+range_format(action: 'auto-fit-columns', sheetName: 'Sales', rangeAddress: 'A:F')
+```
+
+A date formatted as `yyyy-mm-dd` or a currency value formatted as `$#,##0.00` does not fit the
+default column width, so Excel renders the cell as `#####`. A screenshot taken before auto-fit will
+show those columns as unreadable hash marks. Auto-fit before Step 5, not after.
+
+Use `range_format auto-fit-rows` as well when any cell has `wrapText` enabled.
+
+## Step 4: Position Charts with No Overlaps
 
 **Charts have automatic collision detection and three positioning modes:**
 
@@ -79,13 +99,14 @@ All chart operations automatically warn about overlaps. If a result includes an 
 - Keep chart sizes consistent (same row/column span)
 - **Always check result messages** for overlap warnings
 
-## Step 4: Verify with Screenshot
+## Step 5: Verify with Screenshot
 
 **Always take a screenshot after creating charts or complex layouts:**
 
 ```
 screenshot(capture, rangeAddress='A1:M50')
 → Confirm: no overlaps, professional spacing, readable labels
+→ Confirm: no column renders as ##### (if it does, go back to Step 3 and auto-fit)
 → If issues found: chart(fit-to-range) to reposition, then screenshot again
 ```
 
@@ -122,7 +143,7 @@ Sheet "Detail":
 
 - [ ] Data in Excel Tables (not plain ranges)
 - [ ] Number formats applied (currency, dates, percentages)
-- [ ] Column widths appropriate for content
+- [ ] `range_format auto-fit-columns` run after formatting (no `#####` cells)
 - [ ] Chart titles are descriptive
 - [ ] Chart axis labels formatted (currency, percentages)
 - [ ] No chart overlaps with data or other charts

--- a/skills/excel-mcp/references/range.md
+++ b/skills/excel-mcp/references/range.md
@@ -91,8 +91,8 @@ range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
 
 ## Format Codes
 
-| Type | Code | Example |
-|------|------|---------|
+| Type | Code | Example (en-US) |
+|------|------|-----------------|
 | Number | `#,##0.00` | 1,234.56 |
 | Dollar | `$#,##0.00` | $1,234.56 |
 | Euro | `€#,##0.00` | €1,234.56 |
@@ -107,6 +107,16 @@ range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
 | Text | `@` | (as-is) |
 
 All format codes are auto-translated to the user's locale. Use US codes (d/m/y for dates, . for decimal, , for thousands).
+
+**The `Example` column assumes en-US regional settings — rendering is locale-dependent.** Excel
+interprets the `,` and `.` in a format code according to the user's locale, and the same is true of
+the `d`/`m`/`y` date codes. So `$#,##0.00` displays as `$1,234.56` on en-US but `$1.234,56` on de-DE,
+and `mm/dd/yyyy` follows the locale's date separator. This is correct behaviour, not a bug — do not
+rewrite a format code because a screenshot shows swapped separators, and do not tell the user a
+literal rendering without accounting for their regional settings.
+
+After applying a number format, run `range_format auto-fit-columns` — formatted values are wider
+than raw ones and will render as `#####` at the default column width.
 
 ## Actions
 

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -105,8 +105,8 @@ Always apply number formats after setting values. Without formatting:
 
 **Common format codes (US locale, auto-translated):**
 
-| Data Type | Format Code | Result |
-|-----------|-------------|--------|
+| Data Type | Format Code | Result (en-US) |
+|-----------|-------------|----------------|
 | USD | `$#,##0.00` | $1,234.56 |
 | EUR | `€#,##0.00` | €1,234.56 |
 | Number | `#,##0.00` | 1,234.56 |
@@ -114,11 +114,18 @@ Always apply number formats after setting values. Without formatting:
 | Date (ISO) | `yyyy-mm-dd` | 2025-01-22 |
 | Date (US) | `mm/dd/yyyy` | 01/22/2025 |
 
+**Rendered output is locale-dependent.** The `Result` column assumes en-US regional settings. Excel
+interprets `,` and `.` in a format code according to the user's locale, so `$#,##0.00` displays as
+`$1,234.56` on en-US but `$1.234,56` on de-DE — same code, different separators. Always write the US
+form (it is auto-translated), never promise a literal rendering, and never "correct" a format code
+because a screenshot shows swapped separators.
+
 **Workflow:**
 ```
 1. range set-values (data is now in cells)
 2. range set-number-format (apply format to range)
-3. range_format auto-fit-columns (when content would clip at default width)
+3. range_format auto-fit-columns (widen columns to fit — formatted dates and
+   long numbers render as ##### at the default column width)
 ```
 
 ### Format Tabular Data as Excel Tables

--- a/skills/shared/dashboard.md
+++ b/skills/shared/dashboard.md
@@ -7,9 +7,10 @@ Every report or dashboard should follow this sequence:
 ```
 1. Structure data → Excel Tables (never plain ranges)
 2. Format values → Number formats by data type
-3. Add visuals → Charts with explicit positioning
-4. Verify layout → Screenshot to confirm no overlaps
-5. Save and close → Persist changes
+3. Fit columns → auto-fit so nothing renders as #####
+4. Add visuals → Charts with explicit positioning
+5. Verify layout → Screenshot to confirm no overlaps
+6. Save and close → Persist changes
 ```
 
 ## Step 1: Structure Data as Excel Tables
@@ -32,8 +33,8 @@ table(create, tableName='SalesData', rangeAddress='A1:D20')
 
 **Apply number formats AFTER setting values — not before:**
 
-| Data Type | Format Code | Result |
-|-----------|-------------|--------|
+| Data Type | Format Code | Result (en-US) |
+|-----------|-------------|----------------|
 | Currency (USD) | `$#,##0.00` | $1,234.56 |
 | Currency (EUR) | `€#,##0.00` | €1,234.56 |
 | Percentage | `0.0%` | 12.3% |
@@ -43,7 +44,26 @@ table(create, tableName='SalesData', rangeAddress='A1:D20')
 
 **Always use US format codes** — Excel translates automatically to the user's locale.
 
-## Step 3: Position Charts with No Overlaps
+**Rendered output is locale-dependent.** The `Result` column assumes en-US regional settings. Excel
+interprets `,` and `.` in a format code according to the user's locale, so `$#,##0.00` displays as
+`$1,234.56` on en-US but `$1.234,56` on de-DE. Same code, different separators — this is correct
+behaviour, not a formatting bug. Never promise a literal rendering when reporting back to the user.
+
+## Step 3: Fit Columns to Content
+
+**Number formats make cells WIDER, so auto-fit immediately after formatting:**
+
+```
+range_format(action: 'auto-fit-columns', sheetName: 'Sales', rangeAddress: 'A:F')
+```
+
+A date formatted as `yyyy-mm-dd` or a currency value formatted as `$#,##0.00` does not fit the
+default column width, so Excel renders the cell as `#####`. A screenshot taken before auto-fit will
+show those columns as unreadable hash marks. Auto-fit before Step 5, not after.
+
+Use `range_format auto-fit-rows` as well when any cell has `wrapText` enabled.
+
+## Step 4: Position Charts with No Overlaps
 
 **Charts have automatic collision detection and three positioning modes:**
 
@@ -79,13 +99,14 @@ All chart operations automatically warn about overlaps. If a result includes an 
 - Keep chart sizes consistent (same row/column span)
 - **Always check result messages** for overlap warnings
 
-## Step 4: Verify with Screenshot
+## Step 5: Verify with Screenshot
 
 **Always take a screenshot after creating charts or complex layouts:**
 
 ```
 screenshot(capture, rangeAddress='A1:M50')
 → Confirm: no overlaps, professional spacing, readable labels
+→ Confirm: no column renders as ##### (if it does, go back to Step 3 and auto-fit)
 → If issues found: chart(fit-to-range) to reposition, then screenshot again
 ```
 
@@ -122,7 +143,7 @@ Sheet "Detail":
 
 - [ ] Data in Excel Tables (not plain ranges)
 - [ ] Number formats applied (currency, dates, percentages)
-- [ ] Column widths appropriate for content
+- [ ] `range_format auto-fit-columns` run after formatting (no `#####` cells)
 - [ ] Chart titles are descriptive
 - [ ] Chart axis labels formatted (currency, percentages)
 - [ ] No chart overlaps with data or other charts

--- a/skills/shared/range.md
+++ b/skills/shared/range.md
@@ -91,8 +91,8 @@ range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
 
 ## Format Codes
 
-| Type | Code | Example |
-|------|------|---------|
+| Type | Code | Example (en-US) |
+|------|------|-----------------|
 | Number | `#,##0.00` | 1,234.56 |
 | Dollar | `$#,##0.00` | $1,234.56 |
 | Euro | `€#,##0.00` | €1,234.56 |
@@ -107,6 +107,16 @@ range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
 | Text | `@` | (as-is) |
 
 All format codes are auto-translated to the user's locale. Use US codes (d/m/y for dates, . for decimal, , for thousands).
+
+**The `Example` column assumes en-US regional settings — rendering is locale-dependent.** Excel
+interprets the `,` and `.` in a format code according to the user's locale, and the same is true of
+the `d`/`m`/`y` date codes. So `$#,##0.00` displays as `$1,234.56` on en-US but `$1.234,56` on de-DE,
+and `mm/dd/yyyy` follows the locale's date separator. This is correct behaviour, not a bug — do not
+rewrite a format code because a screenshot shows swapped separators, and do not tell the user a
+literal rendering without accounting for their regional settings.
+
+After applying a number format, run `range_format auto-fit-columns` — formatted values are wider
+than raw ones and will render as `#####` at the default column width.
 
 ## Actions
 

--- a/skills/templates/SKILL.cli.sbn
+++ b/skills/templates/SKILL.cli.sbn
@@ -17,8 +17,16 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
 
 - Windows host with Microsoft Excel installed (2016+)
 - Uses COM interop — does NOT work on macOS or Linux
-- GitHub Copilot `excel-cli` plugin auto-downloads the latest Windows runtime on first use
-- Direct skill-only installs require `excelcli.exe` on PATH
+- **Every command below invokes `excelcli` directly, so it must resolve on PATH.**
+  Installing the `excel-cli` plugin does *not* put it there — the global shim is opt-in. Run
+  `com.github.copilot\bin\install-global.ps1` from the installed plugin folder once (it writes
+  `excelcli.cmd` / `excelcli.ps1` into `~\.copilot\bin` and adds that to your user PATH), or
+  install the runtime independently via the standalone release zip or
+  `dotnet tool install --global Sbroenne.ExcelMcp.CLI`.
+  If `excelcli` is not found, report that and stop — do not guess at a path.
+- The runtime itself is downloaded and cached on first use under
+  `~\.copilot\plugin-runtime\mcp-server-excel\excel-cli`, so only the first invocation needs
+  network access
 
 ## Workflow Checklist
 

--- a/skills/templates/SKILL.mcp.sbn
+++ b/skills/templates/SKILL.mcp.sbn
@@ -74,11 +74,20 @@ Always apply number formats after setting values:
 | Percent | `0.00%` | 15.00% |
 | Date (ISO) | `yyyy-mm-dd` | 2025-01-22 |
 
+Write format codes in US notation (`,` grouping, `.` decimal) regardless of the machine's
+locale — Excel translates them. The **rendered** separators follow the user's Windows regional
+settings, so `$#,##0.00` shows `$1.234,56` on a German system. Don't "fix" that by swapping the
+separators in the format code; it would break on every other locale.
+
 **Workflow:**
 ```
 1. range set-values (data is now in cells)
 2. range set-number-format (apply format)
+3. range_format auto-fit-columns (formatted values are wider than raw ones)
 ```
+
+Step 3 is not optional. A column sized for `45678` is too narrow once that value renders as
+`2025-01-22` or `$1,234.56`, and Excel displays `#####` instead of the number.
 
 ### Rule 4: Use Excel Tables (Not Plain Ranges)
 

--- a/src/ExcelMcp.McpServer/McpToolSurface.cs
+++ b/src/ExcelMcp.McpServer/McpToolSurface.cs
@@ -1,0 +1,102 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using ModelContextProtocol.Server;
+
+namespace Sbroenne.ExcelMcp.McpServer;
+
+/// <summary>
+/// Derives the server's advertised tool and operation counts from the ACTUAL MCP tool
+/// registration instead of hard-coded literals.
+///
+/// WHY THIS EXISTS
+/// ---------------
+/// The <c>--help</c> banner used to hard-code "Provides 22 tools with 195+ operations". The real
+/// surface grew to 31 tools / 326 operations without anyone updating that string, so the binary
+/// contradicted its own READMEs, SKILL.md files and its live <c>tools/list</c> response.
+/// Reflecting over the registration makes that class of drift structurally impossible.
+///
+/// HOW THE NUMBERS ARE DERIVED
+/// ---------------------------
+/// Every MCP tool in this server is a single <c>[McpServerTool]</c> method on an
+/// <c>[McpServerToolType]</c> class (hand-written or emitted by <c>McpToolGenerator</c>), and every
+/// one of them dispatches on a required <c>action</c> parameter whose type is an action enum.
+/// So:
+///   tools      = number of [McpServerTool] methods
+///   operations = sum of Enum.GetValues(actionEnumType).Length over those methods
+///
+/// This mirrors the discovery loop in <see cref="GeminiCompatibleToolRegistration"/>, which is what
+/// actually registers the tools, so both walk the same surface.
+/// </summary>
+internal static class McpToolSurface
+{
+    /// <summary>Name of the dispatch parameter every tool exposes as an enum.</summary>
+    private const string ActionParameterName = "action";
+
+    /// <summary>One entry per registered MCP tool.</summary>
+    /// <param name="Name">The tool name as advertised over the protocol (e.g. "range_format").</param>
+    /// <param name="OperationCount">Number of values in the tool's <c>action</c> enum, or 0 if it has none.</param>
+    internal sealed record ToolInfo(string Name, int OperationCount);
+
+    private static readonly ImmutableArray<ToolInfo> DiscoveredTools = Discover(typeof(McpToolSurface).Assembly);
+
+    /// <summary>All MCP tools registered by this server.</summary>
+    public static ImmutableArray<ToolInfo> Tools => DiscoveredTools;
+
+    /// <summary>Number of MCP tools this server registers.</summary>
+    public static int ToolCount => DiscoveredTools.Length;
+
+    /// <summary>Total number of operations (action enum values) across all registered tools.</summary>
+    public static int OperationCount => DiscoveredTools.Sum(t => t.OperationCount);
+
+    private static ImmutableArray<ToolInfo> Discover(Assembly toolAssembly)
+    {
+        const BindingFlags MethodFlags = BindingFlags.Public | BindingFlags.NonPublic |
+                                         BindingFlags.Static | BindingFlags.Instance |
+                                         BindingFlags.DeclaredOnly;
+
+        var tools = ImmutableArray.CreateBuilder<ToolInfo>();
+
+        foreach (var toolType in toolAssembly.GetTypes())
+        {
+            if (toolType.GetCustomAttribute<McpServerToolTypeAttribute>() is null)
+            {
+                continue;
+            }
+
+            foreach (var method in toolType.GetMethods(MethodFlags))
+            {
+                if (method.GetCustomAttribute<McpServerToolAttribute>() is not { } toolAttribute)
+                {
+                    continue;
+                }
+
+                tools.Add(new ToolInfo(
+                    toolAttribute.Name ?? method.Name,
+                    CountOperations(method)));
+            }
+        }
+
+        return tools.ToImmutable();
+    }
+
+    /// <summary>
+    /// Counts a tool's operations as the number of values in its <c>action</c> enum parameter.
+    /// Returns 0 when a tool has no such parameter; <c>McpToolSurfaceTests</c> fails the build if
+    /// that ever happens, so the total can never silently under-report.
+    /// </summary>
+    private static int CountOperations(MethodInfo method)
+    {
+        var actionParameter = Array.Find(
+            method.GetParameters(),
+            p => string.Equals(p.Name, ActionParameterName, StringComparison.Ordinal));
+
+        if (actionParameter is null)
+        {
+            return 0;
+        }
+
+        var actionType = Nullable.GetUnderlyingType(actionParameter.ParameterType) ?? actionParameter.ParameterType;
+
+        return actionType.IsEnum ? Enum.GetValues(actionType).Length : 0;
+    }
+}

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -433,7 +433,7 @@ public class Program
             Excel MCP Server v{version}
 
             An MCP (Model Context Protocol) server for Microsoft Excel automation.
-            Provides 22 tools with 195+ operations for AI assistants.
+            Provides 31 tools with 326 operations for AI assistants.
 
             Usage:
               mcp-excel.exe [options]

--- a/src/ExcelMcp.McpServer/Program.cs
+++ b/src/ExcelMcp.McpServer/Program.cs
@@ -426,14 +426,27 @@ public class Program
     /// <summary>
     /// Shows help information.
     /// </summary>
-    private static void ShowHelp()
+    private static void ShowHelp() => Console.WriteLine(BuildHelpText());
+
+    /// <summary>
+    /// Builds the help banner.
+    ///
+    /// The tool and operation counts are DERIVED from the live <c>[McpServerTool]</c> registration
+    /// via <see cref="McpToolSurface"/>, never hard-coded. A hard-coded literal here previously
+    /// drifted to "22 tools with 195+ operations" while the real surface was 31 tools / 326
+    /// operations, contradicting every README and the server's own <c>tools/list</c> response.
+    ///
+    /// Exposed internally, rather than inlined into <see cref="ShowHelp"/>, so tests can assert
+    /// that the banner really does track the registration.
+    /// </summary>
+    internal static string BuildHelpText()
     {
         var version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "1.0.0";
-        Console.WriteLine($"""
+        return $"""
             Excel MCP Server v{version}
 
             An MCP (Model Context Protocol) server for Microsoft Excel automation.
-            Provides 31 tools with 326 operations for AI assistants.
+            Provides {McpToolSurface.ToolCount} tools with {McpToolSurface.OperationCount} operations for AI assistants.
 
             Usage:
               mcp-excel.exe [options]
@@ -453,7 +466,7 @@ public class Program
 
             Source:
               https://github.com/sbroenne/mcp-server-excel
-            """);
+            """;
     }
 
     /// <summary>

--- a/tests/ExcelMcp.McpServer.Tests/Integration/McpToolSurfaceTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/McpToolSurfaceTests.cs
@@ -1,0 +1,94 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration;
+
+/// <summary>
+/// Guards the tool/operation counts the MCP server advertises in its own <c>--help</c> banner.
+///
+/// THE BUG THIS PREVENTS
+/// ---------------------
+/// The banner used to carry the hard-coded literal "Provides 22 tools with 195+ operations".
+/// The real surface had grown to 31 tools / 326 operations, so the binary told users something
+/// that contradicted every README, SKILL.md and the live <c>tools/list</c> response.
+///
+/// <see cref="McpToolSurface"/> now derives BOTH numbers by reflecting over the actual
+/// <c>[McpServerToolType]</c>/<c>[McpServerTool]</c> registration, so the banner cannot drift
+/// from the registration again. These tests lock in that derivation and cross-check it against
+/// the ground truth enforced everywhere else (scripts/check-doc-counts.ps1).
+/// </summary>
+/// <inheritdoc/>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "ToolSurface")]
+[Trait("RequiresExcel", "false")]
+public class McpToolSurfaceTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Ground truth, verified against the live <c>tools/list</c> response of the shipped server
+    /// and enforced across every user-facing doc by scripts/check-doc-counts.ps1.
+    /// </summary>
+    private const int ExpectedToolCount = 31;
+
+    /// <summary>Sum of the <c>action</c> enum values across all registered tools.</summary>
+    private const int ExpectedOperationCount = 326;
+
+    [Fact]
+    public void ToolSurface_MatchesDocumentedGroundTruth()
+    {
+        foreach (var tool in McpToolSurface.Tools.OrderBy(t => t.Name, StringComparer.Ordinal))
+        {
+            output.WriteLine($"  {tool.Name}: {tool.OperationCount}");
+        }
+
+        Assert.Equal(ExpectedToolCount, McpToolSurface.ToolCount);
+        Assert.Equal(ExpectedOperationCount, McpToolSurface.OperationCount);
+    }
+
+    [Fact]
+    public void EveryRegisteredTool_ExposesAnActionEnum()
+    {
+        // The operation count is only trustworthy while every tool routes through an `action`
+        // enum. A tool without one would silently contribute 0 operations.
+        var offenders = McpToolSurface.Tools.Where(t => t.OperationCount == 0).ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "These MCP tools have no 'action' enum parameter, so McpToolSurface cannot count their " +
+            $"operations: {string.Join(", ", offenders.Select(t => t.Name))}");
+    }
+
+    [Fact]
+    public void ToolNames_AreUnique()
+    {
+        var duplicates = McpToolSurface.Tools
+            .GroupBy(t => t.Name, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        Assert.True(duplicates.Count == 0, $"Duplicate MCP tool names: {string.Join(", ", duplicates)}");
+    }
+
+    [Fact]
+    public void HelpText_AdvertisesTheDerivedCounts()
+    {
+        var help = Program.BuildHelpText();
+        output.WriteLine(help);
+
+        Assert.Contains(
+            $"Provides {McpToolSurface.ToolCount} tools with {McpToolSurface.OperationCount} operations",
+            help,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HelpText_DoesNotCarryTheStaleHardCodedCounts()
+    {
+        var help = Program.BuildHelpText();
+
+        Assert.DoesNotContain("22 tools", help, StringComparison.Ordinal);
+        Assert.DoesNotContain("195+", help, StringComparison.Ordinal);
+    }
+}

--- a/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
@@ -148,7 +148,8 @@ public sealed class PluginBootstrapBuildTests
                 version);
             AssertSkillDirectoryMatchesSource(
                 Path.Combine(RepoRoot, "skills", "excel-cli"),
-                Path.Combine(outputDir, "excel-cli", "skills", "excel-cli"));
+                Path.Combine(outputDir, "excel-cli", "skills", "excel-cli"),
+                version);
             AssertLocalSkillLinksResolve(Path.Combine(outputDir, "excel-mcp", "skills", "excel-mcp"));
             AssertLocalSkillLinksResolve(Path.Combine(outputDir, "excel-cli", "skills", "excel-cli"));
 
@@ -793,15 +794,19 @@ public sealed class PluginBootstrapBuildTests
     {
         var sourceFiles = Directory.GetFiles(sourceSkillRoot, "*", SearchOption.AllDirectories)
             .Select(path => Path.GetRelativePath(sourceSkillRoot, path))
+            .Where(path => path != "VERSION")
             .OrderBy(path => path, StringComparer.Ordinal)
             .ToArray();
         var builtFiles = Directory.GetFiles(builtSkillRoot, "*", SearchOption.AllDirectories)
             .Select(path => Path.GetRelativePath(builtSkillRoot, path))
+            .Where(path => path != "VERSION")
             .OrderBy(path => path, StringComparer.Ordinal)
             .ToArray();
 
+        // VERSION is stamped by the build rather than copied from the canonical skill, so it is
+        // compared separately instead of being required to exist in the source.
         Assert.Equal(sourceFiles, builtFiles);
-        foreach (var relativePath in sourceFiles.Where(path => path != "VERSION"))
+        foreach (var relativePath in sourceFiles)
         {
             Assert.Equal(
                 File.ReadAllText(Path.Combine(sourceSkillRoot, relativePath)),

--- a/tests/ExcelMcp.SkillGeneration.Tests/PluginSkillVersionTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/PluginSkillVersionTests.cs
@@ -1,0 +1,188 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.SkillGeneration.Tests;
+
+/// <summary>
+/// Verifies that every Agent Skill shipped inside a built plugin carries a VERSION file stamped with
+/// the version the plugin was built at.
+/// </summary>
+/// <remarks>
+/// Regression guard: the published excel-cli plugin shipped without a VERSION file while excel-mcp
+/// shipped with one. Two defects combined to cause it — the excel-cli Copy-AgentSkill call omitted
+/// -Version, and Copy-AgentSkill only ever updated a VERSION file that already existed in the skill
+/// source instead of creating one. These tests fail if either regresses, and they are agnostic to how
+/// many skills a plugin ships so a future third skill is covered automatically.
+/// </remarks>
+public sealed class PluginSkillVersionTests
+{
+    private const string TestVersion = "9.9.9-skillversion";
+    private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string BuildPluginsScript = Path.Combine(RepoRoot, "scripts", "Build-Plugins.ps1");
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginSkillVersion")]
+    public async Task BuildPlugins_StampsVersionFileIntoEverySkillDirectory()
+    {
+        var sandbox = CreateSandbox("plugin-skill-version");
+        try
+        {
+            var outputDir = Path.Combine(sandbox, "built-plugins");
+
+            var result = await RunPowerShellFileAsync(
+                BuildPluginsScript,
+                ["-Version", TestVersion, "-OutputDir", outputDir]);
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"Build-Plugins.ps1 failed with exit code {result.ExitCode}.{Environment.NewLine}{result.CombinedOutput}");
+
+            var skillDirectories = Directory
+                .GetDirectories(outputDir)
+                .Select(pluginDir => Path.Combine(pluginDir, "skills"))
+                .Where(Directory.Exists)
+                .SelectMany(Directory.GetDirectories)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+
+            // Guard against a vacuous pass if the output layout ever changes.
+            Assert.True(
+                skillDirectories.Count >= 2,
+                $"Expected at least one skill per plugin, found {skillDirectories.Count} under {outputDir}.");
+
+            foreach (var skillDirectory in skillDirectories)
+            {
+                var versionFile = Path.Combine(skillDirectory, "VERSION");
+
+                Assert.True(
+                    File.Exists(versionFile),
+                    $"Built skill '{skillDirectory}' is missing a VERSION file.");
+
+                Assert.Equal(TestVersion, File.ReadAllText(versionFile).Trim());
+            }
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginSkillVersion")]
+    public void ExcelMcpSkillSource_KeepsVersionFile_BecauseBuildScriptsReadItAsFallbackVersion()
+    {
+        // Build-Plugins.ps1 and Build-AgentSkills.ps1 both fall back to skills/excel-mcp/VERSION when
+        // no explicit -Version is supplied. Deleting it would silently break unversioned builds.
+        var versionFile = Path.Combine(RepoRoot, "skills", "excel-mcp", "VERSION");
+
+        Assert.True(File.Exists(versionFile), $"Canonical fallback version source is missing: {versionFile}");
+        Assert.False(string.IsNullOrWhiteSpace(File.ReadAllText(versionFile)));
+    }
+
+    private static string CreateSandbox(string name)
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"excelmcp-{name}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteDirectoryIfExists(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Sbroenne.ExcelMcp.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output directory.");
+    }
+
+    private static async Task<ProcessResult> RunPowerShellFileAsync(
+        string scriptPath,
+        IReadOnlyList<string> arguments,
+        int timeoutMs = 120000)
+    {
+        var escapedScriptPath = scriptPath.Replace("'", "''");
+        var escapedArguments = arguments
+            .Select(argument => argument.Length > 0 && argument[0] == '-'
+                ? argument
+                : $"'{argument.Replace("'", "''")}'");
+        var commandText = $"& '{escapedScriptPath}' {string.Join(" ", escapedArguments)}";
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot
+        };
+
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-ExecutionPolicy");
+        startInfo.ArgumentList.Add("Bypass");
+        startInfo.ArgumentList.Add("-Command");
+        startInfo.ArgumentList.Add(commandText);
+
+        using var process = new Process { StartInfo = startInfo };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                stdout.AppendLine(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                stderr.AppendLine(e.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        using var timeout = new CancellationTokenSource(timeoutMs);
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"PowerShell script '{scriptPath}' timed out after {timeoutMs}ms.");
+        }
+
+        return new ProcessResult(process.ExitCode, stdout.ToString(), stderr.ToString());
+    }
+
+    private sealed record ProcessResult(int ExitCode, string Stdout, string Stderr)
+    {
+        public string CombinedOutput => $"{Stdout}{Environment.NewLine}{Stderr}";
+    }
+}


### PR DESCRIPTION
Follow-up to #779. Fixes the P2 (documentation and packaging accuracy) findings from the plugin evaluation.

## 1. Stale MCP help banner — fixed by deriving the counts, not by restating them

`mcp-excel --help` advertised `Provides 22 tools with 195+ operations`. The server actually registers **31 tools with 326 operations**.

I verified the advertised figures rather than trusting either side: I enumerated the live `tools/list` (31 tools) and summed the `action` enum values across all 31 tool schemas — exactly **326**. So the READMEs and skills were already correct; only the binary's banner was stale.

The root cause was that the banner was a **hard-coded literal**, and `scripts/check-doc-counts.ps1` validated 16 documentation files but never looked at `src/ExcelMcp.McpServer/Program.cs` — so the one string users actually see at the terminal was the only one nobody was checking.

Correcting the literal would have fixed today's number and left the drift mechanism intact. Instead:

- **New `McpToolSurface`** reflects over the actual `[McpServerToolType]` / `[McpServerTool]` registration — the same surface `GeminiCompatibleToolRegistration` walks — and counts operations as the values of each tool's required `action` enum. Reflection independently reproduces **31 / 326**, matching `check-doc-counts.ps1`.
- **The banner interpolates those values**, so it cannot disagree with the server's own `tools/list` again.
- **`check-doc-counts.ps1` now asserts the opposite of what it used to.** Instead of validating a literal, it fails if anyone reintroduces a hard-coded count in the banner — *including a count that is correct on the day it is written*, which is exactly how this bug was born.
- **`McpToolSurfaceTests`** pins the derivation, cross-checks it against the documented ground truth, and fails the build if any tool stops exposing an `action` enum (which would silently under-report the total).

Mutation-verified (3 mutations, all killed):

| Mutation | Caught by |
|---|---|
| Reintroduce `22 tools with 195+ operations` | `check-doc-counts.ps1` |
| Hard-code the *correct* `31 tools with 326 operations` | `check-doc-counts.ps1` |
| Break the operation derivation (`CountOperations` → 0) | `McpToolSurfaceTests` (2 tests) |

## 2. CLI skill VERSION was never stamped — two independent causes

`skills/excel-cli/VERSION` drifted from the release version. There were two separate bugs, and fixing either alone left it broken:

1. `Copy-AgentSkill` in `scripts/Build-Plugins.ps1` only wrote VERSION when the file already existed (`Test-Path` guard at `Build-Plugins.ps1:110-112` on `main`), so a fresh output tree never got one.
2. The excel-cli call site never passed `-Version` at all — compare `Build-Plugins.ps1:307` (excel-mcp, passes `-Version $Version`) with `:343` (excel-cli, omits it). Both line references are against `origin/main` @ `9b1f040`.

Because the two are independent, fixing either alone leaves excel-cli unstamped: remove the `Test-Path` guard and line 343 still supplies no version; pass `-Version` and the guard still skips the write.

Both fixed. Additionally, `Assert-AgentSkill` now **verifies** that every packaged skill carries a VERSION matching the build version, so the build fails rather than silently shipping an unstamped skill. `PluginSkillVersionTests` runs `Build-Plugins.ps1` end-to-end and asserts the stamp across every skill of every plugin — it is agnostic to how many skills exist, so a future third skill is covered automatically.

Mutation-verified: restoring both original defects fails `PluginSkillVersionTests`.

## 3. Misleading skill rules

Found while following the skills literally against a real workbook:

- **`excelcli` is not necessarily on PATH.** Every CLI skill example uses a bare `excelcli`, but the global shim is documented as optional — an agent following the skill hits command-not-found. The Preconditions section now states the requirement and how to satisfy it.
- **Number formats are locale-sensitive.** The skill claimed `$#,##0.00` renders `$1,234.56`; on a de-DE machine it renders `$1.500,00`. Now noted, along with a warning against "fixing" the format code.
- **Formatting workflow left `#####` in date columns.** The "format professionally" workflow had no auto-fit step. Added a required step 3 using `range_format auto-fit-columns` (verified against `IRangeFormatCommands.cs` and the generated manifest — auto-fit belongs to `range_format`, not `range`).

Note that `skills/excel-{cli,mcp}/SKILL.md` are **generated** from `skills/templates/SKILL.{cli,mcp}.sbn` via Scriban. The templates are the edit surface; the `.md` diffs here are Release-build output.

## Verification

- `dotnet test tests/ExcelMcp.SkillGeneration.Tests` — **36/36** green.
- `dotnet test tests/ExcelMcp.McpServer.Tests` (non-Excel) — 118/119; the single failure is `StdinPipeMonitorTests.Start_WhenStdinIsPipe_ReturnsTimer`, which is **pre-existing and unrelated** (confirmed by stashing this PR's changes and re-running — it still fails). It depends on how the test host redirects stdin.
- `scripts/check-doc-counts.ps1` — passes, and mutation-verified against both a stale and a correct-but-hard-coded banner.
- Built `mcp-excel.exe --help` prints `Provides 31 tools with 326 operations`.
- Full pre-commit gate (including Excel-dependent E2E) passed.

## Not included, deliberately

`skills/excel-cli/VERSION` was **not** added to source. Only excel-mcp's copy is ever read as a version source — both consumers hardcode the path (`Build-Plugins.ps1:48`, `Build-AgentSkills.ps1:347`) — and the VS Code extension's `copy:skills` xcopies *only* `skills/excel-mcp`, so an excel-cli copy would be unreadable, unshipped, and merely stamped. It is pure dead weight guaranteed to drift, especially as its counterpart is pinned at `1.7.0` while the plugins are on 1.10.x. The build now stamps VERSION unconditionally and asserts it, which is what actually ships, so VERSION is treated as build output rather than source.

The stale `skills/excel-mcp/VERSION` itself is left alone here and tracked separately as #791: it is the `-Version` fallback *and*, transitively, the baseline `Assert-AgentSkill -ExpectedVersion` compares against, so a local build with no `-Version` stamps `1.7.0` and validates clean. Releases are unaffected — `publish-plugins.yml:270` always passes `-Version` from the tag.
