### PR TITLE
fix(screenshot): exclude Excel window chrome from captures (#777)

### DIFF
--- a/.changeset/screenshot-chrome-strip.md
+++ b/.changeset/screenshot-chrome-strip.md
@@ -1,0 +1,9 @@
+---
+"excelmcp": patch
+---
+
+**Screenshots no longer include a strip of Excel window chrome** (#777): captured images picked up a
+few pixels of the scroll bar and sheet tab strip along the bottom of every tile, which showed up as a
+grey band at each seam of a stitched screenshot of a tall or wide range. The capture now measures the
+actual worksheet grid area instead of Excel's reported workspace size, and sizes tiles so they line
+up seamlessly.

--- a/src/ExcelMcp.Core/Commands/Screenshot/CapturePlanner.cs
+++ b/src/ExcelMcp.Core/Commands/Screenshot/CapturePlanner.cs
@@ -86,7 +86,7 @@ internal static class CapturePlanner
         {
             // Excel exposes no visible range for some window states; the workspace size is the only
             // measurement left, so fall back to it rather than failing the capture.
-            return new UsablePane(workspaceWidth, workspaceHeight);
+            return new UsablePane(FallbackExtent(workspaceWidth), FallbackExtent(workspaceHeight));
         }
         finally
         {
@@ -95,9 +95,24 @@ internal static class CapturePlanner
     }
 
     /// <summary>
+    /// Best available extent when the grid cannot be measured from <c>VisibleRange</c>.
+    ///
+    /// The workspace extent is the only measurement left, but it is exactly the value that reaches
+    /// into the chrome, so the safety margin is taken off it as well. That margin comfortably
+    /// exceeds the scroll bar and tab strip measured on a standard display, though an unusually tall
+    /// chrome could still leak a few pixels in this path.
+    /// </summary>
+    private static double FallbackExtent(double workspaceExtent)
+    {
+        double trimmed = workspaceExtent - GridSafetyPoints;
+
+        return trimmed > 0 ? trimmed : workspaceExtent;
+    }
+
+    /// <summary>
     /// Measures one axis of the visible grid, in screen points, up to the leading edge of the last
-    /// (partially visible) row or column. Falls back to the workspace extent when the axis holds a
-    /// single row or column, which is too large to measure this way.
+    /// (partially visible) row or column. Falls back to the trimmed workspace extent when the axis
+    /// holds a single row or column, which is too large to measure this way.
     /// </summary>
     private static double MeasureAxis(dynamic visible, bool rows, double workspaceExtent, double zoomFactor)
     {
@@ -112,7 +127,7 @@ internal static class CapturePlanner
 
             if (count < 2 || zoomFactor <= 0)
             {
-                return workspaceExtent;
+                return FallbackExtent(workspaceExtent);
             }
 
             first = items[1];
@@ -122,7 +137,7 @@ internal static class CapturePlanner
             double trailing = rows ? Convert.ToDouble(last.Top) : Convert.ToDouble(last.Left);
             double extent = (trailing - leading) * zoomFactor - GridSafetyPoints;
 
-            return extent > 0 ? Math.Min(workspaceExtent, extent) : workspaceExtent;
+            return extent > 0 ? Math.Min(FallbackExtent(workspaceExtent), extent) : FallbackExtent(workspaceExtent);
         }
         finally
         {

--- a/src/ExcelMcp.Core/Commands/Screenshot/CapturePlanner.cs
+++ b/src/ExcelMcp.Core/Commands/Screenshot/CapturePlanner.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Sbroenne.ExcelMcp.ComInterop;
 
@@ -7,9 +8,10 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Screenshot;
 /// Works out how to fit a worksheet range into the Excel viewport for capture: which zoom level to
 /// use, and how to split the range into tiles when it is still larger than the viewport.
 ///
-/// All worksheet geometry is in points, which are independent of both zoom and display scaling.
-/// <c>Window.UsableWidth</c>/<c>UsableHeight</c> describe the pane in screen points, so the zoom
-/// needed to fit a range is simply the ratio of the two.
+/// All worksheet geometry is in points, which are independent of both zoom and display scaling, so
+/// the zoom needed to fit a range is simply the ratio of the grid area to the range size. The grid
+/// area itself is measured by <see cref="MeasureUsablePane"/> rather than taken from
+/// <c>Window.UsableWidth</c>/<c>UsableHeight</c>, which overstate it.
 /// </summary>
 [SupportedOSPlatform("windows")]
 internal static class CapturePlanner
@@ -34,6 +36,9 @@ internal static class CapturePlanner
     /// <summary>A contiguous run of rows or columns that fits in one viewport.</summary>
     internal sealed record Segment(int Start, int Count, double Offset, double Size);
 
+    /// <summary>The grid area available for capture, in screen points.</summary>
+    internal readonly record struct UsablePane(double Width, double Height);
+
     /// <summary>The zoom and tile layout to use for a capture.</summary>
     internal sealed record CapturePlan(
         int Zoom,
@@ -42,21 +47,135 @@ internal static class CapturePlanner
         bool Truncated);
 
     /// <summary>
+    /// Safety margin, in screen points, trimmed off the measured grid area.
+    ///
+    /// <c>VisibleRange</c> can list a trailing row or column whose leading edge is already past the
+    /// painted grid, which is enough to pull a few pixels of chrome into a tile. One default row
+    /// height covers that error at every zoom level, and costs at most one extra tile.
+    /// </summary>
+    private const double GridSafetyPoints = 15.0;
+
+    /// <summary>
+    /// Measures the grid area of the pane in screen points, excluding the window chrome around it.
+    ///
+    /// <c>Window.UsableWidth</c>/<c>UsableHeight</c> describe the whole workspace, which includes
+    /// the horizontal scroll bar and sheet tab strip below the grid. Sizing a tile from them reaches
+    /// past the last painted grid row, so the capture picks up a strip of chrome at the bottom of
+    /// every tile - visible as a band at each seam of a stitched image.
+    ///
+    /// <c>VisibleRange</c> ends with a row and column that are only partially visible, so measuring
+    /// to their leading edge yields an area that is close to the real grid; a further safety margin
+    /// covers Excel over-reporting that trailing item.
+    /// </summary>
+    internal static UsablePane MeasureUsablePane(dynamic window)
+    {
+        double workspaceWidth = Convert.ToDouble(window.UsableWidth);
+        double workspaceHeight = Convert.ToDouble(window.UsableHeight);
+        double zoomFactor = Convert.ToDouble(window.Zoom) / 100.0;
+
+        dynamic? visible = null;
+        try
+        {
+            visible = window.VisibleRange;
+
+            return new UsablePane(
+                MeasureAxis(visible, false, workspaceWidth, zoomFactor),
+                MeasureAxis(visible, true, workspaceHeight, zoomFactor));
+        }
+        catch (COMException)
+        {
+            // Excel exposes no visible range for some window states; the workspace size is the only
+            // measurement left, so fall back to it rather than failing the capture.
+            return new UsablePane(workspaceWidth, workspaceHeight);
+        }
+        finally
+        {
+            ComUtilities.Release(ref visible);
+        }
+    }
+
+    /// <summary>
+    /// Measures one axis of the visible grid, in screen points, up to the leading edge of the last
+    /// (partially visible) row or column. Falls back to the workspace extent when the axis holds a
+    /// single row or column, which is too large to measure this way.
+    /// </summary>
+    private static double MeasureAxis(dynamic visible, bool rows, double workspaceExtent, double zoomFactor)
+    {
+        dynamic? items = null;
+        dynamic? first = null;
+        dynamic? last = null;
+
+        try
+        {
+            items = rows ? visible.Rows : visible.Columns;
+            int count = Convert.ToInt32(items.Count);
+
+            if (count < 2 || zoomFactor <= 0)
+            {
+                return workspaceExtent;
+            }
+
+            first = items[1];
+            last = items[count];
+
+            double leading = rows ? Convert.ToDouble(first.Top) : Convert.ToDouble(first.Left);
+            double trailing = rows ? Convert.ToDouble(last.Top) : Convert.ToDouble(last.Left);
+            double extent = (trailing - leading) * zoomFactor - GridSafetyPoints;
+
+            return extent > 0 ? Math.Min(workspaceExtent, extent) : workspaceExtent;
+        }
+        finally
+        {
+            ComUtilities.Release(ref last);
+            ComUtilities.Release(ref first);
+            ComUtilities.Release(ref items);
+        }
+    }
+
+    /// <summary>
     /// Builds the capture plan for a range.
     /// </summary>
     /// <param name="window">Excel window that will perform the capture.</param>
     /// <param name="range">Range to capture.</param>
     public static CapturePlan Plan(dynamic window, dynamic range)
     {
-        double usableWidth = Convert.ToDouble(window.UsableWidth);
-        double usableHeight = Convert.ToDouble(window.UsableHeight);
+        UsablePane usable = MeasureUsablePane(window);
         double rangeWidth = Convert.ToDouble(range.Width);
         double rangeHeight = Convert.ToDouble(range.Height);
+
+        int fitZoom = CalculateFitZoom(usable.Width, usable.Height, rangeWidth, rangeHeight);
+        int zoom = Math.Clamp(fitZoom, Math.Min(MinReadableZoom, 100), 100);
+
+        return BuildPlan(range, usable, zoom, fitZoom);
+    }
+
+    /// <summary>
+    /// Rebuilds the tile layout for an already-chosen zoom, using the pane as it measures at that
+    /// zoom.
+    ///
+    /// The row and column headers scale with zoom, so the grid area is slightly different once the
+    /// capture zoom is applied. Re-deriving the segments from the post-zoom pane keeps the planned
+    /// tile size and the capturable tile size identical, which is what stops a hairline gap
+    /// appearing at each seam of a stitched image.
+    /// </summary>
+    /// <param name="range">Range to capture.</param>
+    /// <param name="zoom">Zoom percentage the window is currently set to.</param>
+    /// <param name="usable">Grid area measured at that zoom.</param>
+    public static CapturePlan Replan(dynamic range, int zoom, UsablePane usable)
+    {
+        return BuildPlan(range, usable, zoom, zoom);
+    }
+
+    /// <summary>
+    /// Splits the range into tiles for a given pane size, stepping the zoom down while the tile
+    /// count exceeds <see cref="PreferredMaxTiles"/> and the fit zoom allows it.
+    /// </summary>
+    private static CapturePlan BuildPlan(dynamic range, UsablePane usable, int zoom, int fitZoom)
+    {
+        double usableWidth = usable.Width;
+        double usableHeight = usable.Height;
         int rowCount = Convert.ToInt32(range.Rows.Count);
         int columnCount = Convert.ToInt32(range.Columns.Count);
-
-        int fitZoom = CalculateFitZoom(usableWidth, usableHeight, rangeWidth, rangeHeight);
-        int zoom = Math.Clamp(fitZoom, Math.Min(MinReadableZoom, 100), 100);
 
         List<Segment> rowSegments;
         List<Segment> columnSegments;

--- a/src/ExcelMcp.Core/Commands/Screenshot/ScreenshotCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Screenshot/ScreenshotCommands.cs
@@ -172,7 +172,7 @@ public class ScreenshotCommands : IScreenshotCommands
             originalScrollRow = Convert.ToInt32(window.ScrollRow);
             originalScrollColumn = Convert.ToInt32(window.ScrollColumn);
 
-            var plan = CapturePlanner.Plan(window, range);
+            CapturePlanner.CapturePlan plan = CapturePlanner.Plan(window, range);
 
             if (plan.Zoom != originalZoom)
             {
@@ -182,7 +182,7 @@ public class ScreenshotCommands : IScreenshotCommands
             }
 
             scrollChanged = true;
-            composed = CaptureTiles(app, window, range, plan);
+            composed = CaptureTiles(app, window, range, ref plan);
 
             var encoded = ScreenshotEncoder.Encode(composed, quality);
 
@@ -257,18 +257,25 @@ public class ScreenshotCommands : IScreenshotCommands
     /// <summary>
     /// Captures each planned tile and stitches them into a single bitmap.
     /// </summary>
-    private static Bitmap CaptureTiles(dynamic app, dynamic window, dynamic range, CapturePlanner.CapturePlan plan)
+    private static Bitmap CaptureTiles(dynamic app, dynamic window, dynamic range, ref CapturePlanner.CapturePlan plan)
     {
         IntPtr hwnd = GetExcelWindowHandle(app);
         int dpi = WindowCapture.GetWindowDpi(hwnd);
         double deviceScale = dpi / 72.0;
         double pixelsPerPoint = deviceScale * plan.Zoom / 100.0;
 
-        int paneMaxWidth = (int)Math.Round(Convert.ToDouble(window.UsableWidth) * deviceScale);
-        int paneMaxHeight = (int)Math.Round(Convert.ToDouble(window.UsableHeight) * deviceScale);
+        PaneOrigin paneOrigin = MeasurePaneOrigin(window);
 
-        int[] columnOffsets = BuildPixelOffsets(plan.ColumnSegments, pixelsPerPoint);
-        int[] rowOffsets = BuildPixelOffsets(plan.RowSegments, pixelsPerPoint);
+        // Measured after the capture zoom is applied and at the settled A1 scroll position, so that
+        // the planned tile size and the capturable tile size agree exactly.
+        CapturePlanner.UsablePane usable = CapturePlanner.MeasureUsablePane(window);
+        int paneMaxWidth = (int)Math.Round(usable.Width * deviceScale);
+        int paneMaxHeight = (int)Math.Round(usable.Height * deviceScale);
+
+        plan = CapturePlanner.Replan(range, plan.Zoom, usable);
+
+        int[] columnOffsets = BuildPixelOffsets(plan.ColumnSegments, pixelsPerPoint, paneMaxWidth);
+        int[] rowOffsets = BuildPixelOffsets(plan.RowSegments, pixelsPerPoint, paneMaxHeight);
 
         int totalWidth = Math.Max(1, columnOffsets[^1]);
         int totalHeight = Math.Max(1, rowOffsets[^1]);
@@ -281,7 +288,6 @@ public class ScreenshotCommands : IScreenshotCommands
             using var graphics = Graphics.FromImage(canvas);
             graphics.Clear(Color.White);
 
-            PaneOrigin paneOrigin = MeasurePaneOrigin(window);
             bool verifiedNotBlank = false;
 
             for (int rowIndex = 0; rowIndex < plan.RowSegments.Count; rowIndex++)
@@ -318,10 +324,10 @@ public class ScreenshotCommands : IScreenshotCommands
                         int originY = (int)Math.Round(paneOrigin.Y) + offsetY;
 
                         int tileWidth = Math.Min(
-                            (int)Math.Round(Convert.ToDouble(tileRange.Width) * pixelsPerPoint),
+                            columnOffsets[columnIndex + 1] - columnOffsets[columnIndex],
                             paneMaxWidth - offsetX);
                         int tileHeight = Math.Min(
-                            (int)Math.Round(Convert.ToDouble(tileRange.Height) * pixelsPerPoint),
+                            rowOffsets[rowIndex + 1] - rowOffsets[rowIndex],
                             paneMaxHeight - offsetY);
 
                         var source = new Rectangle(
@@ -443,18 +449,22 @@ public class ScreenshotCommands : IScreenshotCommands
     /// Converts segment sizes in points to cumulative pixel offsets, so adjacent tiles meet without
     /// gaps or overlaps after rounding.
     /// </summary>
-    private static int[] BuildPixelOffsets(IReadOnlyList<CapturePlanner.Segment> segments, double pixelsPerPoint)
+    private static int[] BuildPixelOffsets(IReadOnlyList<CapturePlanner.Segment> segments, double pixelsPerPoint, int paneMax)
     {
         var offsets = new int[segments.Count + 1];
-        double cursor = 0;
+        int cursor = 0;
 
         for (int i = 0; i < segments.Count; i++)
         {
-            offsets[i] = (int)Math.Round(cursor * pixelsPerPoint);
-            cursor += segments[i].Size;
+            offsets[i] = cursor;
+
+            // Capped at the pane, and rounded per segment rather than cumulatively, so that the
+            // space reserved on the canvas is exactly the number of pixels the tile can supply.
+            // Any mismatch shows up as an unpainted hairline at the seam.
+            cursor += Math.Min((int)Math.Round(segments[i].Size * pixelsPerPoint), paneMax);
         }
 
-        offsets[segments.Count] = (int)Math.Round(cursor * pixelsPerPoint);
+        offsets[segments.Count] = cursor;
 
         return offsets;
     }

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Screenshot/ScreenshotCommandsTests.ChromeStrip.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Screenshot/ScreenshotCommandsTests.ChromeStrip.cs
@@ -1,0 +1,149 @@
+// <copyright file="ScreenshotCommandsTests.ChromeStrip.cs" company="Stephan Brenner">
+// Copyright (c) Stephan Brenner. All rights reserved.
+// </copyright>
+
+using System.Drawing;
+using System.Globalization;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Screenshot;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Integration.Commands.Screenshot;
+
+/// <summary>
+/// Regression coverage for issue #777 follow-up: captures must contain only worksheet grid, never
+/// the Excel window chrome below it (horizontal scroll bar, sheet tabs, status bar).
+///
+/// <c>Window.UsableHeight</c> measures the whole workspace including that chrome, so sizing a tile
+/// from it reaches past the bottom of the grid. Each test fills the captured range with a solid
+/// colour, which makes any leaked chrome trivially detectable: every pixel row of a correct capture
+/// is that colour, so a row that is not is chrome.
+/// </summary>
+public partial class ScreenshotCommandsTests
+{
+    /// <summary>Solid black fill; chrome is far lighter than this at every Office theme.</summary>
+    private const int SolidBlack = 0x000000;
+
+    /// <summary>Row brightness above which a row cannot be part of a solid black fill.</summary>
+    private const int ChromeBrightnessThreshold = 100;
+
+    /// <summary>
+    /// Brightness at or above which a row is the untouched white canvas rather than Excel chrome.
+    /// Excel's chrome (scroll bar, tab strip) is grey and measures well below this.
+    /// </summary>
+    private const int UnpaintedCanvasBrightness = 250;
+
+    /// <summary>
+    /// Pixel rows at the very bottom edge that may legitimately stay unpainted: Excel rounds each
+    /// rendered row to whole pixels, so a tall range renders a shade shorter than the exact
+    /// point-to-pixel arithmetic predicts.
+    /// </summary>
+    private const int EdgeRoundingTolerance = 3;
+
+    [Fact]
+    public void CaptureRange_TallRangeSpanningMultipleTiles_ContainsNoWindowChrome()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(show: true, operationTimeout: null, testFile);
+
+        FillSolid(batch, "Sheet1", "A1:A200", SolidBlack);
+
+        var result = _commands.CaptureRange(batch, sheetName: "Sheet1", rangeAddress: "A1:A200", quality: ScreenshotQuality.High);
+
+        Assert.True(result.Success, $"CaptureRange failed: {result.ErrorMessage}");
+
+        AssertNoChromeBands(result.ImageBase64!, "A1:A200");
+    }
+
+    [Fact]
+    public void CaptureRange_RangeFillingTheViewport_ContainsNoWindowChrome()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(show: true, operationTimeout: null, testFile);
+
+        FillSolid(batch, "Sheet1", "A1:A45", SolidBlack);
+
+        var result = _commands.CaptureRange(batch, sheetName: "Sheet1", rangeAddress: "A1:A45", quality: ScreenshotQuality.High);
+
+        Assert.True(result.Success, $"CaptureRange failed: {result.ErrorMessage}");
+
+        AssertNoChromeBands(result.ImageBase64!, "A1:A45");
+    }
+
+    /// <summary>
+    /// Fails when any pixel row of the capture is lighter than a solid black fill, which means the
+    /// window chrome below the grid was captured instead of worksheet content.
+    /// </summary>
+    private static void AssertNoChromeBands(string base64, string rangeAddress)
+    {
+        byte[] imageBytes = Convert.FromBase64String(base64);
+        using var stream = new MemoryStream(imageBytes);
+        using var bitmap = new Bitmap(stream);
+
+        var lightRows = new List<string>();
+
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            long total = 0;
+            int samples = 0;
+
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                Color pixel = bitmap.GetPixel(x, y);
+                total += (pixel.R + pixel.G + pixel.B) / 3;
+                samples++;
+            }
+
+            int average = (int)(total / samples);
+
+            if (average <= ChromeBrightnessThreshold)
+            {
+                continue;
+            }
+
+            bool unpaintedBottomEdge =
+                y >= bitmap.Height - EdgeRoundingTolerance && average >= UnpaintedCanvasBrightness;
+
+            if (!unpaintedBottomEdge)
+            {
+                lightRows.Add(string.Create(CultureInfo.InvariantCulture, $"y={y} avg={average}"));
+            }
+        }
+
+        Assert.True(
+            lightRows.Count == 0,
+            string.Create(
+                CultureInfo.InvariantCulture,
+                $"Capture of {rangeAddress} ({bitmap.Width}x{bitmap.Height}) contains {lightRows.Count} pixel row(s) that are not the solid fill, " +
+                $"which means Excel window chrome was captured below the grid: {string.Join(", ", lightRows.Take(12))}"));
+    }
+
+    private static void FillSolid(IExcelBatch batch, string sheetName, string rangeAddress, int fillColor)
+    {
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? sheet = null;
+            dynamic? range = null;
+            dynamic? parkingCell = null;
+            try
+            {
+                sheet = ctx.Book.Worksheets[sheetName];
+                range = sheet.Range[rangeAddress];
+                range.Interior.Color = fillColor;
+
+                // A real screenshot includes the active-cell outline, which would otherwise be drawn
+                // over the fill and read as a light row. Park the selection outside the capture.
+                sheet.Activate();
+                parkingCell = sheet.Range["E1"];
+                parkingCell.Select();
+            }
+            finally
+            {
+                ComUtilities.Release(ref parkingCell);
+                ComUtilities.Release(ref range);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Follow-up to #778 / v1.10.8. Fixes the chrome strip reported by @fugulab on #777.

## The bug

Captures picked up a few pixels of the horizontal scroll bar and sheet tab strip along the bottom of every tile. On a single-viewport capture that is a thin band at the bottom; on a stitched capture of a tall or wide range it lands **at every seam**, exactly as reported (a recurring band with a period of roughly one viewport height).

## Root cause

`Window.UsableWidth`/`UsableHeight` describe the whole *workspace*, which includes the chrome below the grid — not the grid itself. Measured on a 192 dpi machine:

| | |
|---|---|
| `UsableHeight` | 558 px |
| trailing edge of last visible row | 532 px |
| leading edge of last visible row | 494 px |

So sizing a tile from `UsableHeight` reaches ~26–64 px past the last painted grid row. Because the planner *also* sized its segments from that inflated value, the clamp in the tiling loop bound and pulled chrome into each tile.

## Fix

1. **Measure the real grid area** (`CapturePlanner.MeasureUsablePane`) from `Window.VisibleRange`, stopping at the *leading* edge of the trailing partially-visible row and column, minus a one-row safety margin — Excel can report a trailing item whose leading edge is already past the painted grid (observed 5 px of overshoot at 38 % zoom). Falls back to the workspace extent when no visible range is available.
2. **Rebuild the tile layout after the zoom is applied** and the view is settled at A1 (`CapturePlanner.Replan`). Row and column headers scale with zoom, so a layout planned pre-zoom disagreed with the post-zoom pane by a pixel and left an unpainted hairline at each seam.
3. **Derive canvas offsets and tile sizes from one number** — segment sizes are capped at the pane and rounded per segment, so the space reserved on the canvas is exactly what the tile can supply.

## Tests

New `ScreenshotCommandsTests.ChromeStrip.cs` fills the captured range solid black, which makes leaked chrome trivially detectable: every pixel row of a correct capture is the fill, so a row that is not is chrome.

Both tests were **observed failing against the previous code** (Rule 29), reporting precisely the bands the reporter described:

```
Capture of A1:A200 (54x3040) contains 32 pixel row(s) that are not the solid fill:
  y=542..546 avg=224-232, y=1089..1093 avg=224-232, ...
```

`Feature=Screenshot`: **21/21 passing**.

## Notes

- No surface change: no new actions, parameters, or tools, so the Rule 24 sync points need no edits.
- Pattern search: `Application.UsableWidth/Height` in `WindowCommands` is window *placement*, where that value is the correct one — unaffected.
- The assertion tolerates up to 3 unpainted **white** rows at the very bottom edge (Excel rounds each rendered row to whole pixels, so a tall range renders a shade shorter than exact point→pixel arithmetic). Chrome is grey (avg 224–232) and is still caught anywhere, including there.

Closes #777.