### PR TITLE
fix(plugins): harden the runtime bootstrap against corrupt caches and races

### DIFF
--- a/.changeset/plugin-bootstrap-p1-robustness.md
+++ b/.changeset/plugin-bootstrap-p1-robustness.md
@@ -1,0 +1,32 @@
+---
+"excelmcp": patch
+---
+
+Harden the plugin runtime bootstrap against corrupt caches, concurrent installs, and rate limits.
+
+Follow-up to the offline-fallback fix. `download.ps1` for both `excel-cli` and `excel-mcp` now:
+
+- **Validates the cached archive instead of merely testing for its presence.** A truncated
+  download used to wedge the plugin permanently: the release tag still matched, so no download was
+  attempted, yet extraction failed on every subsequent run. Recovery required manually deleting
+  the cache. The archive is now opened and checked before it is trusted.
+- **Downloads to a temp file and renames into place**, so an interrupted transfer can never leave
+  a partial archive that a later run mistakes for a complete one.
+- **Extracts into a staging directory and swaps it in**, rather than deleting the release
+  directory first. This also fixes a destructive failure mode: `Remove-Item -Recurse` deletes every
+  sibling file before it reaches a locked executable and fails, leaving a half-destroyed install.
+  The executable is now probed for a lock *before* anything is removed, and a runtime that is
+  currently in use is kept rather than partially overwritten.
+- **Retries once with a fresh download** if an install fails, instead of failing permanently.
+- **Serializes installs with a named mutex**, so concurrent sessions cannot race on the same
+  archive and release directory.
+- **Verifies the resolved runtime's version** from the version stamped into the file. Running the
+  runtime with `--version` was deliberately avoided: it performs its own network update check,
+  which is exactly wrong inside a bootstrap that must work offline.
+- **Sends `GITHUB_TOKEN` / `GH_TOKEN` as a bearer token** when present. Unauthenticated GitHub API
+  access is 60 requests/hour per source IP, a budget shared by everyone behind a corporate NAT and
+  routinely exhausted — the most common cause of release metadata being unreachable.
+- **Re-checks for updates on a time window for non-Copilot installs.** Outside a Copilot session
+  the session id is the constant `"standalone"`, so it always equalled the previously recorded one
+  and the freshness check never fired again. PATH and shim installs were pinned forever to
+  whatever they first downloaded, despite the docs promising the newest runtime.

--- a/.github/plugins/excel-cli/bin/download.ps1
+++ b/.github/plugins/excel-cli/bin/download.ps1
@@ -18,7 +18,19 @@ $CacheRoot = Join-Path $env:USERPROFILE ".copilot\plugin-runtime\mcp-server-exce
 $DownloadsDir = Join-Path $CacheRoot "downloads"
 $ReleasesDir = Join-Path $CacheRoot "releases"
 $StatePath = Join-Path $CacheRoot "bootstrap-state.json"
-$SessionId = if ([string]::IsNullOrWhiteSpace($env:COPILOT_AGENT_SESSION_ID)) { "standalone" } else { $env:COPILOT_AGENT_SESSION_ID }
+$HasCopilotSession = -not [string]::IsNullOrWhiteSpace($env:COPILOT_AGENT_SESSION_ID)
+$SessionId = if ($HasCopilotSession) { $env:COPILOT_AGENT_SESSION_ID } else { "standalone" }
+
+# Outside a Copilot session the session id is the constant "standalone", so it always equals the
+# previously recorded one and the freshness check would never fire again. PATH and shim installs
+# would then be pinned forever to whatever they first downloaded. Fall back to elapsed time there.
+$StandaloneRecheckHours = 24
+
+try {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+} catch {
+    # Already loaded, or running on a host where the type is available without an explicit load.
+}
 
 function Write-Status {
     param(
@@ -47,6 +59,115 @@ function Ensure-Directory {
     if (-not (Test-Path $Path)) {
         New-Item -ItemType Directory -Path $Path -Force | Out-Null
     }
+}
+
+function Test-ZipArchive {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $false
+    }
+
+    # Presence is not integrity. An interrupted transfer leaves a truncated file that Test-Path
+    # happily reports as a usable cached download, which then fails at extraction on every run.
+    $archive = $null
+    try {
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+        return $archive.Entries.Count -gt 0
+    } catch {
+        return $false
+    } finally {
+        if ($null -ne $archive) {
+            $archive.Dispose()
+        }
+    }
+}
+
+function Test-FileLocked {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $false
+    }
+
+    $stream = $null
+    try {
+        $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        return $false
+    } catch {
+        return $true
+    } finally {
+        if ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+}
+
+function Get-BinaryProductVersion {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    # Read the version stamped into the file rather than running the binary with --version: this
+    # is instant, works offline, and has no side effects. The runtime's own --version performs an
+    # update check, which is precisely wrong inside a bootstrap that must survive being offline.
+    try {
+        $productVersion = (Get-Item $Path).VersionInfo.ProductVersion
+    } catch {
+        return $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($productVersion)) {
+        return $null
+    }
+
+    # Release builds stamp SemVer 2 build metadata, for example "1.10.7+d526b22d0eda".
+    return ($productVersion -split '\+', 2)[0].Trim()
+}
+
+function Test-BinaryMatchesVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [string]$ExpectedVersion
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ExpectedVersion)) {
+        return $true
+    }
+
+    $actualVersion = Get-BinaryProductVersion -Path $Path
+
+    # Missing version metadata is not treated as a mismatch. An unidentifiable runtime is still
+    # better than no runtime, and the install path already validated the package contents.
+    if ([string]::IsNullOrWhiteSpace($actualVersion)) {
+        return $true
+    }
+
+    return $actualVersion -eq $ExpectedVersion
+}
+
+function Get-RuntimeCacheMutex {
+    # Local\ rather than Global\ deliberately: creating a global kernel object requires
+    # SeCreateGlobalPrivilege, which standard users do not hold. The cache lives under the user
+    # profile, so a per-logon-session lock is exactly the right scope.
+    return [System.Threading.Mutex]::new($false, "Local\excelmcp-plugin-$PluginName")
+}
+
+function Test-FreshnessWindowElapsed {
+    param([Parameter(Mandatory = $true)]$State)
+
+    if ([string]::IsNullOrWhiteSpace($State.checkedAtUtc)) {
+        return $true
+    }
+
+    try {
+        $checkedAtUtc = [DateTime]::Parse(
+            $State.checkedAtUtc,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::RoundtripKind)
+    } catch {
+        return $true
+    }
+
+    return ([DateTime]::UtcNow - $checkedAtUtc.ToUniversalTime()) -ge [TimeSpan]::FromHours($StandaloneRecheckHours)
 }
 
 function New-State {
@@ -99,6 +220,14 @@ function Get-LatestReleaseMetadata {
             "User-Agent" = "excel-cli-plugin-bootstrap"
         }
 
+        # Unauthenticated GitHub API access is 60 requests/hour per source IP. Behind corporate
+        # NAT that budget is shared by everyone on the network and is routinely exhausted, which
+        # is the most common cause of a bootstrap failing to reach the release metadata.
+        $token = if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) { $env:GITHUB_TOKEN } elseif (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) { $env:GH_TOKEN } else { $null }
+        if ($null -ne $token) {
+            $headers["Authorization"] = "Bearer $token"
+        }
+
         $release = Invoke-RestMethod -Uri $ReleaseApiUrl -Headers $headers
         $releaseVersion = $release.tag_name -replace '^v', ''
         $assetName = "ExcelMcp-CLI-$releaseVersion-windows.zip"
@@ -119,18 +248,17 @@ function Get-LatestReleaseMetadata {
     }
 }
 
-function Resolve-BinaryPath {
-    param([Parameter(Mandatory = $true)]$State)
+function Find-ReleaseBinary {
+    param(
+        [string]$Version,
+        [string]$ExpectedVersion
+    )
 
-    if (-not [string]::IsNullOrWhiteSpace($State.binaryPath) -and (Test-Path $State.binaryPath)) {
-        return $State.binaryPath
-    }
-
-    if ([string]::IsNullOrWhiteSpace($State.latestVersion)) {
+    if ([string]::IsNullOrWhiteSpace($Version)) {
         return $null
     }
 
-    $releaseDir = Join-Path $ReleasesDir $State.latestVersion
+    $releaseDir = Join-Path $ReleasesDir $Version
     if (-not (Test-Path $releaseDir)) {
         return $null
     }
@@ -140,7 +268,106 @@ function Resolve-BinaryPath {
         return $null
     }
 
+    if (-not (Test-BinaryMatchesVersion -Path $binary.FullName -ExpectedVersion $ExpectedVersion)) {
+        return $null
+    }
+
     return $binary.FullName
+}
+
+function Resolve-BinaryPath {
+    param(
+        [Parameter(Mandatory = $true)]$State,
+        [string]$ExpectedVersion
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($State.binaryPath) -and (Test-Path $State.binaryPath)) {
+        if (Test-BinaryMatchesVersion -Path $State.binaryPath -ExpectedVersion $ExpectedVersion) {
+            return $State.binaryPath
+        }
+    }
+
+    return Find-ReleaseBinary -Version $State.latestVersion -ExpectedVersion $ExpectedVersion
+}
+
+function Save-RuntimeArchive {
+    param(
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [Parameter(Mandatory = $true)][string]$DestinationPath
+    )
+
+    # Download to a sibling temp file and rename into place, so an interrupted transfer can never
+    # leave a truncated archive that a later run mistakes for a complete cached download.
+    $partialPath = "$DestinationPath.$([Guid]::NewGuid().ToString('N')).part"
+
+    try {
+        Ensure-Directory -Path (Split-Path -Parent $DestinationPath)
+        Invoke-WebRequest -Uri $Uri -OutFile $partialPath
+
+        if (-not (Test-ZipArchive -Path $partialPath)) {
+            throw "Downloaded package '$(Split-Path $DestinationPath -Leaf)' is not a readable archive."
+        }
+
+        if (Test-Path $DestinationPath) {
+            Remove-Item -Path $DestinationPath -Force
+        }
+
+        Move-Item -Path $partialPath -Destination $DestinationPath
+    } finally {
+        if (Test-Path $partialPath) {
+            Remove-Item -Path $partialPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Install-RuntimeArchive {
+    param(
+        [Parameter(Mandatory = $true)][string]$ZipPath,
+        [Parameter(Mandatory = $true)][string]$ReleaseDir
+    )
+
+    # Extract into a staging directory and swap it into place, so a failed or concurrent
+    # extraction never leaves a half-populated release directory behind.
+    $stagingDir = Join-Path $ReleasesDir (".staging-" + [Guid]::NewGuid().ToString("N"))
+
+    try {
+        Ensure-Directory -Path $stagingDir
+        Expand-Archive -Path $ZipPath -DestinationPath $stagingDir -Force
+
+        $staged = Get-ChildItem -Path $stagingDir -Recurse -File -Filter $ExecutableName | Select-Object -First 1
+        if ($null -eq $staged) {
+            throw "Downloaded package '$(Split-Path $ZipPath -Leaf)' did not contain $ExecutableName."
+        }
+
+        if (Test-Path $ReleaseDir) {
+            $installed = Get-ChildItem -Path $ReleaseDir -Recurse -File -Filter $ExecutableName | Select-Object -First 1
+
+            # Probe for a lock *before* deleting anything. Remove-Item -Recurse deletes every
+            # unlocked file it reaches before failing on the locked executable, which destroys a
+            # working install and leaves nothing usable behind.
+            if ($null -ne $installed -and (Test-FileLocked -Path $installed.FullName)) {
+                Write-StatusError "[excel-cli] $ExecutableName is in use and cannot be replaced right now; keeping the existing install."
+                return [pscustomobject]@{ Path = $installed.FullName; Installed = $false }
+            }
+
+            Remove-Item -Path $ReleaseDir -Recurse -Force
+        }
+
+        Ensure-Directory -Path (Split-Path -Parent $ReleaseDir)
+        Move-Item -Path $stagingDir -Destination $ReleaseDir
+        $stagingDir = $null
+
+        $binary = Get-ChildItem -Path $ReleaseDir -Recurse -File -Filter $ExecutableName | Select-Object -First 1
+        if ($null -eq $binary) {
+            throw "Downloaded package '$(Split-Path $ZipPath -Leaf)' did not contain $ExecutableName."
+        }
+
+        return [pscustomobject]@{ Path = $binary.FullName; Installed = $true }
+    } finally {
+        if (-not [string]::IsNullOrWhiteSpace($stagingDir) -and (Test-Path $stagingDir)) {
+            Remove-Item -Path $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 function Ensure-LatestRuntime {
@@ -153,7 +380,7 @@ function Ensure-LatestRuntime {
     # This is checked before any download so that a warm cache never needs the network, even
     # when the cached .zip has been removed by a disk cleanup tool.
     if (-not $Force -and $State.cachedReleaseTag -eq $State.latestTag) {
-        $cachedBinary = Resolve-BinaryPath -State $State
+        $cachedBinary = Resolve-BinaryPath -State $State -ExpectedVersion $State.latestVersion
         if (-not [string]::IsNullOrWhiteSpace($cachedBinary) -and (Test-Path $cachedBinary)) {
             return $cachedBinary
         }
@@ -166,32 +393,85 @@ function Ensure-LatestRuntime {
     $downloadZipPath = Join-Path $DownloadsDir $State.assetName
     $releaseDir = Join-Path $ReleasesDir $State.latestVersion
 
-    $downloadRequired = $Force -or -not (Test-Path $downloadZipPath) -or $State.cachedReleaseTag -ne $State.latestTag
-    if ($downloadRequired) {
-        Write-Status "[excel-cli] Downloading $($State.assetName)..." "Yellow"
-        Invoke-WebRequest -Uri $State.assetUrl -OutFile $downloadZipPath
-    } else {
-        Write-Status "[excel-cli] Reusing cached package $($State.assetName)." "DarkGray"
+    # Serialize installs across concurrent sessions. Without this, two bootstraps race on the same
+    # zip path and release directory, and each can observe the other's partially written files.
+    $mutex = Get-RuntimeCacheMutex
+    $acquired = $false
+
+    try {
+        try {
+            $acquired = $mutex.WaitOne([TimeSpan]::FromMinutes(10))
+        } catch [System.Threading.AbandonedMutexException] {
+            # The previous holder died mid-install. We now own the lock and re-validate below.
+            $acquired = $true
+        }
+
+        # Another session may have completed the install while this one waited for the lock. This
+        # deliberately looks only inside the target release directory rather than trusting the
+        # recorded binaryPath, which still points at the previous release during an upgrade.
+        if (-not $Force) {
+            $installedBinary = Find-ReleaseBinary -Version $State.latestVersion -ExpectedVersion $State.latestVersion
+            if (-not [string]::IsNullOrWhiteSpace($installedBinary) -and (Test-Path $installedBinary)) {
+                $State.cachedReleaseTag = $State.latestTag
+                $State.binaryPath = $installedBinary
+                Save-State -State $State
+                return $installedBinary
+            }
+        }
+
+        $lastError = $null
+
+        for ($attempt = 1; $attempt -le 2; $attempt++) {
+            try {
+                # Validating the cached archive rather than merely testing for its presence is what
+                # breaks the permanent wedge: a corrupt zip whose tag still matches used to skip the
+                # download and then fail extraction on every subsequent run, forever.
+                $downloadRequired = $Force -or $attempt -gt 1 -or $State.cachedReleaseTag -ne $State.latestTag -or -not (Test-ZipArchive -Path $downloadZipPath)
+
+                if ($downloadRequired) {
+                    Write-Status "[excel-cli] Downloading $($State.assetName)..." "Yellow"
+                    Save-RuntimeArchive -Uri $State.assetUrl -DestinationPath $downloadZipPath
+                } else {
+                    Write-Status "[excel-cli] Reusing cached package $($State.assetName)." "DarkGray"
+                }
+
+                Write-Status "[excel-cli] Extracting $($State.assetName)..." "Yellow"
+                $result = Install-RuntimeArchive -ZipPath $downloadZipPath -ReleaseDir $releaseDir
+
+                # Only record the tag when the new runtime actually landed. If the install was
+                # skipped because the executable was in use, the next run must try again.
+                if ($result.Installed) {
+                    $State.cachedReleaseTag = $State.latestTag
+                }
+
+                $State.binaryPath = $result.Path
+                Save-State -State $State
+
+                return $result.Path
+            } catch {
+                $lastError = $_
+
+                # Discard the cached archive so the retry starts from a clean download rather than
+                # repeating the same failure against the same bytes.
+                if (Test-Path $downloadZipPath) {
+                    Remove-Item -Path $downloadZipPath -Force -ErrorAction SilentlyContinue
+                }
+
+                if ($attempt -lt 2) {
+                    Write-StatusError "[excel-cli] Runtime install failed: $($_.Exception.Message)"
+                    Write-StatusError "[excel-cli] Retrying once with a fresh download."
+                }
+            }
+        }
+
+        throw $lastError
+    } finally {
+        if ($acquired) {
+            $mutex.ReleaseMutex()
+        }
+
+        $mutex.Dispose()
     }
-
-    if (Test-Path $releaseDir) {
-        Remove-Item -Path $releaseDir -Recurse -Force
-    }
-
-    Ensure-Directory -Path $releaseDir
-    Write-Status "[excel-cli] Extracting $($State.assetName)..." "Yellow"
-    Expand-Archive -Path $downloadZipPath -DestinationPath $releaseDir -Force
-
-    $binary = Get-ChildItem -Path $releaseDir -Recurse -File -Filter $ExecutableName | Select-Object -First 1
-    if ($null -eq $binary) {
-        throw "Downloaded package '$($State.assetName)' did not contain $ExecutableName."
-    }
-
-    $State.cachedReleaseTag = $State.latestTag
-    $State.binaryPath = $binary.FullName
-    Save-State -State $State
-
-    return $binary.FullName
 }
 
 if ($env:OS -ne "Windows_NT") {
@@ -200,6 +480,10 @@ if ($env:OS -ne "Windows_NT") {
 
 $state = Get-State
 $sessionNeedsFreshnessCheck = $Force -or [string]::IsNullOrWhiteSpace($state.checkedSessionId) -or $state.checkedSessionId -ne $SessionId
+
+if (-not $sessionNeedsFreshnessCheck -and -not $HasCopilotSession) {
+    $sessionNeedsFreshnessCheck = Test-FreshnessWindowElapsed -State $state
+}
 
 if ($sessionNeedsFreshnessCheck) {
     try {

--- a/.github/plugins/excel-mcp/bin/download.ps1
+++ b/.github/plugins/excel-mcp/bin/download.ps1
@@ -18,7 +18,19 @@ $CacheRoot = Join-Path $env:USERPROFILE ".copilot\plugin-runtime\mcp-server-exce
 $DownloadsDir = Join-Path $CacheRoot "downloads"
 $ReleasesDir = Join-Path $CacheRoot "releases"
 $StatePath = Join-Path $CacheRoot "bootstrap-state.json"
-$SessionId = if ([string]::IsNullOrWhiteSpace($env:COPILOT_AGENT_SESSION_ID)) { "standalone" } else { $env:COPILOT_AGENT_SESSION_ID }
+$HasCopilotSession = -not [string]::IsNullOrWhiteSpace($env:COPILOT_AGENT_SESSION_ID)
+$SessionId = if ($HasCopilotSession) { $env:COPILOT_AGENT_SESSION_ID } else { "standalone" }
+
+# Outside a Copilot session the session id is the constant "standalone", so it always equals the
+# previously recorded one and the freshness check would never fire again. PATH and shim installs
+# would then be pinned forever to whatever they first downloaded. Fall back to elapsed time there.
+$StandaloneRecheckHours = 24
+
+try {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+} catch {
+    # Already loaded, or running on a host where the type is available without an explicit load.
+}
 
 function Write-Status {
     param(
@@ -47,6 +59,115 @@ function Ensure-Directory {
     if (-not (Test-Path $Path)) {
         New-Item -ItemType Directory -Path $Path -Force | Out-Null
     }
+}
+
+function Test-ZipArchive {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $false
+    }
+
+    # Presence is not integrity. An interrupted transfer leaves a truncated file that Test-Path
+    # happily reports as a usable cached download, which then fails at extraction on every run.
+    $archive = $null
+    try {
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+        return $archive.Entries.Count -gt 0
+    } catch {
+        return $false
+    } finally {
+        if ($null -ne $archive) {
+            $archive.Dispose()
+        }
+    }
+}
+
+function Test-FileLocked {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $false
+    }
+
+    $stream = $null
+    try {
+        $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        return $false
+    } catch {
+        return $true
+    } finally {
+        if ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+}
+
+function Get-BinaryProductVersion {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    # Read the version stamped into the file rather than running the binary with --version: this
+    # is instant, works offline, and has no side effects. The runtime's own --version performs an
+    # update check, which is precisely wrong inside a bootstrap that must survive being offline.
+    try {
+        $productVersion = (Get-Item $Path).VersionInfo.ProductVersion
+    } catch {
+        return $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($productVersion)) {
+        return $null
+    }
+
+    # Release builds stamp SemVer 2 build metadata, for example "1.10.7+d526b22d0eda".
+    return ($productVersion -split '\+', 2)[0].Trim()
+}
+
+function Test-BinaryMatchesVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [string]$ExpectedVersion
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ExpectedVersion)) {
+        return $true
+    }
+
+    $actualVersion = Get-BinaryProductVersion -Path $Path
+
+    # Missing version metadata is not treated as a mismatch. An unidentifiable runtime is still
+    # better than no runtime, and the install path already validated the package contents.
+    if ([string]::IsNullOrWhiteSpace($actualVersion)) {
+        return $true
+    }
+
+    return $actualVersion -eq $ExpectedVersion
+}
+
+function Get-RuntimeCacheMutex {
+    # Local\ rather than Global\ deliberately: creating a global kernel object requires
+    # SeCreateGlobalPrivilege, which standard users do not hold. The cache lives under the user
+    # profile, so a per-logon-session lock is exactly the right scope.
+    return [System.Threading.Mutex]::new($false, "Local\excelmcp-plugin-$PluginName")
+}
+
+function Test-FreshnessWindowElapsed {
+    param([Parameter(Mandatory = $true)]$State)
+
+    if ([string]::IsNullOrWhiteSpace($State.checkedAtUtc)) {
+        return $true
+    }
+
+    try {
+        $checkedAtUtc = [DateTime]::Parse(
+            $State.checkedAtUtc,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::RoundtripKind)
+    } catch {
+        return $true
+    }
+
+    return ([DateTime]::UtcNow - $checkedAtUtc.ToUniversalTime()) -ge [TimeSpan]::FromHours($StandaloneRecheckHours)
 }
 
 function New-State {
@@ -99,6 +220,14 @@ function Get-LatestReleaseMetadata {
             "User-Agent" = "excel-mcp-plugin-bootstrap"
         }
 
+        # Unauthenticated GitHub API access is 60 requests/hour per source IP. Behind corporate
+        # NAT that budget is shared by everyone on the network and is routinely exhausted, which
+        # is the most common cause of a bootstrap failing to reach the release metadata.
+        $token = if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) { $env:GITHUB_TOKEN } elseif (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) { $env:GH_TOKEN } else { $null }
+        if ($null -ne $token) {
+            $headers["Authorization"] = "Bearer $token"
+        }
+
         $release = Invoke-RestMethod -Uri $ReleaseApiUrl -Headers $headers
         $releaseVersion = $release.tag_name -replace '^v', ''
         $assetName = "ExcelMcp-MCP-Server-$releaseVersion-windows.zip"
@@ -119,18 +248,17 @@ function Get-LatestReleaseMetadata {
     }
 }
 
-function Resolve-BinaryPath {
-    param([Parameter(Mandatory = $true)]$State)
+function Find-ReleaseBinary {
+    param(
+        [string]$Version,
+        [string]$ExpectedVersion
+    )
 
-    if (-not [string]::IsNullOrWhiteSpace($State.binaryPath) -and (Test-Path $State.binaryPath)) {
-        return $State.binaryPath
-    }
-
-    if ([string]::IsNullOrWhiteSpace($State.latestVersion)) {
+    if ([string]::IsNullOrWhiteSpace($Version)) {
         return $null
     }
 
-    $releaseDir = Join-Path $ReleasesDir $State.latestVersion
+    $releaseDir = Join-Path $ReleasesDir $Version
     if (-not (Test-Path $releaseDir)) {
         return $null
     }
@@ -140,7 +268,106 @@ function Resolve-BinaryPath {
         return $null
     }
 
+    if (-not (Test-BinaryMatchesVersion -Path $binary.FullName -ExpectedVersion $ExpectedVersion)) {
+        return $null
+    }
+
     return $binary.FullName
+}
+
+function Resolve-BinaryPath {
+    param(
+        [Parameter(Mandatory = $true)]$State,
+        [string]$ExpectedVersion
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($State.binaryPath) -and (Test-Path $State.binaryPath)) {
+        if (Test-BinaryMatchesVersion -Path $State.binaryPath -ExpectedVersion $ExpectedVersion) {
+            return $State.binaryPath
+        }
+    }
+
+    return Find-ReleaseBinary -Version $State.latestVersion -ExpectedVersion $ExpectedVersion
+}
+
+function Save-RuntimeArchive {
+    param(
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [Parameter(Mandatory = $true)][string]$DestinationPath
+    )
+
+    # Download to a sibling temp file and rename into place, so an interrupted transfer can never
+    # leave a truncated archive that a later run mistakes for a complete cached download.
+    $partialPath = "$DestinationPath.$([Guid]::NewGuid().ToString('N')).part"
+
+    try {
+        Ensure-Directory -Path (Split-Path -Parent $DestinationPath)
+        Invoke-WebRequest -Uri $Uri -OutFile $partialPath
+
+        if (-not (Test-ZipArchive -Path $partialPath)) {
+            throw "Downloaded package '$(Split-Path $DestinationPath -Leaf)' is not a readable archive."
+        }
+
+        if (Test-Path $DestinationPath) {
+            Remove-Item -Path $DestinationPath -Force
+        }
+
+        Move-Item -Path $partialPath -Destination $DestinationPath
+    } finally {
+        if (Test-Path $partialPath) {
+            Remove-Item -Path $partialPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Install-RuntimeArchive {
+    param(
+        [Parameter(Mandatory = $true)][string]$ZipPath,
+        [Parameter(Mandatory = $true)][string]$ReleaseDir
+    )
+
+    # Extract into a staging directory and swap it into place, so a failed or concurrent
+    # extraction never leaves a half-populated release directory behind.
+    $stagingDir = Join-Path $ReleasesDir (".staging-" + [Guid]::NewGuid().ToString("N"))
+
+    try {
+        Ensure-Directory -Path $stagingDir
+        Expand-Archive -Path $ZipPath -DestinationPath $stagingDir -Force
+
+        $staged = Get-ChildItem -Path $stagingDir -Recurse -File -Filter $ExecutableName | Select-Object -First 1
+        if ($null -eq $staged) {
+            throw "Downloaded package '$(Split-Path $ZipPath -Leaf)' did not contain $ExecutableName."
+        }
+
+        if (Test-Path $ReleaseDir) {
+            $installed = Get-ChildItem -Path $ReleaseDir -Recurse -File -Filter $ExecutableName | Select-Object -First 1
+
+            # Probe for a lock *before* deleting anything. Remove-Item -Recurse deletes every
+            # unlocked file it reaches before failing on the locked executable, which destroys a
+            # working install and leaves nothing usable behind.
+            if ($null -ne $installed -and (Test-FileLocked -Path $installed.FullName)) {
+                Write-StatusError "[excel-mcp] $ExecutableName is in use and cannot be replaced right now; keeping the existing install."
+                return [pscustomobject]@{ Path = $installed.FullName; Installed = $false }
+            }
+
+            Remove-Item -Path $ReleaseDir -Recurse -Force
+        }
+
+        Ensure-Directory -Path (Split-Path -Parent $ReleaseDir)
+        Move-Item -Path $stagingDir -Destination $ReleaseDir
+        $stagingDir = $null
+
+        $binary = Get-ChildItem -Path $ReleaseDir -Recurse -File -Filter $ExecutableName | Select-Object -First 1
+        if ($null -eq $binary) {
+            throw "Downloaded package '$(Split-Path $ZipPath -Leaf)' did not contain $ExecutableName."
+        }
+
+        return [pscustomobject]@{ Path = $binary.FullName; Installed = $true }
+    } finally {
+        if (-not [string]::IsNullOrWhiteSpace($stagingDir) -and (Test-Path $stagingDir)) {
+            Remove-Item -Path $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 function Ensure-LatestRuntime {
@@ -153,7 +380,7 @@ function Ensure-LatestRuntime {
     # This is checked before any download so that a warm cache never needs the network, even
     # when the cached .zip has been removed by a disk cleanup tool.
     if (-not $Force -and $State.cachedReleaseTag -eq $State.latestTag) {
-        $cachedBinary = Resolve-BinaryPath -State $State
+        $cachedBinary = Resolve-BinaryPath -State $State -ExpectedVersion $State.latestVersion
         if (-not [string]::IsNullOrWhiteSpace($cachedBinary) -and (Test-Path $cachedBinary)) {
             return $cachedBinary
         }
@@ -166,32 +393,85 @@ function Ensure-LatestRuntime {
     $downloadZipPath = Join-Path $DownloadsDir $State.assetName
     $releaseDir = Join-Path $ReleasesDir $State.latestVersion
 
-    $downloadRequired = $Force -or -not (Test-Path $downloadZipPath) -or $State.cachedReleaseTag -ne $State.latestTag
-    if ($downloadRequired) {
-        Write-Status "[excel-mcp] Downloading $($State.assetName)..." "Yellow"
-        Invoke-WebRequest -Uri $State.assetUrl -OutFile $downloadZipPath
-    } else {
-        Write-Status "[excel-mcp] Reusing cached package $($State.assetName)." "DarkGray"
+    # Serialize installs across concurrent sessions. Without this, two bootstraps race on the same
+    # zip path and release directory, and each can observe the other's partially written files.
+    $mutex = Get-RuntimeCacheMutex
+    $acquired = $false
+
+    try {
+        try {
+            $acquired = $mutex.WaitOne([TimeSpan]::FromMinutes(10))
+        } catch [System.Threading.AbandonedMutexException] {
+            # The previous holder died mid-install. We now own the lock and re-validate below.
+            $acquired = $true
+        }
+
+        # Another session may have completed the install while this one waited for the lock. This
+        # deliberately looks only inside the target release directory rather than trusting the
+        # recorded binaryPath, which still points at the previous release during an upgrade.
+        if (-not $Force) {
+            $installedBinary = Find-ReleaseBinary -Version $State.latestVersion -ExpectedVersion $State.latestVersion
+            if (-not [string]::IsNullOrWhiteSpace($installedBinary) -and (Test-Path $installedBinary)) {
+                $State.cachedReleaseTag = $State.latestTag
+                $State.binaryPath = $installedBinary
+                Save-State -State $State
+                return $installedBinary
+            }
+        }
+
+        $lastError = $null
+
+        for ($attempt = 1; $attempt -le 2; $attempt++) {
+            try {
+                # Validating the cached archive rather than merely testing for its presence is what
+                # breaks the permanent wedge: a corrupt zip whose tag still matches used to skip the
+                # download and then fail extraction on every subsequent run, forever.
+                $downloadRequired = $Force -or $attempt -gt 1 -or $State.cachedReleaseTag -ne $State.latestTag -or -not (Test-ZipArchive -Path $downloadZipPath)
+
+                if ($downloadRequired) {
+                    Write-Status "[excel-mcp] Downloading $($State.assetName)..." "Yellow"
+                    Save-RuntimeArchive -Uri $State.assetUrl -DestinationPath $downloadZipPath
+                } else {
+                    Write-Status "[excel-mcp] Reusing cached package $($State.assetName)." "DarkGray"
+                }
+
+                Write-Status "[excel-mcp] Extracting $($State.assetName)..." "Yellow"
+                $result = Install-RuntimeArchive -ZipPath $downloadZipPath -ReleaseDir $releaseDir
+
+                # Only record the tag when the new runtime actually landed. If the install was
+                # skipped because the executable was in use, the next run must try again.
+                if ($result.Installed) {
+                    $State.cachedReleaseTag = $State.latestTag
+                }
+
+                $State.binaryPath = $result.Path
+                Save-State -State $State
+
+                return $result.Path
+            } catch {
+                $lastError = $_
+
+                # Discard the cached archive so the retry starts from a clean download rather than
+                # repeating the same failure against the same bytes.
+                if (Test-Path $downloadZipPath) {
+                    Remove-Item -Path $downloadZipPath -Force -ErrorAction SilentlyContinue
+                }
+
+                if ($attempt -lt 2) {
+                    Write-StatusError "[excel-mcp] Runtime install failed: $($_.Exception.Message)"
+                    Write-StatusError "[excel-mcp] Retrying once with a fresh download."
+                }
+            }
+        }
+
+        throw $lastError
+    } finally {
+        if ($acquired) {
+            $mutex.ReleaseMutex()
+        }
+
+        $mutex.Dispose()
     }
-
-    if (Test-Path $releaseDir) {
-        Remove-Item -Path $releaseDir -Recurse -Force
-    }
-
-    Ensure-Directory -Path $releaseDir
-    Write-Status "[excel-mcp] Extracting $($State.assetName)..." "Yellow"
-    Expand-Archive -Path $downloadZipPath -DestinationPath $releaseDir -Force
-
-    $binary = Get-ChildItem -Path $releaseDir -Recurse -File -Filter $ExecutableName | Select-Object -First 1
-    if ($null -eq $binary) {
-        throw "Downloaded package '$($State.assetName)' did not contain $ExecutableName."
-    }
-
-    $State.cachedReleaseTag = $State.latestTag
-    $State.binaryPath = $binary.FullName
-    Save-State -State $State
-
-    return $binary.FullName
 }
 
 if ($env:OS -ne "Windows_NT") {
@@ -200,6 +480,10 @@ if ($env:OS -ne "Windows_NT") {
 
 $state = Get-State
 $sessionNeedsFreshnessCheck = $Force -or [string]::IsNullOrWhiteSpace($state.checkedSessionId) -or $state.checkedSessionId -ne $SessionId
+
+if (-not $sessionNeedsFreshnessCheck -and -not $HasCopilotSession) {
+    $sessionNeedsFreshnessCheck = Test-FreshnessWindowElapsed -State $state
+}
 
 if ($sessionNeedsFreshnessCheck) {
     try {

--- a/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -858,6 +859,396 @@ public sealed class PluginBootstrapBuildTests
         }
     }
 
+    [Theory]
+    [InlineData("excel-cli", "excelcli.exe", "ExcelMcp-CLI-{0}-windows.zip")]
+    [InlineData("excel-mcp", "mcp-excel.exe", "ExcelMcp-MCP-Server-{0}-windows.zip")]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_CorruptCachedArchive_SelfHeals(
+        string pluginName,
+        string executableName,
+        string assetNameFormat)
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox($"download-corrupt-zip-{pluginName}");
+        try
+        {
+            var userProfile = Path.Combine(sandbox, "user");
+            Directory.CreateDirectory(userProfile);
+
+            var harnessPath = CreateDownloadHarnessScript(sandbox);
+            var version = "1.2.3";
+            var tag = $"v{version}";
+            var assetName = string.Format(CultureInfo.InvariantCulture, assetNameFormat, version);
+
+            var firstResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", tag,
+                    "-AssetName", assetName,
+                    "-Mode", "success"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-a",
+                    ["OS"] = "Windows_NT"
+                });
+
+            Assert.Equal(0, firstResult.ExitCode);
+
+            // Recreate the wedge: a truncated archive left behind by an interrupted transfer,
+            // with the extracted runtime gone. The cached tag still matches, so a presence-only
+            // check would skip the download and then fail extraction on every single run.
+            var pluginCache = Path.Combine(userProfile, ".copilot", "plugin-runtime", "mcp-server-excel", pluginName);
+            File.WriteAllText(Path.Combine(pluginCache, "downloads", assetName), "truncated");
+            Directory.Delete(Path.Combine(pluginCache, "releases", version), recursive: true);
+
+            ResetMockCalls(userProfile);
+
+            var secondResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", tag,
+                    "-AssetName", assetName,
+                    "-Mode", "success",
+                    "-QuietMode"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-b",
+                    ["OS"] = "Windows_NT"
+                });
+
+            Assert.Equal(0, secondResult.ExitCode);
+            Assert.EndsWith(executableName, secondResult.Stdout.Trim(), StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(secondResult.Stdout.Trim()), "Expected a usable runtime after self-healing.");
+
+            // The corrupt archive must be discarded and refetched rather than reused.
+            Assert.Equal(1, ReadMockCallCount(userProfile, "web"));
+
+            // Validating the archive up front means extraction is attempted exactly once. A
+            // presence-only check would extract the corrupt file, fail, and only then recover.
+            Assert.Equal(1, ReadMockCallCount(userProfile, "expand"));
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Theory]
+    [InlineData("excel-cli", "excelcli.exe", "ExcelMcp-CLI-{0}-windows.zip")]
+    [InlineData("excel-mcp", "mcp-excel.exe", "ExcelMcp-MCP-Server-{0}-windows.zip")]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_StandaloneInstall_ReChecksOnceTheWindowElapses(
+        string pluginName,
+        string executableName,
+        string assetNameFormat)
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox($"download-standalone-window-{pluginName}");
+        try
+        {
+            var userProfile = Path.Combine(sandbox, "user");
+            Directory.CreateDirectory(userProfile);
+
+            var harnessPath = CreateDownloadHarnessScript(sandbox);
+            var version = "1.2.3";
+            var assetName = string.Format(CultureInfo.InvariantCulture, assetNameFormat, version);
+
+            // No COPILOT_AGENT_SESSION_ID: this is the PATH/shim install, where the session id is
+            // the constant "standalone" and therefore always equals the previously recorded one.
+            var env = new Dictionary<string, string>
+            {
+                ["USERPROFILE"] = userProfile,
+                ["OS"] = "Windows_NT"
+            };
+
+            var firstResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", $"v{version}",
+                    "-AssetName", assetName,
+                    "-Mode", "success"
+                ],
+                environmentVariables: env);
+
+            Assert.Equal(0, firstResult.ExitCode);
+
+            ResetMockCalls(userProfile);
+
+            var immediateResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", $"v{version}",
+                    "-AssetName", assetName,
+                    "-Mode", "success",
+                    "-QuietMode"
+                ],
+                environmentVariables: env);
+
+            Assert.Equal(0, immediateResult.ExitCode);
+            Assert.Equal(0, ReadMockCallCount(userProfile, "rest"));
+
+            // Age the recorded check past the staleness window.
+            var statePath = GetBootstrapStatePath(userProfile, pluginName);
+            var state = JsonNode.Parse(File.ReadAllText(statePath))!;
+            state["checkedAtUtc"] = DateTime.UtcNow.AddHours(-48).ToString("o", CultureInfo.InvariantCulture);
+            File.WriteAllText(statePath, state.ToJsonString());
+
+            ResetMockCalls(userProfile);
+
+            var agedResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", $"v{version}",
+                    "-AssetName", assetName,
+                    "-Mode", "success",
+                    "-QuietMode"
+                ],
+                environmentVariables: env);
+
+            Assert.Equal(0, agedResult.ExitCode);
+            Assert.Equal(1, ReadMockCallCount(userProfile, "rest"));
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Theory]
+    [InlineData("excel-cli", "excelcli.exe", "ExcelMcp-CLI-{0}-windows.zip", "GITHUB_TOKEN")]
+    [InlineData("excel-mcp", "mcp-excel.exe", "ExcelMcp-MCP-Server-{0}-windows.zip", "GH_TOKEN")]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_TokenInEnvironment_AuthenticatesReleaseLookup(
+        string pluginName,
+        string executableName,
+        string assetNameFormat,
+        string tokenVariable)
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox($"download-token-{pluginName}");
+        try
+        {
+            var userProfile = Path.Combine(sandbox, "user");
+            Directory.CreateDirectory(userProfile);
+
+            var harnessPath = CreateDownloadHarnessScript(sandbox);
+            var version = "1.2.3";
+            var assetName = string.Format(CultureInfo.InvariantCulture, assetNameFormat, version);
+
+            var arguments = new[]
+            {
+                "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                "-ExecutableName", executableName,
+                "-Tag", $"v{version}",
+                "-AssetName", assetName,
+                "-Mode", "success",
+                "-QuietMode"
+            };
+
+            var anonymousResult = await RunPowerShellFileAsync(
+                harnessPath,
+                arguments,
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-a",
+                    ["OS"] = "Windows_NT"
+                });
+
+            Assert.Equal(0, anonymousResult.ExitCode);
+
+            var headersPath = Path.Combine(userProfile, "mock-calls", "rest-headers.txt");
+            Assert.DoesNotContain("Authorization=", File.ReadAllText(headersPath), StringComparison.Ordinal);
+
+            var authenticatedResult = await RunPowerShellFileAsync(
+                harnessPath,
+                arguments,
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-b",
+                    ["OS"] = "Windows_NT",
+                    [tokenVariable] = "token-value"
+                });
+
+            Assert.Equal(0, authenticatedResult.ExitCode);
+            Assert.Contains("Authorization=Bearer token-value", File.ReadAllText(headersPath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Theory]
+    [InlineData("excel-cli", "excelcli.exe", "ExcelMcp-CLI-{0}-windows.zip")]
+    [InlineData("excel-mcp", "mcp-excel.exe", "ExcelMcp-MCP-Server-{0}-windows.zip")]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_RunningRuntime_KeepsWorkingInstall(
+        string pluginName,
+        string executableName,
+        string assetNameFormat)
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox($"download-locked-runtime-{pluginName}");
+        try
+        {
+            var userProfile = Path.Combine(sandbox, "user");
+            Directory.CreateDirectory(userProfile);
+
+            var harnessPath = CreateDownloadHarnessScript(sandbox);
+            var version = "1.2.3";
+            var assetName = string.Format(CultureInfo.InvariantCulture, assetNameFormat, version);
+            var env = new Dictionary<string, string>
+            {
+                ["USERPROFILE"] = userProfile,
+                ["COPILOT_AGENT_SESSION_ID"] = "session-a",
+                ["OS"] = "Windows_NT"
+            };
+
+            var firstResult = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", $"v{version}",
+                    "-AssetName", assetName,
+                    "-Mode", "success"
+                ],
+                environmentVariables: env);
+
+            Assert.Equal(0, firstResult.ExitCode);
+
+            var releaseDir = Path.Combine(
+                userProfile,
+                ".copilot",
+                "plugin-runtime",
+                "mcp-server-excel",
+                pluginName,
+                "releases",
+                version);
+
+            var installedBinary = Directory.GetFiles(releaseDir, executableName, SearchOption.AllDirectories).Single();
+            var companionFile = Path.Combine(Path.GetDirectoryName(installedBinary)!, "LICENSE.txt");
+            File.WriteAllText(companionFile, "license text");
+
+            env["COPILOT_AGENT_SESSION_ID"] = "session-b";
+
+            // Hold the executable open, exactly as a running runtime would. Deleting the release
+            // directory would remove every sibling file before failing on the locked executable,
+            // which is how a working install used to end up half destroyed.
+            using (File.Open(installedBinary, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                var lockedResult = await RunPowerShellFileAsync(
+                    harnessPath,
+                    [
+                        "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                        "-ExecutableName", executableName,
+                        "-Tag", $"v{version}",
+                        "-AssetName", assetName,
+                        "-Mode", "success",
+                        "-QuietMode",
+                        "-ForceMode"
+                    ],
+                    environmentVariables: env);
+
+                Assert.Equal(0, lockedResult.ExitCode);
+                Assert.Equal(installedBinary, lockedResult.Stdout.Trim(), ignoreCase: true);
+            }
+
+            Assert.True(File.Exists(installedBinary), "The in-use runtime must survive.");
+            Assert.True(File.Exists(companionFile), "Sibling files must not be destroyed by a blocked upgrade.");
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_VersionCheck_ReadsStampedFileMetadata()
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        // Running the runtime with --version would trigger its own network update check, which is
+        // exactly wrong inside a bootstrap that must work offline. The script therefore reads the
+        // version stamped into the file, and this asserts that it agrees with the OS.
+        var stampedBinary = Path.Combine(Environment.SystemDirectory, "notepad.exe");
+        Assert.True(File.Exists(stampedBinary), $"Expected a version-stamped binary at {stampedBinary}");
+
+        var expectedVersion = FileVersionInfo.GetVersionInfo(stampedBinary).ProductVersion!.Split('+')[0].Trim();
+
+        var sandbox = CreateSandbox("download-version-metadata");
+        try
+        {
+            var unstampedBinary = Path.Combine(sandbox, "unstamped.exe");
+            File.WriteAllText(unstampedBinary, "not a real binary");
+
+            var probePath = Path.Combine(sandbox, "probe.ps1");
+            File.WriteAllText(
+                probePath,
+                $$"""
+                $ErrorActionPreference = "Stop"
+                Set-StrictMode -Version Latest
+
+                $scriptText = [System.IO.File]::ReadAllText("{{GetPluginScriptPath("excel-cli", "download.ps1").Replace("\\", "\\\\")}}", [System.Text.UTF8Encoding]::new($false))
+                $ast = [System.Management.Automation.Language.Parser]::ParseInput($scriptText, [ref]$null, [ref]$null)
+                foreach ($name in @("Get-BinaryProductVersion", "Test-BinaryMatchesVersion")) {
+                    $definition = $ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name }, $true) | Select-Object -First 1
+                    if ($null -eq $definition) { throw "download.ps1 no longer defines $name." }
+                    . ([scriptblock]::Create($definition.Extent.Text))
+                }
+
+                Write-Output "stamped=$(Get-BinaryProductVersion -Path '{{stampedBinary.Replace("\\", "\\\\")}}')"
+                Write-Output "unstamped-is-null=$([string]::IsNullOrWhiteSpace((Get-BinaryProductVersion -Path '{{unstampedBinary.Replace("\\", "\\\\")}}')))"
+                Write-Output "matches=$(Test-BinaryMatchesVersion -Path '{{stampedBinary.Replace("\\", "\\\\")}}' -ExpectedVersion '{{expectedVersion}}')"
+                Write-Output "mismatch=$(Test-BinaryMatchesVersion -Path '{{stampedBinary.Replace("\\", "\\\\")}}' -ExpectedVersion '0.0.1')"
+                Write-Output "unstamped-accepted=$(Test-BinaryMatchesVersion -Path '{{unstampedBinary.Replace("\\", "\\\\")}}' -ExpectedVersion '0.0.1')"
+                """);
+
+            var result = await RunPowerShellFileAsync(probePath, []);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains($"stamped={expectedVersion}", result.Stdout, StringComparison.Ordinal);
+
+            // A file with no version resource cannot be identified, and an unidentifiable runtime
+            // is still better than no runtime, so it is accepted rather than rejected.
+            Assert.Contains("unstamped-is-null=True", result.Stdout, StringComparison.Ordinal);
+            Assert.Contains("unstamped-accepted=True", result.Stdout, StringComparison.Ordinal);
+
+            Assert.Contains("matches=True", result.Stdout, StringComparison.Ordinal);
+            Assert.Contains("mismatch=False", result.Stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
     [Fact]
     [Trait("Category", "Integration")]
     [Trait("Feature", "PluginBootstrap")]
@@ -1291,11 +1682,15 @@ public sealed class PluginBootstrapBuildTests
                 [Parameter(Mandatory = $true)]
                 [string]$Mode,
 
-                [switch]$QuietMode
+                [switch]$QuietMode,
+
+                [switch]$ForceMode
             )
 
             $ErrorActionPreference = "Stop"
             Set-StrictMode -Version Latest
+
+            Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
 
             $callDir = Join-Path $env:USERPROFILE "mock-calls"
             New-Item -ItemType Directory -Path $callDir -Force | Out-Null
@@ -1315,6 +1710,11 @@ public sealed class PluginBootstrapBuildTests
                 )
 
                 Add-MockCall -Name "rest"
+
+                if ($null -ne $Headers) {
+                    $headerLines = foreach ($key in ($Headers.Keys | Sort-Object)) { "$key=$($Headers[$key])" }
+                    Set-Content -Path (Join-Path $callDir "rest-headers.txt") -Value $headerLines -Encoding UTF8
+                }
 
                 switch ($Mode) {
                     "api-fail" {
@@ -1362,7 +1762,27 @@ public sealed class PluginBootstrapBuildTests
                 }
 
                 New-Item -ItemType Directory -Path (Split-Path -Parent $OutFile) -Force | Out-Null
-                Set-Content -Path $OutFile -Value "fake zip payload" -Encoding UTF8
+
+                if ($Mode -eq "corrupt-download") {
+                    # A truncated transfer: the file exists but is not a readable archive.
+                    Set-Content -Path $OutFile -Value "not a zip" -Encoding UTF8
+                    return
+                }
+
+                # A real archive, so that the bootstrap's integrity validation is exercised for
+                # what it is rather than being satisfied by an arbitrary placeholder file.
+                $stagingDir = Join-Path ([System.IO.Path]::GetTempPath()) ([Guid]::NewGuid().ToString("N"))
+                New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
+                try {
+                    Set-Content -Path (Join-Path $stagingDir $ExecutableName) -Value "fake runtime" -Encoding UTF8
+                    if (Test-Path $OutFile) {
+                        Remove-Item -Path $OutFile -Force
+                    }
+
+                    [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDir, $OutFile)
+                } finally {
+                    Remove-Item -Path $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
+                }
             }
 
             function Expand-Archive {
@@ -1374,6 +1794,18 @@ public sealed class PluginBootstrapBuildTests
 
                 Add-MockCall -Name "expand"
 
+                # Faithful to the real cmdlet: extraction of an unreadable archive fails. Without
+                # this the mock would happily "extract" a truncated download and hide exactly the
+                # corruption handling these tests exist to cover.
+                $probe = $null
+                try {
+                    $probe = [System.IO.Compression.ZipFile]::OpenRead($Path)
+                } catch {
+                    throw "Simulated extraction failure: '$Path' is not a readable archive."
+                } finally {
+                    if ($null -ne $probe) { $probe.Dispose() }
+                }
+
                 New-Item -ItemType Directory -Path $DestinationPath -Force | Out-Null
                 if ($Mode -eq "missing-binary-after-extract") {
                     Set-Content -Path (Join-Path $DestinationPath "README.txt") -Value "no runtime" -Encoding UTF8
@@ -1384,11 +1816,11 @@ public sealed class PluginBootstrapBuildTests
             }
 
             $env:OS = "Windows_NT"
-            if ($QuietMode) {
-                & $ScriptPath -PassThru -Quiet
-            } else {
-                & $ScriptPath -PassThru
-            }
+            $scriptArgs = @{ PassThru = $true }
+            if ($QuietMode) { $scriptArgs["Quiet"] = $true }
+            if ($ForceMode) { $scriptArgs["Force"] = $true }
+
+            & $ScriptPath @scriptArgs
             """);
 
         return harnessPath;
@@ -1461,6 +1893,14 @@ public sealed class PluginBootstrapBuildTests
         startInfo.ArgumentList.Add("Bypass");
         startInfo.ArgumentList.Add("-Command");
         startInfo.ArgumentList.Add(commandText);
+
+        // The bootstrap reads ambient environment. Scrub the variables it consults so that a
+        // developer machine or CI runner which happens to define them cannot silently change
+        // what these tests exercise; callers opt back in by passing them explicitly.
+        foreach (var ambientName in new[] { "COPILOT_AGENT_SESSION_ID", "GITHUB_TOKEN", "GH_TOKEN" })
+        {
+            startInfo.Environment.Remove(ambientName);
+        }
 
         if (environmentVariables != null)
         {


### PR DESCRIPTION
> **Stacked on #779** — base is `sbroenne-plugin-bootstrap-p0-fixes`. Review after that merges; the diff shown against `main` will include #779's commit until then.
>
> CI reports no checks here because `ci.yml` only triggers on pull requests targeting `main`. Checks will run once #779 merges and this retargets. It was validated locally: 51/51 `SkillGeneration` tests plus the full pre-commit gate.

Follow-up to #779, which made the bootstrap survive an unreachable release API. This addresses the remaining robustness findings from the plugin evaluation. Six independent failure modes, each reproduced against the real cache before being fixed.

## 1. A truncated archive wedged the plugin permanently

`-not (Test-Path $downloadZipPath)` tested presence, not integrity. With a partial archive on disk and no extracted runtime, `downloadRequired` was `false` (the file exists and the tag matches), so nothing was re-downloaded — and extraction then failed. State was never updated, so **every subsequent run repeated the same failure**. The only recovery was manually deleting the cache or passing `-Force`.

- The archive is now opened and validated before it is trusted.
- Downloads land in a `.part` file that is renamed into place, so an interrupted transfer cannot leave something a later run mistakes for a complete download.
- A failed install retries once with a fresh download rather than failing permanently.

## 2. Extraction destroyed a working install

The old code deleted the release directory before extracting. `Remove-Item -Recurse` removes every sibling file before it reaches the locked `.exe` and *then* fails — so an upgrade attempted while the runtime was running deleted `LICENSE` and friends and left a broken install behind. I reproduced this during the evaluation.

- Extraction now stages into a scratch directory and swaps it into place.
- The executable is probed for a lock **before** anything is removed. A runtime that is currently in use is kept as-is rather than half-overwritten, and the release tag is deliberately *not* recorded in that case so the next run retries.

## 3. Concurrent sessions raced

Two bootstraps could write the same archive path and release directory simultaneously. Installs are now serialized with a named mutex. `Local\` rather than `Global\` deliberately: creating a global kernel object requires `SeCreateGlobalPrivilege`, which standard users do not hold, and the cache is per-user anyway.

## 4. Unauthenticated release lookups

Unauthenticated GitHub API access is 60 requests/hour **per source IP**. Behind a corporate NAT that budget is shared by everyone on the network and is routinely exhausted — which is the most common reason the release metadata is unreachable in the first place, i.e. the direct trigger for the bug #779 fixed. `GITHUB_TOKEN` / `GH_TOKEN` are now sent as a bearer token when present.

## 5. Standalone installs never updated

`$SessionId` falls back to the constant `"standalone"` when `COPILOT_AGENT_SESSION_ID` is unset — the PATH/shim case. After the first run, `checkedSessionId` was `"standalone"`, which always equals itself, so the freshness check never fired again. **PATH and shim installs were pinned forever to whatever they first downloaded**, despite the documentation promising the newest runtime. Those now re-check on a 24-hour window.

## 6. The resolved runtime's version was never verified

`bootstrap-state.json` was trusted blindly. The resolved binary's version is now checked against the expected release.

Read from the version stamped into the file, **not** by running `excelcli --version` — that prints an ASCII-art banner that would need regex-scraping, and it performs its own network update check, which is precisely wrong inside a bootstrap whose entire purpose here is to work offline. `(Get-Item $exe).VersionInfo.ProductVersion` is instant, offline-safe, and needs no subprocess.

The check is strict on the fast path (so upgrades are not skipped) but lenient in the offline degradation path, where an older working runtime beats no runtime at all. Missing version metadata is likewise accepted rather than rejected.

## Testing

Nine new tests, and **each was mutation-verified**: I broke the corresponding fix and confirmed the test fails, then restored it. All five mutations killed their tests.

Two harness problems surfaced and were fixed, both of which affected the credibility of the *existing* tests too:

- The mock `Invoke-WebRequest` wrote a placeholder text file, and the mock `Expand-Archive` ignored its input entirely — so no test could ever have exercised archive corruption. The mock now builds real archives and fails on unreadable ones.
- `ProcessStartInfo.Environment` inherits the parent environment, so ambient `COPILOT_AGENT_SESSION_ID` / `GITHUB_TOKEN` on the developer machine leaked into the tests. This was not hypothetical — my first run of the new token test failed because the host already had a `GITHUB_TOKEN`. The harness now scrubs those variables so callers must opt in explicitly.

One real regression was caught this way: the post-lock double-check initially reused `state.binaryPath`, which still points at the *previous* release mid-upgrade, so upgrades silently resolved to the old binary. It now looks only inside the target release directory.

Beyond the mocked suite, I verified against the live release infrastructure using a 246 MB copy of the real cache:

- Offline (blackholed proxy) with a warm cache → exit 0, degrades with a stderr warning.
- Online → performed a genuine **1.10.7 → 1.10.8 upgrade**, no staging or `.part` leftovers.
- Corrupted the current release archive and deleted its runtime → re-downloaded 71.7 MB, reinstalled, and the resulting `excelcli.exe` runs.
- Resolved binary reports `1.10.8+3a7abdc9…`, matching the expected version after build-metadata stripping.

`dotnet test tests/ExcelMcp.SkillGeneration.Tests` — 51/51 green. Full pre-commit gate passed.

## Deliberately not included

- **Version pinning / compatibility range.** A v1.10.x plugin will still pull a future v2.x with breaking tool schemas. That needs a policy decision about which runtime versions a given plugin version accepts, not just code.
- **Checksum publication.** There is no `.sha256` next to the release assets today, so there is nothing to verify against. That is a release-pipeline change and warrants its own PR.
- **Deduplicating the two `download.ps1` copies.** They remain byte-identical modulo plugin-specific tokens, enforced by the existing parity test.
