### PR TITLE
feat!: unify CLI and MCP automation contracts

### DIFF
--- a/.changeset/canonical-file-lifecycle.md
+++ b/.changeset/canonical-file-lifecycle.md
@@ -1,0 +1,10 @@
+---
+"excelmcp": major
+---
+
+**Canonical file lifecycle** (#798, #799): CLI and MCP now expose the same
+list/open/create/close/test workflow. Standalone CLI save and the MCP
+`close-workbook` no-op are removed; file testing shares one result model with
+openability and deterministic IRM/AIP read-only requirements. IRM detection now
+requires the rights-management data-space marker, so ordinary password-encrypted
+OOXML files are not incorrectly forced into read-only mode.

--- a/.changeset/canonical-public-inputs.md
+++ b/.changeset/canonical-public-inputs.md
@@ -1,0 +1,8 @@
+---
+"excelmcp": patch
+---
+
+**Canonical public inputs** (#782, #783, #784, #801): CLI, batch JSON, and MCP
+now use integer seconds for timeouts, validate the same supported ranges, and
+resolve inline-or-file content aliases once at shared dispatch. Manual session
+open/create now enforces its documented 10-3600 second operation timeout.

--- a/.changeset/compact-truthful-power-query-reads.md
+++ b/.changeset/compact-truthful-power-query-reads.md
@@ -1,0 +1,10 @@
+---
+"excelmcp": major
+---
+
+**Compact, truthful Power Query reads** (#787, #800): `powerquery list` now
+returns bounded M previews and exact worksheet/Data Model load state without
+serializing full formulas. Use `powerquery view` for full M code. List inspection
+errors now fail explicitly instead of silently omitting queries. The public
+`PowerQueryInfo.Formula` getter and setter remain available for source and binary
+compatibility, but are obsolete and excluded from list JSON.

--- a/.changeset/exact-power-query-identity.md
+++ b/.changeset/exact-power-query-identity.md
@@ -1,0 +1,13 @@
+---
+"excelmcp": patch
+---
+
+**Exact Power Query and connection cleanup** (#786, #796, #797): Power Query
+load detection, refresh, unload, delete, Data Model lookup, and evaluate cleanup
+now use exact case-insensitive mashup `Location` identity instead of substring or
+display-name matching. Connection delete/load-to removes only QueryTables owned
+by the exact WorkbookConnection, preserving similarly named and unrelated
+workbook objects. Queries loaded to both a worksheet and the Data Model now
+refresh both destinations instead of leaving model data stale. Evaluate removes
+Excel-generated `Connection`/`Connection1` artifacts before save and returns an
+actionable error if cleanup fails.

--- a/.changeset/safe-owned-process-cleanup.md
+++ b/.changeset/safe-owned-process-cleanup.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Safer CLI cleanup** (#789): builds and test workflows now stop only the CLI daemon and Excel processes owned by their selected pipe, preserving unrelated Excel sessions. Daemon lifecycle locks use disjoint, case-insensitive hashed pipe identities so case variants, suffixes, special characters, and long names cannot collide. When cleanup sources are newer than the installed build output, pre-build cleanup uses an isolated current client so the owned daemon cannot lock the rebuild.

--- a/.changeset/strict-generated-action-contracts.md
+++ b/.changeset/strict-generated-action-contracts.md
@@ -1,0 +1,9 @@
+---
+"excelmcp": patch
+---
+
+**Strict generated action contracts** (#781, #788): CLI direct commands, CLI batch,
+and MCP now reject unknown enum values and parameters that do not apply to the
+selected action. Power Query load destinations accept the documented
+`worksheet`, `data-model`, and `both` aliases without falling back to an
+unintended load mode.

--- a/.changeset/truthful-cli-daemon-status.md
+++ b/.changeset/truthful-cli-daemon-status.md
@@ -1,0 +1,11 @@
+---
+"excelmcp": patch
+---
+
+**Truthful CLI daemon status** (#785): `service status` now distinguishes
+stopped, running, and unresponsive daemons, while `session list` returns an empty
+list only for confirmed empty states. Both commands probe the configured service
+before consulting daemon mutex state, so externally hosted services remain
+visible. Shared control-command and startup readiness timeouts tolerate slow
+daemon startup without converting transport failures into successful stopped or
+empty results.

--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -64,7 +64,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## What You Can Do
 
-**31 feature command categories with 326 operations** for comprehensive Excel automation:
+**31 feature command categories with 325 operations** for comprehensive Excel automation:
 
 - **Power Query** (12 ops) — Create, update, refresh queries; M code management
 - **Data Model/DAX** (20 ops) — Measures, relationships, source metadata, EVALUATE queries

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -53,7 +53,7 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ## What You Can Do
 
-**31 specialized tools with 326 operations** for comprehensive Excel automation:
+**31 specialized tools with 325 operations** for comprehensive Excel automation:
 
 ### Core Operations
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,14 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
 
     <!-- Build settings -->
+    <!-- A stale CLI cannot stop its daemon before its normal output is replaced.
+         The cleanup script sets this to build a current client in a unique,
+         isolated tree without touching or sharing intermediate project files. -->
+    <BaseOutputPath Condition="'$(ExcelMcpCleanupRoot)' != ''">$(ExcelMcpCleanupRoot)\bin\$(MSBuildProjectName)\</BaseOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(ExcelMcpCleanupRoot)' != ''">$(ExcelMcpCleanupRoot)\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <MSBuildProjectExtensionsPath Condition="'$(ExcelMcpCleanupRoot)' != ''">$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
+    <DefaultItemExcludes Condition="'$(ExcelMcpCleanupRoot)' != ''">$(DefaultItemExcludes);$(MSBuildProjectDirectory)\bin\**;$(MSBuildProjectDirectory)\obj\**</DefaultItemExcludes>
+
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>14</LangVersion>
@@ -62,12 +70,17 @@
   </PropertyGroup>
 
   <!--
-    Pre-build cleanup: gracefully stop ExcelMCP Service and kill Excel processes.
-    Prevents file locking during build. Skipped in CI (no Excel/Service there).
+    Pre-build cleanup: before the CLI project replaces its output, ask the
+    current CLI cleanup implementation to stop only the daemon and Excel
+    processes tracked for the selected pipe. Restricting this target to the CLI
+    project prevents parallel solution builds from launching cleanup clients
+    that lock the CLI output.
+    Skipped in CI (no Excel/Service there).
   -->
-  <Target Name="StopExcelMcpProcesses" BeforeTargets="Build" Condition="'$(CI)' != 'true' AND '$(ExcelMcpSkipCleanup)' != 'true'">
+  <Target Name="StopExcelMcpProcesses"
+          BeforeTargets="BeforeBuild"
+          Condition="'$(MSBuildProjectName)' == 'ExcelMcp.CLI' AND '$(CI)' != 'true' AND '$(ExcelMcpSkipCleanup)' != 'true'">
     <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)scripts\Stop-ExcelMcpProcesses.ps1&quot;"
-          IgnoreExitCode="true"
           StandardOutputImportance="low" />
   </Target>
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # ExcelMcp - Complete Feature Reference
 
-**31 specialized tools with 326 operations for comprehensive Excel automation**
+**31 specialized tools with 325 operations for comprehensive Excel automation**
 
 Excel MCP Server automates the real Microsoft Excel application through four focused capability areas. Start with the category that matches your goal, or use the quick reference below.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ its official COM API. It can refresh Power Query, recalculate formulas, evaluate
 DAX, run VBA and Python `=PY()`, and preserve PivotTables, charts, macros, the
 Data Model, and workbook formatting.
 
-**31 tools with 326 operations** cover end-to-end Excel automation.
+**31 tools with 325 operations** cover end-to-end Excel automation.
 
 > [!IMPORTANT]
 > Requires **Windows**, **Microsoft Excel 2016 or later**, and an interactive
@@ -55,7 +55,7 @@ while automating them.
 - **[Automation & advanced](https://excelmcpserver.dev/features/automation-advanced/):**
   VBA, Python in Excel, Goal Seek, scenarios, data tables, windows, and XML Maps.
 
-Explore the [complete reference for all 326 operations](https://excelmcpserver.dev/features/).
+Explore the [complete reference for all 325 operations](https://excelmcpserver.dev/features/).
 
 ## See It in Action
 

--- a/docs/COM-API-BEHAVIOR-FINDINGS.md
+++ b/docs/COM-API-BEHAVIOR-FINDINGS.md
@@ -81,8 +81,10 @@ query.Formula = ModifiedQuery;  // Updates M code
   - **NO `IsConnectionOnly`, `LoadDestination`, or similar property exists**
 - "Connection-only" is the **ABSENCE** of load destinations (no ListObject, no Data Model connection)
 - To convert loaded query to connection-only:
-  1. Find and remove worksheet tables (ListObjects with matching QueryTable)
-  2. Find and remove Data Model connections (connections with "Query - {name}" pattern)
+  1. Parse the mashup connection properties once and remove worksheet tables whose
+     QueryTable has an exact case-insensitive `Location` match
+  2. Remove Data Model destinations by the same exact identity (or exact model-table
+     name where Excel exposes only a model connection)
   3. Keep the query in `Workbook.Queries` collection
   
 **Implication:** Connection-only must be implemented by removing ALL load destinations.
@@ -95,7 +97,7 @@ query.Formula = ModifiedQuery;  // Updates M code
 // Current Unload implementation (INCOMPLETE):
 foreach (ListObject in worksheet.ListObjects)
 {
-    if (QueryTable.Connection.Contains(queryName))
+    if (ParseMashupLocation(QueryTable.Connection).Equals(queryName, OrdinalIgnoreCase))
         listObject.Unlist();
 }
 // BUG: Never checks/removes Data Model connections!
@@ -115,14 +117,14 @@ foreach (ListObject in worksheet.ListObjects)
 // Step 1: Remove worksheet tables (existing behavior)
 foreach (ListObject in worksheet.ListObjects)
 {
-    if (QueryTable.Connection.Contains(queryName))
+    if (ParseMashupLocation(QueryTable.Connection).Equals(queryName, OrdinalIgnoreCase))
         listObject.Unlist();
 }
 
 // Step 2: Remove Data Model connections (MISSING!)
 foreach (Connection in workbook.Connections)
 {
-    if (connection.Name == $"Query - {queryName}")
+    if (ParseMashupLocation(connection.Connection).Equals(queryName, OrdinalIgnoreCase))
         connection.Delete();
 }
 
@@ -152,6 +154,25 @@ foreach (Connection in workbook.Connections)
 **Current Status:** Root cause unknown. The error appears to be related to internal Excel state that cannot be cleared programmatically via COM automation. Workaround: manually save and reopen the workbook in Excel UI.
 
 **See:** GitHub Issue #323
+
+---
+
+### Formula Getter Partial-Failure Fixture Investigation
+
+No deterministic real-Excel fixture could make an enumerable `WorkbookQuery`
+expose its `Name` while throwing `COMException` from the `Formula` getter.
+The investigation covered connection-only, worksheet, Data Model-only, combined,
+empty, whitespace, unexecuted invalid-M, structure-protected, deleted-reference,
+and legacy `.xls` query states. Enumerable queries remained readable through
+`Formula`; deleted queries were removed from the collection.
+The Data Model dirty state from Scenario 15 affects the `Formula` setter, not the
+getter. Excel's supported COM API also removes deleted queries from `Queries`
+rather than leaving an inspectable broken entry.
+
+**Decision:** `powerquery list` no longer catches a broad per-query
+`COMException`. An unexpected inspection failure now fails the operation instead
+of silently dropping a query. No partial-success warning contract was added
+because it could not be backed by a deterministic real-Excel regression fixture.
 
 ---
 

--- a/docs/COPILOT-PLUGIN-DISTRIBUTION.md
+++ b/docs/COPILOT-PLUGIN-DISTRIBUTION.md
@@ -6,7 +6,7 @@ This document outlines how the Excel MCP Server and Excel CLI are distributed as
 
 ExcelMcp is published as **two complementary plugins** in the GitHub Copilot plugin marketplace:
 
-- **`excel-mcp`** — MCP Server with 31 tools (326 operations) for conversational AI (Claude Desktop, Copilot chat)
+- **`excel-mcp`** — MCP Server with 31 tools (325 operations) for conversational AI (Claude Desktop, Copilot chat)
 - **`excel-cli`** — CLI-only skill for coding agents (token-efficient, `--help` discoverable)
 
 Both plugins are maintained in a separate published repository and auto-synced from this source repo.
@@ -67,7 +67,7 @@ copilot plugin install excel-cli@mcp-server-excel-plugins
 
 ### Excel MCP Plugin
 
-Provides the full MCP Server with 31 tools (326 operations) for conversational AI:
+Provides the full MCP Server with 31 tools (325 operations) for conversational AI:
 
 ```powershell
 copilot plugin install excel-mcp@mcp-server-excel-plugins

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -198,6 +198,23 @@ dotnet build -c Release
 # Code follows style guidelines (automatic via EditorConfig)
 ```
 
+Before the CLI project replaces its output, local builds call
+`scripts\Stop-ExcelMcpProcesses.ps1` once. The script delegates cleanup to
+`excelcli service stop`. Cleanup is scoped to `EXCELMCP_CLI_PIPE` and validates
+tracked PID start times. Excel identities remain recorded for their daemon
+generation through shutdown, so a failed final Excel exit cannot lose ownership
+metadata. Daemon, startup, and tracker mutexes use separate semantic namespaces
+over a case-insensitive SHA-256 pipe identity, so case variants, suffixes,
+separators, special characters, and long pipe names cannot collide across
+pipes or mutex roles. If the normal
+CLI binary predates ownership-lifecycle sources, the
+script first builds a current cleanup client in an isolated temporary output;
+this stops the tracked daemon before its loaded normal-output assemblies are
+replaced. A true first build with no CLI binary remains a safe no-op. Cleanup
+never sweeps all Excel processes. `Test-E2E.ps1` and
+`Test-CliWorkflow.ps1` allocate a private pipe for each invocation so parallel
+worktrees cannot stop each other's daemon or Excel instances.
+
 **For Complex Features:**
 - ✅ Add integration tests for all Excel operations
 - ✅ Test round-trip persistence (create → save → reload → verify)

--- a/docs/LEGACY-COM-API-COVERAGE.md
+++ b/docs/LEGACY-COM-API-COVERAGE.md
@@ -17,8 +17,9 @@ safe for an automation server, and testable against a real Excel instance.
 | Workbook links | `workbook` list/update/break external links | Exposes explicit link inspection and mutation without update prompts. |
 | Worksheet page setup | `sheetstyle` get/set page setup | Covers orientation, fit-to-page, and centering metadata without invoking print UI. |
 
-XML content is parsed with DTD processing disabled. XML schemas must be supplied
-as inline content (or read through the generated `schema_file` parameter), and
+XML content is parsed with DTD processing disabled. XML schemas and import data
+must each use exactly one inline value or readable file alias (`schemaFile` /
+`xmlDataFile` in batch JSON, snake_case in MCP, kebab-case in the CLI), and
 XSD `import`/`include`/`redefine` dependencies are rejected so Excel cannot implicitly fetch
 external schemas. XML imports also reject `xsi:schemaLocation` and
 `xsi:noNamespaceSchemaLocation` before invoking Excel, preventing HTTP, UNC, or

--- a/docs/features/AUTOMATION-ADVANCED.md
+++ b/docs/features/AUTOMATION-ADVANCED.md
@@ -32,6 +32,11 @@ excelcli vba import --session <id> --module-name MyModule --vba-code-file code.v
 excelcli session close --session <id> --save
 ```
 
+VBA imports and updates accept either inline code or `--vba-code-file`, never
+both. Batch JSON uses `vbaCodeFile`; MCP uses `vba_code_file`. The file must
+exist and be readable. VBA execution timeouts are integer seconds from 1 through
+2147483.
+
 ---
 
 ## 🐍 Python in Excel (2 operations)

--- a/docs/features/CELLS-WORKBOOKS.md
+++ b/docs/features/CELLS-WORKBOOKS.md
@@ -6,7 +6,7 @@ Read, write, calculate, and format cells while managing worksheets, workbooks, n
 
 ---
 
-## 📁 File Operations (6 operations)
+## 📁 File Operations (5 operations)
 
 Open, create, and close Excel workbooks. Every other tool works on a session opened here.
 
@@ -14,9 +14,8 @@ Open, create, and close Excel workbooks. Every other tool works on a session ope
 - **List Sessions:** View all active Excel sessions
 - **Open:** Open workbook and create session (returns session ID for all subsequent operations). IRM/AIP-protected files are automatically detected and opened read-only with Excel visible for credential authentication — no extra parameters needed.
 - **Close:** Close session with optional save
-- **Close Workbook:** Close workbook without closing Excel
 - **Create Empty:** Create new .xlsx or .xlsm workbook
-- **Test:** Verify workbook can be opened and is accessible. Returns `isIrmProtected` flag for IRM/AIP-protected files.
+- **Test:** Report existence, extension validity, openability, and IRM/AIP requirements through `canOpen`, `isIrmProtected`, `willOpenReadOnly`, and `requiresVisibleSession`.
 
 ---
 

--- a/docs/features/DATA-ANALYTICS.md
+++ b/docs/features/DATA-ANALYTICS.md
@@ -11,8 +11,8 @@ Import, transform, model, and summarize data with Power Query, DAX, Excel Tables
 Import, transform, and refresh data with Power Query. Every operation is a single-call atomic workflow.
 
 **Discovery:**
-- **List:** List all Power Query queries in workbook
-- **View:** View the M code of a Power Query
+- **List:** Return compact query metadata, exact load state, and an M preview of at most 80 characters; full M is never included
+- **View:** View one query's full M code and exact load state
 - **Get Load Config:** Get current load configuration
 
 **Lifecycle:**
@@ -32,6 +32,13 @@ Import, transform, and refresh data with Power Query. Every operation is a singl
 
 **Notes:**
 - **M-code formatting:** M code is preserved exactly by default. Create and Update can opt in to remote formatting with `formatMCode=true`, which sends M code to powerqueryformatter.com and adds network latency. If remote formatting fails, the original M code is saved unchanged.
+- **Inline or file input:** Required M, DAX, and DMV text accepts exactly one inline value or its matching file alias (`mCodeFile`, `daxFormulaFile`, `daxQueryFile`, or `dmvQueryFile` in batch JSON; snake_case in MCP; kebab-case options in the CLI). Optional `update-measure` DAX input may omit both forms; whenever a value is supplied, inline and file forms remain mutually exclusive. Files must exist and be readable.
+- **Timeout representation:** Public CLI, batch, and MCP timeouts are integer seconds. Power Query refresh/refresh-all accepts 0–2147483; omission or `0` uses the 30-minute data-operation default. Connection, Data Model, PivotTable, and VBA timeouts accept 1–2147483.
+- **Load destinations:** `worksheet`, `data-model`, `both`, and `connection-only` are case-insensitive aliases for the corresponding generated enum values. Unknown values are rejected before any load destination is changed.
+- **Action-specific parameters:** CLI and MCP schemas expose the category-wide parameter union, but each action rejects explicitly supplied parameters it does not use. In particular, `load-to` rejects `timeout` and uses the fixed 30-minute data-operation timeout.
+- **Truthful reads:** List, View, and Get Load Config share exact worksheet/Data Model-aware load detection. List fails explicitly if Excel cannot inspect a query rather than silently omitting it.
+- **Exact query identity:** Load detection, refresh, load-to, unload, and delete compare the parsed mashup `Location` exactly and case-insensitively, so prefix names such as `A` and `AA` cannot affect each other.
+- **Evaluate cleanup:** Temporary queries, worksheets, tables, and generically named workbook connections are removed by exact mashup identity. Cleanup failures return an actionable error and never report success.
 
 ---
 
@@ -202,6 +209,7 @@ Create and refresh external OLEDB/ODBC data connections.
 **Notes:**
 - **Supported types:** OLEDB (requires Microsoft.ACE.OLEDB.16.0 or similar), ODBC (requires ODBC driver installed), and Power Query connections (atomic redirect to `powerquery`).
 - **Text/web imports:** Use `querytable` for direct local text/CSV or legacy HTML imports; use `powerquery` for transformations and modern connectors.
+- **Safe cleanup:** Connection delete and load-to remove only QueryTables owned by the exact WorkbookConnection; similarly named QueryTables are preserved.
 
 ---
 

--- a/docs/guides/EXCEL-COM-VS-FILE-PARSERS.md
+++ b/docs/guides/EXCEL-COM-VS-FILE-PARSERS.md
@@ -73,7 +73,7 @@ The dividing line in practice: **generating a new simple file** favours parsers;
 
 Raw COM automation from a script is possible but unpleasant — STA threading, COM
 object lifetime, message filters, and Excel process cleanup are all easy to get
-wrong and leak `EXCEL.EXE` processes. ExcelMcp handles that layer and exposes 326
+wrong and leak `EXCEL.EXE` processes. ExcelMcp handles that layer and exposes 325
 operations across 31 tools through two equal entry points:
 
 - an **MCP server** for conversational AI clients (Claude, Copilot, Cursor)

--- a/docs/guides/REFRESH-POWER-QUERY.md
+++ b/docs/guides/REFRESH-POWER-QUERY.md
@@ -28,8 +28,8 @@ know the operation names — but they are useful when scripting.
     The assistant opens a session, refreshes, then closes it:
 
     ```text
-    file(action: 'open', filePath: 'C:\reports\Q3-report.xlsx')
-    powerquery(action: 'refresh', queryName: 'SalesData', refreshTimeoutSeconds: 300)
+    file(action: 'open', path: 'C:\reports\Q3-report.xlsx')
+    powerquery(action: 'refresh', query_name: 'SalesData', timeout_seconds: 300)
     file(action: 'close', save: true)
     ```
 
@@ -41,9 +41,22 @@ know the operation names — but they are useful when scripting.
     excelcli -q session close --session $session --save
     ```
 
-`refresh` defaults to a **30-minute** timeout when the timeout is omitted or `0`.
-For quick queries pass something smaller (60–120 seconds) so a stuck refresh fails
+Public timeout values are always integer seconds. `refresh` defaults to a
+**30-minute** data-operation timeout when its timeout is omitted or `0`. For
+quick queries pass something smaller (60–120 seconds) so a stuck refresh fails
 fast instead of holding the session.
+
+## Understand timeout ownership
+
+| Timeout | Configure it with | Applies to | Default and range |
+|---|---|---|---|
+| Session operation timeout | MCP `file open/create` `timeout_seconds`; CLI `session open/create --timeout` | Workbook startup and operations that do not supply a dedicated data-operation timeout, including Power Query `create`, `update`, and `evaluate` | 120 seconds; 10–3600 |
+| Refresh/data-operation timeout | The refresh action's MCP `timeout_seconds`, CLI `--timeout`, or batch `timeout` | Power Query `refresh` and `refresh-all`; `load-to` uses the same 30-minute default but has no caller override | Power Query omitted/`0`: 1800 seconds; explicit range 0–2147483. Other timeout-bearing categories use 1–2147483. |
+
+A dedicated refresh/data-operation timeout replaces the session operation wait
+for that operation; the two limits are not layered. `powerquery load-to` has no
+caller timeout option and uses the fixed 30-minute data-operation timeout;
+passing `timeout` is rejected as action-inapplicable rather than ignored.
 
 ## Refresh everything
 
@@ -69,6 +82,11 @@ preview *without* creating a permanent query:
 useful than the COM exception you get from a failed `create`. Skipping it is how
 workbooks end up polluted with broken queries.
 
+For large M programs, use `m_code_file` in MCP, `--m-code-file` in the CLI, or
+`mCodeFile` in batch JSON. Supply exactly one of the inline and file forms. The
+file must exist and be readable; file content is resolved once by shared
+dispatch.
+
 Use `create` for a new query and `update` for one that already exists — `create`
 fails with "Query 'X' already exists", and `update` fails with "not found". Run
 `powerquery list` first if you are unsure.
@@ -85,6 +103,11 @@ excelcli -q datamodel list-tables --session $session    # if loading to the Data
 
 In `list` output, `IsConnectionOnly = true` means the query has **no** data
 destination. A query loaded only to the Data Model is *not* connection-only.
+List includes exact load mode, formula character count, and an M preview of at
+most 80 characters; use `powerquery view` for one query's complete M code.
+List, View, and Get Load Config share one exact worksheet/Data Model-aware
+detector. If Excel cannot inspect a query, List fails instead of silently
+omitting it from a successful response.
 
 ## Choose where the data lands
 

--- a/gh-pages/docs/faq.md
+++ b/gh-pages/docs/faq.md
@@ -31,7 +31,7 @@ possible - you don't need to memorize it.
 
 ### CLI or MCP Server - which should I install?
 
-Both expose the **same 326 operations**. Use the **MCP Server** for
+Both expose the **same 325 operations**. Use the **MCP Server** for
 conversational AI (Claude Desktop, VS Code Chat); use the **CLI** (`excelcli`)
 for coding agents and scripting, where it uses ~64% fewer tokens. You can
 install both. See [Installation](installation.md).

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,6 +1,6 @@
 ---
 title: Excel Automation Features
-description: Explore 31 Excel automation tools and 326 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
+description: Explore 31 Excel automation tools and 325 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
 keywords: "Excel automation features, Excel MCP tools, Power Query automation, DAX, PivotTables, VBA, Excel AI"
 ---
 
@@ -11,7 +11,7 @@ keywords: "Excel automation features, Excel MCP tools, Power Query automation, D
   <figcaption>A PivotTable — revenue by region and quarter with grand totals — created in the real Excel application from a plain-language request.</figcaption>
 </figure>
 
-Excel MCP Server provides **31 specialized tools and 326 operations** for
+Excel MCP Server provides **31 specialized tools and 325 operations** for
 automating the real Microsoft Excel application. You can ask your AI assistant
 in plain language—the reference pages below are for discovering what is
 possible and looking up individual operations.

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -128,7 +128,7 @@ hide:
 
 </div>
 
-[See all 31 tools and 326 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 31 tools and 325 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## Popular guides
 

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -121,7 +121,7 @@ GUIDE_SOURCES = {
     "guides-excel-com-vs-file-parsers.md": "docs/guides/EXCEL-COM-VS-FILE-PARSERS.md",
 }
 
-
+
 # skills/shared/*.md: the expert reference corpus shipped inside the skill
 # packages and MCP prompts. Published verbatim so the site and the agent
 # guidance can never disagree. Value = (output name, page title).
@@ -609,8 +609,8 @@ def _write_llm_outputs(config) -> None:
         "# Excel MCP Server",
         "",
         "> Excel MCP Server (ExcelMcp) automates the real Microsoft Excel "
-        "application through its COM API, exposing 31 tools and 326 operations "
-        "to AI assistants over the Model Context Protocol and to scripts through "
+        "application through its COM API, exposing 31 tools and 325 operations to AI assistants "
+        "over the Model Context Protocol and to scripts through "
         "the `excelcli` command line. Unlike file-parser libraries it can refresh "
         "Power Query, evaluate DAX against the Data Model, refresh PivotTables, "
         "and run VBA, because Excel itself does the work. Windows-only; requires "

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -13,7 +13,7 @@ Excel MCP Server lets you automate Excel through conversation with Claude:
 - **Automate** - VBA macros, batch operations, data refresh
 - **Agent Mode** - Say "show me Excel" and watch AI work in real-time, side-by-side with Claude
 
-**31 tools with 326 operations** for comprehensive Excel automation.
+**31 tools with 325 operations** for comprehensive Excel automation.
 
 ## Requirements
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Excel (Windows)",
   "version": "1.7.0",
   "description": "Manage Sheets, Power Query, DAX, VBA, PowerPivot, Tables, Ranges, Charts, Formatting, Validation & more - requires Excel to be installed",
-  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 326 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
+  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 325 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/scripts/Build-AgentSkills.ps1
+++ b/scripts/Build-AgentSkills.ps1
@@ -272,10 +272,10 @@ function Generate-CliReference {
     $content.Add("## Common Pitfalls")
     $content.Add("")
     $content.Add("- ``--values-file`` requires an existing JSON or CSV file; use ``--values`` for inline JSON.")
-    $content.Add("- ``--timeout`` must be greater than zero; omit it to use the command default.")
+    $content.Add("- ``--timeout`` ranges are action-specific: session open/create accepts 10-3600; Power Query refresh/refresh-all accepts 0-2147483 (0 keeps the default); other generated timeout actions accept 1-2147483.")
     $content.Add("- ``pythoninexcel get-result --max-wait-seconds`` must be at least 1 and shorter than the session operation timeout.")
     $content.Add("- ``--values`` and list parameters use JSON arrays; range values use a two-dimensional array.")
-    $content.Add("- Power Query operations may take 30 seconds or longer; use a generous positive timeout.")
+    $content.Add("- Power Query operations may take 30 seconds or longer; use a deliberate data-operation timeout or 0 for the default.")
     $content.Add("")
 
     $refsDir = Join-Path $SkillPath "references"

--- a/scripts/Stop-ExcelMcpProcesses.ps1
+++ b/scripts/Stop-ExcelMcpProcesses.ps1
@@ -1,23 +1,26 @@
 <#
 .SYNOPSIS
-    Stops the ExcelMCP Service gracefully and kills Excel processes before build.
+    Stops the ExcelMCP CLI service and Excel processes owned by one CLI pipe.
 .DESCRIPTION
-    Pre-build cleanup script that:
-    1. Gracefully stops the ExcelMCP Service via named pipe (service.shutdown)
-    2. Kills any remaining Excel (EXCEL.EXE) processes
+    Invokes the CLI-owned service stop path for EXCELMCP_CLI_PIPE (or the
+    default user pipe when no override is set). The CLI validates tracked
+    process start times before stopping anything.
 
-    This prevents file locking issues during build when the service or Excel
-    holds handles to assemblies or workbooks.
+    If an existing CLI is older than the ownership lifecycle sources, a
+    current cleanup client is built in an isolated temporary output first.
+    If no CLI binary exists yet, the script safely does nothing. It never
+    scans for or stops unrelated Excel or service processes.
 .NOTES
-    Called from Directory.Build.props as a BeforeBuild target.
+    Called once from Directory.Build.props before the CLI project builds.
     Safe to run when no processes are running (silently succeeds).
 #>
 
 param(
+    [string]$PipeName = $env:EXCELMCP_CLI_PIPE,
     [switch]$Verbose
 )
 
-$ErrorActionPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
 
 function Write-Status($message) {
     if ($Verbose) {
@@ -25,103 +28,149 @@ function Write-Status($message) {
     }
 }
 
-# ----------------------------------------------
-# 1. Gracefully stop ExcelMCP Service via CLI
-# ----------------------------------------------
-function Stop-ExcelMcpService {
-    # Look for excelcli in build output directories (Debug/Release)
-    $scriptDir = Split-Path -Parent $PSScriptRoot  # repo root
-    $cliPaths = @(
-        "$scriptDir\src\ExcelMcp.CLI\bin\Debug\net10.0-windows\excelcli.exe",
-        "$scriptDir\src\ExcelMcp.CLI\bin\Release\net10.0-windows\excelcli.exe"
-    )
-    $excelcli = $cliPaths | Where-Object { Test-Path $_ } | Select-Object -First 1
-
-    if ($excelcli) {
-        Write-Status "Using CLI: $excelcli"
-        $output = & $excelcli service stop --quiet 2>&1
-        $exitCode = $LASTEXITCODE
-        if ($exitCode -eq 0) {
-            # Parse JSON to check if service was running
-            try {
-                $result = $output | ConvertFrom-Json
-                if ($result.message -eq 'Service is not running.') {
-                    Write-Status "ExcelMCP Service was not running"
-                } else {
-                    Write-Host "  ExcelMCP Service stopped gracefully" -ForegroundColor Green
-                }
-            } catch {
-                Write-Status "Service stop completed (exit code 0)"
-            }
-        } else {
-            Write-Status "CLI service stop returned exit code $exitCode, falling back to process kill"
-            Stop-ExcelMcpServiceFallback
-        }
-    } else {
-        Write-Status "excelcli not found (first build?), using fallback"
-        Stop-ExcelMcpServiceFallback
-    }
-}
-
-function Stop-ExcelMcpServiceFallback {
-    # Fallback: direct named pipe shutdown (works without CLI binary)
-    $sid = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
-    $pipeName = "excelmcp-$sid"
-
-    $pipeExists = Test-Path "\\.\pipe\$pipeName"
-    if (-not $pipeExists) {
-        Write-Status "ExcelMCP Service not running (no pipe found)"
+function Remove-StagingClient([string]$path) {
+    if ([string]::IsNullOrWhiteSpace($path) -or -not (Test-Path -LiteralPath $path)) {
         return
     }
 
-    Write-Status "ExcelMCP Service detected, sending shutdown via pipe..."
     try {
-        $pipe = New-Object System.IO.Pipes.NamedPipeClientStream('.', $pipeName, [System.IO.Pipes.PipeDirection]::InOut)
-        $pipe.Connect(3000)
-
-        $writer = New-Object System.IO.StreamWriter($pipe, [System.Text.Encoding]::UTF8, 4096)
-        $writer.AutoFlush = $true
-        $reader = New-Object System.IO.StreamReader($pipe, [System.Text.Encoding]::UTF8)
-
-        $writer.WriteLine('{"Command":"service.shutdown"}')
-        $response = $reader.ReadLine()
-        Write-Status "Service response: $response"
-
-        $reader.Dispose()
-        $writer.Dispose()
-        $pipe.Dispose()
-
-        Start-Sleep -Milliseconds 500
-        Write-Host "  ExcelMCP Service stopped gracefully" -ForegroundColor Green
+        Remove-Item -LiteralPath $path -Recurse -Force
     }
     catch {
-        Write-Status "Could not connect to pipe: $($_.Exception.Message)"
-        $serviceProcs = Get-Process -Name 'Sbroenne.ExcelMcp.McpServer', 'Sbroenne.ExcelMcp.Service' -ErrorAction SilentlyContinue
-        if ($serviceProcs) {
-            $serviceProcs | Stop-Process -Force -ErrorAction SilentlyContinue
-            Write-Host "  ExcelMCP Service processes killed (pipe unavailable)" -ForegroundColor Yellow
-        }
+        Write-Host "  Isolated owned-cleanup client could not be removed: $($_.Exception.Message)" -ForegroundColor Yellow
     }
 }
 
-# ----------------------------------------------
-# 2. Kill Excel processes
-# ----------------------------------------------
-function Stop-ExcelProcesses {
-    $excelProcs = Get-Process -Name 'EXCEL' -ErrorAction SilentlyContinue
-    if ($excelProcs) {
-        $count = $excelProcs.Count
-        $excelProcs | Stop-Process -Force -ErrorAction SilentlyContinue
-        Start-Sleep -Milliseconds 500
-        Write-Host "  Killed $count Excel process(es)" -ForegroundColor Yellow
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$cliPaths = @(
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\bin\Release\net10.0-windows\excelcli.exe'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\bin\Debug\net10.0-windows\excelcli.exe')
+)
+$safetyInputs = @(
+    $PSCommandPath,
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Commands\ServiceCommands.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonAutoStart.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonPipeIdentity.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonProcessTracker.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonStartupLock.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonTrackingJson.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\OwnedProcessCleanup.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\ExcelMcp.Cleanup.csproj'),
+    (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\Program.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\ParameterTransforms.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.Service\ServiceClient.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.Service\ServiceProtocol.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.Service\Rpc\IExcelDaemonRpc.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.ComInterop\ServiceClient\ServiceProtocol.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Program.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.ComInterop\Session\ExcelBatch.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.ComInterop\Session\ExcelProcessIdentity.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.ComInterop\Session\OwnedProcessGuard.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.ComInterop\Session\SessionManager.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.Service\ServiceSecurity.cs')
+)
+$latestSafetyInput = $safetyInputs |
+    Where-Object { Test-Path $_ } |
+    ForEach-Object { (Get-Item $_).LastWriteTimeUtc } |
+    Sort-Object -Descending |
+    Select-Object -First 1
+$availableClis = @($cliPaths |
+    Where-Object { Test-Path $_ } |
+    ForEach-Object { Get-Item $_ } |
+    Sort-Object LastWriteTimeUtc -Descending |
+    Select-Object -First 1)
+$excelcli = $availableClis |
+    Where-Object { $_.LastWriteTimeUtc -ge $latestSafetyInput } |
+    Select-Object -First 1
+$stagingRoot = $null
+$useCleanupBootstrap = $false
+
+if (-not $excelcli) {
+    if ($availableClis.Count -eq 0) {
+        Write-Status 'excelcli is missing; owned cleanup skipped safely'
+        exit 0
+    }
+
+    $stagingRoot = Join-Path ([System.IO.Path]::GetTempPath()) "excelmcp-cleanup-$PID-$([Guid]::NewGuid().ToString('N'))"
+    $cleanupProject = Join-Path $repoRoot 'src\ExcelMcp.Cleanup\ExcelMcp.Cleanup.csproj'
+    $stagedCliPath = Join-Path $stagingRoot 'bin\ExcelMcp.Cleanup\Release\net10.0-windows\excelmcp-cleanup.exe'
+    Write-Status "Existing CLI is older than the cleanup sources; building isolated cleanup client in $stagingRoot"
+
+    try {
+        $buildOutput = & dotnet build $cleanupProject `
+            --configuration Release `
+            -p:ExcelMcpCleanupRoot=$stagingRoot `
+            -p:ExcelMcpSkipCleanup=true `
+            -p:NuGetAudit=false `
+            -maxcpucount:1 `
+            -nodeReuse:false `
+            --verbosity quiet 2>&1
+        $buildExitCode = $LASTEXITCODE
+    }
+    catch {
+        Write-Host "  Isolated owned-cleanup client could not be built: $($_.Exception.Message). No process sweep was attempted." -ForegroundColor Yellow
+        Remove-StagingClient $stagingRoot
+        exit 1
+    }
+
+    if ($buildExitCode -ne 0 -or -not (Test-Path $stagedCliPath)) {
+        Write-Host "  Isolated owned-cleanup client build failed with exit code $buildExitCode. No process sweep was attempted." -ForegroundColor Yellow
+        if ($buildOutput) {
+            Write-Status ($buildOutput | Out-String).Trim()
+        }
+        Remove-StagingClient $stagingRoot
+        exit $(if ($buildExitCode -ne 0) { $buildExitCode } else { 1 })
+    }
+
+    $excelcli = Get-Item $stagedCliPath
+    $useCleanupBootstrap = $true
+}
+
+$previousPipeName = $env:EXCELMCP_CLI_PIPE
+try {
+    if ([string]::IsNullOrWhiteSpace($PipeName)) {
+        Remove-Item Env:EXCELMCP_CLI_PIPE -ErrorAction SilentlyContinue
+        Write-Status 'Using the default CLI pipe'
     }
     else {
-        Write-Status "No Excel processes running"
+        $env:EXCELMCP_CLI_PIPE = $PipeName
+        Write-Status "Using CLI pipe: $PipeName"
     }
+
+    Write-Status "Using CLI: $($excelcli.FullName)"
+    try {
+        if ($useCleanupBootstrap) {
+            $output = & $excelcli.FullName 2>&1
+        }
+        else {
+            $output = & $excelcli.FullName service stop --quiet 2>&1
+        }
+        $exitCode = $LASTEXITCODE
+    }
+    catch {
+        Write-Host "  Owned CLI cleanup could not start: $($_.Exception.Message). No process sweep was attempted." -ForegroundColor Yellow
+        exit 1
+    }
+
+    if ($exitCode -ne 0) {
+        Write-Host "  Owned CLI cleanup failed with exit code $exitCode. No process sweep was attempted." -ForegroundColor Yellow
+        if ($output) {
+            Write-Status ($output | Out-String).Trim()
+        }
+        exit $exitCode
+    }
+
+    Write-Status 'Owned CLI cleanup completed'
+}
+finally {
+    if ($null -eq $previousPipeName) {
+        Remove-Item Env:EXCELMCP_CLI_PIPE -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:EXCELMCP_CLI_PIPE = $previousPipeName
+    }
+
+    Remove-StagingClient $stagingRoot
 }
 
-# ----------------------------------------------
-# Run cleanup
-# ----------------------------------------------
-Stop-ExcelMcpService
-Stop-ExcelProcesses
+exit 0

--- a/scripts/Test-CliWorkflow.ps1
+++ b/scripts/Test-CliWorkflow.ps1
@@ -26,7 +26,8 @@
 
 [CmdletBinding()]
 param(
-    [switch]$KeepFile  # Don't delete the test file after completion
+    [switch]$KeepFile,  # Don't delete the test file after completion
+    [string]$PipeName
 )
 
 $ErrorActionPreference = 'Stop'
@@ -43,6 +44,34 @@ if (-not (Test-Path $cliPath)) {
 
 $cli = (Resolve-Path $cliPath).Path
 Write-Host "Using CLI: $cli" -ForegroundColor Cyan
+
+$previousPipeName = $env:EXCELMCP_CLI_PIPE
+$selectedPipeName = if (-not [string]::IsNullOrWhiteSpace($PipeName)) {
+    $PipeName
+}
+else {
+    "excelmcp-cli-workflow-$PID-$([Guid]::NewGuid().ToString('N'))"
+}
+$env:EXCELMCP_CLI_PIPE = $selectedPipeName
+Write-Host "Using private CLI pipe: $selectedPipeName" -ForegroundColor DarkGray
+
+function Reset-CliWorkflowEnvironment {
+    $cleanupExitCode = 0
+    try {
+        & (Join-Path $PSScriptRoot 'Stop-ExcelMcpProcesses.ps1') -PipeName $selectedPipeName
+        $cleanupExitCode = $LASTEXITCODE
+    }
+    finally {
+        if ($null -eq $previousPipeName) {
+            Remove-Item Env:EXCELMCP_CLI_PIPE -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:EXCELMCP_CLI_PIPE = $previousPipeName
+        }
+    }
+
+    return $cleanupExitCode
+}
 
 # Generate unique test file
 $testFile = Join-Path $env:TEMP "cli-workflow-test-$(Get-Random).xlsx"
@@ -85,10 +114,12 @@ function Test-Step {
 # TEST WORKFLOW
 # ============================================================================
 
+try {
 Write-Host "`n========================================" -ForegroundColor Cyan
 Write-Host "Excel CLI Workflow Test" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 
+:workflow do {
 # 1. Create session (auto-starts daemon, creates file)
 $session = Test-Step "Create session (create file)" {
     & $cli -q session create $testFile | ConvertFrom-Json
@@ -99,7 +130,8 @@ $session = Test-Step "Create session (create file)" {
 
 if (-not $session.sessionId) {
     Write-Host "`nFATAL: Could not open session. Aborting." -ForegroundColor Red
-    exit 1
+    $failed++
+    break workflow
 }
 
 $sessionId = $session.sessionId
@@ -206,6 +238,7 @@ Test-Step "Verify file exists" {
     param($r)
     $r -match "bytes"
 }
+} while ($false)
 
 # ============================================================================
 # SUMMARY
@@ -227,8 +260,19 @@ if (-not $KeepFile -and (Test-Path $testFile)) {
 
 if ($failed -gt 0) {
     Write-Host "`nSome tests FAILED!" -ForegroundColor Red
-    exit 1
+    $workflowExitCode = 1
 } else {
     Write-Host "`nAll tests PASSED!" -ForegroundColor Green
-    exit 0
+    $workflowExitCode = 0
 }
+}
+finally {
+    $cleanupExitCode = Reset-CliWorkflowEnvironment
+}
+
+if ($cleanupExitCode -ne 0) {
+    Write-Error "Owned CLI cleanup failed with exit code $cleanupExitCode."
+    exit $cleanupExitCode
+}
+
+exit $workflowExitCode

--- a/scripts/Test-E2E.ps1
+++ b/scripts/Test-E2E.ps1
@@ -6,7 +6,8 @@
 .DESCRIPTION
     Builds the Release solution unless -SkipBuild is supplied, then runs:
     1. The CLI workflow smoke test.
-    2. The MCP all-tools end-to-end smoke test.
+    2. The stale-build graceful-save acceptance test.
+    3. The MCP all-tools end-to-end smoke test.
 
     The script fails if either gate fails or if the MCP filter matches no tests.
 
@@ -16,16 +17,29 @@
 
 [CmdletBinding()]
 param(
-    [switch]$SkipBuild
+    [switch]$SkipBuild,
+    [string]$PipeName
 )
 
 $ErrorActionPreference = 'Stop'
 $rootDir = Split-Path -Parent $PSScriptRoot
+$cliTestProject = Join-Path $rootDir 'tests\ExcelMcp.CLI.Tests\ExcelMcp.CLI.Tests.csproj'
 $mcpTestProject = Join-Path $rootDir 'tests\ExcelMcp.McpServer.Tests\ExcelMcp.McpServer.Tests.csproj'
+$staleCleanupAcceptanceFilter = 'FullyQualifiedName~PreBuildGracefulSaveAcceptanceTests.StaleLockedBuildCleanup'
 $smokeTestFilter = 'FullyQualifiedName~McpServerSmokeTests.SmokeTest_AllTools_E2EWorkflow'
+$previousPipeName = $env:EXCELMCP_CLI_PIPE
+$selectedPipeName = if ([string]::IsNullOrWhiteSpace($PipeName)) {
+    "excelmcp-e2e-$PID-$([Guid]::NewGuid().ToString('N'))"
+}
+else {
+    $PipeName
+}
+$env:EXCELMCP_CLI_PIPE = $selectedPipeName
 
 Push-Location $rootDir
 try {
+    Write-Host "Using private CLI pipe: $selectedPipeName" -ForegroundColor DarkGray
+
     if (-not $SkipBuild) {
         Write-Host 'Building Release solution...' -ForegroundColor Cyan
         dotnet build Sbroenne.ExcelMcp.sln --configuration Release -p:NuGetAudit=false --verbosity minimal
@@ -36,14 +50,38 @@ try {
 
     Write-Host ''
     Write-Host 'Running CLI workflow E2E test...' -ForegroundColor Cyan
-    & (Join-Path $PSScriptRoot 'Test-CliWorkflow.ps1')
+    & (Join-Path $PSScriptRoot 'Test-CliWorkflow.ps1') -PipeName $selectedPipeName
     if ($LASTEXITCODE -ne 0) {
         throw "CLI workflow E2E test failed with exit code $LASTEXITCODE."
     }
 
     Write-Host ''
+    Write-Host 'Running stale-build graceful-save acceptance test...' -ForegroundColor Cyan
+    $staleCleanupOutput = dotnet test $cliTestProject `
+        --configuration Release `
+        --no-build `
+        --filter $staleCleanupAcceptanceFilter `
+        --verbosity minimal `
+        --blame-hang-timeout 6m `
+        -- RunConfiguration.MaxCpuCount=1 2>&1 | Out-String
+    $staleCleanupExitCode = $LASTEXITCODE
+
+    Write-Host $staleCleanupOutput
+
+    if ($staleCleanupOutput -notmatch 'Passed!.*Passed:\s*[1-9]') {
+        throw "No stale-build graceful-save acceptance test passed. Verify the filter still matches $staleCleanupAcceptanceFilter."
+    }
+
+    if ($staleCleanupExitCode -ne 0) {
+        throw "Stale-build graceful-save acceptance test failed with exit code $staleCleanupExitCode."
+    }
+
+    Write-Host ''
     Write-Host 'Running MCP all-tools E2E test...' -ForegroundColor Cyan
-    & (Join-Path $PSScriptRoot 'Stop-ExcelMcpProcesses.ps1')
+    & (Join-Path $PSScriptRoot 'Stop-ExcelMcpProcesses.ps1') -PipeName $selectedPipeName
+    if ($LASTEXITCODE -ne 0) {
+        throw "Owned CLI cleanup failed with exit code $LASTEXITCODE before the MCP E2E test."
+    }
 
     $testOutput = dotnet test $mcpTestProject `
         --configuration Release `
@@ -67,8 +105,25 @@ try {
     Write-Host 'All Excel-dependent E2E tests passed.' -ForegroundColor Green
 }
 finally {
-    & (Join-Path $PSScriptRoot 'Stop-ExcelMcpProcesses.ps1')
-    Pop-Location
+    $cleanupExitCode = 0
+    try {
+        & (Join-Path $PSScriptRoot 'Stop-ExcelMcpProcesses.ps1') -PipeName $selectedPipeName
+        $cleanupExitCode = $LASTEXITCODE
+    }
+    finally {
+        if ($null -eq $previousPipeName) {
+            Remove-Item Env:EXCELMCP_CLI_PIPE -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:EXCELMCP_CLI_PIPE = $previousPipeName
+        }
+        Pop-Location
+    }
+
+}
+
+if ($cleanupExitCode -ne 0) {
+    throw "Owned CLI cleanup failed with exit code $cleanupExitCode after E2E validation."
 }
 
 $global:LASTEXITCODE = 0

--- a/scripts/audit-core-coverage.ps1
+++ b/scripts/audit-core-coverage.ps1
@@ -432,7 +432,7 @@ $extraEnums = $results | Where-Object { $_.Gap -lt 0 }
 if ($extraEnums.Count -gt 0) {
     Write-Host ""
     Write-Host "Note: Some enums have more values than Core methods" -ForegroundColor Yellow
-    Write-Host "This might be intentional (MCP-specific actions like 'close-workbook')" -ForegroundColor Gray
+    Write-Host "This might be intentional for adapter-specific lifecycle actions" -ForegroundColor Gray
     $extraEnums | ForEach-Object {
         Write-Host "  - $($_.Interface): $([math]::Abs($_.Gap)) extra enum values" -ForegroundColor Yellow
     }
@@ -472,7 +472,7 @@ if ($CheckNaming) {
                           "GetColumnNumberFormat", "SetColumnNumberFormat",
                           # Table slicer methods exposed via SlicerAction (cross-interface enum)
                           "CreateTableSlicer", "ListTableSlicers", "SetTableSlicerSelection", "DeleteTableSlicer")
-        "FileAction" = @("CloseWorkbook", "Open", "Save", "Close", "List", "Create")  # MCP-specific session actions
+        "FileAction" = @("Open", "Close", "List", "Create")  # Adapter-specific session actions
         "RangeAction" = @("SetNumberFormatCustom", "InsertCells", "DeleteCells", "InsertRows", "DeleteRows",
                           "InsertColumns", "DeleteColumns", "Find", "Replace", "Sort",
                           "AddHyperlink", "RemoveHyperlink", "ListHyperlinks", "GetHyperlink",

--- a/scripts/check-mcp-core-implementations.ps1
+++ b/scripts/check-mcp-core-implementations.ps1
@@ -45,7 +45,7 @@ function Get-InterfaceMethodNames {
 
 # Known intentional exceptions (documented in CORE-METHOD-RENAMING-SUMMARY.md)
 $knownExceptions = @{
-    "FileAction" = @("CloseWorkbook", "Open", "Save", "Close", "List", "Create")  # Session management actions (MCP-specific)
+    "FileAction" = @("Open", "Close", "List", "Create")  # Adapter-specific session actions
     "TableAction" = @("ApplyFilterValues", "SortMulti")  # Composite operations
     "TableColumnAction" = @("ApplyFilterValues", "SortMulti")  # Composite operations
     "RangeAction" = @("SetNumberFormatCustom")  # Maps to SetNumberFormat Core method (intentional name difference for LLM usability)

--- a/scripts/pre-commit.ps1
+++ b/scripts/pre-commit.ps1
@@ -129,25 +129,13 @@ if ($currentBranch -eq "main") {
 Write-Host "Branch check passed - on '$currentBranch' (not main)" -ForegroundColor Green
 Write-Host ""
 
-# Kill stale Excel and MCP server processes to avoid file locks on Release binaries
-Write-Host "Killing stale Excel and server processes..." -ForegroundColor Cyan
-
-$killedProcesses = @()
-foreach ($procName in @("EXCEL", "excelcli", "Sbroenne.ExcelMcp.McpServer", "Sbroenne.ExcelMcp.Service")) {
-    $procs = Get-Process -Name $procName -ErrorAction SilentlyContinue
-    if ($procs) {
-        $procs | Stop-Process -Force -ErrorAction SilentlyContinue
-        $killedProcesses += "$procName ($($procs.Count))"
-    }
-}
-
-if ($killedProcesses.Count -gt 0) {
-    Write-Host "   Killed: $($killedProcesses -join ', ')" -ForegroundColor Yellow
-    # Brief pause to let file handles release
-    Start-Sleep -Milliseconds 500
-}
-else {
-    Write-Host "   No stale processes found" -ForegroundColor Gray
+# Stop only processes owned by the selected CLI pipe before touching Release binaries.
+Write-Host "Stopping pipe-owned ExcelMCP processes..." -ForegroundColor Cyan
+$ownedCleanupScript = Join-Path $PSScriptRoot "Stop-ExcelMcpProcesses.ps1"
+& $ownedCleanupScript -Verbose
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Pipe-owned cleanup failed with exit code $LASTEXITCODE." -ForegroundColor Red
+    exit 1
 }
 
 Stop-DotNetBuildServers

--- a/skills/excel-cli/SKILL.md
+++ b/skills/excel-cli/SKILL.md
@@ -194,10 +194,10 @@ Available command groups:
 See [CLI command reference and common pitfalls](./references/cli-commands.md#common-pitfalls) for examples. Key issues:
 
 - `--values-file` expects a path to an existing file; use `--values` for inline JSON.
-- `--timeout` must be a positive integer; omit it to use the default timeout.
+- `--timeout` ranges are action-specific: session open/create accepts 10-3600; Power Query refresh/refresh-all accepts 0-2147483 (0 keeps the default); other generated timeout actions accept 1-2147483.
 - `--values` takes a 2D JSON array such as `'[["Name","Age"],["Alice",30]]'`.
 - List parameters such as `--selected-items` require JSON arrays.
-- Power Query operations can take 30+ seconds; use generous timeouts.
+- Power Query operations can take 30+ seconds; use a deliberate data-operation timeout or 0 for the default.
 
 ## Reference Documentation
 

--- a/skills/excel-cli/references/anti-patterns.md
+++ b/skills/excel-cli/references/anti-patterns.md
@@ -418,7 +418,8 @@ powerquery(action: 'refresh', ...)
 - Catch syntax errors and missing sources BEFORE persisting
 - See actual data preview (columns, sample rows)
 - Better error messages than COM exceptions
-- No cleanup needed - temporary objects auto-deleted
+- Temporary objects are removed by exact mashup identity; cleanup failures are
+  surfaced with recovery guidance instead of returning success
 - Like a REPL for M code
 
 ### When Evaluate IS Optional

--- a/skills/excel-cli/references/behavioral-rules.md
+++ b/skills/excel-cli/references/behavioral-rules.md
@@ -174,6 +174,12 @@ After completing operations, report:
 
 ### Session Lifecycle
 
+Use `file(action: 'test')` or `excelcli -q session test <path>` before opening
+when access or information protection is uncertain. The shared result reports
+`canOpen`, `isIrmProtected`, `willOpenReadOnly`, and `requiresVisibleSession`.
+IRM/AIP files report `canOpen:false` until the required interactive Excel
+authentication occurs; open them with a visible session.
+
 Always close sessions when done:
 
 ```
@@ -270,10 +276,35 @@ Choose load destination based on workflow:
 
 | Destination | When to Use |
 |-------------|-------------|
-| `worksheet` | View data, simple analysis |
-| `data-model` | DAX measures, PivotTables, relationships |
-| `both` | View data AND use in DAX |
+| `worksheet` / `load-to-table` | View data, simple analysis |
+| `data-model` / `load-to-data-model` | DAX measures, PivotTables, relationships |
+| `both` / `load-to-both` | View data AND use in DAX |
 | `connection-only` | Data staging, intermediate queries |
+
+Values are case-insensitive. Unknown enum values and parameters that do not
+belong to the selected action are rejected instead of being defaulted or ignored.
+
+### Canonical Public Inputs
+
+- Public timeouts are integer seconds: MCP uses `timeout_seconds`, CLI uses
+  `--timeout`, and batch JSON uses `timeout`. Do not send TimeSpan strings or
+  numeric strings.
+- Session open/create accepts 10-3600 seconds. Its operation timeout controls
+  workbook startup and operations that do not provide a dedicated data-operation
+  timeout.
+- Power Query refresh/refresh-all accepts 0-2147483; omitted or `0` uses the
+  30-minute data-operation default. Connection, Data Model, PivotTable, and VBA
+  timeouts accept 1-2147483.
+- Power Query refresh/refresh-all use their data-operation timeout instead of
+  layering the session operation timeout. `load-to` has no caller timeout and
+  uses the fixed 30-minute data-operation timeout; create/update/evaluate use the
+  session operation timeout.
+- For required generated inline/file pairs, supply exactly one form. Optional
+  pairs may omit both, but inline and file forms are always mutually exclusive.
+  Batch aliases are
+  `mCodeFile`, `vbaCodeFile`, `daxFormulaFile`, `daxQueryFile`, `dmvQueryFile`,
+  `schemaFile`, and `xmlDataFile`; MCP uses snake_case and CLI uses kebab-case.
+  The file must exist and be readable.
 
 ### Refresh After Create
 

--- a/skills/excel-cli/references/cli-commands.md
+++ b/skills/excel-cli/references/cli-commands.md
@@ -12,20 +12,20 @@ Excel what-if analysis with Goal Seek, scenarios, scenario reports, and one- or 
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | (required) |
-| `--formula-cell` | (required for: goal-seek) |
-| `--goal` | (required for: goal-seek) |
-| `--changing-cell` | (required for: goal-seek) |
-| `--scenario-name` | (required for: create-scenario, update-scenario, show-scenario, delete-scenario) |
-| `--changing-cells` | (required for: create-scenario, update-scenario) |
-| `--values` | (required for: create-scenario, update-scenario) (JSON format) |
-| `--comment` | Comment |
-| `--locked` | Locked |
-| `--hidden` | Hidden |
-| `--report-type` | ReportType |
-| `--result-cells` | ResultCells |
-| `--table-range` | (required for: create-data-table) |
-| `--row-input-cell` | RowInputCell |
-| `--column-input-cell` | ColumnInputCell |
+| `--formula-cell` | (required for: goal-seek) (valid for: goal-seek) |
+| `--goal` | (required for: goal-seek) (valid for: goal-seek) |
+| `--changing-cell` | (required for: goal-seek) (valid for: goal-seek) |
+| `--scenario-name` | (required for: create-scenario, update-scenario, show-scenario, delete-scenario) (valid for: create-scenario, update-scenario, show-scenario, delete-scenario) |
+| `--changing-cells` | (required for: create-scenario, update-scenario) (valid for: create-scenario, update-scenario) |
+| `--values` | (required for: create-scenario, update-scenario) (valid for: create-scenario, update-scenario) (JSON format) |
+| `--comment` | (valid for: create-scenario) |
+| `--locked` | (valid for: create-scenario) |
+| `--hidden` | (valid for: create-scenario) |
+| `--report-type` | (valid for: create-scenario-summary) |
+| `--result-cells` | (valid for: create-scenario-summary) |
+| `--table-range` | (required for: create-data-table) (valid for: create-data-table) |
+| `--row-input-cell` | (valid for: create-data-table) |
+| `--column-input-cell` | (valid for: create-data-table) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### batch
@@ -47,10 +47,10 @@ Control Excel recalculation (automatic vs manual). Set manual mode before bulk w
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--mode` | Target calculation mode (required for: set-mode) |
-| `--scope` | Scope: Workbook, Sheet, or Range (required for: calculate) |
-| `--sheet` | Sheet name (required for Sheet/Range scope) |
-| `--range` | Range address (required for Range scope) |
+| `--mode` | Target calculation mode (required for: set-mode) (valid for: set-mode) |
+| `--scope` | Scope: Workbook, Sheet, or Range (required for: calculate) (valid for: calculate) |
+| `--sheet` | Sheet name (required for Sheet/Range scope) (valid for: calculate) |
+| `--range` | Range address (required for Range scope) (valid for: calculate) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### chart
@@ -62,18 +62,18 @@ Chart lifecycle - create, read, move, and delete embedded charts. POSITIONING (c
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--chart-name` | Name of the chart (or shape name) (required for: read, delete, move, fit-to-range) |
-| `--sheet` | Target worksheet name (required for: create-from-range, create-from-table, create-from-pivottable, fit-to-range) |
-| `--source-range-address` | Data range for the chart (e.g., A1:D10) (required for: create-from-range) |
-| `--chart-type` | Type of chart to create (required for: create-from-range, create-from-table, create-from-pivottable) |
-| `--left` | Left position in points from worksheet edge |
-| `--top` | Top position in points from worksheet edge |
-| `--width` | Chart width in points |
-| `--height` | Chart height in points |
-| `--target-range` | Cell range to position chart within (e.g., 'F2:K15'). PREFERRED over left/top. When set, left/top are ignored |
-| `--table-name` | Name of the Excel Table (required for: create-from-table) |
-| `--pivot-table-name` | Name of the source PivotTable (required for: create-from-pivottable) |
-| `--range` | Range to fit the chart to (e.g., A1:D10) (required for: fit-to-range) |
+| `--chart-name` | Name of the chart (or shape name) (required for: read, delete, move, fit-to-range) (valid for: read, create-from-range, create-from-table, create-from-pivottable, delete, move, fit-to-range) |
+| `--sheet` | Target worksheet name (required for: create-from-range, create-from-table, create-from-pivottable, fit-to-range) (valid for: create-from-range, create-from-table, create-from-pivottable, fit-to-range) |
+| `--source-range-address` | Data range for the chart (e.g., A1:D10) (required for: create-from-range) (valid for: create-from-range) |
+| `--chart-type` | Type of chart to create (required for: create-from-range, create-from-table, create-from-pivottable) (valid for: create-from-range, create-from-table, create-from-pivottable) |
+| `--left` | Left position in points from worksheet edge (valid for: create-from-range, create-from-table, create-from-pivottable, move) |
+| `--top` | Top position in points from worksheet edge (valid for: create-from-range, create-from-table, create-from-pivottable, move) |
+| `--width` | Chart width in points (valid for: create-from-range, create-from-table, create-from-pivottable, move) |
+| `--height` | Chart height in points (valid for: create-from-range, create-from-table, create-from-pivottable, move) |
+| `--target-range` | Cell range to position chart within (e.g., 'F2:K15'). PREFERRED over left/top. When set, left/top are ignored. (valid for: create-from-range, create-from-table, create-from-pivottable) |
+| `--table-name` | Name of the Excel Table (required for: create-from-table) (valid for: create-from-table) |
+| `--pivot-table-name` | Name of the source PivotTable (required for: create-from-pivottable) (valid for: create-from-pivottable) |
+| `--range` | Range to fit the chart to (e.g., A1:D10) (required for: fit-to-range) (valid for: fit-to-range) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### chartconfig
@@ -86,58 +86,58 @@ Chart configuration - data source, series, type, title, axis labels, legend, and
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--chart-name` | Name of the chart (required) |
-| `--source-range` | New data source range (e.g., Sheet1!A1:D10) (required for: set-source-range) |
-| `--series-name` | Display name for the series (required for: add-series) |
-| `--values-range` | Range containing series values (e.g., B2:B10) (required for: add-series) |
-| `--category-range` | Optional range for category labels (e.g., A2:A10) |
-| `--series-index` | 1-based index of the series to remove (required for: remove-series, set-series-format, set-series-chart-type, list-trendlines, add-trendline, delete-trendline, set-trendline) |
-| `--chart-type` | New chart type to apply (required for: set-chart-type, set-series-chart-type) |
-| `--title` | Title text to display (required for: set-title, set-axis-title) |
-| `--axis` | Which axis to set title for (Category, Value, SeriesAxis) (required for: set-axis-title, get-axis-number-format, set-axis-number-format, get-axis-scale, set-axis-scale, set-gridlines) |
-| `--number-format` | Excel number format code (e.g., "$#,##0", "0.00%") (required for: set-axis-number-format) |
-| `--visible` | True to show legend, false to hide (required for: show-legend) |
-| `--legend-position` | Optional position for the legend |
-| `--style-id` | Excel chart style ID (1-48 for most chart types) (required for: set-style) |
-| `--placement` | Placement mode: 1=MoveAndSize, 2=Move, 3=FreeFloating (required for: set-placement) |
-| `--print-object` | Whether the embedded chart prints with the worksheet |
-| `--locked` | Whether the embedded chart is locked when the worksheet is protected |
-| `--rounded-corners` | Whether the embedded chart uses rounded corners |
-| `--show-value` | Show data values on labels |
-| `--show-percentage` | Show percentage values. Only meaningful for pie and doughnut chart types; setting to true on other chart types has no visual effect |
-| `--show-series-name` | Show series name on labels |
-| `--show-category-name` | Show category name on labels |
-| `--show-bubble-size` | Show bubble size (bubble charts) |
-| `--separator` | Separator string between label components |
-| `--label-position` | Position of data labels relative to data points |
-| `--minimum-scale` | Minimum axis value (null for auto) |
-| `--maximum-scale` | Maximum axis value (null for auto) |
-| `--major-unit` | Major gridline interval (null for auto) |
-| `--minor-unit` | Minor gridline interval (null for auto) |
-| `--show-major` | Show major gridlines (null to keep current) |
-| `--show-minor` | Show minor gridlines (null to keep current) |
-| `--marker-style` | Marker shape style |
-| `--marker-size` | Marker size in points (2-72) |
-| `--marker-background-color` | Marker fill color (#RRGGBB) |
-| `--marker-foreground-color` | Marker border color (#RRGGBB) |
-| `--invert-if-negative` | Invert colors for negative values |
-| `--fill-color` | Series fill color as #RRGGBB |
-| `--fill-transparency` | Series fill transparency from 0 (opaque) to 1 (transparent) |
-| `--line-color` | Series line color as #RRGGBB |
-| `--line-weight` | Series line weight in points |
-| `--plot-by` | Interpret source rows or columns as data series |
-| `--display-blanks-as` | How blank cells appear: gaps, zeroes, or interpolation |
-| `--plot-visible-only` | True to omit hidden rows and columns |
-| `--area` | Chart area or plot area (required for: set-area-format) |
-| `--trendline-type` | Type of trendline (Linear, Exponential, etc.) (required for: add-trendline) |
-| `--order` | Polynomial order (2-6, for Polynomial type) |
-| `--period` | Moving average period (for MovingAverage type) |
-| `--forward` | Periods to extend forward |
-| `--backward` | Periods to extend backward |
-| `--intercept` | Force trendline through specific Y-intercept |
-| `--display-equation` | Display trendline equation on chart |
-| `--display-r-squared` | Display R-squared value on chart |
-| `--name` | Custom name for the trendline |
-| `--trendline-index` | 1-based index of the trendline to delete (required for: delete-trendline, set-trendline) |
+| `--source-range` | New data source range (e.g., Sheet1!A1:D10) (required for: set-source-range) (valid for: set-source-range) |
+| `--series-name` | Display name for the series (required for: add-series) (valid for: add-series) |
+| `--values-range` | Range containing series values (e.g., B2:B10) (required for: add-series) (valid for: add-series) |
+| `--category-range` | Optional range for category labels (e.g., A2:A10) (valid for: add-series) |
+| `--series-index` | 1-based index of the series to remove (required for: remove-series, set-series-format, set-series-chart-type, list-trendlines, add-trendline, delete-trendline, set-trendline) (valid for: remove-series, set-data-labels, set-series-format, set-series-chart-type, list-trendlines, add-trendline, delete-trendline, set-trendline) |
+| `--chart-type` | New chart type to apply (required for: set-chart-type, set-series-chart-type) (valid for: set-chart-type, set-series-chart-type) |
+| `--title` | Title text to display (required for: set-title, set-axis-title) (valid for: set-title, set-axis-title) |
+| `--axis` | Which axis to set title for (Category, Value, SeriesAxis) (required for: set-axis-title, get-axis-number-format, set-axis-number-format, get-axis-scale, set-axis-scale, set-gridlines) (valid for: set-axis-title, get-axis-number-format, set-axis-number-format, get-axis-scale, set-axis-scale, set-gridlines) |
+| `--number-format` | Excel number format code (e.g., "$#,##0", "0.00%") (required for: set-axis-number-format) (valid for: set-axis-number-format) |
+| `--visible` | True to show legend, false to hide (required for: show-legend) (valid for: show-legend) |
+| `--legend-position` | Optional position for the legend (valid for: show-legend) |
+| `--style-id` | Excel chart style ID (1-48 for most chart types) (required for: set-style) (valid for: set-style) |
+| `--placement` | Placement mode: 1=MoveAndSize, 2=Move, 3=FreeFloating (required for: set-placement) (valid for: set-placement) |
+| `--print-object` | Whether the embedded chart prints with the worksheet (valid for: set-placement) |
+| `--locked` | Whether the embedded chart is locked when the worksheet is protected (valid for: set-placement) |
+| `--rounded-corners` | Whether the embedded chart uses rounded corners (valid for: set-placement) |
+| `--show-value` | Show data values on labels (valid for: set-data-labels) |
+| `--show-percentage` | Show percentage values. Only meaningful for pie and doughnut chart types; setting to true on other chart types has no visual effect. (valid for: set-data-labels) |
+| `--show-series-name` | Show series name on labels (valid for: set-data-labels) |
+| `--show-category-name` | Show category name on labels (valid for: set-data-labels) |
+| `--show-bubble-size` | Show bubble size (bubble charts) (valid for: set-data-labels) |
+| `--separator` | Separator string between label components (valid for: set-data-labels) |
+| `--label-position` | Position of data labels relative to data points (valid for: set-data-labels) |
+| `--minimum-scale` | Minimum axis value (null for auto) (valid for: set-axis-scale) |
+| `--maximum-scale` | Maximum axis value (null for auto) (valid for: set-axis-scale) |
+| `--major-unit` | Major gridline interval (null for auto) (valid for: set-axis-scale) |
+| `--minor-unit` | Minor gridline interval (null for auto) (valid for: set-axis-scale) |
+| `--show-major` | Show major gridlines (null to keep current) (valid for: set-gridlines) |
+| `--show-minor` | Show minor gridlines (null to keep current) (valid for: set-gridlines) |
+| `--marker-style` | Marker shape style (valid for: set-series-format) |
+| `--marker-size` | Marker size in points (2-72) (valid for: set-series-format) |
+| `--marker-background-color` | Marker fill color (#RRGGBB) (valid for: set-series-format) |
+| `--marker-foreground-color` | Marker border color (#RRGGBB) (valid for: set-series-format) |
+| `--invert-if-negative` | Invert colors for negative values (valid for: set-series-format) |
+| `--fill-color` | Series fill color as #RRGGBB (valid for: set-series-format, set-area-format) |
+| `--fill-transparency` | Series fill transparency from 0 (opaque) to 1 (transparent) (valid for: set-series-format, set-area-format) |
+| `--line-color` | Series line color as #RRGGBB (valid for: set-series-format, set-area-format) |
+| `--line-weight` | Series line weight in points (valid for: set-series-format, set-area-format) |
+| `--plot-by` | Interpret source rows or columns as data series (valid for: set-plot-options) |
+| `--display-blanks-as` | How blank cells appear: gaps, zeroes, or interpolation (valid for: set-plot-options) |
+| `--plot-visible-only` | True to omit hidden rows and columns (valid for: set-plot-options) |
+| `--area` | Chart area or plot area (required for: set-area-format) (valid for: set-area-format) |
+| `--trendline-type` | Type of trendline (Linear, Exponential, etc.) (required for: add-trendline) (valid for: add-trendline) |
+| `--order` | Polynomial order (2-6, for Polynomial type) (valid for: add-trendline) |
+| `--period` | Moving average period (for MovingAverage type) (valid for: add-trendline) |
+| `--forward` | Periods to extend forward (valid for: add-trendline, set-trendline) |
+| `--backward` | Periods to extend backward (valid for: add-trendline, set-trendline) |
+| `--intercept` | Force trendline through specific Y-intercept (valid for: add-trendline, set-trendline) |
+| `--display-equation` | Display trendline equation on chart (valid for: add-trendline, set-trendline) |
+| `--display-r-squared` | Display R-squared value on chart (valid for: add-trendline, set-trendline) |
+| `--name` | Custom name for the trendline (valid for: add-trendline, set-trendline) |
+| `--trendline-index` | 1-based index of the trendline to delete (required for: delete-trendline, set-trendline) (valid for: delete-trendline, set-trendline) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### conditionalformat
@@ -150,51 +150,51 @@ Conditional formatting - visual rules based on cell values. TYPES: cellValue (re
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | Sheet name (empty for active sheet) (required) |
-| `--range` | Range address (A1 notation or named range) (required for: add-rule, clear-rules, list-rules) |
-| `--rule-type` | Rule type: cellValue (or cell-value), expression, colorScale, dataBar, top10, iconSet, uniqueValues, blanksCondition, timePeriod, aboveAverage. Both camelCase and kebab-case accepted. (required for: add-rule) |
-| `--operator-type` | Required for cellValue rules. XlFormatConditionOpe rator: equal, notEqual, greater, less, greaterEqual, lessEqual, between, notBetween |
-| `--formula1` | Required for cellValue and expression rules. First formula/value for condition |
-| `--formula2` | Required for between/notBetween cellValue rules. Second formula/value |
-| `--interior-color` | Fill color (#RRGGBB or color index) |
-| `--interior-pattern` | Interior pattern (1=Solid, -4142=None, 9=Gray50, etc.) |
-| `--font-color` | Font color (#RRGGBB or color index) |
-| `--font-bold` | Bold font |
-| `--font-italic` | Italic font |
-| `--border-style` | Border style: none, continuous, dash, dot, etc |
-| `--border-color` | Border color (#RRGGBB or color index) |
-| `--color-scale-min-type` | colorScale minimum stop type: minimum, number, percent, percentile, formula |
-| `--color-scale-min-value` | colorScale minimum stop value (for number/percent/perce ntile/formula) |
-| `--color-scale-min-color` | colorScale minimum stop color (#RRGGBB) |
-| `--color-scale-mid-type` | colorScale midpoint stop type (supply to create a 3-color scale) |
-| `--color-scale-mid-value` | colorScale midpoint stop value |
-| `--color-scale-mid-color` | colorScale midpoint stop color (#RRGGBB) |
-| `--color-scale-max-type` | colorScale maximum stop type: maximum, number, percent, percentile, formula |
-| `--color-scale-max-value` | colorScale maximum stop value |
-| `--color-scale-max-color` | colorScale maximum stop color (#RRGGBB) |
-| `--data-bar-color` | dataBar fill color (#RRGGBB) |
-| `--data-bar-negative-color` | dataBar negative-value bar color (#RRGGBB) |
-| `--data-bar-direction` | dataBar fill direction: context, leftToRight, rightToLeft |
-| `--data-bar-show-value` | dataBar show the cell value alongside the bar |
-| `--data-bar-min-type` | dataBar minimum point type: automaticMinimum, minimum, number, percent, percentile, formula |
-| `--data-bar-min-value` | dataBar minimum point value |
-| `--data-bar-max-type` | dataBar maximum point type: automaticMaximum, maximum, number, percent, percentile, formula |
-| `--data-bar-max-value` | dataBar maximum point value |
-| `--icon-set-id` | iconSet id: 3Arrows, 3TrafficLights1, 4Ratings, 5Quarters, etc |
-| `--icon-set-reverse` | iconSet reverse icon order |
-| `--icon-set-show-icon-only` | iconSet show only the icon (hide the value) |
-| `--icon-threshold1-type` | iconSet threshold 1 type: percent, number, percentile, formula |
-| `--icon-threshold1-value` | iconSet threshold 1 value |
-| `--icon-threshold2-type` | iconSet threshold 2 type |
-| `--icon-threshold2-value` | iconSet threshold 2 value |
-| `--icon-threshold3-type` | iconSet threshold 3 type |
-| `--icon-threshold3-value` | iconSet threshold 3 value |
-| `--icon-threshold4-type` | iconSet threshold 4 type |
-| `--icon-threshold4-value` | iconSet threshold 4 value |
-| `--rank` | top10 rank (number of values, or percent when top10Percent is true) |
-| `--top10-percent` | top10 treat rank as a percentage |
-| `--top-bottom` | top10 direction: top or bottom |
-| `--above-below` | aboveAverage selector: aboveAverage, belowAverage, aboveStdDev, belowStdDev, equalAboveAverage, equalBelowAverage |
-| `--date-period` | timePeriod period: today, yesterday, tomorrow, last7Days, thisWeek, lastWeek, nextWeek, thisMonth, lastMonth, nextMonth |
+| `--range` | Range address (A1 notation or named range) (required for: add-rule, clear-rules, list-rules) (valid for: add-rule, clear-rules, list-rules) |
+| `--rule-type` | Rule type: cellValue (or cell-value), expression, colorScale, dataBar, top10, iconSet, uniqueValues, blanksCondition, timePeriod, aboveAverage. Both camelCase and kebab-case accepted. (required for: add-rule) (valid for: add-rule) |
+| `--operator-type` | Required for cellValue rules. XlFormatConditionOpe rator: equal, notEqual, greater, less, greaterEqual, lessEqual, between, notBetween (valid for: add-rule) |
+| `--formula1` | Required for cellValue and expression rules. First formula/value for condition (valid for: add-rule) |
+| `--formula2` | Required for between/notBetween cellValue rules. Second formula/value (valid for: add-rule) |
+| `--interior-color` | Fill color (#RRGGBB or color index) (valid for: add-rule) |
+| `--interior-pattern` | Interior pattern (1=Solid, -4142=None, 9=Gray50, etc.) (valid for: add-rule) |
+| `--font-color` | Font color (#RRGGBB or color index) (valid for: add-rule) |
+| `--font-bold` | Bold font (valid for: add-rule) |
+| `--font-italic` | Italic font (valid for: add-rule) |
+| `--border-style` | Border style: none, continuous, dash, dot, etc. (valid for: add-rule) |
+| `--border-color` | Border color (#RRGGBB or color index) (valid for: add-rule) |
+| `--color-scale-min-type` | colorScale minimum stop type: minimum, number, percent, percentile, formula (valid for: add-rule) |
+| `--color-scale-min-value` | colorScale minimum stop value (for number/percent/perce ntile/formula) (valid for: add-rule) |
+| `--color-scale-min-color` | colorScale minimum stop color (#RRGGBB) (valid for: add-rule) |
+| `--color-scale-mid-type` | colorScale midpoint stop type (supply to create a 3-color scale) (valid for: add-rule) |
+| `--color-scale-mid-value` | colorScale midpoint stop value (valid for: add-rule) |
+| `--color-scale-mid-color` | colorScale midpoint stop color (#RRGGBB) (valid for: add-rule) |
+| `--color-scale-max-type` | colorScale maximum stop type: maximum, number, percent, percentile, formula (valid for: add-rule) |
+| `--color-scale-max-value` | colorScale maximum stop value (valid for: add-rule) |
+| `--color-scale-max-color` | colorScale maximum stop color (#RRGGBB) (valid for: add-rule) |
+| `--data-bar-color` | dataBar fill color (#RRGGBB) (valid for: add-rule) |
+| `--data-bar-negative-color` | dataBar negative-value bar color (#RRGGBB) (valid for: add-rule) |
+| `--data-bar-direction` | dataBar fill direction: context, leftToRight, rightToLeft (valid for: add-rule) |
+| `--data-bar-show-value` | dataBar show the cell value alongside the bar (valid for: add-rule) |
+| `--data-bar-min-type` | dataBar minimum point type: automaticMinimum, minimum, number, percent, percentile, formula (valid for: add-rule) |
+| `--data-bar-min-value` | dataBar minimum point value (valid for: add-rule) |
+| `--data-bar-max-type` | dataBar maximum point type: automaticMaximum, maximum, number, percent, percentile, formula (valid for: add-rule) |
+| `--data-bar-max-value` | dataBar maximum point value (valid for: add-rule) |
+| `--icon-set-id` | iconSet id: 3Arrows, 3TrafficLights1, 4Ratings, 5Quarters, etc. (valid for: add-rule) |
+| `--icon-set-reverse` | iconSet reverse icon order (valid for: add-rule) |
+| `--icon-set-show-icon-only` | iconSet show only the icon (hide the value) (valid for: add-rule) |
+| `--icon-threshold1-type` | iconSet threshold 1 type: percent, number, percentile, formula (valid for: add-rule) |
+| `--icon-threshold1-value` | iconSet threshold 1 value (valid for: add-rule) |
+| `--icon-threshold2-type` | iconSet threshold 2 type (valid for: add-rule) |
+| `--icon-threshold2-value` | iconSet threshold 2 value (valid for: add-rule) |
+| `--icon-threshold3-type` | iconSet threshold 3 type (valid for: add-rule) |
+| `--icon-threshold3-value` | iconSet threshold 3 value (valid for: add-rule) |
+| `--icon-threshold4-type` | iconSet threshold 4 type (valid for: add-rule) |
+| `--icon-threshold4-value` | iconSet threshold 4 value (valid for: add-rule) |
+| `--rank` | top10 rank (number of values, or percent when top10Percent is true) (valid for: add-rule) |
+| `--top10-percent` | top10 treat rank as a percentage (valid for: add-rule) |
+| `--top-bottom` | top10 direction: top or bottom (valid for: add-rule) |
+| `--above-below` | aboveAverage selector: aboveAverage, belowAverage, aboveStdDev, belowStdDev, equalAboveAverage, equalBelowAverage (valid for: add-rule) |
+| `--date-period` | timePeriod period: today, yesterday, tomorrow, last7Days, thisWeek, lastWeek, nextWeek, thisMonth, lastMonth, nextMonth (valid for: add-rule) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### connection
@@ -206,16 +206,16 @@ Data connections (OLEDB, ODBC, ODC import). TEXT/WEB/CSV: Use querytable for dir
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--connection-name` | Name of the connection to view (required for: view, create, refresh, get-refresh-status, cancel-refresh, delete, load-to, get-properties, set-properties, test) |
-| `--connection-string` | OLEDB or ODBC connection string (required for: create) |
-| `--command-text` | SQL query or table name |
-| `--description` | Optional description for the connection |
-| `--timeout` | Optional timeout for the refresh operation Accepts seconds (e.g. 600) or TimeSpan format (e.g. 00:10:00) |
-| `--sheet` | Target worksheet name (required for: load-to) |
-| `--background-query` | Run query in background (null to keep current) |
-| `--refresh-on-file-open` | Refresh when file opens (null to keep current) |
-| `--save-password` | Save password in connection (null to keep current) |
-| `--refresh-period` | Auto-refresh interval in minutes (null to keep current) |
+| `--connection-name` | Name of the connection to view (required for: view, create, refresh, get-refresh-status, cancel-refresh, delete, load-to, get-properties, set-properties, test) (valid for: view, create, refresh, get-refresh-status, cancel-refresh, delete, load-to, get-properties, set-properties, test) |
+| `--connection-string` | OLEDB or ODBC connection string (required for: create) (valid for: create, set-properties) |
+| `--command-text` | SQL query or table name (valid for: create, set-properties) |
+| `--description` | Optional description for the connection (valid for: create, set-properties) |
+| `--timeout` | Optional public timeout in whole seconds from 1 through 2147483; converted to TimeSpan at shared dispatch (valid for: refresh) |
+| `--sheet` | Target worksheet name (required for: load-to) (valid for: load-to) |
+| `--background-query` | Run query in background (null to keep current) (valid for: set-properties) |
+| `--refresh-on-file-open` | Refresh when file opens (null to keep current) (valid for: set-properties) |
+| `--save-password` | Save password in connection (null to keep current) (valid for: set-properties) |
+| `--refresh-period` | Auto-refresh interval in minutes (null to keep current) (valid for: set-properties) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### datamodel
@@ -227,20 +227,20 @@ Data Model (Power Pivot) - DAX measures and table management. CRITICAL: WORKSHEE
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--table-name` | Name of the table to list columns from (required for: list-columns, read-table, delete-table, create-measure) |
-| `--measure-name` | Name of the measure to get (required for: read, delete-measure, create-measure, update-measure) |
-| `--old-name` | Current name of the table (required for: rename-table) |
-| `--new-name` | New name for the table (required for: rename-table) |
-| `--timeout` | Optional: Timeout for the refresh operation Accepts seconds (e.g. 600) or TimeSpan format (e.g. 00:10:00) |
-| `--dax-formula` | DAX formula for the measure (required for: create-measure) |
-| `--dax-formula-file` | Path to file containing daxFormula |
-| `--format-type` | Optional: Format type (Currency, Decimal, Percentage, General) |
-| `--description` | Optional: Description of the measure |
-| `--format-dax` | Whether to send the DAX formula to the remote daxformatter.com service before saving. Defaults to false to preserve privacy |
-| `--dax-query` | DAX EVALUATE query (e.g., "EVALUATE 'TableName'" or "EVALUATE SUMMARIZE(...)") (required for: evaluate) |
-| `--dax-query-file` | Path to file containing daxQuery |
-| `--dmv-query` | DMV query in SQL-like syntax (e.g., "SELECT * FROM $SYSTEM.TMSCHEMA_TABLES") (required for: execute-dmv) |
-| `--dmv-query-file` | Path to file containing dmvQuery |
+| `--table-name` | Name of the table to list columns from (required for: list-columns, read-table, delete-table, create-measure) (valid for: list-columns, read-table, list-measures, delete-table, refresh, create-measure) |
+| `--measure-name` | Name of the measure to get (required for: read, delete-measure, create-measure, update-measure) (valid for: read, delete-measure, create-measure, update-measure) |
+| `--old-name` | Current name of the table (required for: rename-table) (valid for: rename-table) |
+| `--new-name` | New name for the table (required for: rename-table) (valid for: rename-table) |
+| `--timeout` | Optional public timeout in whole seconds from 1 through 2147483; converted to TimeSpan at shared dispatch (valid for: refresh) |
+| `--dax-formula` | DAX formula. Public callers must supply either inline daxFormula or a readable daxFormulaFile, not both. (required for: create-measure) (valid for: create-measure, update-measure) |
+| `--dax-formula-file` | Path to a readable file containing daxFormula; use instead of inline daxFormula, not together (valid for: create-measure, update-measure) |
+| `--format-type` | Optional: Format type (Currency, Decimal, Percentage, General) (valid for: create-measure, update-measure) |
+| `--description` | Optional: Description of the measure (valid for: create-measure, update-measure) |
+| `--format-dax` | Whether to send the DAX formula to the remote daxformatter.com service before saving. Defaults to false to preserve privacy. (valid for: create-measure, update-measure) |
+| `--dax-query` | DAX EVALUATE query. Public callers must supply either inline daxQuery or a readable daxQueryFile, not both. (required for: evaluate) (valid for: evaluate) |
+| `--dax-query-file` | Path to a readable file containing daxQuery; use instead of inline daxQuery, not together (valid for: evaluate) |
+| `--dmv-query` | DMV query in SQL-like syntax. Public callers must supply either inline dmvQuery or a readable dmvQueryFile, not both. (required for: execute-dmv) (valid for: execute-dmv) |
+| `--dmv-query-file` | Path to a readable file containing dmvQuery; use instead of inline dmvQuery, not together (valid for: execute-dmv) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### datamodelrelationship
@@ -252,11 +252,11 @@ Data Model relationships - link tables for cross-table DAX calculations. CRITICA
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--from-table` | Source table name (required for: read-relationship, create-relationship, update-relationship, delete-relationship) |
-| `--from-column` | Source column name (required for: read-relationship, create-relationship, update-relationship, delete-relationship) |
-| `--to-table` | Target table name (required for: read-relationship, create-relationship, update-relationship, delete-relationship) |
-| `--to-column` | Target column name (required for: read-relationship, create-relationship, update-relationship, delete-relationship) |
-| `--active` | Whether the relationship should be active (default: true) (required for: update-relationship) |
+| `--from-table` | Source table name (required for: read-relationship, create-relationship, update-relationship, delete-relationship) (valid for: read-relationship, create-relationship, update-relationship, delete-relationship) |
+| `--from-column` | Source column name (required for: read-relationship, create-relationship, update-relationship, delete-relationship) (valid for: read-relationship, create-relationship, update-relationship, delete-relationship) |
+| `--to-table` | Target table name (required for: read-relationship, create-relationship, update-relationship, delete-relationship) (valid for: read-relationship, create-relationship, update-relationship, delete-relationship) |
+| `--to-column` | Target column name (required for: read-relationship, create-relationship, update-relationship, delete-relationship) (valid for: read-relationship, create-relationship, update-relationship, delete-relationship) |
+| `--active` | Whether the relationship should be active (default: true) (required for: update-relationship) (valid for: create-relationship, update-relationship) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### diag
@@ -267,12 +267,12 @@ Diagnostic commands for testing CLI/MCP infrastructure without Excel. These comm
 
 | Parameter | Description |
 |-----------|-------------|
-| `--message` | The message to echo back (required) (required for: echo) |
-| `--tag` | Optional tag to include in the response |
-| `--name` | Required name parameter (required for: validate-params) |
-| `--count` | Required integer parameter (required for: validate-params) |
-| `--label` | Optional label parameter |
-| `--verbose` | Optional boolean flag (default: false) |
+| `--message` | The message to echo back (required) (required for: echo) (valid for: echo) |
+| `--tag` | Optional tag to include in the response (valid for: echo) |
+| `--name` | Required name parameter (required for: validate-params) (valid for: validate-params) |
+| `--count` | Required integer parameter (required for: validate-params) (valid for: validate-params) |
+| `--label` | Optional label parameter (valid for: validate-params) |
+| `--verbose` | Optional boolean flag (default: false) (valid for: validate-params) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### drawing
@@ -285,39 +285,39 @@ Worksheet drawing objects and sparklines. OBJECTS: list/read/update/delete image
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | (required) |
-| `--object-name` | (required for: get-object, update-object, delete-object) |
-| `--image-path` | (required for: add-image) |
-| `--name` | Name |
-| `--left` | Left |
-| `--top` | Top |
-| `--width` | Width |
-| `--height` | Height |
-| `--lock-aspect-ratio` | LockAspectRatio |
-| `--shape-type` | ShapeType |
-| `--text` | (required for: add-text-box) |
-| `--fill-color` | FillColor |
-| `--line-color` | LineColor |
-| `--line-weight` | LineWeight |
-| `--font-size` | FontSize |
-| `--font-color` | FontColor |
-| `--connector-type` | ConnectorType |
-| `--begin-x` | BeginX |
-| `--begin-y` | BeginY |
-| `--end-x` | EndX |
-| `--end-y` | EndY |
-| `--control-type` | ControlType |
-| `--linked-cell` | LinkedCell |
-| `--input-range` | InputRange |
-| `--new-name` | New name (for rename) |
-| `--rotation` | Rotation |
-| `--visible` | Visible |
-| `--locked` | Locked |
-| `--placement` | Placement |
-| `--alternative-text` | AlternativeText |
-| `--location-range` | (required for: get-sparkline, add-sparkline, update-sparkline, delete-sparkline) |
-| `--source-range` | (required for: add-sparkline) |
-| `--sparkline-type` | SparklineType |
-| `--show-markers` | ShowMarkers |
+| `--object-name` | (required for: get-object, update-object, delete-object) (valid for: get-object, update-object, delete-object) |
+| `--image-path` | (required for: add-image) (valid for: add-image) |
+| `--name` | (valid for: add-image, add-shape, add-text-box, add-connector, add-form-control) |
+| `--left` | (valid for: add-image, add-shape, add-text-box, add-form-control, update-object) |
+| `--top` | (valid for: add-image, add-shape, add-text-box, add-form-control, update-object) |
+| `--width` | (valid for: add-image, add-shape, add-text-box, add-form-control, update-object) |
+| `--height` | (valid for: add-image, add-shape, add-text-box, add-form-control, update-object) |
+| `--lock-aspect-ratio` | (valid for: add-image) |
+| `--shape-type` | (valid for: add-shape) |
+| `--text` | (required for: add-text-box) (valid for: add-shape, add-text-box, add-form-control, update-object) |
+| `--fill-color` | (valid for: add-shape, add-text-box, update-object) |
+| `--line-color` | (valid for: add-shape, add-text-box, add-connector, update-object, add-sparkline, update-sparkline) |
+| `--line-weight` | (valid for: add-shape, add-connector, update-object) |
+| `--font-size` | (valid for: add-text-box, update-object) |
+| `--font-color` | (valid for: add-text-box, update-object) |
+| `--connector-type` | (valid for: add-connector) |
+| `--begin-x` | (valid for: add-connector) |
+| `--begin-y` | (valid for: add-connector) |
+| `--end-x` | (valid for: add-connector) |
+| `--end-y` | (valid for: add-connector) |
+| `--control-type` | (valid for: add-form-control) |
+| `--linked-cell` | (valid for: add-form-control, update-object) |
+| `--input-range` | (valid for: add-form-control, update-object) |
+| `--new-name` | (valid for: update-object) |
+| `--rotation` | (valid for: update-object) |
+| `--visible` | (valid for: update-object) |
+| `--locked` | (valid for: update-object) |
+| `--placement` | (valid for: update-object) |
+| `--alternative-text` | (valid for: update-object) |
+| `--location-range` | (required for: get-sparkline, add-sparkline, update-sparkline, delete-sparkline) (valid for: get-sparkline, add-sparkline, update-sparkline, delete-sparkline) |
+| `--source-range` | (required for: add-sparkline) (valid for: add-sparkline, update-sparkline) |
+| `--sparkline-type` | (valid for: add-sparkline, update-sparkline) |
+| `--show-markers` | (valid for: add-sparkline, update-sparkline) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### namedrange
@@ -329,9 +329,9 @@ Named ranges for formulas/parameters. LIST: returns visible user-defined names; 
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--name` | Name of the named range (required for: write, read, update, create, delete) |
-| `--value` | Value to set (required for: write) |
-| `--reference` | New cell reference (e.g., Sheet1!$A$1:$B$10) (required for: update, create) |
+| `--name` | Name of the named range (required for: write, read, update, create, delete) (valid for: write, read, update, create, delete) |
+| `--value` | Value to set (required for: write) (valid for: write) |
+| `--reference` | New cell reference (e.g., Sheet1!$A$1:$B$10) (required for: update, create) (valid for: update, create) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### pivottable
@@ -343,19 +343,19 @@ PivotTable lifecycle management: create from various sources, list, read details
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--pivot-table-name` | Name of the PivotTable (required for: read, create-from-range, create-from-table, create-from-datamodel, delete, refresh, get-cache-options, set-cache-options, drill-through) |
-| `--source-sheet` | Source worksheet name (required for: create-from-range) |
-| `--source-range` | Source range address (e.g., "A1:F100") (required for: create-from-range) |
-| `--destination-sheet` | Destination worksheet name (required for: create-from-range, create-from-table, create-from-datamodel) |
-| `--destination-cell` | Destination cell address (e.g., "A1") (required for: create-from-range, create-from-table, create-from-datamodel) |
-| `--table-name` | Name of the Excel Table (required for: create-from-table, create-from-datamodel) |
-| `--timeout` | Optional timeout for the refresh operation Accepts seconds (e.g. 600) or TimeSpan format (e.g. 00:10:00) |
-| `--enable-refresh` | Allow the PivotCache to refresh |
-| `--refresh-on-file-open` | Refresh the PivotCache when the workbook opens |
-| `--missing-items-limit` | How many deleted source items Excel retains in the cache |
-| `--optimize-cache` | Optimize the cache when it is constructed |
-| `--save-source-data` | Save source records with the PivotTable |
-| `--cell-address` | Value-cell address on the PivotTable worksheet (for example, G4) (required for: drill-through) |
+| `--pivot-table-name` | Name of the PivotTable (required for: read, create-from-range, create-from-table, create-from-datamodel, delete, refresh, get-cache-options, set-cache-options, drill-through) (valid for: read, create-from-range, create-from-table, create-from-datamodel, delete, refresh, get-cache-options, set-cache-options, drill-through) |
+| `--source-sheet` | Source worksheet name (required for: create-from-range) (valid for: create-from-range) |
+| `--source-range` | Source range address (e.g., "A1:F100") (required for: create-from-range) (valid for: create-from-range) |
+| `--destination-sheet` | Destination worksheet name (required for: create-from-range, create-from-table, create-from-datamodel) (valid for: create-from-range, create-from-table, create-from-datamodel) |
+| `--destination-cell` | Destination cell address (e.g., "A1") (required for: create-from-range, create-from-table, create-from-datamodel) (valid for: create-from-range, create-from-table, create-from-datamodel) |
+| `--table-name` | Name of the Excel Table (required for: create-from-table, create-from-datamodel) (valid for: create-from-table, create-from-datamodel) |
+| `--timeout` | Optional public timeout in whole seconds from 1 through 2147483; converted to TimeSpan at shared dispatch (valid for: refresh) |
+| `--enable-refresh` | Allow the PivotCache to refresh (valid for: set-cache-options) |
+| `--refresh-on-file-open` | Refresh the PivotCache when the workbook opens (valid for: set-cache-options) |
+| `--missing-items-limit` | How many deleted source items Excel retains in the cache (valid for: set-cache-options) |
+| `--optimize-cache` | Optimize the cache when it is constructed (valid for: set-cache-options) |
+| `--save-source-data` | Save source records with the PivotTable (valid for: set-cache-options) |
+| `--cell-address` | Value-cell address on the PivotTable worksheet (for example, G4) (required for: drill-through) (valid for: drill-through) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### pivottablecalc
@@ -368,17 +368,17 @@ PivotTable calculated fields/members, layout configuration, and data extraction.
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--pivot-table-name` | Name of the PivotTable (required) |
-| `--field-name` | Name for the calculated field (required for: create-calculated-field, delete-calculated-field, set-subtotals) |
-| `--formula` | Formula using field references (e.g., "=Revenue-Cost") (required for: create-calculated-field, create-calculated-member) |
-| `--member-name` | Name for the calculated member (MDX naming format) (required for: create-calculated-member, delete-calculated-member) |
-| `--type` | Type of calculated member (Member, Set, or Measure) |
-| `--solve-order` | Solve order for calculation precedence (default: 0) |
-| `--display-folder` | Display folder path for organizing measures (optional) |
-| `--number-format` | Number format code for the calculated member (optional) |
-| `--row-layout` | Layout form: 0=Compact, 1=Tabular, 2=Outline (required for: set-layout) |
-| `--show-subtotals` | True to show automatic subtotals, false to hide (required for: set-subtotals) |
-| `--show-row-grand-totals` | Show row grand totals (bottom summary row) (required for: set-grand-totals) |
-| `--show-column-grand-totals` | Show column grand totals (right summary column) (required for: set-grand-totals) |
+| `--field-name` | Name for the calculated field (required for: create-calculated-field, delete-calculated-field, set-subtotals) (valid for: create-calculated-field, delete-calculated-field, set-subtotals) |
+| `--formula` | Formula using field references (e.g., "=Revenue-Cost") (required for: create-calculated-field, create-calculated-member) (valid for: create-calculated-field, create-calculated-member) |
+| `--member-name` | Name for the calculated member (MDX naming format) (required for: create-calculated-member, delete-calculated-member) (valid for: create-calculated-member, delete-calculated-member) |
+| `--type` | Type of calculated member (Member, Set, or Measure) (valid for: create-calculated-member) |
+| `--solve-order` | Solve order for calculation precedence (default: 0) (valid for: create-calculated-member) |
+| `--display-folder` | Display folder path for organizing measures (optional) (valid for: create-calculated-member) |
+| `--number-format` | Number format code for the calculated member (optional) (valid for: create-calculated-member) |
+| `--row-layout` | Layout form: 0=Compact, 1=Tabular, 2=Outline (required for: set-layout) (valid for: set-layout) |
+| `--show-subtotals` | True to show automatic subtotals, false to hide (required for: set-subtotals) (valid for: set-subtotals) |
+| `--show-row-grand-totals` | Show row grand totals (bottom summary row) (required for: set-grand-totals) (valid for: set-grand-totals) |
+| `--show-column-grand-totals` | Show column grand totals (right summary column) (required for: set-grand-totals) (valid for: set-grand-totals) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### pivottablefield
@@ -391,42 +391,42 @@ PivotTable field management: add/remove/configure fields, filtering, sorting, an
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--pivot-table-name` | Name of the PivotTable (required) |
-| `--field-name` | Name of the field to add (required for: add-row-field, add-column-field, add-value-field, add-filter-field, remove-field, set-field-function, set-field-name, set-field-format, set-field-filter, sort-field, group-by-date, group-by-numeric, group-items) |
-| `--position` | Optional position in row area (1-based) |
-| `--aggregation-function` | Aggregation function (for Regular and OLAP auto-create mode) (required for: set-field-function) |
-| `--custom-name` | Optional custom name for the field/measure (required for: set-field-name) |
-| `--number-format` | Number format string (required for: set-field-format) |
-| `--selected-values` | Values to show (others will be hidden) (required for: set-field-filter) (JSON format) |
-| `--direction` | Sort direction |
-| `--interval` | Grouping interval (Months, Quarters, Years) (required for: group-by-date) |
-| `--start` | Starting value (null = use field minimum) |
-| `--end-value` | Ending value (null = use field maximum) |
-| `--interval-size` | Size of each group (e.g., 100 for groups of 100) (required for: group-by-numeric) |
-| `--item-names` | Exact item captions to group (required for: group-items) (JSON format) |
-| `--group-name` | Caption for the new group (required for: group-items) |
-| `--grouped-field-name` | Generated grouped field name (required for: ungroup-field) |
+| `--field-name` | Name of the field to add (required for: add-row-field, add-column-field, add-value-field, add-filter-field, remove-field, set-field-function, set-field-name, set-field-format, set-field-filter, sort-field, group-by-date, group-by-numeric, group-items) (valid for: add-row-field, add-column-field, add-value-field, add-filter-field, remove-field, set-field-function, set-field-name, set-field-format, set-field-filter, sort-field, group-by-date, group-by-numeric, group-items) |
+| `--position` | Optional position in row area (1-based) (valid for: add-row-field, add-column-field) |
+| `--aggregation-function` | Aggregation function (for Regular and OLAP auto-create mode) (required for: set-field-function) (valid for: add-value-field, set-field-function) |
+| `--custom-name` | Optional custom name for the field/measure (required for: set-field-name) (valid for: add-value-field, set-field-name) |
+| `--number-format` | Number format string (required for: set-field-format) (valid for: set-field-format) |
+| `--selected-values` | Values to show (others will be hidden) (required for: set-field-filter) (valid for: set-field-filter) (JSON format) |
+| `--direction` | Sort direction (valid for: sort-field) |
+| `--interval` | Grouping interval (Months, Quarters, Years) (required for: group-by-date) (valid for: group-by-date) |
+| `--start` | Starting value (null = use field minimum) (valid for: group-by-numeric) |
+| `--end-value` | Ending value (null = use field maximum) (valid for: group-by-numeric) |
+| `--interval-size` | Size of each group (e.g., 100 for groups of 100) (required for: group-by-numeric) (valid for: group-by-numeric) |
+| `--item-names` | Exact item captions to group (required for: group-items) (valid for: group-items) (JSON format) |
+| `--group-name` | Caption for the new group (required for: group-items) (valid for: group-items) |
+| `--grouped-field-name` | Generated grouped field name (required for: ungroup-field) (valid for: ungroup-field) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### powerquery
 
-Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACTICE): 1. evaluate - Test M code WITHOUT persisting (catches syntax errors, validates sources, shows data preview) 2. create/update - Store VALIDATED query in workbook 3. refresh/load-to - Load data to destination Skip evaluate only for trivial literal tables. IF CREATE/UPDATE FAILS: Use evaluate to get the actual M engine error message, fix code, retry. DATETIME COLUMNS: Always include Table.TransformColumnTypes() in M code to set column types explicitly. Without explicit types, dates may be stored as numbers and Data Model relationships may fail. DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'. Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures. M-CODE: Preserved exactly by default. Set formatMCode=true only with explicit user consent; it sends M code to powerqueryformatter.com. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60 or similar. timeout=0 or omitted uses the 30 min default
+Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACTICE): 1. evaluate - Test M code WITHOUT persisting (catches syntax errors, validates sources, shows data preview) 2. create/update - Store VALIDATED query in workbook 3. refresh/load-to - Load data to destination Skip evaluate only for trivial literal tables. IF CREATE/UPDATE FAILS: Use evaluate to get the actual M engine error message, fix code, retry. DATETIME COLUMNS: Always include Table.TransformColumnTypes() in M code to set column types explicitly. Without explicit types, dates may be stored as numbers and Data Model relationships may fail. DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'. Values are case-insensitive and unknown values are rejected. Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures. M-CODE: Preserved exactly by default. Set formatMCode=true only with explicit user consent; it sends M code to powerqueryformatter.com. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: Refresh accepts a caller timeout; load-to uses the fixed 30-minute data-operation timeout. READS: list returns compact metadata, exact load state, and an M preview of at most 80 characters. Use view for one query's full M code
 
 **Actions:** `list`, `view`, `refresh`, `get-load-config`, `delete`, `create`, `update`, `load-to`, `refresh-all`, `rename`, `unload`, `evaluate`
 
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--query-name` | Name of the query to view (required for: view, refresh, get-load-config, delete, create, update, load-to, unload) |
-| `--timeout` | Maximum time to wait for refresh (required for: refresh) Accepts seconds (e.g. 600) or TimeSpan format (e.g. 00:10:00) |
-| `--m-code` | Raw M code (inline string) (required for: create, update, evaluate) |
-| `--m-code-file` | Path to file containing mCode |
-| `--load-destination` | Load destination mode (required for: load-to) |
-| `--target-sheet` | Target worksheet name (required for LoadToTable and LoadToBoth; defaults to query name when omitted) |
-| `--target-cell-address` | Optional target cell address for worksheet loads (e.g., "B5"). Required when loading to an existing worksheet with other data |
-| `--format-m-code` | Whether to send M code to the remote powerqueryformatter.com service before saving. Defaults to false to preserve privacy |
-| `--refresh` | Whether to refresh data after update (default: true) |
-| `--old-name` | Current name of the query (required for: rename) |
-| `--new-name` | New name for the query (required for: rename) |
+| `--query-name` | Name of the query to view (required for: view, refresh, get-load-config, delete, create, update, load-to, unload) (valid for: view, refresh, get-load-config, delete, create, update, load-to, unload) |
+| `--timeout` | Public input is whole seconds from 0 through 2147483. Omitted or 0 uses the 30-minute data-operation default. (valid for: refresh, refresh-all) |
+| `--m-code` | Raw M code. Public callers must supply either inline mCode or a readable mCodeFile, not both. (required for: create, update, evaluate) (valid for: create, update, evaluate) |
+| `--m-code-file` | Path to a readable file containing mCode; use instead of inline mCode, not together (valid for: create, update, evaluate) |
+| `--load-destination` | Load destination mode (required for: load-to) (valid for: create, load-to) |
+| `--target-sheet` | Target worksheet name (required for LoadToTable and LoadToBoth; defaults to query name when omitted) (valid for: create, load-to) |
+| `--target-cell-address` | Optional target cell address for worksheet loads (e.g., "B5"). Required when loading to an existing worksheet with other data. (valid for: create, load-to) |
+| `--format-m-code` | Whether to send M code to the remote powerqueryformatter.com service before saving. Defaults to false to preserve privacy. (valid for: create, update) |
+| `--refresh` | Whether to refresh data after update (default: true) (valid for: update) |
+| `--old-name` | Current name of the query (required for: rename) (valid for: rename) |
+| `--new-name` | New name for the query (required for: rename) (valid for: rename) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### pythoninexcel
@@ -440,9 +440,9 @@ Microsoft 365 "Python in Excel" (=PY()) formulas. REQUIRES: a real Excel session
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | Worksheet name (required) |
 | `--range` | Target cell address (e.g. "D1") (required) |
-| `--code` | Python source code (e.g. "xl('A1:A6').sum()") (required for: set-formula) |
-| `--return-type` | 0 = Excel Value (default), 1 = Python Object |
-| `--max-wait-seconds` | Maximum seconds to poll for the cloud result before giving up (default: 30). Must be shorter than the session operation timeout. Returns as soon as the result is ready |
+| `--code` | Python source code (e.g. "xl('A1:A6').sum()") (required for: set-formula) (valid for: set-formula) |
+| `--return-type` | 0 = Excel Value (default), 1 = Python Object (valid for: set-formula) |
+| `--max-wait-seconds` | Maximum seconds to poll for the cloud result before giving up (default: 30). Must be shorter than the session operation timeout. Returns as soon as the result is ready. (valid for: get-result) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### querytable
@@ -454,23 +454,23 @@ Worksheet QueryTable lifecycle and configuration for local COM text, CSV, and le
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--sheet` | (required for: view, create-text, create-web, set-properties, refresh, get-refresh-status, cancel-refresh, delete) |
-| `--query-table-name` | (required for: view, create-text, create-web, set-properties, refresh, get-refresh-status, cancel-refresh, delete) |
-| `--source-path` | (required for: create-text) |
-| `--destination-address` | (required for: create-text, create-web) |
-| `--delimiter` | Delimiter |
-| `--text-qualifier` | TextQualifier |
-| `--encoding` | Encoding |
-| `--has-headers` | HasHeaders |
-| `--url` | (required for: create-web) |
-| `--selection-type` | SelectionType |
-| `--web-tables` | WebTables |
-| `--formatting` | Formatting |
-| `--background-query` | BackgroundQuery |
-| `--refresh-on-file-open` | RefreshOnFileOpen |
-| `--refresh-period` | RefreshPeriod |
-| `--adjust-column-width` | AdjustColumnWidth |
-| `--preserve-formatting` | PreserveFormatting |
+| `--sheet` | (required for: view, create-text, create-web, set-properties, refresh, get-refresh-status, cancel-refresh, delete) (valid for: view, create-text, create-web, set-properties, refresh, get-refresh-status, cancel-refresh, delete) |
+| `--query-table-name` | (required for: view, create-text, create-web, set-properties, refresh, get-refresh-status, cancel-refresh, delete) (valid for: view, create-text, create-web, set-properties, refresh, get-refresh-status, cancel-refresh, delete) |
+| `--source-path` | (required for: create-text) (valid for: create-text) |
+| `--destination-address` | (required for: create-text, create-web) (valid for: create-text, create-web) |
+| `--delimiter` | (valid for: create-text) |
+| `--text-qualifier` | (valid for: create-text) |
+| `--encoding` | (valid for: create-text) |
+| `--has-headers` | (valid for: create-text) |
+| `--url` | (required for: create-web) (valid for: create-web) |
+| `--selection-type` | (valid for: create-web) |
+| `--web-tables` | (valid for: create-web) |
+| `--formatting` | (valid for: create-web) |
+| `--background-query` | (valid for: set-properties) |
+| `--refresh-on-file-open` | (valid for: set-properties) |
+| `--refresh-period` | (valid for: set-properties) |
+| `--adjust-column-width` | (valid for: set-properties) |
+| `--preserve-formatting` | (valid for: set-properties) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### range
@@ -482,20 +482,20 @@ Core range operations: get/set values and formulas, copy ranges, clear content, 
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--sheet` | Name of the worksheet containing the range - REQUIRED for cell addresses, use empty string for named ranges only (required for: get-values, set-values, get-formulas, set-formulas, validate-formulas, clear-all, clear-contents, clear-formats, get-number-formats, set-number-format, set-number-formats, get-used-range, get-current-region, get-info) |
-| `--range` | Cell range address (e.g., 'A1', 'A1:D10', 'B:D') or named range name (e.g., 'SalesData') (required for: get-values, set-values, get-formulas, set-formulas, validate-formulas, clear-all, clear-contents, clear-formats, get-number-formats, set-number-format, set-number-formats, get-info) |
-| `--values` | 2D array of values to set - rows are outer array, columns are inner array (e.g., [[1,2,3],[4,5,6]] for 2 rows x 3 cols). Optional if valuesFile is provided. (JSON format) |
-| `--values-file` | Path to a JSON or CSV file containing the values. JSON: 2D array. CSV: rows/columns. Alternative to inline values parameter |
-| `--formulas` | 2D array of formulas to set - include '=' prefix (e.g., [['=A1+B1', '=SUM(A:A)'], ['=C1*2', '=AVERAGE(B:B)']]). Optional if formulasFile is provided. (JSON format) |
-| `--formulas-file` | Path to a JSON file containing the formulas as a 2D array. Alternative to inline formulas parameter |
-| `--source-sheet` | Source worksheet name for copy operations (required for: copy, copy-values, copy-formulas) |
-| `--source-range` | Source range address for copy operations (e.g., 'A1:D10') (required for: copy, copy-values, copy-formulas) |
-| `--target-sheet` | Target worksheet name for copy operations (required for: copy, copy-values, copy-formulas) |
-| `--target-range` | Target range address - can be single cell for paste destination (e.g., 'A1') (required for: copy, copy-values, copy-formulas) |
-| `--format-code` | Number format code in US locale (e.g., '#,##0.00' for numbers, 'mm/dd/yyyy' for dates, '0.00%' for percentages, 'General' for default, '@' for text) (required for: set-number-format) |
-| `--formats` | 2D array of format codes - same dimensions as target range (e.g., [['#,##0.00', '0.00%'], ['mm/dd/yyyy', 'General']]). Optional if formatsFile is provided. (JSON format) |
-| `--formats-file` | Path to a JSON file containing 2D array of format codes. Alternative to inline formats parameter |
-| `--cell-address` | Single cell address (e.g., 'B5') - expands to contiguous data region around this cell (required for: get-current-region) |
+| `--sheet` | Name of the worksheet containing the range - REQUIRED for cell addresses, use empty string for named ranges only (required for: get-values, set-values, get-formulas, set-formulas, validate-formulas, clear-all, clear-contents, clear-formats, get-number-formats, set-number-format, set-number-formats, get-used-range, get-current-region, get-info) (valid for: get-values, set-values, get-formulas, set-formulas, validate-formulas, clear-all, clear-contents, clear-formats, get-number-formats, set-number-format, set-number-formats, get-used-range, get-current-region, get-info) |
+| `--range` | Cell range address (e.g., 'A1', 'A1:D10', 'B:D') or named range name (e.g., 'SalesData') (required for: get-values, set-values, get-formulas, set-formulas, validate-formulas, clear-all, clear-contents, clear-formats, get-number-formats, set-number-format, set-number-formats, get-info) (valid for: get-values, set-values, get-formulas, set-formulas, validate-formulas, clear-all, clear-contents, clear-formats, get-number-formats, set-number-format, set-number-formats, get-info) |
+| `--values` | 2D array of values to set - rows are outer array, columns are inner array (e.g., [[1,2,3],[4,5,6]] for 2 rows x 3 cols). Optional if valuesFile is provided. (valid for: set-values) (JSON format) |
+| `--values-file` | Path to a JSON or CSV file containing the values. JSON: 2D array. CSV: rows/columns. Alternative to inline values parameter. (valid for: set-values) |
+| `--formulas` | 2D array of formulas to set - include '=' prefix (e.g., [['=A1+B1', '=SUM(A:A)'], ['=C1*2', '=AVERAGE(B:B)']]). Optional if formulasFile is provided. (valid for: set-formulas, validate-formulas) (JSON format) |
+| `--formulas-file` | Path to a JSON file containing the formulas as a 2D array. Alternative to inline formulas parameter. (valid for: set-formulas, validate-formulas) |
+| `--source-sheet` | Source worksheet name for copy operations (required for: copy, copy-values, copy-formulas) (valid for: copy, copy-values, copy-formulas) |
+| `--source-range` | Source range address for copy operations (e.g., 'A1:D10') (required for: copy, copy-values, copy-formulas) (valid for: copy, copy-values, copy-formulas) |
+| `--target-sheet` | Target worksheet name for copy operations (required for: copy, copy-values, copy-formulas) (valid for: copy, copy-values, copy-formulas) |
+| `--target-range` | Target range address - can be single cell for paste destination (e.g., 'A1') (required for: copy, copy-values, copy-formulas) (valid for: copy, copy-values, copy-formulas) |
+| `--format-code` | Number format code in US locale (e.g., '#,##0.00' for numbers, 'mm/dd/yyyy' for dates, '0.00%' for percentages, 'General' for default, '@' for text) (required for: set-number-format) (valid for: set-number-format) |
+| `--formats` | 2D array of format codes - same dimensions as target range (e.g., [['#,##0.00', '0.00%'], ['mm/dd/yyyy', 'General']]). Optional if formatsFile is provided. (valid for: set-number-formats) (JSON format) |
+| `--formats-file` | Path to a JSON file containing 2D array of format codes. Alternative to inline formats parameter. (valid for: set-number-formats) |
+| `--cell-address` | Single cell address (e.g., 'B5') - expands to contiguous data region around this cell (required for: get-current-region) (valid for: get-current-region) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### rangeedit
@@ -509,15 +509,15 @@ Range editing operations: insert/delete cells, rows, and columns; find/replace t
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | Name of the worksheet containing the range (required) |
 | `--range` | Cell range address where cells will be inserted (e.g., 'A1:D10') (required) |
-| `--insert-shift` | Direction to shift existing cells: 'Down' or 'Right' (required for: insert-cells) |
-| `--delete-shift` | Direction to shift remaining cells: 'Up' or 'Left' (required for: delete-cells) |
-| `--search-value` | Text or value to search for (required for: find) |
-| `--find-options` | Search options: matchCase (default: false), matchEntireCell (default: false), searchFormulas (default: true) (required for: find) |
-| `--find-value` | Text or value to search for (required for: replace) |
-| `--replace-value` | Text or value to replace matches with (required for: replace) |
-| `--replace-options` | Replace options: matchCase (default: false), matchEntireCell (default: false), replaceAll (default: true) (required for: replace) |
-| `--sort-columns` | Array of sort specifications: [{columnIndex: 1, ascending: true}, ...] - columnIndex is 1-based relative to range (required for: sort) (JSON format) |
-| `--has-headers` | Whether the range has a header row to exclude from sorting (default: true) |
+| `--insert-shift` | Direction to shift existing cells: 'Down' or 'Right' (required for: insert-cells) (valid for: insert-cells) |
+| `--delete-shift` | Direction to shift remaining cells: 'Up' or 'Left' (required for: delete-cells) (valid for: delete-cells) |
+| `--search-value` | Text or value to search for (required for: find) (valid for: find) |
+| `--find-options` | Search options: matchCase (default: false), matchEntireCell (default: false), searchFormulas (default: true) (required for: find) (valid for: find) |
+| `--find-value` | Text or value to search for (required for: replace) (valid for: replace) |
+| `--replace-value` | Text or value to replace matches with (required for: replace) (valid for: replace) |
+| `--replace-options` | Replace options: matchCase (default: false), matchEntireCell (default: false), replaceAll (default: true) (required for: replace) (valid for: replace) |
+| `--sort-columns` | Array of sort specifications: [{columnIndex: 1, ascending: true}, ...] - columnIndex is 1-based relative to range (required for: sort) (valid for: sort) (JSON format) |
+| `--has-headers` | Whether the range has a header row to exclude from sorting (default: true) (valid for: sort) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### rangeformat
@@ -530,39 +530,39 @@ Range formatting operations: apply styles, set fonts/colors/borders, add data va
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | Name of the worksheet containing the range (required) |
-| `--range` | Cell range address (e.g., 'A1:D10') (required for: set-style, get-style, format-range, validate-range, get-validation, remove-validation, auto-fit-columns, auto-fit-rows, merge-cells, unmerge-cells, get-merge-info, set-column-width, set-row-height) |
-| `--style-name` | Built-in or custom style name (e.g., 'Heading 1', 'Good', 'Bad', 'Currency', 'Percent'). Use 'Normal' to reset. (required for: set-style) |
-| `--font-name` | Font family name (e.g., 'Arial', 'Calibri', 'Times New Roman') |
-| `--font-size` | Font size in points (e.g., 10, 11, 12, 14, 16) |
-| `--bold` | Whether to apply bold formatting |
-| `--italic` | Whether to apply italic formatting |
-| `--underline` | Whether to apply underline formatting |
-| `--font-color` | Font (foreground) color as hex '#RRGGBB' (e.g., '#FF0000' for red) |
-| `--fill-color` | Cell fill (background) color as hex '#RRGGBB' (e.g., '#FFFF00' for yellow) |
-| `--border-style` | Border line style: 'continuous', 'dash', 'dot', 'dashdot', 'dashdotdot', 'double', 'slantdashdot', 'none' |
-| `--border-color` | Border color as hex '#RRGGBB' |
-| `--border-weight` | Border weight: 'hairline', 'thin', 'medium', 'thick' |
-| `--horizontal-alignment` | Horizontal text alignment: 'left', 'center', 'right', 'justify', 'fill' |
-| `--vertical-alignment` | Vertical text alignment: 'top', 'center' (or 'middle'), 'bottom', 'justify' |
-| `--wrap-text` | Whether to wrap text within cells |
-| `--orientation` | Text rotation in degrees (-90 to 90, or 255 for vertical) |
-| `--range-addresses` | Cell range addresses to format (e.g., 'A1:D1', 'A3:D3') (required for: format-ranges) |
-| `--number-format` | Excel number format code applied to all target ranges (e.g., '0.00%' for percentage, '$#,##0.00' for currency, 'm/d/yyyy' for date). LLMs know Excel format codes natively |
-| `--validation-type` | Data validation type: 'list', 'whole', 'decimal', 'date', 'time', 'textLength', 'custom' (required for: validate-range) |
-| `--validation-operator` | Validation comparison operator: 'between', 'notBetween', 'equal', 'notEqual', 'greaterThan', 'lessThan', 'greaterThanOrEqual', 'lessThanOrEqual' |
-| `--formula1` | First validation formula/value - for list validation use range '=$A$1:$A$10' or inline '"A,B,C"' |
-| `--formula2` | Second validation formula/value - required only for 'between' and 'notBetween' operators |
-| `--show-input-message` | Whether to show input message when cell is selected (default: false) |
-| `--input-title` | Title for the input message popup |
-| `--input-message` | Text for the input message popup |
-| `--show-error-alert` | Whether to show error alert on invalid input (default: true) |
-| `--error-style` | Error alert style: 'stop' (prevents entry), 'warning' (allows override), 'information' (allows entry) |
-| `--error-title` | Title for the error alert popup |
-| `--error-message` | Text for the error alert popup |
-| `--ignore-blank` | Whether to allow blank cells in validation (default: true) |
-| `--show-dropdown` | Whether to show dropdown arrow for list validation (default: true) |
-| `--column-width` | Width in points (1 point = 1/72 inch, approx 0.35mm). Standard width ~8.43 points. Range: 0.25-409 points. (required for: set-column-width) |
-| `--row-height` | Height in points (1 point = 1/72 inch, approx 0.35mm). Default row height ~15 points. Range: 0-409 points. (required for: set-row-height) |
+| `--range` | Cell range address (e.g., 'A1:D10') (required for: set-style, get-style, format-range, validate-range, get-validation, remove-validation, auto-fit-columns, auto-fit-rows, merge-cells, unmerge-cells, get-merge-info, set-column-width, set-row-height) (valid for: set-style, get-style, format-range, validate-range, get-validation, remove-validation, auto-fit-columns, auto-fit-rows, merge-cells, unmerge-cells, get-merge-info, set-column-width, set-row-height) |
+| `--style-name` | Built-in or custom style name (e.g., 'Heading 1', 'Good', 'Bad', 'Currency', 'Percent'). Use 'Normal' to reset. (required for: set-style) (valid for: set-style) |
+| `--font-name` | Font family name (e.g., 'Arial', 'Calibri', 'Times New Roman') (valid for: format-range, format-ranges) |
+| `--font-size` | Font size in points (e.g., 10, 11, 12, 14, 16) (valid for: format-range, format-ranges) |
+| `--bold` | Whether to apply bold formatting (valid for: format-range, format-ranges) |
+| `--italic` | Whether to apply italic formatting (valid for: format-range, format-ranges) |
+| `--underline` | Whether to apply underline formatting (valid for: format-range, format-ranges) |
+| `--font-color` | Font (foreground) color as hex '#RRGGBB' (e.g., '#FF0000' for red) (valid for: format-range, format-ranges) |
+| `--fill-color` | Cell fill (background) color as hex '#RRGGBB' (e.g., '#FFFF00' for yellow) (valid for: format-range, format-ranges) |
+| `--border-style` | Border line style: 'continuous', 'dash', 'dot', 'dashdot', 'dashdotdot', 'double', 'slantdashdot', 'none' (valid for: format-range, format-ranges) |
+| `--border-color` | Border color as hex '#RRGGBB' (valid for: format-range, format-ranges) |
+| `--border-weight` | Border weight: 'hairline', 'thin', 'medium', 'thick' (valid for: format-range, format-ranges) |
+| `--horizontal-alignment` | Horizontal text alignment: 'left', 'center', 'right', 'justify', 'fill' (valid for: format-range, format-ranges) |
+| `--vertical-alignment` | Vertical text alignment: 'top', 'center' (or 'middle'), 'bottom', 'justify' (valid for: format-range, format-ranges) |
+| `--wrap-text` | Whether to wrap text within cells (valid for: format-range, format-ranges) |
+| `--orientation` | Text rotation in degrees (-90 to 90, or 255 for vertical) (valid for: format-range, format-ranges) |
+| `--range-addresses` | Cell range addresses to format (e.g., 'A1:D1', 'A3:D3') (required for: format-ranges) (valid for: format-ranges) |
+| `--number-format` | Excel number format code applied to all target ranges (e.g., '0.00%' for percentage, '$#,##0.00' for currency, 'm/d/yyyy' for date). LLMs know Excel format codes natively. (valid for: format-ranges) |
+| `--validation-type` | Data validation type: 'list', 'whole', 'decimal', 'date', 'time', 'textLength', 'custom' (required for: validate-range) (valid for: validate-range) |
+| `--validation-operator` | Validation comparison operator: 'between', 'notBetween', 'equal', 'notEqual', 'greaterThan', 'lessThan', 'greaterThanOrEqual', 'lessThanOrEqual' (valid for: validate-range) |
+| `--formula1` | First validation formula/value - for list validation use range '=$A$1:$A$10' or inline '"A,B,C"' (valid for: validate-range) |
+| `--formula2` | Second validation formula/value - required only for 'between' and 'notBetween' operators (valid for: validate-range) |
+| `--show-input-message` | Whether to show input message when cell is selected (default: false) (valid for: validate-range) |
+| `--input-title` | Title for the input message popup (valid for: validate-range) |
+| `--input-message` | Text for the input message popup (valid for: validate-range) |
+| `--show-error-alert` | Whether to show error alert on invalid input (default: true) (valid for: validate-range) |
+| `--error-style` | Error alert style: 'stop' (prevents entry), 'warning' (allows override), 'information' (allows entry) (valid for: validate-range) |
+| `--error-title` | Title for the error alert popup (valid for: validate-range) |
+| `--error-message` | Text for the error alert popup (valid for: validate-range) |
+| `--ignore-blank` | Whether to allow blank cells in validation (default: true) (valid for: validate-range) |
+| `--show-dropdown` | Whether to show dropdown arrow for list validation (default: true) (valid for: validate-range) |
+| `--column-width` | Width in points (1 point = 1/72 inch, approx 0.35mm). Standard width ~8.43 points. Range: 0.25-409 points. (required for: set-column-width) (valid for: set-column-width) |
+| `--row-height` | Height in points (1 point = 1/72 inch, approx 0.35mm). Default row height ~15 points. Range: 0-409 points. (required for: set-row-height) (valid for: set-row-height) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### rangelink
@@ -575,14 +575,14 @@ Hyperlink, threaded comment, and cell protection operations for Excel ranges. Us
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | Name of the worksheet (required) |
-| `--cell-address` | Single cell address (e.g., 'A1') (required for: add-hyperlink, update-hyperlink, get-hyperlink, add-threaded-comment, list-threaded-comments, add-threaded-comment-reply, delete-threaded-comment) |
-| `--url` | Optional external URL or file path. Omit for an internal workbook link |
-| `--display-text` | Text to display in the cell (optional, defaults to URL) |
-| `--tooltip` | Tooltip text shown on hover (optional) |
-| `--sub-address` | Optional internal workbook target such as "'Sheet2'!A1" |
-| `--range` | Cell range address to remove hyperlinks from (e.g., 'A1:D10') (required for: remove-hyperlink, set-cell-lock, get-cell-lock) |
-| `--text` | (required for: add-threaded-comment, add-threaded-comment-reply) |
-| `--locked` | Lock status: true = locked (protected when sheet protection enabled), false = unlocked (editable) (required for: set-cell-lock) |
+| `--cell-address` | Single cell address (e.g., 'A1') (required for: add-hyperlink, update-hyperlink, get-hyperlink, add-threaded-comment, list-threaded-comments, add-threaded-comment-reply, delete-threaded-comment) (valid for: add-hyperlink, update-hyperlink, get-hyperlink, add-threaded-comment, list-threaded-comments, add-threaded-comment-reply, delete-threaded-comment) |
+| `--url` | Optional external URL or file path. Omit for an internal workbook link. (valid for: add-hyperlink, update-hyperlink) |
+| `--display-text` | Text to display in the cell (optional, defaults to URL) (valid for: add-hyperlink, update-hyperlink) |
+| `--tooltip` | Tooltip text shown on hover (optional) (valid for: add-hyperlink, update-hyperlink) |
+| `--sub-address` | Optional internal workbook target such as "'Sheet2'!A1" (valid for: add-hyperlink, update-hyperlink) |
+| `--range` | Cell range address to remove hyperlinks from (e.g., 'A1:D10') (required for: remove-hyperlink, set-cell-lock, get-cell-lock) (valid for: remove-hyperlink, set-cell-lock, get-cell-lock) |
+| `--text` | (required for: add-threaded-comment, add-threaded-comment-reply) (valid for: add-threaded-comment, add-threaded-comment-reply) |
+| `--locked` | Lock status: true = locked (protected when sheet protection enabled), false = unlocked (editable) (required for: set-cell-lock) (valid for: set-cell-lock) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### screenshot
@@ -595,7 +595,7 @@ Capture Excel worksheet content as images for visual verification. Photographs t
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | Worksheet name (null for active sheet) |
-| `--range` | Range to capture (e.g., "A1:F20") |
+| `--range` | Range to capture (e.g., "A1:F20") (valid for: capture) |
 | `--quality` | Image quality: Medium (default, JPEG 75% scale), High (PNG full scale), Low (JPEG 50% scale) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
@@ -605,15 +605,15 @@ Service lifecycle management: start, stop, status
 
 #### service start
 
-Start the ExcelMCP Service if not already running
+Start the ExcelMCP Service if needed and wait up to 30 seconds for readiness
 
 #### service stop
 
-Gracefully stop the ExcelMCP Service
+Stop the CLI service and its pipe-owned Excel processes
 
 #### service status
 
-Show service status (running, PID, sessions, uptime)
+Show stopped, starting, running, or unresponsive daemon state; readiness checks wait up to 10 seconds
 
 ### session
 
@@ -626,7 +626,7 @@ Create a new Excel file, open it, and create a session. Add --show for visible E
 | Parameter | Description |
 |-----------|-------------|
 | `<file>` | Path to the new Excel file to create |
-| `--timeout` | Session open/create and operation timeout in seconds (default: 120) |
+| `--timeout` | Session open/create and operation timeout in whole seconds (default: 120; range: 10-3600) |
 | `--show` | Show the Excel window for IRM/auth prompts instead of running hidden |
 
 #### session open
@@ -636,7 +636,7 @@ Open an Excel file and create a session. Add --show for visible Excel
 | Parameter | Description |
 |-----------|-------------|
 | `<file>` | Path to the Excel file to open |
-| `--timeout` | Session open and operation timeout in seconds (default: 120) |
+| `--timeout` | Session open and operation timeout in whole seconds (default: 120; range: 10-3600) |
 | `--show` | Show the Excel window for IRM/auth prompts instead of running hidden |
 
 #### session close
@@ -650,15 +650,15 @@ Close a session. Use --save to persist changes
 
 #### session list
 
-List active sessions
+List active sessions; transport failures return unresponsive instead of an empty list
 
-#### session save
+#### session test
 
-Save a session without closing it
+Test file existence, validity, openability, and IRM/AIP read-only requirements
 
 | Parameter | Description |
 |-----------|-------------|
-| `--session` | Session ID to save |
+| `<file>` | Full path to test for existence, validity, openability, and IRM/AIP requirements |
 
 ### sheet
 
@@ -669,18 +669,18 @@ Worksheet lifecycle management: create, rename, copy, delete, move, list sheets.
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--file-path` | Optional file path when batch contains multiple workbooks. If omitted, uses primary workbook |
-| `--sheet` | Name for the new worksheet (required for: create, delete, move) |
-| `--old-name` | Current name of the worksheet (required for: rename) |
-| `--new-name` | New name for the worksheet (required for: rename) |
-| `--source-name` | Name of the source worksheet (required for: copy) |
-| `--target-name` | Name for the copied worksheet (required for: copy) |
-| `--before-sheet` | Optional: Name of sheet to position before |
-| `--after-sheet` | Optional: Name of sheet to position after |
-| `--source-file` | Full path to the source workbook (required for: copy-to-file, move-to-file) |
-| `--source-sheet` | Name of the sheet to copy (required for: copy-to-file, move-to-file) |
-| `--target-file` | Full path to the target workbook (required for: copy-to-file, move-to-file) |
-| `--target-sheet-name` | Optional: New name for the copied sheet (default: keeps original name) |
+| `--file-path` | Optional file path when batch contains multiple workbooks. If omitted, uses primary workbook. (valid for: list, create) |
+| `--sheet` | Name for the new worksheet (required for: create, delete, move) (valid for: create, delete, move) |
+| `--old-name` | Current name of the worksheet (required for: rename) (valid for: rename) |
+| `--new-name` | New name for the worksheet (required for: rename) (valid for: rename) |
+| `--source-name` | Name of the source worksheet (required for: copy) (valid for: copy) |
+| `--target-name` | Name for the copied worksheet (required for: copy) (valid for: copy) |
+| `--before-sheet` | Optional: Name of sheet to position before (valid for: move, copy-to-file, move-to-file) |
+| `--after-sheet` | Optional: Name of sheet to position after (valid for: move, copy-to-file, move-to-file) |
+| `--source-file` | Full path to the source workbook (required for: copy-to-file, move-to-file) (valid for: copy-to-file, move-to-file) |
+| `--source-sheet` | Name of the sheet to copy (required for: copy-to-file, move-to-file) (valid for: copy-to-file, move-to-file) |
+| `--target-file` | Full path to the target workbook (required for: copy-to-file, move-to-file) (valid for: copy-to-file, move-to-file) |
+| `--target-sheet-name` | Optional: New name for the copied sheet (default: keeps original name) (valid for: copy-to-file) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### slicer
@@ -692,15 +692,15 @@ Slicer visual filters for PivotTables and Excel Tables. PIVOTTABLE SLICERS: crea
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--pivot-table-name` | Name of the PivotTable to create slicer for (required for: create-slicer) |
-| `--field-name` | Name of the field to use for the slicer (required for: create-slicer) |
-| `--slicer-name` | Name for the new slicer (required for: create-slicer, set-slicer-selection, delete-slicer, create-table-slicer, set-table-slicer-selection, delete-table-slicer) |
-| `--destination-sheet` | Worksheet where slicer will be placed (required for: create-slicer, create-table-slicer) |
-| `--position` | Top-left cell position for the slicer (e.g., "H2") (required for: create-slicer, create-table-slicer) |
-| `--selected-items` | Items to select (show in PivotTable) (required for: set-slicer-selection, set-table-slicer-selection) (JSON format) |
-| `--clear-first` | If true, clears existing selection before setting new items (default: true) |
-| `--table-name` | Name of the Excel Table (required for: create-table-slicer) |
-| `--column-name` | Name of the column to use for the slicer (required for: create-table-slicer) |
+| `--pivot-table-name` | Name of the PivotTable to create slicer for (required for: create-slicer) (valid for: create-slicer, list-slicers) |
+| `--field-name` | Name of the field to use for the slicer (required for: create-slicer) (valid for: create-slicer) |
+| `--slicer-name` | Name for the new slicer (required for: create-slicer, set-slicer-selection, delete-slicer, create-table-slicer, set-table-slicer-selection, delete-table-slicer) (valid for: create-slicer, set-slicer-selection, delete-slicer, create-table-slicer, set-table-slicer-selection, delete-table-slicer) |
+| `--destination-sheet` | Worksheet where slicer will be placed (required for: create-slicer, create-table-slicer) (valid for: create-slicer, create-table-slicer) |
+| `--position` | Top-left cell position for the slicer (e.g., "H2") (required for: create-slicer, create-table-slicer) (valid for: create-slicer, create-table-slicer) |
+| `--selected-items` | Items to select (show in PivotTable) (required for: set-slicer-selection, set-table-slicer-selection) (valid for: set-slicer-selection, set-table-slicer-selection) (JSON format) |
+| `--clear-first` | If true, clears existing selection before setting new items (default: true) (valid for: set-slicer-selection, set-table-slicer-selection) |
+| `--table-name` | Name of the Excel Table (required for: create-table-slicer) (valid for: create-table-slicer, list-table-slicers) |
+| `--column-name` | Name of the column to use for the slicer (required for: create-table-slicer) (valid for: create-table-slicer) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### table
@@ -712,22 +712,22 @@ Excel Tables (ListObjects) - lifecycle and data operations. Tables provide struc
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--sheet` | Name of the worksheet to create the table on (required for: create, create-from-dax) |
-| `--table-name` | Name for the new table (must be unique in workbook) (required for: create, rename, delete, read, resize, toggle-totals, set-column-total, append, get-data, set-style, add-to-data-model, create-from-dax, update-dax, get-dax) |
-| `--range` | Cell range address for the table (e.g., 'A1:D10') (required for: create) |
-| `--has-headers` | True if first row contains column headers (default: true) |
-| `--table-style` | Table style name (e.g., 'TableStyleMedium2', 'TableStyleLight1'). Optional. (required for: set-style) |
-| `--new-name` | New name for the table (must be unique in workbook) (required for: rename) |
-| `--new-range` | New range address (e.g., 'A1:F20') (required for: resize) |
-| `--show-totals` | True to show totals row, false to hide (required for: toggle-totals) |
-| `--column-name` | Name of the column to set total function on (required for: set-column-total) |
-| `--total-function` | Totals function name: Sum, Count, Average, Min, Max, CountNums, StdDev, Var, None (required for: set-column-total) |
-| `--rows` | 2D array of row data to append - column order must match table columns. Optional if rowsFile is provided. (JSON format) |
-| `--rows-file` | Path to a JSON or CSV file containing the rows to append. JSON: 2D array. CSV: rows/columns. Alternative to inline rows parameter |
-| `--visible-only` | True to return only visible (non-filtered) rows; false for all rows (default: false) |
-| `--strip-bracket-column-names` | When true, renames source table columns that contain literal bracket characters (removes brackets) beforeadding to the Data Model. This modifies the Excel table column headers in the worksheet |
-| `--dax-query` | DAX EVALUATE query (e.g., 'EVALUATE Sales' or 'EVALUATE SUMMARIZE(...) ') (required for: create-from-dax, update-dax) |
-| `--target-cell` | Target cell address for table placement (default: 'A1') |
+| `--sheet` | Name of the worksheet to create the table on (required for: create, create-from-dax) (valid for: create, create-from-dax) |
+| `--table-name` | Name for the new table (must be unique in workbook) (required for: create, rename, delete, read, resize, toggle-totals, set-column-total, append, get-data, set-style, add-to-data-model, create-from-dax, update-dax, get-dax) (valid for: create, rename, delete, read, resize, toggle-totals, set-column-total, append, get-data, set-style, add-to-data-model, create-from-dax, update-dax, get-dax) |
+| `--range` | Cell range address for the table (e.g., 'A1:D10') (required for: create) (valid for: create) |
+| `--has-headers` | True if first row contains column headers (default: true) (valid for: create) |
+| `--table-style` | Table style name (e.g., 'TableStyleMedium2', 'TableStyleLight1'). Optional. (required for: set-style) (valid for: create, set-style) |
+| `--new-name` | New name for the table (must be unique in workbook) (required for: rename) (valid for: rename) |
+| `--new-range` | New range address (e.g., 'A1:F20') (required for: resize) (valid for: resize) |
+| `--show-totals` | True to show totals row, false to hide (required for: toggle-totals) (valid for: toggle-totals) |
+| `--column-name` | Name of the column to set total function on (required for: set-column-total) (valid for: set-column-total) |
+| `--total-function` | Totals function name: Sum, Count, Average, Min, Max, CountNums, StdDev, Var, None (required for: set-column-total) (valid for: set-column-total) |
+| `--rows` | 2D array of row data to append - column order must match table columns. Optional if rowsFile is provided. (valid for: append) (JSON format) |
+| `--rows-file` | Path to a JSON or CSV file containing the rows to append. JSON: 2D array. CSV: rows/columns. Alternative to inline rows parameter. (valid for: append) |
+| `--visible-only` | True to return only visible (non-filtered) rows; false for all rows (default: false) (valid for: get-data) |
+| `--strip-bracket-column-names` | When true, renames source table columns that contain literal bracket characters (removes brackets) beforeadding to the Data Model. This modifies the Excel table column headers in the worksheet. (valid for: add-to-data-model) |
+| `--dax-query` | DAX EVALUATE query (e.g., 'EVALUATE Sales' or 'EVALUATE SUMMARIZE(...) ') (required for: create-from-dax, update-dax) (valid for: create-from-dax, update-dax) |
+| `--target-cell` | Target cell address for table placement (default: 'A1') (valid for: create-from-dax) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### tablecolumn
@@ -740,16 +740,16 @@ Table column, filtering, and sorting operations for Excel Tables (ListObjects). 
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--table-name` | Name of the Excel table (required) |
-| `--column-name` | Name of the column to filter (required for: apply-filter, apply-filter-values, add-column, remove-column, sort, get-column-number-format, set-column-number-format) |
-| `--criteria` | Filter criteria string (e.g., '>100', '=Active', '<>Closed') (required for: apply-filter) |
-| `--values` | List of exact values to include in the filter (required for: apply-filter-values) (JSON format) |
-| `--position` | 1-based column position (optional, defaults to end of table) |
-| `--old-name` | Current column name (required for: rename-column) |
-| `--new-name` | New column name (required for: rename-column) |
-| `--region` | Table region: 'Data', 'Headers', 'Totals', or 'All' (required for: get-structured-reference) |
-| `--ascending` | Sort order: true = ascending (A-Z, 0-9), false = descending (default: true) |
-| `--sort-columns` | List of sort specifications: [{columnName: 'Col1', ascending: true}, ...] - applied in order (required for: sort-multi) (JSON format) |
-| `--format-code` | Number format code in US locale (e.g., '#,##0.00', '0%', 'yyyy-mm-dd') (required for: set-column-number-format) |
+| `--column-name` | Name of the column to filter (required for: apply-filter, apply-filter-values, add-column, remove-column, sort, get-column-number-format, set-column-number-format) (valid for: apply-filter, apply-filter-values, add-column, remove-column, get-structured-reference, sort, get-column-number-format, set-column-number-format) |
+| `--criteria` | Filter criteria string (e.g., '>100', '=Active', '<>Closed') (required for: apply-filter) (valid for: apply-filter) |
+| `--values` | List of exact values to include in the filter (required for: apply-filter-values) (valid for: apply-filter-values) (JSON format) |
+| `--position` | 1-based column position (optional, defaults to end of table) (valid for: add-column) |
+| `--old-name` | Current column name (required for: rename-column) (valid for: rename-column) |
+| `--new-name` | New column name (required for: rename-column) (valid for: rename-column) |
+| `--region` | Table region: 'Data', 'Headers', 'Totals', or 'All' (required for: get-structured-reference) (valid for: get-structured-reference) |
+| `--ascending` | Sort order: true = ascending (A-Z, 0-9), false = descending (default: true) (valid for: sort) |
+| `--sort-columns` | List of sort specifications: [{columnName: 'Col1', ascending: true}, ...] - applied in order (required for: sort-multi) (valid for: sort-multi) (JSON format) |
+| `--format-code` | Number format code in US locale (e.g., '#,##0.00', '0%', 'yyyy-mm-dd') (required for: set-column-number-format) (valid for: set-column-number-format) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### vba
@@ -761,12 +761,12 @@ VBA module and procedure operations for macro-enabled workbooks (.xlsm). PREREQU
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--module-name` | Name of the VBA module (required for: view, import, update, delete) |
-| `--vba-code` | VBA code to import (required for: import, update) |
-| `--vba-code-file` | Path to file containing vbaCode |
-| `--procedure-name` | Name of the procedure to run (for example "Module1.MySub") (required for: run) |
-| `--timeout` | Optional timeout for execution Accepts seconds (e.g. 600) or TimeSpan format (e.g. 00:10:00) |
-| `--parameters` | Optional parameters to pass to the procedure (required for: run) |
+| `--module-name` | Name of the VBA module (required for: view, import, update, delete) (valid for: view, import, update, delete) |
+| `--vba-code` | VBA code. Public callers must supply either inline vbaCode or a readable vbaCodeFile, not both. (required for: import, update) (valid for: import, update) |
+| `--vba-code-file` | Path to a readable file containing vbaCode; use instead of inline vbaCode, not together (valid for: import, update) |
+| `--procedure-name` | Name of the procedure to run (for example "Module1.MySub") (required for: run) (valid for: run) |
+| `--timeout` | Optional public timeout in whole seconds from 1 through 2147483; converted to TimeSpan at shared dispatch (valid for: run) |
+| `--parameters` | Optional parameters to pass to the procedure (valid for: run) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### window
@@ -778,22 +778,22 @@ Control Excel window visibility, position, state, status bar, and worksheet-spec
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--window-state` | Window state: 'normal', 'minimized', or 'maximized' (required for: set-state) |
-| `--left` | Window left position in points |
-| `--top` | Window top position in points |
-| `--width` | Window width in points |
-| `--height` | Window height in points |
-| `--preset` | Preset name: 'left-half', 'right-half', 'top-half', 'bottom-half', 'center', 'full-screen' (required for: arrange) |
-| `--text` | Status bar text to display (e.g. "Building PivotTable from Sales data...") (required for: set-status-bar) |
-| `--sheet` | Worksheet whose view should be inspected (required for: get-view, freeze-panes, unfreeze-panes, set-split, set-zoom, set-display-options) |
-| `--frozen-rows` | Number of rows to freeze from the top (0-1,048,575) |
-| `--frozen-columns` | Number of columns to freeze from the left (0-16,383) |
-| `--split-rows` | Number of rows above the horizontal split (0-1,048,575) |
-| `--split-columns` | Number of columns left of the vertical split (0-16,383) |
-| `--zoom` | Zoom percentage from 10 through 400 (required for: set-zoom) |
-| `--show-gridlines` | Whether to display cell gridlines |
-| `--show-headings` | Whether to display row and column headings |
-| `--show-outline-symbols` | Whether to display outline level symbols |
+| `--window-state` | Window state: 'normal', 'minimized', or 'maximized' (required for: set-state) (valid for: set-state) |
+| `--left` | Window left position in points (valid for: set-position) |
+| `--top` | Window top position in points (valid for: set-position) |
+| `--width` | Window width in points (valid for: set-position) |
+| `--height` | Window height in points (valid for: set-position) |
+| `--preset` | Preset name: 'left-half', 'right-half', 'top-half', 'bottom-half', 'center', 'full-screen' (required for: arrange) (valid for: arrange) |
+| `--text` | Status bar text to display (e.g. "Building PivotTable from Sales data...") (required for: set-status-bar) (valid for: set-status-bar) |
+| `--sheet` | Worksheet whose view should be inspected (required for: get-view, freeze-panes, unfreeze-panes, set-split, set-zoom, set-display-options) (valid for: get-view, freeze-panes, unfreeze-panes, set-split, set-zoom, set-display-options) |
+| `--frozen-rows` | Number of rows to freeze from the top (0-1,048,575) (valid for: freeze-panes) |
+| `--frozen-columns` | Number of columns to freeze from the left (0-16,383) (valid for: freeze-panes) |
+| `--split-rows` | Number of rows above the horizontal split (0-1,048,575) (valid for: set-split) |
+| `--split-columns` | Number of columns left of the vertical split (0-16,383) (valid for: set-split) |
+| `--zoom` | Zoom percentage from 10 through 400 (required for: set-zoom) (valid for: set-zoom) |
+| `--show-gridlines` | Whether to display cell gridlines (valid for: set-display-options) |
+| `--show-headings` | Whether to display row and column headings (valid for: set-display-options) |
+| `--show-outline-symbols` | Whether to display outline level symbols (valid for: set-display-options) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### workbook
@@ -805,26 +805,26 @@ Manage workbook metadata, document properties, Save As/copy operations, fixed-fo
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--include-built-in` | IncludeBuil tIn |
-| `--include-custom` | IncludeCust om |
-| `--property-name` | Document property name (required for: get-document-property, set-document-property, delete-document-property) |
-| `--scope` | Property collection: built-in or custom |
-| `--value` | String value to store (required for: set-document-property) |
-| `--target-path` | Absolute output path in an existing directory (required for: save-as, save-copy-as, export-fixed-format) |
-| `--format` | Output format: auto, xlsx, xlsm, xlsb, or xls |
-| `--overwrite` | Whether an existing output file may be replaced |
-| `--format-type` | FormatType |
-| `--quality` | Quality |
-| `--include-document-properties` | IncludeDocu mentPropert ies |
-| `--ignore-print-areas` | IgnorePrint Areas |
-| `--from-page` | FromPage |
-| `--to-page` | ToPage |
-| `--open-after-publish` | OpenAfterPu blish |
-| `--link-source` | (required for: update-external-link, break-external-link) |
-| `--is-protected` | (required for: set-protection) |
-| `--password` | Password |
-| `--display-gridlines` | DisplayGrid lines |
-| `--display-headings` | DisplayHead ings |
+| `--include-built-in` | (valid for: list-document-properties) |
+| `--include-custom` | (valid for: list-document-properties) |
+| `--property-name` | Document property name (required for: get-document-property, set-document-property, delete-document-property) (valid for: get-document-property, set-document-property, delete-document-property) |
+| `--scope` | Property collection: built-in or custom (valid for: get-document-property, set-document-property) |
+| `--value` | String value to store (required for: set-document-property) (valid for: set-document-property) |
+| `--target-path` | Absolute output path in an existing directory (required for: save-as, save-copy-as, export-fixed-format) (valid for: save-as, save-copy-as, export-fixed-format) |
+| `--format` | Output format: auto, xlsx, xlsm, xlsb, or xls (valid for: save-as) |
+| `--overwrite` | Whether an existing output file may be replaced (valid for: save-as, save-copy-as, export-fixed-format) |
+| `--format-type` | (valid for: export-fixed-format) |
+| `--quality` | (valid for: export-fixed-format) |
+| `--include-document-properties` | (valid for: export-fixed-format) |
+| `--ignore-print-areas` | (valid for: export-fixed-format) |
+| `--from-page` | (valid for: export-fixed-format) |
+| `--to-page` | (valid for: export-fixed-format) |
+| `--open-after-publish` | (valid for: export-fixed-format) |
+| `--link-source` | (required for: update-external-link, break-external-link) (valid for: update-external-link, break-external-link) |
+| `--is-protected` | (required for: set-protection) (valid for: set-protection) |
+| `--password` | (valid for: set-protection) |
+| `--display-gridlines` | (valid for: set-view-options) |
+| `--display-headings` | (valid for: set-view-options) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### worksheetstyle
@@ -837,27 +837,27 @@ Worksheet styling, visibility, protection, grouping, and outline operations. Use
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
 | `--sheet` | Name of the worksheet to color (required) |
-| `--red` | Red color component (0-255) (required for: set-tab-color) |
-| `--green` | Green color component (0-255) (required for: set-tab-color) |
-| `--blue` | Blue color component (0-255) (required for: set-tab-color) |
-| `--is-protected` | Whether the worksheet should be protected (required for: set-protection) |
-| `--password` | Optional password for protecting/unprotecting the sheet |
-| `--cell-address` | Cell address such as A1 (required for: set-comment, get-comment, clear-comment, add-image, add-shape) |
-| `--text` | Cell note text to set (required for: set-comment) |
-| `--image-path` | Absolute path to the image file on disk (required for: add-image) |
-| `--orientation` | Page orientation: 'portrait' or 'landscape' (required for: set-page-setup) |
-| `--fit-to-pages-wide` | Number of pages wide to fit the printout to |
-| `--fit-to-pages-tall` | Number of pages tall to fit the printout to |
-| `--center-horizontally` | Whether to center the printout horizontally on the page |
-| `--center-vertically` | Whether to center the printout vertically on the page |
-| `--visibility` | Visibility level: 'visible', 'hidden', or 'veryhidden' (required for: set-visibility) |
-| `--range` | Row or column range to group (required for: group, ungroup, get-outline-info) |
-| `--axis` | Grouping axis: Rows or Columns (required for: group, ungroup, get-outline-info) |
-| `--summary-row` | Summary row position: above or below |
-| `--summary-column` | Summary column position: left or right |
-| `--automatic-styles` | Whether Excel applies automatic outline styles |
-| `--row-levels` | Optional row outline level to display |
-| `--column-levels` | Optional column outline level to display |
+| `--red` | Red color component (0-255) (required for: set-tab-color) (valid for: set-tab-color) |
+| `--green` | Green color component (0-255) (required for: set-tab-color) (valid for: set-tab-color) |
+| `--blue` | Blue color component (0-255) (required for: set-tab-color) (valid for: set-tab-color) |
+| `--is-protected` | Whether the worksheet should be protected (required for: set-protection) (valid for: set-protection) |
+| `--password` | Optional password for protecting/unprotecting the sheet (valid for: set-protection) |
+| `--cell-address` | Cell address such as A1 (required for: set-comment, get-comment, clear-comment, add-image, add-shape) (valid for: set-comment, get-comment, clear-comment, add-image, add-shape) |
+| `--text` | Cell note text to set (required for: set-comment) (valid for: set-comment) |
+| `--image-path` | Absolute path to the image file on disk (required for: add-image) (valid for: add-image) |
+| `--orientation` | Page orientation: 'portrait' or 'landscape' (required for: set-page-setup) (valid for: set-page-setup) |
+| `--fit-to-pages-wide` | Number of pages wide to fit the printout to (valid for: set-page-setup) |
+| `--fit-to-pages-tall` | Number of pages tall to fit the printout to (valid for: set-page-setup) |
+| `--center-horizontally` | Whether to center the printout horizontally on the page (valid for: set-page-setup) |
+| `--center-vertically` | Whether to center the printout vertically on the page (valid for: set-page-setup) |
+| `--visibility` | Visibility level: 'visible', 'hidden', or 'veryhidden' (required for: set-visibility) (valid for: set-visibility) |
+| `--range` | Row or column range to group (required for: group, ungroup, get-outline-info) (valid for: group, ungroup, get-outline-info) |
+| `--axis` | Grouping axis: Rows or Columns (required for: group, ungroup, get-outline-info) (valid for: group, ungroup, get-outline-info) |
+| `--summary-row` | Summary row position: above or below (valid for: set-outline-settings) |
+| `--summary-column` | Summary column position: left or right (valid for: set-outline-settings) |
+| `--automatic-styles` | Whether Excel applies automatic outline styles (valid for: set-outline-settings) |
+| `--row-levels` | Optional row outline level to display (valid for: show-outline-levels) |
+| `--column-levels` | Optional column outline level to display (valid for: show-outline-levels) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ### xmlmap
@@ -869,25 +869,25 @@ Manage workbook XML maps and exchange XML data without interactive dialogs. SECU
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
-| `--schema` | Inline XSD schema content (required for: add) |
-| `--schema-file` | Path to file containing schema |
-| `--root-element-name` | Optional root element when the schema has multiple roots |
-| `--map-name` | Optional name to assign to the created map (required for: map-range, export-xml, delete) |
-| `--sheet` | Worksheet containing the target range (required for: map-range) |
-| `--range` | Target cell or single-column range (required for: map-range) |
-| `--xpath` | XPath to map (required for: map-range) |
-| `--selection-namespace` | Optional namespace declarations used by prefixed XPath expressions |
-| `--repeating` | Whether to create a repeating XML list mapping |
-| `--xml-data` | Inline XML data (required for: import-xml) |
-| `--xml-data-file` | Path to file containing xmlData |
-| `--start-cell` | Top-left destination cell for automatic mapping |
-| `--overwrite` | Whether imported XML may overwrite mapped cells |
+| `--schema` | XSD schema content. Public callers must supply either inline schema or a readable schemaFile, not both. (required for: add) (valid for: add) |
+| `--schema-file` | Path to a readable file containing schema; use instead of inline schema, not together (valid for: add) |
+| `--root-element-name` | Optional root element when the schema has multiple roots (valid for: add) |
+| `--map-name` | Optional name to assign to the created map (required for: map-range, export-xml, delete) (valid for: add, map-range, import-xml, export-xml, delete) |
+| `--sheet` | Worksheet containing the target range (required for: map-range) (valid for: map-range, import-xml) |
+| `--range` | Target cell or single-column range (required for: map-range) (valid for: map-range) |
+| `--xpath` | XPath to map (required for: map-range) (valid for: map-range) |
+| `--selection-namespace` | Optional namespace declarations used by prefixed XPath expressions (valid for: map-range) |
+| `--repeating` | Whether to create a repeating XML list mapping (valid for: map-range) |
+| `--xml-data` | XML data. Public callers must supply either inline xmlData or a readable xmlDataFile, not both. (required for: import-xml) (valid for: import-xml) |
+| `--xml-data-file` | Path to a readable file containing xmlData; use instead of inline xmlData, not together (valid for: import-xml) |
+| `--start-cell` | Top-left destination cell for automatic mapping (valid for: import-xml) |
+| `--overwrite` | Whether imported XML may overwrite mapped cells (valid for: import-xml) |
 | `--output` | Write output to file instead of stdout. For image results, decodes and saves as binary file |
 
 ## Common Pitfalls
 
 - `--values-file` requires an existing JSON or CSV file; use `--values` for inline JSON.
-- `--timeout` must be greater than zero; omit it to use the command default.
+- `--timeout` ranges are action-specific: session open/create accepts 10-3600; Power Query refresh/refresh-all accepts 0-2147483 (0 keeps the default); other generated timeout actions accept 1-2147483.
 - `pythoninexcel get-result --max-wait-seconds` must be at least 1 and shorter than the session operation timeout.
 - `--values` and list parameters use JSON arrays; range values use a two-dimensional array.
-- Power Query operations may take 30 seconds or longer; use a generous positive timeout.
+- Power Query operations may take 30 seconds or longer; use a deliberate data-operation timeout or 0 for the default.

--- a/skills/excel-cli/references/conditionalformat.md
+++ b/skills/excel-cli/references/conditionalformat.md
@@ -1,6 +1,5 @@
 > **CLI syntax note:** This shared domain guide may use MCP-style `tool(action: ...)` examples as conceptual shorthand. Do not translate or paste those calls mechanically. Use the exact commands and kebab-case options in [cli-commands.md](./cli-commands.md) or live `--help`; notably, MCP `file` open/close maps to CLI `session` open/close, and MCP `worksheet` maps to CLI `sheet`.
 
-````markdown
 # conditionalformat - Server Quirks
 
 **Rule Types**:
@@ -207,5 +206,3 @@ excelcli conditionalformat list-worksheet-rules --session <id> --sheet "Data"
 2. Use `clear-rules` before applying new rules if replacing existing formatting
 3. For row-based highlighting, apply rule to full range (not just one column)
 4. Use relative row references (`$A1`) and absolute column references for row highlighting
-
-````

--- a/skills/excel-cli/references/gotchas.md
+++ b/skills/excel-cli/references/gotchas.md
@@ -28,21 +28,25 @@ Columns, relationships, and measures marked **"Hidden from client tools"** in Po
 
 ## Large Power Query Refreshes Timeout
 
-Default timeout for `powerquery(action: 'refresh')` is **5 minutes**. Power Query operations querying large datasets often exceed this.
+Power Query refresh has a **30-minute** data-operation default when its timeout
+is omitted or `0`. Its data-operation timeout replaces the session operation
+wait for that refresh; the limits are not layered.
 
-**Symptoms:** Operation appears to succeed but data doesn't load, or timeout error after 5 minutes.
-
-**Fix:** Increase timeout when opening the session:
+**Fix:** Set the timeout that owns each operation deliberately:
 
 ```json
 {
   "action": "open",
-  "filePath": "C:\\path\\to\\workbook.xlsx",
-  "timeoutSeconds": 900
+  "path": "C:\\path\\to\\workbook.xlsx",
+  "timeout_seconds": 900
 }
 ```
 
-Set `timeoutSeconds` to match your expected query duration (900 = 15 min, 1800 = 30 min).
+Use `timeout_seconds` on `powerquery refresh` for its data-operation budget and
+on `file open/create` for workbook startup and operations without a dedicated
+data timeout. Public timeout values are integer seconds. Session open/create
+accepts 10-3600; Power Query refresh accepts 0-2147483, with `0` retaining the
+30-minute default.
 
 ## Session Concurrency Requires STA Thread
 

--- a/skills/excel-cli/references/pivottable.md
+++ b/skills/excel-cli/references/pivottable.md
@@ -1,6 +1,5 @@
 > **CLI syntax note:** This shared domain guide may use MCP-style `tool(action: ...)` examples as conceptual shorthand. Do not translate or paste those calls mechanically. Use the exact commands and kebab-case options in [cli-commands.md](./cli-commands.md) or live `--help`; notably, MCP `file` open/close maps to CLI `session` open/close, and MCP `worksheet` maps to CLI `sheet`.
 
-````markdown
 # pivottable - Server Quirks
 
 ## CRITICAL: Required Parameters
@@ -162,5 +161,3 @@ The `layoutStyle` parameter controls PivotTable appearance:
 | "Field not found" | Typo or Data Model not refreshed | Refresh Data Model, check field names |
 | Data doesn't update | Source changed without refresh | Call `pivottable(refresh)` |
 | DAX measures missing | Created on worksheet PivotTable | Use `create-from-datamodel` |
-
-````

--- a/skills/excel-cli/references/powerquery.md
+++ b/skills/excel-cli/references/powerquery.md
@@ -16,7 +16,8 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 - `evaluate` executes M code WITHOUT creating permanent query (test-then-commit)
 - Returns actual data preview with columns and rows in JSON
 - Better error messages than COM exceptions from create/update
-- No cleanup needed - temporary objects auto-deleted
+- Temporary queries, sheets, tables, and mashup connections are deleted by exact
+  `Location`; cleanup failures return an error instead of success
 - Skip evaluate only for trivial literal tables (`#table` with hardcoded values)
 
 **IF CREATE/UPDATE FAILS**: Use `evaluate` to get detailed Power Query error message, fix code, retry.
@@ -28,21 +29,27 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 
 ---
 
-**M-Code Formatting**:
+**M-Code Formatting and reads**:
 
 - Create and Update preserve M code exactly by default and do not call remote services
 - Set `formatMCode=true` only with explicit user consent; it sends M code to powerqueryformatter.com
 - Remote formatting adds ~100-500ms network latency per call
 - Graceful fallback: saves original M code if the formatting service is unavailable
-- Read operations (List, View) return M code as stored (no formatting on read)
+- `list` returns compact metadata, exact load mode, character count, and at most
+  80 characters of `formulaPreview`; it never returns full M code
+- Use `view` to retrieve one query's complete M code and exact load mode
+- Read operations return stored text without formatting
 
 **Data Model workflow**:
 
 Power Query can load data to different destinations:
-- `worksheet` (default): Creates an Excel Table on a worksheet
-- `data-model`: Loads directly to Power Pivot for DAX analysis
-- `both`: Loads to worksheet AND Power Pivot
+- `worksheet` / `load-to-table` (default): Creates an Excel Table on a worksheet
+- `data-model` / `load-to-data-model`: Loads directly to Power Pivot for DAX analysis
+- `both` / `load-to-both`: Loads to worksheet AND Power Pivot
 - `connection-only`: Imports query definition without loading data
+
+Destination values are case-insensitive. Unknown values fail before the query is
+changed; they never fall back to connection-only or another enum default.
 
 To create DAX measures on Power Query data:
 1. Use powerquery create/load-to with `loadDestination='data-model'`
@@ -79,11 +86,16 @@ Alternative path (for existing worksheet tables):
 - Not sure? → Check with list action first, then use update if exists or create if new
 - **ALWAYS evaluate M code FIRST** to catch errors before persisting
 
-**List action and IsConnectionOnly**:
+**List/view load state**:
 
+- `list`, `view`, and `get-load-config` use the same exact-identity detector
+- `loadMode` distinguishes `connection-only`, `load-to-table`,
+  `load-to-data-model`, and `load-to-both`
 - `IsConnectionOnly=true` means query has NO data destination (not in worksheet, not in Data Model)
 - `IsConnectionOnly=false` means query loads data SOMEWHERE (worksheet OR Data Model OR both)
 - A query loaded ONLY to Data Model is NOT connection-only
+- If Excel cannot inspect a query, `list` fails explicitly instead of silently
+  omitting that query
 
 **Inline M code**:
 
@@ -107,6 +119,7 @@ Alternative path (for existing worksheet tables):
 - Assuming unload only removes worksheet data → Also removes Data Model connections
 - Calling rename without trimming newName → Server trims automatically, " Query " becomes "Query"
 - Renaming to conflicting name → Check list first if unsure about existing names
+- Passing an option from another action (for example `mCode` on delete or `timeout` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
 
 **Server-specific quirks**:
 
@@ -114,14 +127,16 @@ Alternative path (for existing worksheet tables):
 - connection-only queries: NOT validated until first execution
 - refresh with loadDestination: Applies load config + refreshes (2-in-1)
 - Single cell returns [[value]] not scalar
-- refresh defaults to 30-minute timeout if `refreshTimeoutSeconds` is 0 or omitted. Any positive value is accepted. For quick queries use a smaller value (e.g., 60-120 seconds).
-- load-to uses the same 30-minute timeout as refresh. If Excel is blocked by privacy dialogs/credentials, you'll get `SuggestedNextActions` instead of a hang—surface them to the user before retrying.
+- Public timeout inputs are integer seconds. Refresh/refresh-all accepts 0-2147483 and defaults to the 30-minute data-operation timeout when `timeout_seconds`/`--timeout` is 0 or omitted. For quick queries use a smaller value (e.g., 60-120 seconds).
+- load-to has no caller timeout parameter and uses the fixed 30-minute data-operation timeout; passing `timeout` to load-to is rejected instead of ignored.
+- Refresh/refresh-all data-operation timeouts replace the session operation wait rather than layering with it. The session timeout controls startup and operations without a dedicated data timeout, including create/update/evaluate. Session open/create accepts 10-3600 seconds and defaults to 120.
 
 **Data Model connection cleanup**:
 
 - Unload removes BOTH worksheet ListObjects AND Data Model connections
 - Delete removes query, worksheet ListObjects, AND Data Model connections
-- Connection naming pattern: "Query - {queryName}" or "Query - {queryName} - suffix"
+- Ownership uses the exact case-insensitive mashup `Location` value, not connection
+  display names; queries such as `A` and `AA` remain isolated
 
 ## M Code - Server-Specific Notes
 

--- a/skills/excel-cli/references/slicer.md
+++ b/skills/excel-cli/references/slicer.md
@@ -1,6 +1,5 @@
 > **CLI syntax note:** This shared domain guide may use MCP-style `tool(action: ...)` examples as conceptual shorthand. Do not translate or paste those calls mechanically. Use the exact commands and kebab-case options in [cli-commands.md](./cli-commands.md) or live `--help`; notably, MCP `file` open/close maps to CLI `session` open/close, and MCP `worksheet` maps to CLI `sheet`.
 
-````markdown
 # slicer - Server Quirks
 
 **Slicer Types**:
@@ -91,5 +90,3 @@ excelcli slicer create-table-slicer --session <id> --table-name "SalesTable" --c
 excelcli slicer list-slicers --session <id>
 excelcli slicer list-table-slicers --session <id>
 ```
-
-````

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -12,7 +12,7 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
 
 # Excel MCP Server Skill
 
-Provides 326 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
+Provides 325 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
 
 ## Workflow Checklist
 

--- a/skills/excel-mcp/references/anti-patterns.md
+++ b/skills/excel-mcp/references/anti-patterns.md
@@ -416,7 +416,8 @@ powerquery(action: 'refresh', ...)
 - Catch syntax errors and missing sources BEFORE persisting
 - See actual data preview (columns, sample rows)
 - Better error messages than COM exceptions
-- No cleanup needed - temporary objects auto-deleted
+- Temporary objects are removed by exact mashup identity; cleanup failures are
+  surfaced with recovery guidance instead of returning success
 - Like a REPL for M code
 
 ### When Evaluate IS Optional

--- a/skills/excel-mcp/references/behavioral-rules.md
+++ b/skills/excel-mcp/references/behavioral-rules.md
@@ -172,6 +172,12 @@ After completing operations, report:
 
 ### Session Lifecycle
 
+Use `file(action: 'test')` or `excelcli -q session test <path>` before opening
+when access or information protection is uncertain. The shared result reports
+`canOpen`, `isIrmProtected`, `willOpenReadOnly`, and `requiresVisibleSession`.
+IRM/AIP files report `canOpen:false` until the required interactive Excel
+authentication occurs; open them with a visible session.
+
 Always close sessions when done:
 
 ```
@@ -268,10 +274,35 @@ Choose load destination based on workflow:
 
 | Destination | When to Use |
 |-------------|-------------|
-| `worksheet` | View data, simple analysis |
-| `data-model` | DAX measures, PivotTables, relationships |
-| `both` | View data AND use in DAX |
+| `worksheet` / `load-to-table` | View data, simple analysis |
+| `data-model` / `load-to-data-model` | DAX measures, PivotTables, relationships |
+| `both` / `load-to-both` | View data AND use in DAX |
 | `connection-only` | Data staging, intermediate queries |
+
+Values are case-insensitive. Unknown enum values and parameters that do not
+belong to the selected action are rejected instead of being defaulted or ignored.
+
+### Canonical Public Inputs
+
+- Public timeouts are integer seconds: MCP uses `timeout_seconds`, CLI uses
+  `--timeout`, and batch JSON uses `timeout`. Do not send TimeSpan strings or
+  numeric strings.
+- Session open/create accepts 10-3600 seconds. Its operation timeout controls
+  workbook startup and operations that do not provide a dedicated data-operation
+  timeout.
+- Power Query refresh/refresh-all accepts 0-2147483; omitted or `0` uses the
+  30-minute data-operation default. Connection, Data Model, PivotTable, and VBA
+  timeouts accept 1-2147483.
+- Power Query refresh/refresh-all use their data-operation timeout instead of
+  layering the session operation timeout. `load-to` has no caller timeout and
+  uses the fixed 30-minute data-operation timeout; create/update/evaluate use the
+  session operation timeout.
+- For required generated inline/file pairs, supply exactly one form. Optional
+  pairs may omit both, but inline and file forms are always mutually exclusive.
+  Batch aliases are
+  `mCodeFile`, `vbaCodeFile`, `daxFormulaFile`, `daxQueryFile`, `dmvQueryFile`,
+  `schemaFile`, and `xmlDataFile`; MCP uses snake_case and CLI uses kebab-case.
+  The file must exist and be readable.
 
 ### Refresh After Create
 

--- a/skills/excel-mcp/references/gotchas.md
+++ b/skills/excel-mcp/references/gotchas.md
@@ -26,21 +26,25 @@ Columns, relationships, and measures marked **"Hidden from client tools"** in Po
 
 ## Large Power Query Refreshes Timeout
 
-Default timeout for `powerquery(action: 'refresh')` is **5 minutes**. Power Query operations querying large datasets often exceed this.
+Power Query refresh has a **30-minute** data-operation default when its timeout
+is omitted or `0`. Its data-operation timeout replaces the session operation
+wait for that refresh; the limits are not layered.
 
-**Symptoms:** Operation appears to succeed but data doesn't load, or timeout error after 5 minutes.
-
-**Fix:** Increase timeout when opening the session:
+**Fix:** Set the timeout that owns each operation deliberately:
 
 ```json
 {
   "action": "open",
-  "filePath": "C:\\path\\to\\workbook.xlsx",
-  "timeoutSeconds": 900
+  "path": "C:\\path\\to\\workbook.xlsx",
+  "timeout_seconds": 900
 }
 ```
 
-Set `timeoutSeconds` to match your expected query duration (900 = 15 min, 1800 = 30 min).
+Use `timeout_seconds` on `powerquery refresh` for its data-operation budget and
+on `file open/create` for workbook startup and operations without a dedicated
+data timeout. Public timeout values are integer seconds. Session open/create
+accepts 10-3600; Power Query refresh accepts 0-2147483, with `0` retaining the
+30-minute default.
 
 ## Session Concurrency Requires STA Thread
 

--- a/skills/excel-mcp/references/powerquery.md
+++ b/skills/excel-mcp/references/powerquery.md
@@ -14,7 +14,8 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 - `evaluate` executes M code WITHOUT creating permanent query (test-then-commit)
 - Returns actual data preview with columns and rows in JSON
 - Better error messages than COM exceptions from create/update
-- No cleanup needed - temporary objects auto-deleted
+- Temporary queries, sheets, tables, and mashup connections are deleted by exact
+  `Location`; cleanup failures return an error instead of success
 - Skip evaluate only for trivial literal tables (`#table` with hardcoded values)
 
 **IF CREATE/UPDATE FAILS**: Use `evaluate` to get detailed Power Query error message, fix code, retry.
@@ -26,21 +27,27 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 
 ---
 
-**M-Code Formatting**:
+**M-Code Formatting and reads**:
 
 - Create and Update preserve M code exactly by default and do not call remote services
 - Set `formatMCode=true` only with explicit user consent; it sends M code to powerqueryformatter.com
 - Remote formatting adds ~100-500ms network latency per call
 - Graceful fallback: saves original M code if the formatting service is unavailable
-- Read operations (List, View) return M code as stored (no formatting on read)
+- `list` returns compact metadata, exact load mode, character count, and at most
+  80 characters of `formulaPreview`; it never returns full M code
+- Use `view` to retrieve one query's complete M code and exact load mode
+- Read operations return stored text without formatting
 
 **Data Model workflow**:
 
 Power Query can load data to different destinations:
-- `worksheet` (default): Creates an Excel Table on a worksheet
-- `data-model`: Loads directly to Power Pivot for DAX analysis
-- `both`: Loads to worksheet AND Power Pivot
+- `worksheet` / `load-to-table` (default): Creates an Excel Table on a worksheet
+- `data-model` / `load-to-data-model`: Loads directly to Power Pivot for DAX analysis
+- `both` / `load-to-both`: Loads to worksheet AND Power Pivot
 - `connection-only`: Imports query definition without loading data
+
+Destination values are case-insensitive. Unknown values fail before the query is
+changed; they never fall back to connection-only or another enum default.
 
 To create DAX measures on Power Query data:
 1. Use powerquery create/load-to with `loadDestination='data-model'`
@@ -77,11 +84,16 @@ Alternative path (for existing worksheet tables):
 - Not sure? → Check with list action first, then use update if exists or create if new
 - **ALWAYS evaluate M code FIRST** to catch errors before persisting
 
-**List action and IsConnectionOnly**:
+**List/view load state**:
 
+- `list`, `view`, and `get-load-config` use the same exact-identity detector
+- `loadMode` distinguishes `connection-only`, `load-to-table`,
+  `load-to-data-model`, and `load-to-both`
 - `IsConnectionOnly=true` means query has NO data destination (not in worksheet, not in Data Model)
 - `IsConnectionOnly=false` means query loads data SOMEWHERE (worksheet OR Data Model OR both)
 - A query loaded ONLY to Data Model is NOT connection-only
+- If Excel cannot inspect a query, `list` fails explicitly instead of silently
+  omitting that query
 
 **Inline M code**:
 
@@ -105,6 +117,7 @@ Alternative path (for existing worksheet tables):
 - Assuming unload only removes worksheet data → Also removes Data Model connections
 - Calling rename without trimming newName → Server trims automatically, " Query " becomes "Query"
 - Renaming to conflicting name → Check list first if unsure about existing names
+- Passing an option from another action (for example `mCode` on delete or `timeout` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
 
 **Server-specific quirks**:
 
@@ -112,14 +125,16 @@ Alternative path (for existing worksheet tables):
 - connection-only queries: NOT validated until first execution
 - refresh with loadDestination: Applies load config + refreshes (2-in-1)
 - Single cell returns [[value]] not scalar
-- refresh defaults to 30-minute timeout if `refreshTimeoutSeconds` is 0 or omitted. Any positive value is accepted. For quick queries use a smaller value (e.g., 60-120 seconds).
-- load-to uses the same 30-minute timeout as refresh. If Excel is blocked by privacy dialogs/credentials, you'll get `SuggestedNextActions` instead of a hang—surface them to the user before retrying.
+- Public timeout inputs are integer seconds. Refresh/refresh-all accepts 0-2147483 and defaults to the 30-minute data-operation timeout when `timeout_seconds`/`--timeout` is 0 or omitted. For quick queries use a smaller value (e.g., 60-120 seconds).
+- load-to has no caller timeout parameter and uses the fixed 30-minute data-operation timeout; passing `timeout` to load-to is rejected instead of ignored.
+- Refresh/refresh-all data-operation timeouts replace the session operation wait rather than layering with it. The session timeout controls startup and operations without a dedicated data timeout, including create/update/evaluate. Session open/create accepts 10-3600 seconds and defaults to 120.
 
 **Data Model connection cleanup**:
 
 - Unload removes BOTH worksheet ListObjects AND Data Model connections
 - Delete removes query, worksheet ListObjects, AND Data Model connections
-- Connection naming pattern: "Query - {queryName}" or "Query - {queryName} - suffix"
+- Ownership uses the exact case-insensitive mashup `Location` value, not connection
+  display names; queries such as `A` and `AA` remain isolated
 
 ## M Code - Server-Specific Notes
 

--- a/skills/shared/anti-patterns.md
+++ b/skills/shared/anti-patterns.md
@@ -416,7 +416,8 @@ powerquery(action: 'refresh', ...)
 - Catch syntax errors and missing sources BEFORE persisting
 - See actual data preview (columns, sample rows)
 - Better error messages than COM exceptions
-- No cleanup needed - temporary objects auto-deleted
+- Temporary objects are removed by exact mashup identity; cleanup failures are
+  surfaced with recovery guidance instead of returning success
 - Like a REPL for M code
 
 ### When Evaluate IS Optional

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -172,6 +172,12 @@ After completing operations, report:
 
 ### Session Lifecycle
 
+Use `file(action: 'test')` or `excelcli -q session test <path>` before opening
+when access or information protection is uncertain. The shared result reports
+`canOpen`, `isIrmProtected`, `willOpenReadOnly`, and `requiresVisibleSession`.
+IRM/AIP files report `canOpen:false` until the required interactive Excel
+authentication occurs; open them with a visible session.
+
 Always close sessions when done:
 
 ```
@@ -268,10 +274,35 @@ Choose load destination based on workflow:
 
 | Destination | When to Use |
 |-------------|-------------|
-| `worksheet` | View data, simple analysis |
-| `data-model` | DAX measures, PivotTables, relationships |
-| `both` | View data AND use in DAX |
+| `worksheet` / `load-to-table` | View data, simple analysis |
+| `data-model` / `load-to-data-model` | DAX measures, PivotTables, relationships |
+| `both` / `load-to-both` | View data AND use in DAX |
 | `connection-only` | Data staging, intermediate queries |
+
+Values are case-insensitive. Unknown enum values and parameters that do not
+belong to the selected action are rejected instead of being defaulted or ignored.
+
+### Canonical Public Inputs
+
+- Public timeouts are integer seconds: MCP uses `timeout_seconds`, CLI uses
+  `--timeout`, and batch JSON uses `timeout`. Do not send TimeSpan strings or
+  numeric strings.
+- Session open/create accepts 10-3600 seconds. Its operation timeout controls
+  workbook startup and operations that do not provide a dedicated data-operation
+  timeout.
+- Power Query refresh/refresh-all accepts 0-2147483; omitted or `0` uses the
+  30-minute data-operation default. Connection, Data Model, PivotTable, and VBA
+  timeouts accept 1-2147483.
+- Power Query refresh/refresh-all use their data-operation timeout instead of
+  layering the session operation timeout. `load-to` has no caller timeout and
+  uses the fixed 30-minute data-operation timeout; create/update/evaluate use the
+  session operation timeout.
+- For required generated inline/file pairs, supply exactly one form. Optional
+  pairs may omit both, but inline and file forms are always mutually exclusive.
+  Batch aliases are
+  `mCodeFile`, `vbaCodeFile`, `daxFormulaFile`, `daxQueryFile`, `dmvQueryFile`,
+  `schemaFile`, and `xmlDataFile`; MCP uses snake_case and CLI uses kebab-case.
+  The file must exist and be readable.
 
 ### Refresh After Create
 

--- a/skills/shared/gotchas.md
+++ b/skills/shared/gotchas.md
@@ -26,21 +26,25 @@ Columns, relationships, and measures marked **"Hidden from client tools"** in Po
 
 ## Large Power Query Refreshes Timeout
 
-Default timeout for `powerquery(action: 'refresh')` is **5 minutes**. Power Query operations querying large datasets often exceed this.
+Power Query refresh has a **30-minute** data-operation default when its timeout
+is omitted or `0`. Its data-operation timeout replaces the session operation
+wait for that refresh; the limits are not layered.
 
-**Symptoms:** Operation appears to succeed but data doesn't load, or timeout error after 5 minutes.
-
-**Fix:** Increase timeout when opening the session:
+**Fix:** Set the timeout that owns each operation deliberately:
 
 ```json
 {
   "action": "open",
-  "filePath": "C:\\path\\to\\workbook.xlsx",
-  "timeoutSeconds": 900
+  "path": "C:\\path\\to\\workbook.xlsx",
+  "timeout_seconds": 900
 }
 ```
 
-Set `timeoutSeconds` to match your expected query duration (900 = 15 min, 1800 = 30 min).
+Use `timeout_seconds` on `powerquery refresh` for its data-operation budget and
+on `file open/create` for workbook startup and operations without a dedicated
+data timeout. Public timeout values are integer seconds. Session open/create
+accepts 10-3600; Power Query refresh accepts 0-2147483, with `0` retaining the
+30-minute default.
 
 ## Session Concurrency Requires STA Thread
 

--- a/skills/shared/powerquery.md
+++ b/skills/shared/powerquery.md
@@ -14,7 +14,8 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 - `evaluate` executes M code WITHOUT creating permanent query (test-then-commit)
 - Returns actual data preview with columns and rows in JSON
 - Better error messages than COM exceptions from create/update
-- No cleanup needed - temporary objects auto-deleted
+- Temporary queries, sheets, tables, and mashup connections are deleted by exact
+  `Location`; cleanup failures return an error instead of success
 - Skip evaluate only for trivial literal tables (`#table` with hardcoded values)
 
 **IF CREATE/UPDATE FAILS**: Use `evaluate` to get detailed Power Query error message, fix code, retry.
@@ -26,21 +27,27 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 
 ---
 
-**M-Code Formatting**:
+**M-Code Formatting and reads**:
 
 - Create and Update preserve M code exactly by default and do not call remote services
 - Set `formatMCode=true` only with explicit user consent; it sends M code to powerqueryformatter.com
 - Remote formatting adds ~100-500ms network latency per call
 - Graceful fallback: saves original M code if the formatting service is unavailable
-- Read operations (List, View) return M code as stored (no formatting on read)
+- `list` returns compact metadata, exact load mode, character count, and at most
+  80 characters of `formulaPreview`; it never returns full M code
+- Use `view` to retrieve one query's complete M code and exact load mode
+- Read operations return stored text without formatting
 
 **Data Model workflow**:
 
 Power Query can load data to different destinations:
-- `worksheet` (default): Creates an Excel Table on a worksheet
-- `data-model`: Loads directly to Power Pivot for DAX analysis
-- `both`: Loads to worksheet AND Power Pivot
+- `worksheet` / `load-to-table` (default): Creates an Excel Table on a worksheet
+- `data-model` / `load-to-data-model`: Loads directly to Power Pivot for DAX analysis
+- `both` / `load-to-both`: Loads to worksheet AND Power Pivot
 - `connection-only`: Imports query definition without loading data
+
+Destination values are case-insensitive. Unknown values fail before the query is
+changed; they never fall back to connection-only or another enum default.
 
 To create DAX measures on Power Query data:
 1. Use powerquery create/load-to with `loadDestination='data-model'`
@@ -77,11 +84,16 @@ Alternative path (for existing worksheet tables):
 - Not sure? → Check with list action first, then use update if exists or create if new
 - **ALWAYS evaluate M code FIRST** to catch errors before persisting
 
-**List action and IsConnectionOnly**:
+**List/view load state**:
 
+- `list`, `view`, and `get-load-config` use the same exact-identity detector
+- `loadMode` distinguishes `connection-only`, `load-to-table`,
+  `load-to-data-model`, and `load-to-both`
 - `IsConnectionOnly=true` means query has NO data destination (not in worksheet, not in Data Model)
 - `IsConnectionOnly=false` means query loads data SOMEWHERE (worksheet OR Data Model OR both)
 - A query loaded ONLY to Data Model is NOT connection-only
+- If Excel cannot inspect a query, `list` fails explicitly instead of silently
+  omitting that query
 
 **Inline M code**:
 
@@ -105,6 +117,7 @@ Alternative path (for existing worksheet tables):
 - Assuming unload only removes worksheet data → Also removes Data Model connections
 - Calling rename without trimming newName → Server trims automatically, " Query " becomes "Query"
 - Renaming to conflicting name → Check list first if unsure about existing names
+- Passing an option from another action (for example `mCode` on delete or `timeout` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
 
 **Server-specific quirks**:
 
@@ -112,14 +125,16 @@ Alternative path (for existing worksheet tables):
 - connection-only queries: NOT validated until first execution
 - refresh with loadDestination: Applies load config + refreshes (2-in-1)
 - Single cell returns [[value]] not scalar
-- refresh defaults to 30-minute timeout if `refreshTimeoutSeconds` is 0 or omitted. Any positive value is accepted. For quick queries use a smaller value (e.g., 60-120 seconds).
-- load-to uses the same 30-minute timeout as refresh. If Excel is blocked by privacy dialogs/credentials, you'll get `SuggestedNextActions` instead of a hang—surface them to the user before retrying.
+- Public timeout inputs are integer seconds. Refresh/refresh-all accepts 0-2147483 and defaults to the 30-minute data-operation timeout when `timeout_seconds`/`--timeout` is 0 or omitted. For quick queries use a smaller value (e.g., 60-120 seconds).
+- load-to has no caller timeout parameter and uses the fixed 30-minute data-operation timeout; passing `timeout` to load-to is rejected instead of ignored.
+- Refresh/refresh-all data-operation timeouts replace the session operation wait rather than layering with it. The session timeout controls startup and operations without a dedicated data timeout, including create/update/evaluate. Session open/create accepts 10-3600 seconds and defaults to 120.
 
 **Data Model connection cleanup**:
 
 - Unload removes BOTH worksheet ListObjects AND Data Model connections
 - Delete removes query, worksheet ListObjects, AND Data Model connections
-- Connection naming pattern: "Query - {queryName}" or "Query - {queryName} - suffix"
+- Ownership uses the exact case-insensitive mashup `Location` value, not connection
+  display names; queries such as `A` and `AA` remain isolated
 
 ## M Code - Server-Specific Notes
 

--- a/skills/templates/SKILL.cli.sbn
+++ b/skills/templates/SKILL.cli.sbn
@@ -194,10 +194,10 @@ Available command groups:
 See [CLI command reference and common pitfalls](./references/cli-commands.md#common-pitfalls) for examples. Key issues:
 
 - `--values-file` expects a path to an existing file; use `--values` for inline JSON.
-- `--timeout` must be a positive integer; omit it to use the default timeout.
+- `--timeout` ranges are action-specific: session open/create accepts 10-3600; Power Query refresh/refresh-all accepts 0-2147483 (0 keeps the default); other generated timeout actions accept 1-2147483.
 - `--values` takes a 2D JSON array such as `'[["Name","Age"],["Alice",30]]'`.
 - List parameters such as `--selected-items` require JSON arrays.
-- Power Query operations can take 30+ seconds; use generous timeouts.
+- Power Query operations can take 30+ seconds; use a deliberate data-operation timeout or 0 for the default.
 
 ## Reference Documentation
 

--- a/specs/SESSION-API-REDESIGN-SPEC.md
+++ b/specs/SESSION-API-REDESIGN-SPEC.md
@@ -7,7 +7,7 @@
 
 ## Executive Summary
 
-This specification proposes a **breaking redesign** of ExcelMcp's session API to use intuitive **Open/Save/Close** semantics exclusively. The goal is to eliminate the "batch" concept entirely and remove all cognitive load from LLMs - every operation works through sessions, always. No backwards compatibility, no dual patterns, no decisions about when to batch.
+This specification proposes a **breaking redesign** of ExcelMcp's session API around one canonical **Open/Close** lifecycle. The goal is to eliminate the "batch" concept entirely and remove all cognitive load from LLMs - every operation works through sessions, always. Persistence occurs only at the atomic close boundary. No backwards compatibility, no dual patterns, no decisions about when to batch.
 
 ## ⚠️ CRITICAL: Excel COM Threading & Concurrency Limitations
 
@@ -115,7 +115,7 @@ This matches Excel UI behavior (cannot open same file twice).
 
 Users and LLMs naturally think in terms of:
 
-- **Open** a file → work with it → **Save** changes → **Close** the file
+- **Open** a file → work with it → **Close**, optionally saving changes atomically
 - NOT: Begin session → track GUID → commit session
 
 This is the universal pattern for file operations across all systems.
@@ -126,10 +126,12 @@ This is the universal pattern for file operations across all systems.
 
 **Sessions are the ONLY way to work with Excel files. No exceptions.**
 
-1. **`file(action: 'open')`** - Opens a workbook, returns a `sessionId`
-2. **`file(action: 'save')`** - Saves changes to an open workbook
-3. **`file(action: 'close')`** - Closes workbook and session
-4. **ALL other tools REQUIRE `sessionId`** - No standalone operation mode
+1. **`file(action: 'list')`** - Lists active sessions
+2. **`file(action: 'open')`** - Opens a workbook, returns a `sessionId`
+3. **`file(action: 'create')`** - Creates a workbook, returns a `sessionId`
+4. **`file(action: 'close')`** - Closes the workbook and session; `save=true` persists changes atomically
+5. **`file(action: 'test')`** - Reports file validity, openability, and IRM/AIP requirements
+6. **ALL other tools REQUIRE `sessionId`** - No standalone operation mode
 
 **Revolutionary Change:** Remove the `batchId` optional parameter pattern entirely. Sessions are mandatory, not optional.
 
@@ -152,10 +154,10 @@ Current Term → New Term → Rationale
 ────────────────────────────────────────────────────────
 batchId      → sessionId  → "Session" is more intuitive than "batch"
 begin        → open       → Universal file operation
-commit       → close      → Universal file operation (does NOT save)
+commit       → close      → Universal file operation with optional atomic save
 batch-of-one → REMOVED    → No standalone operations anymore
 Optional     → REQUIRED   → sessionId is mandatory for all operations
-save param   → REMOVED    → close never saves, use explicit save action
+save param   → RETAINED   → close-with-save is the only persistence operation
 excelPath    → REMOVED    → Session knows the file (except open/create)
 ```
 
@@ -165,21 +167,15 @@ excelPath    → REMOVED    → Session knows the file (except open/create)
 
 ### 1. `file` Tool - Updated Actions
 
-**Current Actions:**
+**Canonical Actions:**
 
-- `create-empty` - Create new workbook
-- `close-workbook` - Emergency close (rarely used)
-- `test` - Connection test
+- **`list`** - Lists active sessions
+- **`open`** - Opens a workbook and returns a session ID
+- **`create`** - Creates a workbook and returns a session ID
+- **`close`** - Closes a session, optionally saving atomically
+- **`test`** - Reports file validity, openability, and IRM/AIP requirements
 
-**New Actions (added):**
-
-- **`open`** - Opens workbook, returns sessionId (replaces batch begin)
-- **`save`** - Saves changes to open session
-- **`close`** - Closes session WITHOUT saving (use explicit save action)
-
-**Removed Actions:**
-
-- None (keep create-empty, test, close-workbook for backwards compat)
+Standalone save and compatibility no-ops are intentionally not part of the lifecycle.
 
 ### 2. API Signatures
 
@@ -192,8 +188,7 @@ excelPath    → REMOVED    → Session knows the file (except open/create)
 REQUIRED WORKFLOW:
 1. open - Opens workbook, returns sessionId (ALWAYS FIRST)
 2. Use sessionId for ALL operations (worksheets, queries, ranges, etc.)
-3. save - Saves changes (EXPLICIT action, call anytime during session)
-4. close - Closes workbook and session (NEVER saves - use explicit save action)
+3. close - Closes workbook and session; save=true persists changes atomically
 
 Sessions are mandatory - there are no standalone operations.")]
 public static async Task<string> ExcelFile(
@@ -204,16 +199,18 @@ public static async Task<string> ExcelFile(
     [Description("Full path to Excel file - required for 'open' and 'create-empty'")]
     string? filePath = null,
 
-    [Description("Session ID from 'open' action - required for 'save' and 'close'")]
-    string? sessionId = null)
+    [Description("Session ID from 'open' action - required for 'close'")]
+    string? sessionId = null,
+
+    [Description("Save changes before close")]
+    bool save = false)
 {
     return action switch
     {
         FileAction.Open => await OpenWorkbookAsync(filePath!),
-        FileAction.Save => await SaveWorkbookAsync(sessionId!),
-        FileAction.Close => await CloseWorkbookAsync(sessionId!),  // No save parameter - close NEVER saves
-        FileAction.CreateEmpty => await CreateEmptyAsync(filePath!),
-        FileAction.Test => TestConnection(),
+        FileAction.Close => await CloseSessionAsync(sessionId!, save),
+        FileAction.Create => await CreateSessionAsync(filePath!),
+        FileAction.Test => TestFile(filePath!),
         _ => throw new McpException($"Unknown action: {action}")
     };
 }
@@ -229,10 +226,10 @@ public static async Task<string> ExcelFile(
   "message": "Workbook opened successfully",
   "suggestedNextActions": [
     "Use sessionId='abc-123-def-456' for all operations",
-    "Call file(action: 'save', sessionId='...') to save changes (explicit only)",
-    "Call file(action: 'close', sessionId='...') when done (does NOT save)"
+    "Call file(action: 'close', sessionId='...', save=true) to persist changes",
+    "Call file(action: 'close', sessionId='...', save=false) to discard changes"
   ],
-  "workflowHint": "Session active. Remember: close does NOT save - use explicit save action."
+  "workflowHint": "Session active. Close with save=true to persist or save=false to discard."
 }
 ```
 
@@ -290,19 +287,19 @@ public static async Task<string> ExcelPowerQuery(
 // Add new actions to existing file tool
 public enum FileAction
 {
-    CreateEmpty,
-    Open,        // NEW - replaces batch begin
-    Save,        // NEW - explicit save
-    Close,       // NEW - replaces batch commit
+    List,
+    Open,
+    Create,
+    Close,
     Test
 }
 ```
 
 **Implementation:**
 
-- `OpenWorkbookAsync()` - Creates session, returns sessionId
-- `SaveWorkbookAsync(sessionId)` - Saves changes
-- `CloseWorkbookAsync(sessionId, save)` - Closes and disposes
+- `OpenSessionAsync()` - Creates session, returns sessionId
+- `CreateSessionAsync()` - Creates workbook and session, returns sessionId
+- `CloseSessionAsync(sessionId, save)` - Optionally saves, then closes and disposes
 
 #### Step 3: Update ALL Tools to Require sessionId (3-5 days)
 
@@ -322,7 +319,7 @@ string? batchId = null
 
 - `ExcelConnectionTool.cs`
 - `ExcelDataModelTool.cs`
-- `ExcelFileTool.cs` (add open/save/close actions)
+- `ExcelFileTool.cs` (add list/open/create/close/test actions)
 - `ExcelNamedRangeTool.cs`
 - `ExcelPivotTableTool.cs`
 - `ExcelPowerQueryTool.cs`
@@ -391,8 +388,7 @@ var session = await CreateSessionAsync("sales.xlsx");
 await GetSession(session).Execute(ctx => ctx.Book.Worksheets.Add("Q1"));  // Op 1
 await GetSession(session).Execute(ctx => ctx.Book.Worksheets.Add("Q2"));  // Op 2
 await GetSession(session).Execute(ctx => ctx.Book.Worksheets.Add("Q3"));  // Op 3
-await SaveSessionAsync(session);
-await CloseSessionAsync(session);
+await CloseSessionAsync(session, save: true);
 
 // Result: 1 Excel instance created/destroyed (fast)
 ```
@@ -429,8 +425,7 @@ var sessions = await Task.WhenAll(files.Select(f => CreateSessionAsync(f)));
 await Task.WhenAll(sessions.Select(async sessId => {
     var session = GetSession(sessId);
     await session.Execute(ctx => ProcessWorkbook(ctx));
-    await SaveSessionAsync(sessId);
-    await CloseSessionAsync(sessId);
+    await CloseSessionAsync(sessId, save: true);
 }));
 
 // Result: True parallelism - operations on different files don't block each other
@@ -633,11 +628,11 @@ New System (Mandatory Sessions):
 - [ ] **RENAME** `ExcelBatch` → `ExcelSession` (implementation)
 - [ ] **RENAME** `_activeBatches` → `_activeSessions` in SessionManager
 - [ ] **RENAME** `BeginBatchAsync` → `OpenSessionAsync` in ExcelSession
-- [ ] **ADD** `FileAction.Open`, `FileAction.Save`, `FileAction.Close` enum values
-- [ ] **IMPLEMENT** `OpenWorkbookAsync()`, `SaveWorkbookAsync()`, `CloseWorkbookAsync()` in ExcelFileTool
+- [ ] **ADD** the canonical `FileAction` list/open/create/close/test enum values
+- [ ] **IMPLEMENT** `OpenSessionAsync()`, `CreateSessionAsync()`, and atomic `CloseSessionAsync(save)` in ExcelFileTool
 - [ ] **CHANGE** all 12 tools: `batchId` (optional) → `sessionId` (required)
 - [ ] **REMOVE** `excelPath` parameter from all 11 tools (except file open/create)
-- [ ] **REMOVE** `save` parameter from close action in file tool
+- [ ] **KEEP** `save` on close as the only persistence operation
 - [ ] **SIMPLIFY** all tool methods: remove WithBatchAsync, direct session lookup
 - [ ] **UPDATE** session to track filePath internally (for excelPath removal)
 
@@ -645,12 +640,12 @@ New System (Mandatory Sessions):
 
 - [ ] **DELETE** all batch-mode specific tests
 - [ ] **REWRITE** all tool tests to use session pattern (open → operate → close)
-- [ ] **ADD** session lifecycle tests (open, save, close actions)
+- [ ] **ADD** session lifecycle tests (list, open, create, close, and test actions)
 - [ ] **ADD** error tests: operate without sessionId → clear error message
 - [ ] **ADD** error tests: sessionId not found → helpful error
 - [ ] **ADD** read-only workflow tests: open → read → close (no save)
-- [ ] **ADD** multiple-save workflow tests: open → modify → save → modify → save → close
-- [ ] **ADD** discard changes tests: open → modify → close (no save = rollback)
+- [ ] **ADD** close-with-save persistence tests: open → modify → close(save=true) → reopen → verify
+- [ ] **ADD** discard changes tests: open → modify → close(save=false) → reopen → verify rollback
 - [ ] **VERIFY** no performance regression (sessions were batches internally)
 - [ ] **TEST** integration with MCP clients (Claude, Copilot) using new API
 - [ ] **ADD** concurrency tests: verify operations within session are serial (not parallel)
@@ -672,7 +667,7 @@ New System (Mandatory Sessions):
 
 ### LLM Guidance
 
-- [ ] Create `session_lifecycle.md` prompt with open/save/close patterns
+- [ ] Create `session_lifecycle.md` prompt with list/open/create/close/test patterns
 - [ ] Update `user_request_patterns.md` with session detection hints
 - [ ] Add session error recovery guidance
 - [ ] Update elicitations to ask about multi-operation intent
@@ -784,8 +779,7 @@ LLMs should track the correct `sessionId` for each workbook and close sessions w
 for each file:
   1. open → sessionId
   2. perform operations (all serial within session)
-  3. save
-  4. close (frees Excel process immediately)
+  3. close(save=true) (persists atomically and frees Excel immediately)
 
 # OR parallel approach for small batches (faster but memory-intensive)
 1. open files 1-5 → get 5 sessionIds (5 Excel processes)
@@ -819,16 +813,15 @@ for each file:
 
 ### 2. Should `save` be implicit on `close` by default?
 
-**Decision:** No, close NEVER saves - explicit save action only
+**Decision:** No. `save` defaults to `false` and must be explicitly enabled on `close`.
 **Rationale:**
 
 - **Explicit is better than implicit** - No surprise saves
-- **LLM clarity** - "save" action = save, "close" action = close (no overlap)
-- **Read-only workflows** - Just open → read → close (no save needed)
-- **Multiple saves** - Save multiple times during session, close at end
-- **Predictable behavior** - close always does same thing (cleanup only)
+- **Atomic lifecycle** - Persistence and teardown happen at one close boundary
+- **Read-only workflows** - Just open → read → close with the default `save=false`
+- **Predictable behavior** - `save=true` persists; `save=false` discards
 
-**Implementation:** Remove `save` parameter from close entirely. Users call `file(action: 'save')` explicitly when needed.
+**Implementation:** Keep `save` on close, default it to `false`, and expose no standalone save action.
 
 ### 3. Should sessions timeout automatically after inactivity?
 
@@ -845,38 +838,30 @@ for each file:
 
 ### 4. What are the save semantics for different workflows?
 
-**Decision:** Explicit save action only, close never saves
+**Decision:** `close(save=true)` is the only persistence operation.
 
 **Workflows supported:**
 
 1. **Read-only workflow:**
 
    ```
-   open → read operations → close (no save needed)
+   open → read operations → close(save=false)
    ```
 
    Use case: List queries, view data, check connections
 
-2. **Single save workflow:**
+2. **Persist changes workflow:**
 
    ```
-   open → modify operations → save → close
+   open → modify operations → close(save=true)
    ```
 
    Use case: Standard edit workflow
 
-3. **Multiple save workflow:**
+3. **Discard changes workflow:**
 
    ```
-   open → modify → save → modify → save → modify → save → close
-   ```
-
-   Use case: Incremental changes, checkpoints, complex multi-step operations
-
-4. **Discard changes workflow:**
-
-   ```
-   open → modify operations → close (no save = changes discarded)
+   open → modify operations → close(save=false)
    ```
 
    Use case: Experimental changes, testing, rollback
@@ -884,9 +869,9 @@ for each file:
 **Rationale:**
 
 - **Explicit control** - User decides when to persist changes
-- **Read-only support** - No save parameter needed anywhere
-- **Flexibility** - Save 0, 1, or N times during session
-- **Predictability** - close always does same thing (cleanup)
+- **Read-only support** - The default close path does not write
+- **Single persistence boundary** - No partial checkpoints or standalone save operation
+- **Predictability** - The close flag fully determines persistence
 
 ### 5. Should we keep `excel_batch` as deprecated alias?
 
@@ -977,7 +962,7 @@ LLM: I'll open the workbook and create 3 worksheets.
 4. worksheet(action: 'create',
                    sheetName: 'Q3', sessionId: 'abc-123')
 
-5. file(action: 'close', sessionId: 'abc-123')
+5. file(action: 'close', sessionId: 'abc-123', save: true)
    → { success: true }
 ```
 
@@ -987,7 +972,7 @@ LLM: I'll open the workbook and create 3 worksheets.
 - "Commit batch" → "Close file" (universal action)
 - `batchId` (optional) → `sessionId` (required)
 - No more decision about "should I batch?"
-- **Close never saves** - explicit save action only
+- **Persistence is atomic with close** - `save=true` saves and closes in one operation
 - **excelPath removed** from all operations except open (session knows the file)
 - Simpler: 5 calls vs 5 calls, but with intuitive naming
 
@@ -1008,14 +993,14 @@ LLM: I'll check which Power Queries are in this workbook.
 
 **Key points:**
 
-- No save action needed (read-only operation)
-- Close doesn't save (no changes made)
+- Use the default `save=false` for read-only work
+- Close discards any incidental changes
 - Simple: open → read → close
 
-### Multiple-Save Workflow Example
+### Atomic Persistence Workflow Example
 
 ```
-LLM: I'll create multiple queries with checkpoints after each one.
+LLM: I'll create multiple queries and persist them when the session closes.
 
 1. file(action: 'open', filePath: 'sales.xlsx')
    → { sessionId: 'abc-123' }
@@ -1024,37 +1009,27 @@ LLM: I'll create multiple queries with checkpoints after each one.
                     queryName: 'SalesData', mCodeFile: 'sales.m')
    → { success: true }
 
-3. file(action: 'save', sessionId: 'abc-123')
-   → { success: true }  // Checkpoint 1
-
-4. powerquery(action: 'import', sessionId: 'abc-123',
+3. powerquery(action: 'import', sessionId: 'abc-123',
                     queryName: 'CustomerInfo', mCodeFile: 'customers.m')
    → { success: true }
 
-5. file(action: 'save', sessionId: 'abc-123')
-   → { success: true }  // Checkpoint 2
-
-6. powerquery(action: 'import', sessionId: 'abc-123',
+4. powerquery(action: 'import', sessionId: 'abc-123',
                     queryName: 'ProductCatalog', mCodeFile: 'products.m')
    → { success: true }
 
-7. file(action: 'save', sessionId: 'abc-123')
-   → { success: true }  // Final checkpoint
-
-8. file(action: 'close', sessionId: 'abc-123')
+5. file(action: 'close', sessionId: 'abc-123', save: true)
    → { success: true }
 ```
 
 **Key points:**
 
-- Multiple explicit save actions during session
-- Each save creates a checkpoint (changes persisted)
-- Close at end does NOT save (last save already persisted everything)
-- Incremental persistence reduces risk of data loss
+- No standalone save operation exists
+- All changes persist atomically when close succeeds with `save=true`
+- `save=false` remains available for read-only or discard workflows
 
 ## Conclusion
 
-This redesign achieves the ultimate goal: **Eliminate all cognitive load from LLMs by making sessions the only way to work with Excel files**. The Open/Save/Close pattern is:
+This redesign achieves the ultimate goal: **Eliminate all cognitive load from LLMs by making sessions the only way to work with Excel files**. The Open/Close pattern is:
 
 1. **Universal** - Every developer/LLM knows file lifecycle (no explanation needed)
 2. **Mandatory** - No decisions about batching, sessions are always used

--- a/src/ExcelMcp.CLI/Commands/BatchCommand.cs
+++ b/src/ExcelMcp.CLI/Commands/BatchCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Sbroenne.ExcelMcp.CLI.Infrastructure;
+using Sbroenne.ExcelMcp.Generated;
 using Sbroenne.ExcelMcp.Service;
 using Spectre.Console.Cli;
 
@@ -62,6 +63,37 @@ internal sealed class BatchCommand : AsyncCommand<BatchCommand.Settings>
             }
         }
 
+        var validationErrors = new Dictionary<int, string>();
+        for (int i = 0; i < commands.Count; i++)
+        {
+            var cmd = commands[i];
+            var argsJson = cmd.Args.HasValue && cmd.Args.Value.ValueKind != JsonValueKind.Undefined
+                ? cmd.Args.Value.GetRawText()
+                : null;
+            try
+            {
+                ServiceRegistry.ValidateCommandArguments(cmd.Command, argsJson);
+            }
+            catch (Exception ex) when (ex is ArgumentException or JsonException or IOException or UnauthorizedAccessException)
+            {
+                validationErrors[i] = ex.Message;
+            }
+        }
+
+        if (validationErrors.Count == commands.Count ||
+            (settings.StopOnError && validationErrors.ContainsKey(0)))
+        {
+            foreach (var validationError in validationErrors.OrderBy(error => error.Key))
+            {
+                WriteValidationError(validationError.Key, commands[validationError.Key].Command, validationError.Value);
+                if (settings.StopOnError)
+                {
+                    break;
+                }
+            }
+            return 1;
+        }
+
         // Connect to daemon (auto-starts if needed)
         using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
 
@@ -72,15 +104,27 @@ internal sealed class BatchCommand : AsyncCommand<BatchCommand.Settings>
         {
             var cmd = commands[i];
             var sessionId = cmd.SessionId ?? activeSession;
+            if (validationErrors.TryGetValue(i, out var validationError))
+            {
+                WriteValidationError(i, cmd.Command, validationError);
+
+                hasErrors = true;
+                if (settings.StopOnError)
+                {
+                    break;
+                }
+                continue;
+            }
+            var argsJson = cmd.Args.HasValue && cmd.Args.Value.ValueKind != JsonValueKind.Undefined
+                ? cmd.Args.Value.GetRawText()
+                : null;
 
             // Build the service request
             var request = new ServiceRequest
             {
                 Command = cmd.Command,
                 SessionId = sessionId,
-                Args = cmd.Args.HasValue && cmd.Args.Value.ValueKind != JsonValueKind.Undefined
-                    ? cmd.Args.Value.GetRawText()
-                    : null,
+                Args = argsJson,
                 Source = "cli-batch"
             };
 
@@ -130,6 +174,17 @@ internal sealed class BatchCommand : AsyncCommand<BatchCommand.Settings>
         }
 
         return hasErrors ? 1 : 0;
+    }
+
+    private static void WriteValidationError(int index, string command, string error)
+    {
+        Console.WriteLine(JsonSerializer.Serialize(new BatchResult
+        {
+            Index = index,
+            Command = command,
+            Success = false,
+            Error = error
+        }, BatchJsonOptions));
     }
 
     /// <summary>
@@ -238,8 +293,9 @@ internal sealed class BatchCommand : AsyncCommand<BatchCommand.Settings>
     private static readonly JsonSerializerOptions BatchJsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        PropertyNameCaseInsensitive = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow
     };
 
     // ── Models ──────────────────────────────────────────────────────

--- a/src/ExcelMcp.CLI/Commands/ServiceCommands.cs
+++ b/src/ExcelMcp.CLI/Commands/ServiceCommands.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using Sbroenne.ExcelMcp.CLI.Infrastructure;
@@ -35,7 +33,7 @@ internal sealed class ServiceStartCommand : AsyncCommand
 }
 
 /// <summary>
-/// Gracefully stops the ExcelMCP CLI Service daemon.
+/// Stops the ExcelMCP CLI Service daemon and Excel processes tracked for its selected pipe.
 /// </summary>
 internal sealed class ServiceStopCommand : AsyncCommand
 {
@@ -46,6 +44,17 @@ internal sealed class ServiceStopCommand : AsyncCommand
     protected override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
         var pipeName = DaemonAutoStart.GetPipeName();
+        return await DaemonAutoStart.WithStartupLockAsync(
+            pipeName,
+            () => ExecuteWithStartupLockAsync(pipeName, cancellationToken),
+            cancellationToken);
+    }
+
+    private static async Task<int> ExecuteWithStartupLockAsync(
+        string pipeName,
+        CancellationToken cancellationToken)
+    {
+        var preShutdownSnapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
         try
         {
             using var client = new ServiceClient(pipeName, connectTimeout: CommandTimeout, requestTimeout: CommandTimeout);
@@ -54,11 +63,17 @@ internal sealed class ServiceStopCommand : AsyncCommand
             {
                 if (await WaitForDaemonExitAsync(pipeName, cancellationToken))
                 {
-                    Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped." }, ServiceProtocol.JsonOptions));
-                    return 0;
+                    return await WriteCleanupResultAsync(
+                        pipeName,
+                        preShutdownSnapshot,
+                        cancellationToken,
+                        "Service stopped.");
                 }
 
-                if (await TryForceStopTrackedDaemonAsync(pipeName, cancellationToken))
+                if (await TryForceStopTrackedDaemonAsync(
+                    pipeName,
+                    preShutdownSnapshot,
+                    cancellationToken))
                 {
                     Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped.", forced = true }, ServiceProtocol.JsonOptions));
                     return 0;
@@ -72,11 +87,17 @@ internal sealed class ServiceStopCommand : AsyncCommand
 
             if (!DaemonAutoStart.IsDaemonMutexHeld(pipeName))
             {
-                Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service not running." }, ServiceProtocol.JsonOptions));
-                return 0;
+                return await WriteCleanupResultAsync(
+                    pipeName,
+                    preShutdownSnapshot,
+                    cancellationToken,
+                    "Service not running.");
             }
 
-            if (await TryForceStopTrackedDaemonAsync(pipeName, cancellationToken))
+            if (await TryForceStopTrackedDaemonAsync(
+                pipeName,
+                preShutdownSnapshot,
+                cancellationToken))
             {
                 Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped.", forced = true }, ServiceProtocol.JsonOptions));
                 return 0;
@@ -95,11 +116,17 @@ internal sealed class ServiceStopCommand : AsyncCommand
         {
             if (!DaemonAutoStart.IsDaemonMutexHeld(pipeName))
             {
-                Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service not running." }, ServiceProtocol.JsonOptions));
-                return 0;
+                return await WriteCleanupResultAsync(
+                    pipeName,
+                    preShutdownSnapshot,
+                    cancellationToken,
+                    "Service not running.");
             }
 
-            if (await TryForceStopTrackedDaemonAsync(pipeName, cancellationToken))
+            if (await TryForceStopTrackedDaemonAsync(
+                pipeName,
+                preShutdownSnapshot,
+                cancellationToken))
             {
                 Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Service stopped.", forced = true }, ServiceProtocol.JsonOptions));
                 return 0;
@@ -123,7 +150,6 @@ internal sealed class ServiceStopCommand : AsyncCommand
         {
             if (!DaemonAutoStart.IsDaemonMutexHeld(pipeName))
             {
-                DaemonProcessTracker.Clear(pipeName);
                 return true;
             }
 
@@ -133,89 +159,47 @@ internal sealed class ServiceStopCommand : AsyncCommand
         return !DaemonAutoStart.IsDaemonMutexHeld(pipeName);
     }
 
-    private static async Task<bool> TryForceStopTrackedDaemonAsync(string pipeName, CancellationToken cancellationToken)
+    private static async Task<bool> TryForceStopTrackedDaemonAsync(
+        string pipeName,
+        OwnedProcessCleanup.ProcessSnapshot preShutdownSnapshot,
+        CancellationToken cancellationToken)
     {
-        if (!DaemonProcessTracker.TryGetTrackedProcess(pipeName, out var trackedProcess))
-        {
-            return false;
-        }
-
-        using var daemonProcess = trackedProcess!;
-        var trackedExcelProcesses = DaemonProcessTracker.GetTrackedExcelProcesses(pipeName);
-        var excelProcessesStopped = true;
-
-        try
-        {
-            foreach (var excelProcess in trackedExcelProcesses)
-            {
-                using (excelProcess)
-                {
-                    excelProcessesStopped &= TryTerminateProcess(excelProcess, entireProcessTree: false);
-                }
-            }
-
-            if (!TryTerminateProcess(daemonProcess, entireProcessTree: true))
-            {
-                return false;
-            }
-
-            using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            waitCts.CancelAfter(ShutdownWaitTimeout);
-            await daemonProcess.WaitForExitAsync(waitCts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            return false;
-        }
-        catch (InvalidOperationException)
-        {
-            // Already exited between lookup and kill.
-        }
-        catch
-        {
-            return false;
-        }
-
-        DaemonProcessTracker.Clear(pipeName);
-        return excelProcessesStopped && await WaitForDaemonExitAsync(pipeName, cancellationToken);
+        var cleanupResult = await OwnedProcessCleanup.CleanupAsync(
+            pipeName,
+            preShutdownSnapshot,
+            cancellationToken);
+        return cleanupResult.Success
+            && cleanupResult.DaemonMatched
+            && await WaitForDaemonExitAsync(pipeName, cancellationToken);
     }
 
-    private static bool TryTerminateProcess(Process process, bool entireProcessTree)
+    private static async Task<int> WriteCleanupResultAsync(
+        string pipeName,
+        OwnedProcessCleanup.ProcessSnapshot preShutdownSnapshot,
+        CancellationToken cancellationToken,
+        string successMessage)
     {
-        try
+        var cleanupResult = await OwnedProcessCleanup.CleanupAsync(
+            pipeName,
+            preShutdownSnapshot,
+            cancellationToken);
+        if (!cleanupResult.Success)
         {
-            if (!process.HasExited)
-            {
-                process.Kill(entireProcessTree);
-            }
+            Console.WriteLine(JsonSerializer.Serialize(
+                new
+                {
+                    success = false,
+                    error = cleanupResult.ErrorMessage
+                        ?? $"One or more processes tracked for CLI pipe '{pipeName}' could not be stopped."
+                },
+                ServiceProtocol.JsonOptions));
+            return 1;
+        }
 
-            return true;
-        }
-        catch (InvalidOperationException)
-        {
-            // The process exited between the state check and termination request.
-            return true;
-        }
-        catch (Win32Exception)
-        {
-            try
-            {
-                process.Refresh();
-                return process.HasExited;
-            }
-            catch (InvalidOperationException)
-            {
-                return true;
-            }
-            catch (Win32Exception)
-            {
-                return false;
-            }
-        }
-        catch (NotSupportedException)
-        {
-            return false;
-        }
+        Console.WriteLine(JsonSerializer.Serialize(
+            new { success = true, message = successMessage },
+            ServiceProtocol.JsonOptions));
+        return 0;
     }
 }
 
@@ -225,53 +209,68 @@ internal sealed class ServiceStopCommand : AsyncCommand
 /// </summary>
 internal sealed class ServiceStatusCommand : AsyncCommand
 {
-    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(2);
-
     protected override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
         var pipeName = DaemonAutoStart.GetPipeName();
-        try
+        var observation = DaemonConnectionPolicy.Observe(pipeName);
+        var response = await DaemonConnectionPolicy.SendControlRequestAsync(
+            pipeName,
+            new ServiceRequest { Command = "service.status" },
+            cancellationToken,
+            observation.IsStopped
+                ? DaemonConnectionPolicy.InitialProbeTimeout
+                : DaemonConnectionPolicy.ControlTimeout);
+        if (response.Success && response.Result != null)
         {
-            using var client = new ServiceClient(pipeName, connectTimeout: CommandTimeout, requestTimeout: CommandTimeout);
-            var response = await client.SendAsync(new ServiceRequest { Command = "service.status" }, cancellationToken);
-            if (response.Success && response.Result != null)
+            var status = ServiceProtocol.Deserialize<ServiceStatus>(response.Result);
+            if (status != null)
             {
-                var status = ServiceProtocol.Deserialize<ServiceStatus>(response.Result);
-                if (status != null)
+                Console.WriteLine(JsonSerializer.Serialize(new
                 {
-                    Console.WriteLine(JsonSerializer.Serialize(new
-                    {
-                        success = true,
-                        running = status.Running,
-                        processId = status.ProcessId,
-                        sessionCount = status.SessionCount,
-                        startTime = status.StartTime,
-                        uptime = status.Uptime.ToString(@"d\.hh\:mm\:ss", CultureInfo.InvariantCulture)
-                    }, ServiceProtocol.JsonOptions));
-                    return 0;
-                }
+                    success = true,
+                    daemonState = DaemonConnectionPolicy.RunningState,
+                    running = status.Running,
+                    processId = status.ProcessId,
+                    sessionCount = status.SessionCount,
+                    startTime = status.StartTime,
+                    uptime = status.Uptime.ToString(@"d\.hh\:mm\:ss", CultureInfo.InvariantCulture)
+                }, ServiceProtocol.JsonOptions));
+                return 0;
             }
+        }
 
-            // ServiceClient returned an error response — surface the actual error
-            // instead of silently assuming "not running" (fixes #507)
-            Console.WriteLine(JsonSerializer.Serialize(new
-            {
-                success = false,
-                running = false,
-                error = response.ErrorMessage ?? "Service returned invalid response"
-            }, ServiceProtocol.JsonOptions));
-            return 1;
-        }
-        catch (Exception ex)
+        if (response.Success)
         {
-            // Unexpected error that escaped ServiceClient — report with details
-            Console.WriteLine(JsonSerializer.Serialize(new
+            response = new ServiceResponse
             {
-                success = false,
-                running = false,
-                error = $"{ex.GetType().Name}: {ex.Message}"
-            }, ServiceProtocol.JsonOptions));
-            return 1;
+                Success = false,
+                Command = "service.status",
+                ErrorCategory = "InvalidResponse",
+                ErrorMessage = "Service returned an invalid status response."
+            };
         }
+
+        var failureState = DaemonConnectionPolicy.ResolveFailureState(pipeName, response);
+        if (failureState.Name == DaemonConnectionPolicy.StoppedState)
+        {
+            return WriteStoppedStatus();
+        }
+
+        return CliErrorOutput.WriteDaemonError(response, failureState.Name, failureState.Running);
+    }
+
+    private static int WriteStoppedStatus()
+    {
+        Console.WriteLine(JsonSerializer.Serialize(new
+        {
+            success = true,
+            daemonState = DaemonConnectionPolicy.StoppedState,
+            running = false,
+            processId = 0,
+            sessionCount = 0,
+            startTime = (DateTime?)null,
+            uptime = TimeSpan.Zero.ToString(@"d\.hh\:mm\:ss", CultureInfo.InvariantCulture)
+        }, ServiceProtocol.JsonOptions));
+        return 0;
     }
 }

--- a/src/ExcelMcp.CLI/Commands/SessionCommands.cs
+++ b/src/ExcelMcp.CLI/Commands/SessionCommands.cs
@@ -1,6 +1,9 @@
 using System.ComponentModel;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Sbroenne.ExcelMcp.CLI.Infrastructure;
+using Sbroenne.ExcelMcp.Core.Models;
+using Sbroenne.ExcelMcp.Core.Utilities;
 using Sbroenne.ExcelMcp.Service;
 using Spectre.Console.Cli;
 
@@ -17,6 +20,19 @@ internal sealed class SessionCreateCommand : AsyncCommand<SessionCreateCommand.S
         if (string.IsNullOrWhiteSpace(settings.FilePath))
         {
             return CliErrorOutput.WriteError("File path is required.");
+        }
+
+        try
+        {
+            ParameterTransforms.ValidateTimeoutSeconds(
+                settings.TimeoutSeconds,
+                "timeout",
+                minimumSeconds: 10,
+                maximumSeconds: 3600);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return CliErrorOutput.WriteError(ex.Message);
         }
 
         using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
@@ -49,7 +65,7 @@ internal sealed class SessionCreateCommand : AsyncCommand<SessionCreateCommand.S
         public string FilePath { get; init; } = string.Empty;
 
         [CommandOption("--timeout <SECONDS>")]
-        [Description("Session open/create and operation timeout in seconds (default: 120)")]
+        [Description("Session open/create and operation timeout in whole seconds (default: 120; range: 10-3600)")]
         public int? TimeoutSeconds { get; init; }
 
         [CommandOption("--show")]
@@ -65,6 +81,19 @@ internal sealed class SessionOpenCommand : AsyncCommand<SessionOpenCommand.Setti
         if (string.IsNullOrWhiteSpace(settings.FilePath))
         {
             return CliErrorOutput.WriteError("File path is required.");
+        }
+
+        try
+        {
+            ParameterTransforms.ValidateTimeoutSeconds(
+                settings.TimeoutSeconds,
+                "timeout",
+                minimumSeconds: 10,
+                maximumSeconds: 3600);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return CliErrorOutput.WriteError(ex.Message);
         }
 
         using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
@@ -97,7 +126,7 @@ internal sealed class SessionOpenCommand : AsyncCommand<SessionOpenCommand.Setti
         public string FilePath { get; init; } = string.Empty;
 
         [CommandOption("--timeout <SECONDS>")]
-        [Description("Session open and operation timeout in seconds (default: 120)")]
+        [Description("Session open and operation timeout in whole seconds (default: 120; range: 10-3600)")]
         public int? TimeoutSeconds { get; init; }
 
         [CommandOption("--show")]
@@ -148,68 +177,101 @@ internal sealed class SessionCloseCommand : AsyncCommand<SessionCloseCommand.Set
 
 internal sealed class SessionListCommand : AsyncCommand
 {
-    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(2);
-
     protected override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
         var pipeName = DaemonAutoStart.GetPipeName();
-        using var client = new ServiceClient(pipeName, connectTimeout: CommandTimeout, requestTimeout: CommandTimeout);
-
-        try
+        var observation = DaemonConnectionPolicy.Observe(pipeName);
+        var response = await DaemonConnectionPolicy.SendControlRequestAsync(
+            pipeName,
+            new ServiceRequest { Command = "session.list" },
+            cancellationToken,
+            observation.IsStopped
+                ? DaemonConnectionPolicy.InitialProbeTimeout
+                : DaemonConnectionPolicy.ControlTimeout);
+        if (response.Success && response.Result != null)
         {
-            var response = await client.SendAsync(new ServiceRequest { Command = "session.list" }, cancellationToken);
-            if (response.Success)
-            {
-                Console.WriteLine(response.Result);
-                return 0;
-            }
-            else
-            {
-                return CliErrorOutput.WriteServiceError(response);
-            }
-        }
-        catch (Exception)
-        {
-            // Daemon not running — no sessions
-            Console.WriteLine(JsonSerializer.Serialize(new { sessions = Array.Empty<object>() }, ServiceProtocol.JsonOptions));
+            var result = JsonNode.Parse(response.Result) as JsonObject
+                ?? throw new JsonException("Service returned an invalid session list response.");
+            result["daemonState"] = DaemonConnectionPolicy.RunningState;
+            Console.WriteLine(result.ToJsonString(ServiceProtocol.JsonOptions));
             return 0;
         }
+
+        if (response.Success)
+        {
+            response = new ServiceResponse
+            {
+                Success = false,
+                Command = "session.list",
+                ErrorCategory = "InvalidResponse",
+                ErrorMessage = "Service returned an invalid session list response."
+            };
+        }
+
+        var failureState = DaemonConnectionPolicy.ResolveFailureState(pipeName, response);
+        if (failureState.Name == DaemonConnectionPolicy.StoppedState)
+        {
+            return WriteStoppedSessionList();
+        }
+
+        return CliErrorOutput.WriteDaemonError(response, failureState.Name, failureState.Running);
+    }
+
+    private static int WriteStoppedSessionList()
+    {
+        Console.WriteLine(JsonSerializer.Serialize(new
+        {
+            success = true,
+            daemonState = DaemonConnectionPolicy.StoppedState,
+            sessions = Array.Empty<object>(),
+            count = 0
+        }, ServiceProtocol.JsonOptions));
+        return 0;
     }
 }
 
-internal sealed class SessionSaveCommand : AsyncCommand<SessionSaveCommand.Settings>
+internal sealed class SessionTestCommand : AsyncCommand<SessionTestCommand.Settings>
 {
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(settings.SessionId))
+        if (string.IsNullOrWhiteSpace(settings.FilePath))
         {
-            return CliErrorOutput.WriteError("Session ID is required.");
+            return CliErrorOutput.WriteError("File path is required.");
         }
 
         using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
         var response = await client.SendAsync(new ServiceRequest
         {
-            Command = "session.save",
-            SessionId = settings.SessionId
+            Command = "session.test",
+            Args = JsonSerializer.Serialize(
+                new { filePath = settings.FilePath },
+                ServiceProtocol.JsonOptions)
         }, cancellationToken);
 
-        if (response.Success)
-        {
-            Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Session saved." }, ServiceProtocol.JsonOptions));
-            return 0;
-        }
-        else
+        if (!response.Success)
         {
             return CliErrorOutput.WriteServiceError(response);
         }
+
+        if (string.IsNullOrWhiteSpace(response.Result))
+        {
+            return CliErrorOutput.WriteError("Service returned an invalid file test response.");
+        }
+
+        var result = ServiceProtocol.Deserialize<FileValidationInfo>(response.Result);
+        if (result == null)
+        {
+            return CliErrorOutput.WriteError("Service returned an invalid file test response.");
+        }
+
+        Console.WriteLine(response.Result);
+        return result.CanOpen ? 0 : 1;
     }
 
     internal sealed class Settings : CommandSettings
     {
-        [CommandOption("-s|--session <SESSION>")]
-        [Description("Session ID to save")]
-        public string SessionId { get; init; } = string.Empty;
+        [CommandArgument(0, "<FILE>")]
+        [Description("Full path to test for existence, validity, openability, and IRM/AIP requirements")]
+        public string FilePath { get; init; } = string.Empty;
     }
 }
-
-

--- a/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+++ b/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
@@ -24,7 +24,7 @@
     <!-- NuGet Package Configuration (secondary distribution — primary is standalone exe) -->
     <PackageId>Sbroenne.ExcelMcp.CLI</PackageId>
     <Title>ExcelMcp CLI</Title>
-    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 326 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
+    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 325 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
     <PackageTags>excel;cli;powerquery;dax;power-pivot;automation;com;rpa;ci-cd;scripting;github-copilot;mcp;windows;dotnet-tool;sbroenne;excel-automation;vba;pivottables;excel-tables;batch-processing;devops</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/sbroenne/mcp-server-excel/releases for release notes</PackageReleaseNotes>
@@ -144,7 +144,7 @@
       OutputPath="$(SkillOutputPath)"
       ManifestPath="$(SkillManifestPath)"
       ExcludeCommands="diag"
-      ExtraOperationCount="6"
+      ExtraOperationCount="5"
       ExtraToolCount="1" />
     <Message Text="Generated CLI Skill: $(SkillOutputPath)" Importance="high" />
   </Target>

--- a/src/ExcelMcp.CLI/Infrastructure/CliErrorOutput.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/CliErrorOutput.cs
@@ -15,7 +15,9 @@ internal static class CliErrorOutput
             null,
             ex.GetType().Name,
             null,
-            ex.InnerException?.Message));
+            ex.InnerException?.Message,
+            null,
+            null));
         return 1;
     }
 
@@ -28,13 +30,33 @@ internal static class CliErrorOutput
             response.SessionId,
             response.ExceptionType,
             response.HResult,
-            response.InnerError));
+            response.InnerError,
+            null,
+            null));
+        return 1;
+    }
+
+    public static int WriteDaemonError(
+        ServiceResponse response,
+        string daemonState,
+        bool running)
+    {
+        Console.WriteLine(Serialize(
+            response.ErrorMessage,
+            response.ErrorCategory,
+            response.Command,
+            response.SessionId,
+            response.ExceptionType,
+            response.HResult,
+            response.InnerError,
+            daemonState,
+            running));
         return 1;
     }
 
     public static int WriteError(string errorMessage, string? errorCategory = null)
     {
-        Console.WriteLine(Serialize(errorMessage, errorCategory, null, null, null, null, null));
+        Console.WriteLine(Serialize(errorMessage, errorCategory, null, null, null, null, null, null, null));
         return 1;
     }
 
@@ -45,7 +67,9 @@ internal static class CliErrorOutput
         string? sessionId,
         string? exceptionType,
         string? hresult,
-        string? innerError)
+        string? innerError,
+        string? daemonState,
+        bool? running)
     {
         return JsonSerializer.Serialize(new ErrorEnvelope
         {
@@ -58,7 +82,9 @@ internal static class CliErrorOutput
             IsError = true,
             ExceptionType = exceptionType,
             HResult = hresult,
-            InnerError = innerError
+            InnerError = innerError,
+            DaemonState = daemonState,
+            Running = running
         }, ServiceProtocol.JsonOptions);
     }
 
@@ -90,5 +116,11 @@ internal static class CliErrorOutput
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? InnerError { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? DaemonState { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Running { get; init; }
     }
 }

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonAutoStart.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonAutoStart.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using Sbroenne.ExcelMcp.Service;
 
@@ -9,14 +10,14 @@ namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
 /// </summary>
 internal static class DaemonAutoStart
 {
-    internal static readonly TimeSpan InitialPingTimeout = TimeSpan.FromSeconds(2);
+    internal static readonly TimeSpan InitialPingTimeout = DaemonConnectionPolicy.InitialProbeTimeout;
     internal static readonly TimeSpan BusyDaemonConnectTimeout = TimeSpan.FromSeconds(3);
     internal static readonly TimeSpan BusyDaemonRetryInterval = TimeSpan.FromMilliseconds(500);
     internal static readonly TimeSpan BusyDaemonWaitTimeout = TimeSpan.FromSeconds(10);
     internal static readonly TimeSpan StartupReadyConnectTimeout = TimeSpan.FromSeconds(1);
     internal static readonly TimeSpan StartupReadyRetryInterval = TimeSpan.FromMilliseconds(250);
-    internal static readonly TimeSpan StartupReadyTimeout = TimeSpan.FromSeconds(10);
-    internal static readonly TimeSpan StartupLockTimeout = StartupReadyTimeout + TimeSpan.FromSeconds(1);
+    internal static readonly TimeSpan StartupReadyTimeout = DaemonConnectionPolicy.StartupReadyTimeout;
+    internal static readonly TimeSpan StartupLockTimeout = DaemonStartupLock.Timeout;
 
     /// <summary>
     /// Gets the pipe name for the CLI daemon (supports env var override for testing).
@@ -31,66 +32,188 @@ internal static class DaemonAutoStart
     public static async Task<ServiceClient> EnsureAndConnectAsync(CancellationToken cancellationToken = default)
     {
         var pipeName = GetPipeName();
+        var startupDeadline = OperationDeadline.Start(StartupReadyTimeout);
+        using var startupCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        startupCts.CancelAfter(StartupReadyTimeout);
 
-        // Fast path: daemon already running and responsive
-        if (await PingAsync(pipeName, InitialPingTimeout, cancellationToken))
+        try
+        {
+            return await EnsureAndConnectCoreAsync(
+                pipeName,
+                startupDeadline,
+                CreateRuntime(pipeName),
+                startupCts.Token);
+        }
+        catch (OperationCanceledException) when (
+            startupCts.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Daemon did not become ready within {FormatDuration(StartupReadyTimeout)}.");
+        }
+    }
+
+    internal static async Task<ServiceClient> EnsureAndConnectCoreAsync(
+        string pipeName,
+        OperationDeadline startupDeadline,
+        Runtime runtime,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+
+        if (await runtime.PingAsync(
+            startupDeadline.Cap(InitialPingTimeout),
+            cancellationToken))
         {
             return new ServiceClient(pipeName);
         }
 
-        // Ping failed — check OS mutex to distinguish "daemon busy" from "daemon not running".
-        // The daemon holds this mutex for its entire lifetime, so its presence means
-        // the daemon is running but temporarily unresponsive (e.g., during a heavy refresh).
-        // This prevents starting a duplicate daemon (and a duplicate tray icon).
-        if (IsDaemonMutexHeld(pipeName))
+        if (runtime.IsDaemonMutexHeld())
         {
-            // Daemon is running but busy — wait briefly for it to become responsive.
-            // If the mutex is still held after the wait window, do NOT try to start a
-            // second daemon: it will immediately exit because the existing process still
-            // owns the mutex. Surface an actionable recovery error instead.
-            var waitUntil = DateTime.UtcNow + BusyDaemonWaitTimeout;
-            while (DateTime.UtcNow < waitUntil)
+            var startupInProgress = RecheckStartupAfterDaemonObservation(
+                startupAlreadyObserved: false,
+                runtime.IsStartupInProgress);
+            var responsivenessDeadline = startupInProgress
+                ? startupDeadline
+                : OperationDeadline.Start(startupDeadline.Cap(BusyDaemonWaitTimeout));
+            while (true)
             {
-                await Task.Delay(BusyDaemonRetryInterval, cancellationToken);
+                if (!startupInProgress && runtime.IsStartupInProgress())
+                {
+                    startupInProgress = true;
+                    responsivenessDeadline = startupDeadline;
+                }
 
-                // Re-check mutex: if the daemon exited while we waited, stop waiting
-                if (!IsDaemonMutexHeld(pipeName))
+                if (responsivenessDeadline.IsExpired)
+                {
                     break;
+                }
 
-                var remaining = waitUntil - DateTime.UtcNow;
-                if (remaining <= TimeSpan.Zero)
+                await Task.Delay(
+                    responsivenessDeadline.Cap(BusyDaemonRetryInterval),
+                    cancellationToken);
+
+                if (!runtime.IsDaemonMutexHeld())
+                {
                     break;
+                }
 
-                if (await PingAsync(pipeName, Min(remaining, BusyDaemonConnectTimeout), cancellationToken))
+                var connectTimeout = responsivenessDeadline.Cap(BusyDaemonConnectTimeout);
+                if (connectTimeout <= TimeSpan.Zero)
+                {
+                    break;
+                }
+
+                if (await runtime.PingAsync(connectTimeout, cancellationToken))
+                {
                     return new ServiceClient(pipeName);
+                }
             }
 
-            if (IsDaemonMutexHeld(pipeName))
+            if (!startupInProgress && runtime.IsStartupInProgress())
             {
+                startupInProgress = true;
+                if (await runtime.WaitForResponsiveDaemonAsync(
+                    startupDeadline,
+                    cancellationToken))
+                {
+                    return new ServiceClient(pipeName);
+                }
+            }
+            var daemonStillRunning = runtime.IsDaemonMutexHeld();
+            startupInProgress = RecheckStartupAfterDaemonObservation(
+                startupInProgress,
+                runtime.IsStartupInProgress);
+            if (ShouldContinueStartupWait(
+                    startupInProgress,
+                    daemonStillRunning,
+                    startupDeadline.IsExpired)
+                && await runtime.WaitForResponsiveDaemonAsync(
+                    startupDeadline,
+                    cancellationToken))
+            {
+                return new ServiceClient(pipeName);
+            }
+
+            if (daemonStillRunning)
+            {
+                if (startupInProgress)
+                {
+                    throw new TimeoutException(
+                        $"Daemon startup did not become ready within {FormatDuration(StartupReadyTimeout)}.");
+                }
+
                 throw new TimeoutException(
                     $"Daemon is running but not responding after {FormatDuration(BusyDaemonWaitTimeout)}. " +
                     "Stop it with 'excelcli service stop' or terminate the stuck excelcli process, then retry.");
             }
-
-            // Daemon exited while we waited — start a replacement.
         }
 
-        if (!await TryStartDaemonWithStartupLockAsync(pipeName, cancellationToken))
-        {
-            if (await WaitForResponsiveDaemonAsync(pipeName, StartupReadyTimeout, cancellationToken))
-                return new ServiceClient(pipeName);
-
-            throw new TimeoutException(
-                $"Daemon startup is already in progress but did not become ready within {FormatDuration(StartupReadyTimeout)}.");
-        }
-
-        if (await PingAsync(pipeName, StartupReadyConnectTimeout, cancellationToken))
+        var startOutcome = await runtime.TryStartDaemonAsync(
+            startupDeadline,
+            cancellationToken);
+        if (startOutcome == StartOutcome.Ready)
         {
             return new ServiceClient(pipeName);
         }
 
-        throw new TimeoutException($"Daemon started but not responding within {FormatDuration(StartupReadyTimeout)}.");
+        if (await runtime.WaitForResponsiveDaemonAsync(
+            startupDeadline,
+            cancellationToken))
+        {
+            return new ServiceClient(pipeName);
+        }
+
+        throw new TimeoutException(startOutcome switch
+        {
+            StartOutcome.LockUnavailable =>
+                $"CLI daemon lifecycle operation did not complete and no responsive daemon became ready within {FormatDuration(StartupReadyTimeout)}.",
+            StartOutcome.ObserveReadiness =>
+                $"Daemon started but not responding within {FormatDuration(StartupReadyTimeout)}.",
+            _ => throw new InvalidOperationException($"Unexpected daemon start outcome '{startOutcome}'.")
+        });
     }
+
+    private static Runtime CreateRuntime(string pipeName) =>
+        new(
+            (timeout, cancellationToken) => PingAsync(pipeName, timeout, cancellationToken),
+            () => IsDaemonMutexHeld(pipeName),
+            () => IsDaemonStartupInProgress(pipeName),
+            (deadline, cancellationToken) =>
+                TryStartDaemonWithStartupLockAsync(pipeName, deadline, cancellationToken),
+            (deadline, cancellationToken) =>
+                WaitForResponsiveDaemonAsync(pipeName, deadline, cancellationToken));
+
+    internal sealed record Runtime(
+        Func<TimeSpan, CancellationToken, Task<bool>> PingAsync,
+        Func<bool> IsDaemonMutexHeld,
+        Func<bool> IsStartupInProgress,
+        Func<OperationDeadline, CancellationToken, Task<StartOutcome>> TryStartDaemonAsync,
+        Func<OperationDeadline, CancellationToken, Task<bool>> WaitForResponsiveDaemonAsync);
+
+    internal enum StartOutcome
+    {
+        LockUnavailable,
+        ObserveReadiness,
+        Ready
+    }
+
+    internal static bool RecheckStartupAfterDaemonObservation(
+        bool startupAlreadyObserved,
+        Func<bool> startupMarkerProbe)
+    {
+        ArgumentNullException.ThrowIfNull(startupMarkerProbe);
+        var startupObservedAfterDaemon = startupMarkerProbe();
+        return startupAlreadyObserved || startupObservedAfterDaemon;
+    }
+
+    internal static bool ShouldContinueStartupWait(
+        bool startupObserved,
+        bool daemonObserved,
+        bool startupDeadlineExpired) =>
+        startupObserved
+        && daemonObserved
+        && !startupDeadlineExpired;
 
     /// <summary>
     /// Checks whether a daemon process currently holds the daemon mutex for the given pipe name.
@@ -98,16 +221,28 @@ internal static class DaemonAutoStart
     /// </summary>
     internal static bool IsDaemonMutexHeld(string pipeName)
     {
+        return IsMutexHeld(GetDaemonMutexName(pipeName))
+            || DaemonStartupLock.GetLegacyDaemonMutexNames(pipeName)
+                .Any(IsMutexHeld);
+    }
+
+    /// <summary>
+    /// Checks whether a CLI process currently holds the active-startup marker.
+    /// </summary>
+    internal static bool IsDaemonStartupInProgress(string pipeName)
+    {
+        return IsMutexHeld(GetDaemonStartingMarkerName(pipeName));
+    }
+
+    private static bool IsMutexHeld(string mutexName)
+    {
         Mutex? mutex = null;
         try
         {
-            // OpenExisting succeeds if any process has this named mutex open.
-            // The daemon opens it with initiallyOwned:true and holds it for its entire lifetime.
-            mutex = Mutex.OpenExisting(GetDaemonMutexName(pipeName));
+            mutex = Mutex.OpenExisting(mutexName);
             if (mutex.WaitOne(TimeSpan.Zero))
             {
                 mutex.ReleaseMutex();
-                DaemonProcessTracker.Clear(pipeName);
                 return false;
             }
 
@@ -116,16 +251,19 @@ internal static class DaemonAutoStart
         catch (AbandonedMutexException)
         {
             try { mutex?.ReleaseMutex(); } catch (ApplicationException) { }
-            DaemonProcessTracker.Clear(pipeName);
             return false;
         }
         catch (WaitHandleCannotBeOpenedException)
         {
-            return false; // No process has this mutex — daemon is not running
+            return false;
         }
-        catch (Exception)
+        catch (IOException)
         {
-            return false; // Access denied or other error — assume not running
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
         }
         finally
         {
@@ -138,22 +276,43 @@ internal static class DaemonAutoStart
     /// Used by both the daemon (to acquire) and the client (to detect a running daemon).
     /// </summary>
     internal static string GetDaemonMutexName(string pipeName) =>
-        $"ExcelMcpCli_{pipeName}";
+        DaemonStartupLock.GetDaemonMutexName(pipeName);
 
     internal static string GetDaemonStartupLockName(string pipeName) =>
-        $"{GetDaemonMutexName(pipeName)}_startup";
+        DaemonStartupLock.GetStartupMutexName(pipeName);
 
-    private static Task<bool> TryStartDaemonWithStartupLockAsync(string pipeName, CancellationToken cancellationToken)
+    internal static string GetDaemonStartingMarkerName(string pipeName) =>
+        DaemonStartupLock.GetStartingMarkerName(pipeName);
+
+    internal static Task<T> WithStartupLockAsync<T>(
+        string pipeName,
+        Func<Task<T>> action,
+        CancellationToken cancellationToken)
+    {
+        return DaemonStartupLock.WithLockAsync(
+            pipeName,
+            action,
+            cancellationToken);
+    }
+
+    private static Task<StartOutcome> TryStartDaemonWithStartupLockAsync(
+        string pipeName,
+        OperationDeadline startupDeadline,
+        CancellationToken cancellationToken)
     {
         return Task.Run(() =>
         {
             using var startupMutex = new Mutex(initiallyOwned: false, GetDaemonStartupLockName(pipeName), out _);
+            Mutex? startingMarker = null;
             var startupLockAcquired = false;
+            var startingMarkerAcquired = false;
             try
             {
                 try
                 {
-                    startupLockAcquired = startupMutex.WaitOne(StartupLockTimeout);
+                    var lockTimeout = startupDeadline.Cap(StartupLockTimeout);
+                    startupLockAcquired = lockTimeout > TimeSpan.Zero
+                        && startupMutex.WaitOne(lockTimeout);
                 }
                 catch (AbandonedMutexException)
                 {
@@ -161,43 +320,104 @@ internal static class DaemonAutoStart
                 }
 
                 if (!startupLockAcquired)
-                    return false;
+                    return StartOutcome.LockUnavailable;
 
                 // Another CLI process may have started the daemon while this process waited.
-                if (PingAsync(pipeName, InitialPingTimeout, cancellationToken).GetAwaiter().GetResult())
-                    return true;
+                var pingTimeout = startupDeadline.Cap(InitialPingTimeout);
+                if (pingTimeout > TimeSpan.Zero
+                    && PingAsync(pipeName, pingTimeout, cancellationToken).GetAwaiter().GetResult())
+                {
+                    return StartOutcome.Ready;
+                }
+
+                if (IsDaemonMutexHeld(pipeName))
+                {
+                    return StartOutcome.ObserveReadiness;
+                }
+
+                startingMarker = new Mutex(
+                    initiallyOwned: false,
+                    GetDaemonStartingMarkerName(pipeName),
+                    out _);
+                try
+                {
+                    startingMarkerAcquired = startingMarker.WaitOne(TimeSpan.Zero);
+                }
+                catch (AbandonedMutexException)
+                {
+                    startingMarkerAcquired = true;
+                }
+
+                if (!startingMarkerAcquired)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not acquire the daemon starting marker for CLI pipe '{pipeName}'.");
+                }
+
+                var cleanupResult = OwnedProcessCleanup
+                    .CleanupAsync(pipeName, cancellationToken)
+                    .GetAwaiter()
+                    .GetResult();
+                if (!cleanupResult.Success)
+                {
+                    throw new InvalidOperationException(
+                        $"{cleanupResult.ErrorMessage ?? $"Tracked processes for CLI pipe '{pipeName}' could not be stopped."} " +
+                        "Run 'excelcli service stop' and retry.");
+                }
 
                 // No daemon running — start it.
-                StartDaemonAsync(pipeName, cancellationToken).GetAwaiter().GetResult();
-                return true;
+                StartDaemonAsync(
+                    pipeName,
+                    startupDeadline,
+                    cancellationToken).GetAwaiter().GetResult();
+                return StartOutcome.Ready;
             }
             finally
             {
+                if (startingMarkerAcquired)
+                {
+                    startingMarker!.ReleaseMutex();
+                }
+                startingMarker?.Dispose();
+
                 if (startupLockAcquired)
+                {
                     startupMutex.ReleaseMutex();
+                }
             }
         }, cancellationToken);
     }
 
-    private static async Task<bool> WaitForResponsiveDaemonAsync(string pipeName, TimeSpan timeout, CancellationToken cancellationToken)
+    private static async Task<bool> WaitForResponsiveDaemonAsync(
+        string pipeName,
+        OperationDeadline startupDeadline,
+        CancellationToken cancellationToken)
     {
-        var waitUntil = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < waitUntil)
+        while (!startupDeadline.IsExpired)
         {
-            await Task.Delay(StartupReadyRetryInterval, cancellationToken);
+            await Task.Delay(
+                startupDeadline.Cap(StartupReadyRetryInterval),
+                cancellationToken);
 
-            var remaining = waitUntil - DateTime.UtcNow;
-            if (remaining <= TimeSpan.Zero)
+            var connectTimeout = startupDeadline.Cap(StartupReadyConnectTimeout);
+            if (connectTimeout <= TimeSpan.Zero)
+            {
                 break;
+            }
 
-            if (await PingAsync(pipeName, Min(remaining, StartupReadyConnectTimeout), cancellationToken))
+            if (await PingAsync(pipeName, connectTimeout, cancellationToken))
+            {
                 return true;
+            }
         }
 
         return false;
     }
 
-    private static async Task StartDaemonAsync(string pipeName, CancellationToken cancellationToken)
+    private static async Task StartDaemonAsync(
+        string pipeName,
+        OperationDeadline startupDeadline,
+        CancellationToken cancellationToken)
     {
         var exePath = ResolveDaemonExecutablePath();
 
@@ -211,21 +431,27 @@ internal static class DaemonAutoStart
             WorkingDirectory = Path.GetDirectoryName(exePath) ?? Environment.CurrentDirectory
         };
 
-        try
-        {
-            using var daemonProcess = Process.Start(startInfo)
-                ?? throw new InvalidOperationException($"Failed to start daemon process '{exePath}'.");
+        var daemonProcess = StartDaemonProcess(
+            startupDeadline,
+            cancellationToken,
+            exePath,
+            () => Process.Start(startInfo));
 
-            // Wait for daemon to be ready.
-            var waitUntil = DateTime.UtcNow + StartupReadyTimeout;
-            while (DateTime.UtcNow < waitUntil)
+        using (daemonProcess)
+        {
+            while (!startupDeadline.IsExpired)
             {
-                await Task.Delay(StartupReadyRetryInterval, cancellationToken);
+                await Task.Delay(
+                    startupDeadline.Cap(StartupReadyRetryInterval),
+                    cancellationToken);
                 if (daemonProcess.HasExited)
                 {
                     if (daemonProcess.ExitCode == 0)
                     {
-                        if (await WaitForResponsiveDaemonAsync(pipeName, waitUntil - DateTime.UtcNow, cancellationToken))
+                        if (await WaitForResponsiveDaemonAsync(
+                            pipeName,
+                            startupDeadline,
+                            cancellationToken))
                         {
                             GC.KeepAlive(daemonProcess);
                             return;
@@ -241,23 +467,49 @@ internal static class DaemonAutoStart
                         $"Daemon process exited before becoming ready (exit code {daemonProcess.ExitCode}).");
                 }
 
-                var remaining = waitUntil - DateTime.UtcNow;
-                if (remaining <= TimeSpan.Zero)
+                var connectTimeout = startupDeadline.Cap(StartupReadyConnectTimeout);
+                if (connectTimeout <= TimeSpan.Zero)
+                {
                     break;
+                }
 
-                if (await PingAsync(pipeName, Min(remaining, StartupReadyConnectTimeout), cancellationToken))
+                if (await PingAsync(pipeName, connectTimeout, cancellationToken))
                 {
                     GC.KeepAlive(daemonProcess);
                     return;
                 }
             }
         }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException($"Failed to start daemon: {ex.Message}", ex);
-        }
 
         throw new TimeoutException($"Daemon started but not responding within {FormatDuration(StartupReadyTimeout)}.");
+    }
+
+    internal static Process StartDaemonProcess(
+        OperationDeadline startupDeadline,
+        CancellationToken cancellationToken,
+        string executablePath,
+        Func<Process?> processStarter)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executablePath);
+        ArgumentNullException.ThrowIfNull(processStarter);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (startupDeadline.IsExpired)
+        {
+            throw new TimeoutException(
+                $"Daemon startup deadline expired before process '{executablePath}' could be launched.");
+        }
+
+        try
+        {
+            return processStarter()
+                ?? throw new InvalidOperationException($"Failed to start daemon process '{executablePath}'.");
+        }
+        catch (Win32Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start daemon process '{executablePath}': {ex.Message}",
+                ex);
+        }
     }
 
     private static string ResolveDaemonExecutablePath()
@@ -284,12 +536,21 @@ internal static class DaemonAutoStart
             : $"{duration.TotalMilliseconds:0} ms";
     }
 
-    private static TimeSpan Min(TimeSpan left, TimeSpan right) => left <= right ? left : right;
-
     private static async Task<bool> PingAsync(string pipeName, TimeSpan connectTimeout, CancellationToken cancellationToken)
     {
-        var requestTimeout = connectTimeout + TimeSpan.FromSeconds(1);
-        using var client = new ServiceClient(pipeName, connectTimeout: connectTimeout, requestTimeout: requestTimeout);
-        return await client.PingAsync(cancellationToken);
+        if (connectTimeout <= TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        using var client = new ServiceClient(
+            pipeName,
+            connectTimeout: connectTimeout,
+            requestTimeout: connectTimeout);
+        var response = await client.SendAsync(
+            new ServiceRequest { Command = "service.ping" },
+            connectTimeout,
+            cancellationToken);
+        return response.Success;
     }
 }

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonConnectionPolicy.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonConnectionPolicy.cs
@@ -1,0 +1,90 @@
+using Sbroenne.ExcelMcp.Service;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+internal static class DaemonConnectionPolicy
+{
+    internal const string RunningState = "running";
+    internal const string StartingState = "starting";
+    internal const string StoppedState = "stopped";
+    internal const string UnresponsiveState = "unresponsive";
+
+    internal static readonly TimeSpan InitialProbeTimeout = TimeSpan.FromSeconds(2);
+    internal static readonly TimeSpan ControlTimeout = TimeSpan.FromSeconds(10);
+    internal static readonly TimeSpan StartupReadyTimeout = TimeSpan.FromSeconds(30);
+
+    internal static async Task<ServiceResponse> SendControlRequestAsync(
+        string pipeName,
+        ServiceRequest request,
+        CancellationToken cancellationToken,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? ControlTimeout;
+        using var client = new ServiceClient(
+            pipeName,
+            connectTimeout: effectiveTimeout,
+            requestTimeout: effectiveTimeout);
+        return await client.SendAsync(
+            request,
+            effectiveTimeout,
+            cancellationToken);
+    }
+
+    internal static bool IsTransportFailure(ServiceResponse response) =>
+        string.Equals(response.ErrorCategory, "Timeout", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(response.ErrorCategory, "ServiceUnavailable", StringComparison.OrdinalIgnoreCase);
+
+    internal static DaemonObservation Observe(string pipeName)
+    {
+        return Observe(
+            () => DaemonAutoStart.IsDaemonStartupInProgress(pipeName),
+            () => DaemonAutoStart.IsDaemonMutexHeld(pipeName));
+    }
+
+    internal static DaemonObservation Observe(
+        Func<bool> startupMarkerProbe,
+        Func<bool> daemonProbe)
+    {
+        ArgumentNullException.ThrowIfNull(startupMarkerProbe);
+        ArgumentNullException.ThrowIfNull(daemonProbe);
+
+        var startupInProgress = startupMarkerProbe();
+        var daemonRunning = daemonProbe();
+        startupInProgress = DaemonAutoStart.RecheckStartupAfterDaemonObservation(
+            startupInProgress,
+            startupMarkerProbe);
+        return new DaemonObservation(daemonRunning, startupInProgress);
+    }
+
+    internal static DaemonFailureState ResolveFailureState(
+        string pipeName,
+        ServiceResponse response)
+    {
+        if (!IsTransportFailure(response))
+        {
+            return new DaemonFailureState(RunningState, Running: true);
+        }
+
+        var observation = Observe(pipeName);
+        if (observation.StartupInProgress)
+        {
+            return new DaemonFailureState(StartingState, Running: false);
+        }
+
+        if (observation.IsStopped)
+        {
+            return new DaemonFailureState(StoppedState, Running: false);
+        }
+
+        return new DaemonFailureState(UnresponsiveState, Running: true);
+    }
+
+    internal readonly record struct DaemonObservation(
+        bool DaemonRunning,
+        bool StartupInProgress)
+    {
+        internal bool IsStopped => !DaemonRunning && !StartupInProgress;
+    }
+
+    internal readonly record struct DaemonFailureState(string Name, bool Running);
+}

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonPipeIdentity.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonPipeIdentity.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+internal static class DaemonPipeIdentity
+{
+    internal static string GetHash(string pipeName) =>
+        Hash(pipeName.ToUpperInvariant());
+
+    internal static string GetCaseSensitiveHash(string pipeName) =>
+        Hash(pipeName);
+
+    internal static IReadOnlyList<string> GetLegacyCaseVariants(string pipeName) =>
+        [
+            .. new[]
+            {
+                pipeName,
+                pipeName.ToUpperInvariant(),
+                pipeName.ToLowerInvariant()
+            }.Distinct(StringComparer.Ordinal)
+        ];
+
+    private static string Hash(string pipeName) =>
+        Convert.ToHexString(SHA256.HashData(
+            Encoding.UTF8.GetBytes(pipeName)));
+}

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonProcessTracker.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonProcessTracker.cs
@@ -1,10 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
-using Sbroenne.ExcelMcp.Service;
-
 namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
 
 /// <summary>
@@ -14,6 +10,23 @@ namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
 internal static class DaemonProcessTracker
 {
     private static readonly object TrackingFileLock = new();
+
+    internal readonly record struct ProcessIdentity(int ProcessId, long StartedAtUtcFileTime);
+    internal sealed record ProcessSnapshot(
+        ProcessIdentity DaemonProcess,
+        IReadOnlyList<ProcessIdentity> ExcelProcesses);
+    internal enum TrackingRecordStatus
+    {
+        Missing,
+        Available,
+        Invalid,
+        Unreadable
+    }
+
+    internal sealed record ProcessSnapshotReadResult(
+        TrackingRecordStatus Status,
+        ProcessSnapshot? Snapshot,
+        string? ErrorMessage);
 
     private sealed class DaemonProcessRecord
     {
@@ -28,16 +41,36 @@ internal static class DaemonProcessTracker
         public long StartedAtUtcFileTime { get; set; }
     }
 
-    public static void RegisterCurrentProcess(string pipeName)
+    private sealed class TrackingMutexLease(IReadOnlyList<Mutex> mutexes) : IDisposable
     {
-        var current = Process.GetCurrentProcess();
-        RegisterProcess(pipeName, current.Id, current.StartTime.ToUniversalTime().ToFileTimeUtc());
+        public void Dispose()
+        {
+            for (var index = mutexes.Count - 1; index >= 0; index--)
+            {
+                mutexes[index].ReleaseMutex();
+                mutexes[index].Dispose();
+            }
+        }
     }
 
-    internal static void RegisterProcess(string pipeName, int processId, long startedAtUtcFileTime)
+    public static ProcessIdentity RegisterCurrentProcess(string pipeName)
     {
+        var current = Process.GetCurrentProcess();
+        return RegisterProcess(
+            pipeName,
+            current.Id,
+            current.StartTime.ToUniversalTime().ToFileTimeUtc());
+    }
+
+    internal static ProcessIdentity RegisterProcess(
+        string pipeName,
+        int processId,
+        long startedAtUtcFileTime)
+    {
+        var identity = new ProcessIdentity(processId, startedAtUtcFileTime);
         lock (TrackingFileLock)
         {
+            using var trackingMutex = AcquireTrackingMutex(pipeName);
             Directory.CreateDirectory(GetTrackingDirectory());
             var record = new DaemonProcessRecord
             {
@@ -47,50 +80,102 @@ internal static class DaemonProcessTracker
 
             WriteRecord(pipeName, record);
         }
+
+        return identity;
     }
 
-    public static void UpdateExcelProcesses(string pipeName, IReadOnlyCollection<int> processIds)
-    {
-        UpdateExcelProcesses(pipeName, () => processIds);
-    }
-
-    internal static void UpdateExcelProcesses(
+    /// <summary>
+    /// Adds currently owned Excel identities to the selected daemon generation.
+    /// Identities remain recorded until generation cleanup so a failed shutdown
+    /// cannot lose a process that was untracked before it actually exited.
+    /// </summary>
+    public static void UpdateExcelProcesses(
         string pipeName,
-        Func<IReadOnlyCollection<int>> getProcessIds)
+        ProcessIdentity daemonIdentity,
+        IReadOnlyCollection<int> processIds)
+    {
+        var observedProcesses = processIds
+            .Distinct()
+            .Select(TryCreateProcessRecord)
+            .Where(process => process != null)
+            .Select(process => new ProcessIdentity(
+                process!.ProcessId,
+                process.StartedAtUtcFileTime))
+            .ToList();
+        _ = TryRecordExcelProcesses(pipeName, daemonIdentity, observedProcesses);
+    }
+
+    internal static void RecordExcelProcesses(
+        string pipeName,
+        ProcessIdentity daemonIdentity,
+        IReadOnlyCollection<ProcessIdentity> processIdentities)
+    {
+        lock (TrackingFileLock)
+        {
+            using var trackingMutex = AcquireTrackingMutex(pipeName);
+            var readResult = ReadRecordCore(pipeName);
+            if (readResult.Status != TrackingRecordStatus.Available
+                || readResult.Record == null)
+            {
+                throw new InvalidOperationException(
+                    readResult.ErrorMessage
+                    ?? $"The daemon tracking record for pipe '{pipeName}' is unavailable.");
+            }
+            var record = readResult.Record;
+
+            if (record.ProcessId != daemonIdentity.ProcessId
+                || record.StartedAtUtcFileTime != daemonIdentity.StartedAtUtcFileTime)
+            {
+                throw new InvalidOperationException(
+                    $"The daemon tracking record for pipe '{pipeName}' belongs to another process generation.");
+            }
+
+            var observedProcesses = processIdentities
+                .Where(process => process.ProcessId > 0 && process.StartedAtUtcFileTime > 0)
+                .Distinct()
+                .Select(process => new TrackedProcessRecord
+                {
+                    ProcessId = process.ProcessId,
+                    StartedAtUtcFileTime = process.StartedAtUtcFileTime
+                })
+                .ToList();
+            record.ExcelProcesses = record.ExcelProcesses
+                .Concat(observedProcesses)
+                .DistinctBy(process => (process.ProcessId, process.StartedAtUtcFileTime))
+                .ToList();
+            WriteRecord(pipeName, record);
+        }
+    }
+
+    internal static bool TryRecordExcelProcesses(
+        string pipeName,
+        ProcessIdentity daemonIdentity,
+        IReadOnlyCollection<ProcessIdentity> processIdentities)
     {
         try
         {
-            lock (TrackingFileLock)
-            {
-                if (!TryReadRecordCore(pipeName, out var record))
-                {
-                    return;
-                }
-
-                record.ExcelProcesses = getProcessIds()
-                    .Distinct()
-                    .Select(TryCreateProcessRecord)
-                    .Where(process => process != null)
-                    .Cast<TrackedProcessRecord>()
-                    .ToList();
-                WriteRecord(pipeName, record);
-            }
+            RecordExcelProcesses(pipeName, daemonIdentity, processIdentities);
+            return true;
         }
         catch (IOException)
         {
-            // Tracking is best-effort and must never break session lifecycle.
+            return false;
         }
         catch (UnauthorizedAccessException)
         {
-            // Tracking is best-effort and must never break session lifecycle.
+            return false;
         }
         catch (JsonException)
         {
-            // A concurrent reader keeps the existing record for a later retry.
+            return false;
         }
         catch (Win32Exception)
         {
-            // Process metadata became unavailable while creating the snapshot.
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
         }
     }
 
@@ -100,10 +185,13 @@ internal static class DaemonProcessTracker
         {
             lock (TrackingFileLock)
             {
-                var trackingFile = GetTrackingFilePath(pipeName);
-                if (File.Exists(trackingFile))
+                using var trackingMutex = AcquireTrackingMutex(pipeName);
+                foreach (var trackingFile in GetTrackingFilePaths(pipeName))
                 {
-                    File.Delete(trackingFile);
+                    if (File.Exists(trackingFile))
+                    {
+                        File.Delete(trackingFile);
+                    }
                 }
             }
         }
@@ -127,7 +215,6 @@ internal static class DaemonProcessTracker
             if (candidate.HasExited)
             {
                 candidate.Dispose();
-                Clear(pipeName);
                 return false;
             }
 
@@ -135,7 +222,6 @@ internal static class DaemonProcessTracker
             if (startedAtUtcFileTime != record.StartedAtUtcFileTime)
             {
                 candidate.Dispose();
-                Clear(pipeName);
                 return false;
             }
 
@@ -148,61 +234,247 @@ internal static class DaemonProcessTracker
         }
     }
 
-    public static IReadOnlyList<Process> GetTrackedExcelProcesses(string pipeName)
+    internal static IReadOnlyList<ProcessIdentity> GetTrackedExcelProcessIdentities(string pipeName)
     {
-        if (!TryReadRecord(pipeName, out var record))
-        {
-            return [];
-        }
-
-        var processes = new List<Process>();
-        foreach (var tracked in record.ExcelProcesses)
-        {
-            var process = TryOpenMatchingProcess(tracked);
-            if (process != null)
-            {
-                processes.Add(process);
-            }
-        }
-
-        return processes;
+        return TryGetProcessSnapshot(pipeName, out var snapshot)
+            ? snapshot.ExcelProcesses
+            : [];
     }
 
-    private static bool TryReadRecord(string pipeName, out DaemonProcessRecord record)
+    internal static bool TryGetProcessSnapshot(string pipeName, out ProcessSnapshot snapshot)
     {
-        record = null!;
+        var readResult = ReadProcessSnapshot(pipeName);
+        if (readResult.Status != TrackingRecordStatus.Available
+            || readResult.Snapshot == null)
+        {
+            snapshot = null!;
+            return false;
+        }
+
+        snapshot = readResult.Snapshot;
+        return true;
+    }
+
+    internal static ProcessSnapshotReadResult ReadProcessSnapshot(string pipeName)
+    {
         try
         {
             lock (TrackingFileLock)
             {
-                return TryReadRecordCore(pipeName, out record);
+                using var trackingMutex = AcquireTrackingMutex(pipeName);
+                var readResult = ReadRecordCore(pipeName);
+                if (readResult.Status != TrackingRecordStatus.Available
+                    || readResult.Record == null)
+                {
+                    return new ProcessSnapshotReadResult(
+                        readResult.Status,
+                        null,
+                        readResult.ErrorMessage);
+                }
+
+                return new ProcessSnapshotReadResult(
+                    TrackingRecordStatus.Available,
+                    new ProcessSnapshot(
+                        new ProcessIdentity(
+                            readResult.Record.ProcessId,
+                            readResult.Record.StartedAtUtcFileTime),
+                        readResult.Record.ExcelProcesses
+                            .Select(tracked => new ProcessIdentity(
+                                tracked.ProcessId,
+                                tracked.StartedAtUtcFileTime))
+                            .ToList()),
+                    null);
             }
         }
-        catch
+        catch (IOException ex)
+        {
+            return UnreadableRecord(pipeName, ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return UnreadableRecord(pipeName, ex);
+        }
+        catch (Win32Exception ex)
+        {
+            return UnreadableRecord(pipeName, ex);
+        }
+    }
+
+    internal static bool ClearIfDaemonMatches(string pipeName, ProcessIdentity daemonIdentity)
+    {
+        try
+        {
+            lock (TrackingFileLock)
+            {
+                using var trackingMutex = AcquireTrackingMutex(pipeName);
+                var readResult = ReadRecordCore(pipeName);
+                if (readResult.Status == TrackingRecordStatus.Missing)
+                {
+                    return true;
+                }
+
+                if (readResult.Status != TrackingRecordStatus.Available
+                    || readResult.Record == null)
+                {
+                    return false;
+                }
+
+                if (readResult.Record.ProcessId != daemonIdentity.ProcessId
+                    || readResult.Record.StartedAtUtcFileTime != daemonIdentity.StartedAtUtcFileTime)
+                {
+                    return true;
+                }
+
+                foreach (var trackingFile in GetTrackingFilePaths(pipeName))
+                {
+                    if (File.Exists(trackingFile))
+                        File.Delete(trackingFile);
+                }
+
+                return true;
+            }
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (JsonException)
         {
             return false;
         }
     }
 
-    private static bool TryReadRecordCore(string pipeName, out DaemonProcessRecord record)
+    private static bool TryReadRecord(string pipeName, out DaemonProcessRecord record)
     {
-        record = null!;
-        var trackingFile = GetTrackingFilePath(pipeName);
-        if (!File.Exists(trackingFile))
+        var readResult = ReadProcessSnapshot(pipeName);
+        if (readResult.Status != TrackingRecordStatus.Available
+            || readResult.Snapshot == null)
         {
+            record = null!;
             return false;
         }
 
-        var json = File.ReadAllText(trackingFile);
-        var parsed = JsonSerializer.Deserialize<DaemonProcessRecord>(json, ServiceProtocol.JsonOptions);
-        if (parsed == null || parsed.ProcessId <= 0 || parsed.StartedAtUtcFileTime <= 0)
+        record = new DaemonProcessRecord
         {
-            return false;
-        }
-
-        record = parsed;
+            ProcessId = readResult.Snapshot.DaemonProcess.ProcessId,
+            StartedAtUtcFileTime = readResult.Snapshot.DaemonProcess.StartedAtUtcFileTime,
+            ExcelProcesses = readResult.Snapshot.ExcelProcesses
+                .Select(process => new TrackedProcessRecord
+                {
+                    ProcessId = process.ProcessId,
+                    StartedAtUtcFileTime = process.StartedAtUtcFileTime
+                })
+                .ToList()
+        };
         return true;
     }
+
+    private static RecordReadResult ReadRecordCore(string pipeName)
+    {
+        DaemonProcessRecord? selected = null;
+        var requiresMigration = false;
+        var canonicalPath = GetTrackingFilePath(pipeName);
+        foreach (var trackingFile in GetTrackingFilePaths(pipeName))
+        {
+            if (!File.Exists(trackingFile))
+            {
+                continue;
+            }
+
+            DaemonProcessRecord? parsed;
+            try
+            {
+                var json = File.ReadAllText(trackingFile);
+                parsed = JsonSerializer.Deserialize<DaemonProcessRecord>(
+                    json,
+                    DaemonTrackingJson.Options);
+            }
+            catch (JsonException ex)
+            {
+                return new RecordReadResult(
+                    TrackingRecordStatus.Invalid,
+                    null,
+                    $"The daemon tracking record '{trackingFile}' is malformed: {ex.Message}");
+            }
+
+            if (!IsValidRecord(parsed))
+            {
+                return new RecordReadResult(
+                    TrackingRecordStatus.Invalid,
+                    null,
+                    $"The daemon tracking record '{trackingFile}' contains invalid process ownership data.");
+            }
+
+            if (selected == null)
+            {
+                selected = parsed;
+                requiresMigration = !string.Equals(
+                    trackingFile,
+                    canonicalPath,
+                    StringComparison.Ordinal);
+                continue;
+            }
+
+            if (selected.ProcessId != parsed!.ProcessId
+                || selected.StartedAtUtcFileTime != parsed.StartedAtUtcFileTime)
+            {
+                return new RecordReadResult(
+                    TrackingRecordStatus.Invalid,
+                    null,
+                    $"Conflicting daemon tracking records exist for pipe '{pipeName}'.");
+            }
+
+            selected.ExcelProcesses = selected.ExcelProcesses
+                .Concat(parsed.ExcelProcesses)
+                .DistinctBy(process => (process.ProcessId, process.StartedAtUtcFileTime))
+                .ToList();
+            requiresMigration |= !string.Equals(
+                trackingFile,
+                canonicalPath,
+                StringComparison.Ordinal);
+        }
+
+        if (selected == null)
+        {
+            return new RecordReadResult(TrackingRecordStatus.Missing, null, null);
+        }
+
+        if (requiresMigration)
+        {
+            WriteRecord(pipeName, selected);
+        }
+
+        return new RecordReadResult(TrackingRecordStatus.Available, selected, null);
+    }
+
+    private static bool IsValidRecord(DaemonProcessRecord? record) =>
+        record is
+        {
+            ProcessId: > 0,
+            StartedAtUtcFileTime: > 0,
+            ExcelProcesses: not null
+        }
+        && record.ExcelProcesses.All(process =>
+            process.ProcessId > 0
+            && process.StartedAtUtcFileTime > 0);
+
+    private static ProcessSnapshotReadResult UnreadableRecord(
+        string pipeName,
+        Exception exception) =>
+        new(
+            TrackingRecordStatus.Unreadable,
+            null,
+            $"The daemon tracking record for pipe '{pipeName}' could not be read: " +
+            $"{exception.GetType().Name}: {exception.Message}");
+
+    private sealed record RecordReadResult(
+        TrackingRecordStatus Status,
+        DaemonProcessRecord? Record,
+        string? ErrorMessage);
 
     private static TrackedProcessRecord? TryCreateProcessRecord(int processId)
     {
@@ -230,27 +502,37 @@ internal static class DaemonProcessTracker
         }
     }
 
-    private static Process? TryOpenMatchingProcess(TrackedProcessRecord tracked)
+    internal static bool TryOpenMatchingProcess(ProcessIdentity tracked, out Process? process)
     {
+        process = null;
         try
         {
-            var process = Process.GetProcessById(tracked.ProcessId);
-            if (process.HasExited ||
-                process.StartTime.ToUniversalTime().ToFileTimeUtc() != tracked.StartedAtUtcFileTime)
+            var candidate = Process.GetProcessById(tracked.ProcessId);
+            if (candidate.HasExited ||
+                candidate.StartTime.ToUniversalTime().ToFileTimeUtc() != tracked.StartedAtUtcFileTime)
             {
-                process.Dispose();
-                return null;
+                candidate.Dispose();
+                return true;
             }
 
-            return process;
+            process = candidate;
+            return true;
         }
         catch (ArgumentException)
         {
-            return null;
+            return true;
         }
         catch (InvalidOperationException)
         {
-            return null;
+            return true;
+        }
+        catch (Win32Exception)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
         }
     }
 
@@ -262,8 +544,19 @@ internal static class DaemonProcessTracker
         {
             File.WriteAllText(
                 temporaryFile,
-                JsonSerializer.Serialize(record, ServiceProtocol.JsonOptions));
+                JsonSerializer.Serialize(record, DaemonTrackingJson.Options));
             File.Move(temporaryFile, trackingFile, overwrite: true);
+            foreach (var legacyTrackingFile in GetTrackingFilePaths(pipeName)
+                         .Where(path => !string.Equals(
+                             path,
+                             trackingFile,
+                             StringComparison.Ordinal)))
+            {
+                if (File.Exists(legacyTrackingFile))
+                {
+                    File.Delete(legacyTrackingFile);
+                }
+            }
         }
         finally
         {
@@ -277,10 +570,92 @@ internal static class DaemonProcessTracker
     private static string GetTrackingDirectory() =>
         Path.Combine(Path.GetTempPath(), "ExcelMcp", "cli-daemon");
 
+    private static TrackingMutexLease AcquireTrackingMutex(string pipeName)
+    {
+        var mutexes = GetTrackingMutexNames(pipeName)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .Select(name => new Mutex(initiallyOwned: false, name))
+            .ToList();
+        var acquiredCount = 0;
+        try
+        {
+            foreach (var mutex in mutexes)
+            {
+                try
+                {
+                    if (!mutex.WaitOne(TimeSpan.FromSeconds(5)))
+                    {
+                        throw new IOException(
+                            $"Timed out waiting for the process tracker lock for pipe '{pipeName}'.");
+                    }
+                }
+                catch (AbandonedMutexException)
+                {
+                    // The abandoned mutex is acquired by the current thread.
+                }
+
+                acquiredCount++;
+            }
+
+            return new TrackingMutexLease(mutexes);
+        }
+        catch
+        {
+            for (var index = acquiredCount - 1; index >= 0; index--)
+            {
+                mutexes[index].ReleaseMutex();
+            }
+
+            foreach (var mutex in mutexes)
+            {
+                mutex.Dispose();
+            }
+
+            throw;
+        }
+    }
+
     internal static string GetTrackingFilePath(string pipeName)
     {
-        var nameBytes = Encoding.UTF8.GetBytes(pipeName);
-        var safeName = Convert.ToHexString(SHA256.HashData(nameBytes));
-        return Path.Combine(GetTrackingDirectory(), $"{safeName}.json");
+        return Path.Combine(
+            GetTrackingDirectory(),
+            $"{DaemonPipeIdentity.GetHash(pipeName)}.json");
+    }
+
+    internal static string GetTrackingMutexName(string pipeName) =>
+        $"ExcelMcpCli_Tracker_{DaemonPipeIdentity.GetHash(pipeName)}";
+
+    private static IReadOnlyList<string> GetTrackingFilePaths(string pipeName)
+    {
+        var canonicalPath = GetTrackingFilePath(pipeName);
+        return
+        [
+            canonicalPath,
+            .. DaemonPipeIdentity.GetLegacyCaseVariants(pipeName)
+                .Select(variant => Path.Combine(
+                    GetTrackingDirectory(),
+                    $"{DaemonPipeIdentity.GetCaseSensitiveHash(variant)}.json"))
+                .Where(path => !string.Equals(
+                    path,
+                    canonicalPath,
+                    StringComparison.Ordinal))
+                .Distinct(StringComparer.Ordinal)
+        ];
+    }
+
+    private static IReadOnlyList<string> GetTrackingMutexNames(string pipeName)
+    {
+        return
+        [
+            GetTrackingMutexName(pipeName),
+            .. DaemonPipeIdentity.GetLegacyCaseVariants(pipeName)
+                .Select(DaemonPipeIdentity.GetCaseSensitiveHash)
+                .SelectMany(hash => new[]
+                {
+                    $"ExcelMcpCli_Tracker_{hash}",
+                    $"ExcelMcpCliTracker_{hash}"
+                })
+        ];
     }
 }

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonStartupLock.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonStartupLock.cs
@@ -1,0 +1,68 @@
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+/// <summary>
+/// Serializes daemon startup and owned teardown for one CLI pipe.
+/// </summary>
+internal static class DaemonStartupLock
+{
+    internal static readonly TimeSpan Timeout = TimeSpan.FromSeconds(11);
+
+    internal static string GetDaemonMutexName(string pipeName) =>
+        $"ExcelMcpCli_Daemon_{DaemonPipeIdentity.GetHash(pipeName)}";
+
+    internal static string GetLegacyDaemonMutexName(string pipeName) =>
+        $"ExcelMcpCli_{pipeName}";
+
+    internal static IReadOnlyList<string> GetLegacyDaemonMutexNames(string pipeName) =>
+        DaemonPipeIdentity.GetLegacyCaseVariants(pipeName)
+            .Select(GetLegacyDaemonMutexName)
+            .ToList();
+
+    internal static string GetStartupMutexName(string pipeName) =>
+        $"ExcelMcpCli_Startup_{DaemonPipeIdentity.GetHash(pipeName)}";
+
+    internal static string GetStartingMarkerName(string pipeName) =>
+        $"ExcelMcpCli_Starting_{DaemonPipeIdentity.GetHash(pipeName)}";
+
+    internal static Task<T> WithLockAsync<T>(
+        string pipeName,
+        Func<Task<T>> action,
+        CancellationToken cancellationToken)
+    {
+        return Task.Run(() =>
+        {
+            using var startupMutex = new Mutex(
+                initiallyOwned: false,
+                GetStartupMutexName(pipeName),
+                out _);
+            var startupLockAcquired = false;
+            try
+            {
+                try
+                {
+                    startupLockAcquired = startupMutex.WaitOne(Timeout);
+                }
+                catch (AbandonedMutexException)
+                {
+                    startupLockAcquired = true;
+                }
+
+                if (!startupLockAcquired)
+                {
+                    throw new TimeoutException(
+                        $"Could not acquire the CLI startup lock for pipe '{pipeName}' " +
+                        $"within {Timeout.TotalSeconds:0} seconds.");
+                }
+
+                return action().GetAwaiter().GetResult();
+            }
+            finally
+            {
+                if (startupLockAcquired)
+                {
+                    startupMutex.ReleaseMutex();
+                }
+            }
+        }, cancellationToken);
+    }
+}

--- a/src/ExcelMcp.CLI/Infrastructure/DaemonTrackingJson.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/DaemonTrackingJson.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+internal static class DaemonTrackingJson
+{
+    internal static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
+}

--- a/src/ExcelMcp.CLI/Infrastructure/OperationDeadline.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/OperationDeadline.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+internal readonly struct OperationDeadline
+{
+    private readonly long _startedAt;
+    private readonly TimeSpan _timeout;
+
+    private OperationDeadline(TimeSpan timeout)
+    {
+        _startedAt = Stopwatch.GetTimestamp();
+        _timeout = timeout;
+    }
+
+    internal static OperationDeadline Start(TimeSpan timeout) => new(timeout);
+
+    internal TimeSpan Remaining
+    {
+        get
+        {
+            var remaining = _timeout - Stopwatch.GetElapsedTime(_startedAt);
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+        }
+    }
+
+    internal bool IsExpired => Remaining <= TimeSpan.Zero;
+
+    internal TimeSpan Cap(TimeSpan maximum)
+    {
+        var remaining = Remaining;
+        return remaining <= maximum ? remaining : maximum;
+    }
+}

--- a/src/ExcelMcp.CLI/Infrastructure/OwnedProcessCleanup.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/OwnedProcessCleanup.cs
@@ -1,0 +1,321 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+/// <summary>
+/// Stops only the daemon and Excel processes recorded for one CLI pipe.
+/// </summary>
+internal static class OwnedProcessCleanup
+{
+    private static readonly TimeSpan ProcessExitTimeout = TimeSpan.FromSeconds(10);
+    private const uint ProcessTerminate = 0x0001;
+    private const uint Synchronize = 0x00100000;
+    private const uint ProcessQueryLimitedInformation = 0x1000;
+    private const uint WaitObject0 = 0x00000000;
+    private const uint WaitTimeout = 0x00000102;
+    private const int ErrorInvalidParameter = 87;
+
+    internal sealed record ProcessSnapshot(
+        DaemonProcessTracker.ProcessIdentity? DaemonProcess,
+        bool DaemonMatched,
+        IReadOnlyList<DaemonProcessTracker.ProcessIdentity> ExcelProcesses,
+        DaemonProcessTracker.TrackingRecordStatus TrackingStatus,
+        string? ErrorMessage);
+
+    internal sealed record CleanupResult(
+        bool Success,
+        bool DaemonMatched,
+        string? ErrorMessage);
+
+    internal static ProcessSnapshot CaptureTrackedProcesses(string pipeName)
+    {
+        var readResult = DaemonProcessTracker.ReadProcessSnapshot(pipeName);
+        if (readResult.Status != DaemonProcessTracker.TrackingRecordStatus.Available
+            || readResult.Snapshot == null)
+        {
+            return new ProcessSnapshot(
+                null,
+                false,
+                [],
+                readResult.Status,
+                readResult.ErrorMessage);
+        }
+        var trackedSnapshot = readResult.Snapshot;
+
+        var daemonValidated = DaemonProcessTracker.TryOpenMatchingProcess(
+            trackedSnapshot.DaemonProcess,
+            out var daemonProcess);
+        if (!daemonValidated)
+        {
+            return new ProcessSnapshot(
+                trackedSnapshot.DaemonProcess,
+                false,
+                [],
+                DaemonProcessTracker.TrackingRecordStatus.Unreadable,
+                $"The tracked daemon process for CLI pipe '{pipeName}' could not be validated.");
+        }
+        var daemonMatched = daemonProcess != null;
+        daemonProcess?.Dispose();
+
+        var identities = new List<DaemonProcessTracker.ProcessIdentity>();
+        foreach (var identity in trackedSnapshot.ExcelProcesses)
+        {
+            if (!DaemonProcessTracker.TryOpenMatchingProcess(identity, out var process))
+            {
+                return new ProcessSnapshot(
+                    trackedSnapshot.DaemonProcess,
+                    daemonMatched,
+                    identities,
+                    DaemonProcessTracker.TrackingRecordStatus.Unreadable,
+                    $"Tracked Excel process {identity.ProcessId} for CLI pipe '{pipeName}' could not be validated.");
+            }
+
+            if (process != null)
+            {
+                process.Dispose();
+                identities.Add(identity);
+            }
+        }
+
+        return new ProcessSnapshot(
+            trackedSnapshot.DaemonProcess,
+            daemonMatched,
+            identities,
+            DaemonProcessTracker.TrackingRecordStatus.Available,
+            null);
+    }
+
+    internal static async Task<CleanupResult> CleanupAsync(
+        string pipeName,
+        CancellationToken cancellationToken)
+    {
+        return await CleanupAsync(
+            pipeName,
+            CaptureTrackedProcesses(pipeName),
+            cancellationToken);
+    }
+
+    internal static async Task<CleanupResult> CleanupAsync(
+        string pipeName,
+        ProcessSnapshot preShutdownSnapshot,
+        CancellationToken cancellationToken)
+    {
+        if (preShutdownSnapshot.TrackingStatus
+            is DaemonProcessTracker.TrackingRecordStatus.Invalid
+            or DaemonProcessTracker.TrackingRecordStatus.Unreadable)
+        {
+            return new CleanupResult(
+                false,
+                false,
+                preShutdownSnapshot.ErrorMessage
+                ?? $"The daemon tracking record for CLI pipe '{pipeName}' is not usable.");
+        }
+
+        if (preShutdownSnapshot.TrackingStatus
+            == DaemonProcessTracker.TrackingRecordStatus.Missing)
+        {
+            return new CleanupResult(true, false, null);
+        }
+
+        var success = true;
+
+        if (preShutdownSnapshot.DaemonMatched
+            && preShutdownSnapshot.DaemonProcess is { } daemonIdentity)
+        {
+            success &= await TryTerminateProcessAsync(daemonIdentity, cancellationToken);
+        }
+
+        IReadOnlyList<DaemonProcessTracker.ProcessIdentity> finalExcelProcesses = [];
+        var finalRead = DaemonProcessTracker.ReadProcessSnapshot(pipeName);
+        if (finalRead.Status
+            is DaemonProcessTracker.TrackingRecordStatus.Invalid
+            or DaemonProcessTracker.TrackingRecordStatus.Unreadable)
+        {
+            return new CleanupResult(
+                false,
+                preShutdownSnapshot.DaemonMatched,
+                finalRead.ErrorMessage
+                ?? $"The daemon tracking record for CLI pipe '{pipeName}' is not usable.");
+        }
+
+        if (preShutdownSnapshot.DaemonProcess is { } expectedDaemon
+            && finalRead.Snapshot is { } finalSnapshot
+            && finalSnapshot.DaemonProcess == expectedDaemon)
+        {
+            finalExcelProcesses = finalSnapshot.ExcelProcesses;
+        }
+
+        var excelProcesses = preShutdownSnapshot.ExcelProcesses
+            .Concat(finalExcelProcesses)
+            .Distinct()
+            .ToList();
+        foreach (var identity in excelProcesses)
+        {
+            success &= await TryTerminateProcessAsync(identity, cancellationToken);
+        }
+
+        if (success)
+        {
+            success = preShutdownSnapshot.DaemonProcess is not { } daemonToClear
+                || DaemonProcessTracker.ClearIfDaemonMatches(pipeName, daemonToClear);
+        }
+
+        return new CleanupResult(
+            success,
+            preShutdownSnapshot.DaemonMatched,
+            success
+                ? null
+                : $"One or more processes tracked for CLI pipe '{pipeName}' could not be stopped.");
+    }
+
+    internal static bool TryTerminateProcess(Process process, bool entireProcessTree)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree);
+            }
+
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (Win32Exception)
+        {
+            try
+            {
+                process.Refresh();
+                return process.HasExited;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+            catch (Win32Exception)
+            {
+                return false;
+            }
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> TryTerminateProcessAsync(
+        DaemonProcessTracker.ProcessIdentity identity,
+        CancellationToken cancellationToken)
+    {
+        if (!TryOpenMatchingProcessHandle(identity, out var processHandle))
+        {
+            return false;
+        }
+
+        if (processHandle == null)
+        {
+            return true;
+        }
+
+        using (processHandle)
+        {
+            try
+            {
+                if (!TerminateProcess(processHandle, 1)
+                    && WaitForSingleObject(processHandle, 0) != WaitObject0)
+                {
+                    return false;
+                }
+
+                var deadline = DateTime.UtcNow + ProcessExitTimeout;
+                while (DateTime.UtcNow < deadline)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var waitResult = WaitForSingleObject(processHandle, 100);
+                    if (waitResult == WaitObject0)
+                    {
+                        return true;
+                    }
+
+                    if (waitResult != WaitTimeout)
+                    {
+                        return false;
+                    }
+
+                    await Task.Yield();
+                }
+
+                return false;
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }
+    }
+
+    private static bool TryOpenMatchingProcessHandle(
+        DaemonProcessTracker.ProcessIdentity identity,
+        out SafeProcessHandle? processHandle)
+    {
+        processHandle = OpenProcess(
+            ProcessTerminate | Synchronize | ProcessQueryLimitedInformation,
+            inheritHandle: false,
+            identity.ProcessId);
+        if (processHandle.IsInvalid)
+        {
+            var error = Marshal.GetLastWin32Error();
+            processHandle.Dispose();
+            processHandle = null;
+            return error == ErrorInvalidParameter;
+        }
+
+        if (!GetProcessTimes(
+                processHandle,
+                out var creationTime,
+                out _,
+                out _,
+                out _))
+        {
+            processHandle.Dispose();
+            processHandle = null;
+            return false;
+        }
+
+        if (creationTime != identity.StartedAtUtcFileTime
+            || WaitForSingleObject(processHandle, 0) == WaitObject0)
+        {
+            processHandle.Dispose();
+            processHandle = null;
+        }
+
+        return true;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern SafeProcessHandle OpenProcess(
+        uint desiredAccess,
+        [MarshalAs(UnmanagedType.Bool)] bool inheritHandle,
+        int processId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetProcessTimes(
+        SafeProcessHandle processHandle,
+        out long creationTime,
+        out long exitTime,
+        out long kernelTime,
+        out long userTime);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool TerminateProcess(SafeProcessHandle processHandle, uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint WaitForSingleObject(SafeProcessHandle handle, uint milliseconds);
+}

--- a/src/ExcelMcp.CLI/Program.cs
+++ b/src/ExcelMcp.CLI/Program.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Sbroenne.ExcelMcp.CLI.Commands;
 using Sbroenne.ExcelMcp.CLI.Generated;
 using Sbroenne.ExcelMcp.CLI.Infrastructure;
+using Sbroenne.ExcelMcp.ComInterop.Session;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -82,11 +83,11 @@ internal sealed class Program
             {
                 branch.SetDescription("Service lifecycle management: start, stop, status.");
                 branch.AddCommand<ServiceStartCommand>("start")
-                    .WithDescription("Start the ExcelMCP Service if not already running.");
+                    .WithDescription("Start the ExcelMCP Service if needed and wait up to 30 seconds for readiness.");
                 branch.AddCommand<ServiceStopCommand>("stop")
-                    .WithDescription("Gracefully stop the ExcelMCP Service.");
+                    .WithDescription("Stop the CLI service and its pipe-owned Excel processes.");
                 branch.AddCommand<ServiceStatusCommand>("status")
-                    .WithDescription("Show service status (running, PID, sessions, uptime).");
+                    .WithDescription("Show stopped, starting, running, or unresponsive daemon state; readiness checks wait up to 10 seconds.");
             });
 
             // Batch command — execute multiple commands in a single process launch
@@ -104,9 +105,9 @@ internal sealed class Program
                 branch.AddCommand<SessionCloseCommand>("close")
                     .WithDescription("Close a session. Use --save to persist changes.");
                 branch.AddCommand<SessionListCommand>("list")
-                    .WithDescription("List active sessions.");
-                branch.AddCommand<SessionSaveCommand>("save")
-                    .WithDescription("Save a session without closing it.");
+                    .WithDescription("List active sessions; transport failures return unresponsive instead of an empty list.");
+                branch.AddCommand<SessionTestCommand>("test")
+                    .WithDescription("Test file existence, validity, openability, and IRM/AIP read-only requirements.");
             });
 
             // Sheet commands
@@ -251,13 +252,64 @@ internal sealed class Program
                 return 0;
             }
         }
-        DaemonProcessTracker.RegisterCurrentProcess(pipeName);
-        Action<IReadOnlyCollection<int>> excelProcessTracker =
-            _ => DaemonProcessTracker.UpdateExcelProcesses(
+        Mutex? legacyDaemonMutex = null;
+        var ownsLegacyDaemonMutex = false;
+        try
+        {
+            legacyDaemonMutex = new Mutex(
+                initiallyOwned: true,
+                DaemonStartupLock.GetLegacyDaemonMutexName(pipeName),
+                out var legacyCreatedNew);
+            ownsLegacyDaemonMutex = legacyCreatedNew;
+            if (!legacyCreatedNew)
+            {
+                try
+                {
+                    ownsLegacyDaemonMutex = legacyDaemonMutex.WaitOne(TimeSpan.Zero);
+                }
+                catch (AbandonedMutexException)
+                {
+                    ownsLegacyDaemonMutex = true;
+                }
+            }
+
+            if (!ownsLegacyDaemonMutex)
+            {
+                legacyDaemonMutex.Dispose();
+                if (ownsDaemonMutex)
+                {
+                    daemonMutex.ReleaseMutex();
+                }
+                daemonMutex.Dispose();
+                return 0;
+            }
+        }
+        catch (IOException)
+        {
+            legacyDaemonMutex?.Dispose();
+            legacyDaemonMutex = null;
+        }
+        catch (ArgumentException)
+        {
+            legacyDaemonMutex?.Dispose();
+            legacyDaemonMutex = null;
+        }
+
+        var daemonIdentity = DaemonProcessTracker.RegisterCurrentProcess(pipeName);
+        Action<ExcelProcessIdentity> excelProcessTracker =
+            process => DaemonProcessTracker.RecordExcelProcesses(
                 pipeName,
-                Sbroenne.ExcelMcp.ComInterop.Session.SessionManager.GetTrackedExcelProcessIds);
-        Sbroenne.ExcelMcp.ComInterop.Session.SessionManager.TrackedExcelProcessesChanged += excelProcessTracker;
-        excelProcessTracker([]);
+                daemonIdentity,
+                [
+                    new DaemonProcessTracker.ProcessIdentity(
+                        process.ProcessId,
+                        process.StartedAtUtcFileTime)
+                ]);
+        SessionManager.ExcelProcessIdentityTracked += excelProcessTracker;
+        foreach (var process in SessionManager.GetTrackedExcelProcesses())
+        {
+            excelProcessTracker(process);
+        }
 
         Service.ExcelMcpService? service = null;
         try
@@ -309,20 +361,41 @@ internal sealed class Program
             }
             finally
             {
+                PersistCurrentExcelProcesses(pipeName, daemonIdentity);
                 service.Dispose();
                 service = null;
             }
         }
         finally
         {
-            service?.Dispose();
-            Sbroenne.ExcelMcp.ComInterop.Session.SessionManager.TrackedExcelProcessesChanged -= excelProcessTracker;
-            DaemonProcessTracker.Clear(pipeName);
+            if (service != null)
+            {
+                PersistCurrentExcelProcesses(pipeName, daemonIdentity);
+                service.Dispose();
+            }
+            SessionManager.ExcelProcessIdentityTracked -= excelProcessTracker;
 
             // Release the daemon mutex so a new daemon can start if needed.
+            if (ownsLegacyDaemonMutex)
+                legacyDaemonMutex!.ReleaseMutex();
+            legacyDaemonMutex?.Dispose();
             if (ownsDaemonMutex)
                 daemonMutex.ReleaseMutex();
             daemonMutex.Dispose();
         }
+    }
+
+    private static void PersistCurrentExcelProcesses(
+        string pipeName,
+        DaemonProcessTracker.ProcessIdentity daemonIdentity)
+    {
+        _ = DaemonProcessTracker.TryRecordExcelProcesses(
+                pipeName,
+                daemonIdentity,
+                SessionManager.GetTrackedExcelProcesses()
+                    .Select(process => new DaemonProcessTracker.ProcessIdentity(
+                        process.ProcessId,
+                        process.StartedAtUtcFileTime))
+                    .ToList());
     }
 }

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides 31 feature command categories with 326 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
+The CLI provides 31 feature command categories with 325 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|
@@ -48,7 +48,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## 📋 What You Can Do
 
-ExcelMcp.CLI provides **326 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
+ExcelMcp.CLI provides **325 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
 
 Drives the **actual Excel application** via COM — not a file-format parser — so live operations (Power Query refresh, recalculation, DAX evaluation, VBA execution) run for real and existing workbooks stay intact.
 
@@ -111,11 +111,31 @@ where.exe excelcli
 ### IRM / AIP Protected Workbooks
 
 ```powershell
+# Inspect deterministic open and protection requirements without launching Excel
+excelcli -q session test "D:\Docs\Protected.xlsx"
+
 # Keep Excel visible so authentication or policy prompts can surface
 excelcli session open "D:\Docs\Protected.xlsx" --show --timeout 120
 ```
 
-Use `--show` whenever hidden automation would block on a sign-in, consent, or information-protection prompt.
+`session test` reports `canOpen`, `isIrmProtected`, `willOpenReadOnly`, and
+`requiresVisibleSession` using the same result model as MCP `file test`. Protected
+files report `canOpen:false` until interactive Excel authentication occurs. Use
+`--show` whenever hidden automation would block on a sign-in, consent, or
+information-protection prompt.
+
+### Daemon Status and Session Discovery
+
+`excelcli -q service status` reports `daemonState` as `stopped`, `starting`,
+`running`, or `unresponsive`. A stopped daemon is a successful status result with
+`running:false`; a transport timeout is an error with `running:true` and
+`daemonState:"unresponsive"`.
+
+`excelcli -q session list` returns an empty `sessions` array only when the daemon
+is confirmed stopped or a responsive daemon confirms it has no sessions.
+Transport failures exit nonzero without a `sessions` property. Status and list
+allow up to 10 seconds for daemon transport readiness, while daemon startup
+allows up to 30 seconds.
 
 ---
 

--- a/src/ExcelMcp.Cleanup/ExcelMcp.Cleanup.csproj
+++ b/src/ExcelMcp.Cleanup/ExcelMcp.Cleanup.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <AssemblyName>excelmcp-cleanup</AssemblyName>
+    <RootNamespace>Sbroenne.ExcelMcp.CLI.Infrastructure</RootNamespace>
+    <NoWarn>$(NoWarn);CS1574;CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PolyType" />
+    <PackageReference Include="StreamJsonRpc" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ExcelMcp.CLI\Infrastructure\DaemonPipeIdentity.cs"
+             Link="Infrastructure\DaemonPipeIdentity.cs" />
+    <Compile Include="..\ExcelMcp.CLI\Infrastructure\DaemonProcessTracker.cs"
+             Link="Infrastructure\DaemonProcessTracker.cs" />
+    <Compile Include="..\ExcelMcp.CLI\Infrastructure\DaemonStartupLock.cs"
+             Link="Infrastructure\DaemonStartupLock.cs" />
+    <Compile Include="..\ExcelMcp.CLI\Infrastructure\DaemonTrackingJson.cs"
+             Link="Infrastructure\DaemonTrackingJson.cs" />
+    <Compile Include="..\ExcelMcp.CLI\Infrastructure\OwnedProcessCleanup.cs"
+             Link="Infrastructure\OwnedProcessCleanup.cs" />
+    <Compile Include="..\ExcelMcp.Service\ServiceSecurity.cs"
+             Link="Service\ServiceSecurity.cs" />
+    <Compile Include="..\ExcelMcp.Service\ServiceClient.cs"
+             Link="Service\ServiceClient.cs" />
+    <Compile Include="..\ExcelMcp.Service\ServiceProtocol.cs"
+             Link="Service\ServiceProtocol.cs" />
+    <Compile Include="..\ExcelMcp.Service\Rpc\IExcelDaemonRpc.cs"
+             Link="Service\Rpc\IExcelDaemonRpc.cs" />
+    <Compile Include="..\ExcelMcp.ComInterop\ServiceClient\ServiceProtocol.cs"
+             Link="ComInterop\ServiceClient\ServiceProtocol.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/ExcelMcp.Cleanup/ParameterTransforms.cs
+++ b/src/ExcelMcp.Cleanup/ParameterTransforms.cs
@@ -1,0 +1,6 @@
+namespace Sbroenne.ExcelMcp.Core.Utilities;
+
+internal static class ParameterTransforms
+{
+    internal const int MaximumTimeoutSeconds = int.MaxValue / 1000;
+}

--- a/src/ExcelMcp.Cleanup/Program.cs
+++ b/src/ExcelMcp.Cleanup/Program.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.Service;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+internal static class Program
+{
+    private static readonly TimeSpan GracefulRequestTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan GracefulExitTimeout = TimeSpan.FromSeconds(12);
+
+    private static async Task<int> Main()
+    {
+        var pipeName = Environment.GetEnvironmentVariable("EXCELMCP_CLI_PIPE")
+            ?? ServiceSecurity.GetCliPipeName();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(45));
+
+        try
+        {
+            var result = await DaemonStartupLock.WithLockAsync(
+                pipeName,
+                () => CleanupWithGracefulShutdownAsync(pipeName, timeout.Token),
+                timeout.Token);
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                success = result.Success,
+                daemonMatched = result.DaemonMatched,
+                error = result.ErrorMessage
+            }));
+            return result.Success ? 0 : 1;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = ex.Message
+            }));
+            return 1;
+        }
+    }
+
+    private static async Task<OwnedProcessCleanup.CleanupResult> CleanupWithGracefulShutdownAsync(
+        string pipeName,
+        CancellationToken cancellationToken)
+    {
+        var snapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+        if (snapshot.TrackingStatus
+            is DaemonProcessTracker.TrackingRecordStatus.Invalid
+            or DaemonProcessTracker.TrackingRecordStatus.Unreadable)
+        {
+            return await OwnedProcessCleanup.CleanupAsync(
+                pipeName,
+                snapshot,
+                cancellationToken);
+        }
+
+        var gracefulAcknowledged = false;
+        try
+        {
+            using var client = new ServiceClient(
+                pipeName,
+                connectTimeout: GracefulRequestTimeout,
+                requestTimeout: GracefulRequestTimeout);
+            var response = await client.SendAsync(
+                new ServiceRequest { Command = "service.shutdown" },
+                GracefulRequestTimeout,
+                cancellationToken);
+            gracefulAcknowledged = response.Success;
+        }
+        catch (IOException)
+        {
+            gracefulAcknowledged = false;
+        }
+        catch (TimeoutException)
+        {
+            gracefulAcknowledged = false;
+        }
+
+        if (gracefulAcknowledged)
+        {
+            _ = await WaitForTrackedDaemonExitAsync(
+                pipeName,
+                snapshot,
+                cancellationToken);
+        }
+
+        return await OwnedProcessCleanup.CleanupAsync(
+            pipeName,
+            snapshot,
+            cancellationToken);
+    }
+
+    private static async Task<bool> WaitForTrackedDaemonExitAsync(
+        string pipeName,
+        OwnedProcessCleanup.ProcessSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        if (!snapshot.DaemonMatched || snapshot.DaemonProcess is not { } expectedDaemon)
+        {
+            return true;
+        }
+
+        var deadline = DateTime.UtcNow + GracefulExitTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var current = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+            if (current.TrackingStatus == DaemonProcessTracker.TrackingRecordStatus.Missing
+                || !current.DaemonMatched
+                || current.DaemonProcess != expectedDaemon)
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
+        }
+
+        return false;
+    }
+}

--- a/src/ExcelMcp.ComInterop/ExcelMcp.ComInterop.csproj
+++ b/src/ExcelMcp.ComInterop/ExcelMcp.ComInterop.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="excelcli" />
     <InternalsVisibleTo Include="Sbroenne.ExcelMcp.ComInterop.Tests" />
     <InternalsVisibleTo Include="Sbroenne.ExcelMcp.Core.Tests" />
   </ItemGroup>

--- a/src/ExcelMcp.ComInterop/FileAccessValidator.cs
+++ b/src/ExcelMcp.ComInterop/FileAccessValidator.cs
@@ -1,3 +1,9 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
 namespace Sbroenne.ExcelMcp.ComInterop;
 
 /// <summary>
@@ -10,18 +16,30 @@ public static class FileAccessValidator
     // IRM/AIP-protected Excel files are stored as OLE2 containers with an EncryptedPackage
     // stream instead of the standard ZIP-based Office Open XML format.
     private static ReadOnlySpan<byte> Ole2Signature => [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
+    private const string DataSpacesStorage = "\u0006DataSpaces";
+    private const string DataSpaceMapStream = "DataSpaceMap";
+    private const string DataSpaceInfoStorage = "DataSpaceInfo";
+    private static readonly HashSet<string> IrmDataSpaceNames =
+        new(StringComparer.Ordinal)
+        {
+            "\tDRMDataSpace",
+            "DRMEncryptedDataSpace"
+        };
 
     /// <summary>
-    /// Detects if the file is IRM/AIP-protected by checking for the OLE2 compound document
-    /// signature on files whose format should be ZIP-based (OOXML). Legacy .xls files are
-    /// always OLE2 by design and are excluded from this check to avoid false positives.
+    /// Detects if the file is IRM/AIP-protected by checking for both the OLE2 compound
+    /// document signature and its structured data-space map and matching definition.
+    /// Ordinary password-encrypted OOXML also uses OLE2 data spaces and must not be
+    /// classified as IRM.
+    /// Legacy .xls files are always OLE2 by design and are excluded.
     /// IRM-protected files must be opened as read-only with Excel visible so the user can
     /// authenticate through the Information Rights Management credential prompt.
     /// </summary>
     /// <param name="filePath">The file path to inspect.</param>
     /// <returns>
-    /// <c>true</c> if the file has the OLE2 Compound Document header AND uses a modern
-    /// OOXML extension (.xlsx, .xlsm, .xlsb), indicating IRM/AIP encryption;
+    /// <c>true</c> if the file has the OLE2 Compound Document header, uses a modern
+    /// OOXML extension (.xlsx, .xlsm, .xlsb), and maps protected content to the legacy
+    /// <c>\tDRMDataSpace</c> or modern <c>DRMEncryptedDataSpace</c> definition;
     /// <c>false</c> for legacy .xls files (always OLE2), standard ZIP-based files, or
     /// if the file cannot be read.
     /// </returns>
@@ -41,19 +59,452 @@ public static class FileAccessValidator
 
         try
         {
-            Span<byte> header = stackalloc byte[8];
-            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            int read = fs.Read(header);
-            if (read < 8)
+            Span<byte> signature = stackalloc byte[8];
+            using (var stream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite))
+            {
+                if (stream.Read(signature) < signature.Length
+                    || !signature.SequenceEqual(Ole2Signature))
+                {
+                    return false;
+                }
+            }
+
+            using var compoundFile = OleCompoundFileReader.Open(filePath);
+            if (!compoundFile.TryReadStream(
+                    $"{DataSpacesStorage}/{DataSpaceMapStream}",
+                    out var map))
+            {
                 return false;
-            return header.SequenceEqual(Ole2Signature);
+            }
+
+            foreach (var dataSpaceName in ReadDataSpaceNames(map))
+            {
+                if (!IrmDataSpaceNames.Contains(dataSpaceName)
+                    || !compoundFile.TryReadStream(
+                        $"{DataSpacesStorage}/{DataSpaceInfoStorage}/{dataSpaceName}",
+                        out var definition))
+                {
+                    continue;
+                }
+
+                if (IsValidDataSpaceDefinition(definition))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
-        catch
+        catch (InvalidDataException)
+        {
+            return false;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
         {
             // Cannot read → treat as not IRM so normal error handling takes over
             return false;
         }
     }
+
+    private static List<string> ReadDataSpaceNames(ReadOnlySpan<byte> map)
+    {
+        const int maximumMapEntries = 1024;
+        if (map.Length < 8
+            || BinaryPrimitives.ReadUInt32LittleEndian(map) != 8)
+        {
+            return [];
+        }
+
+        var entryCount = BinaryPrimitives.ReadUInt32LittleEndian(map[4..]);
+        if (entryCount > maximumMapEntries)
+        {
+            return [];
+        }
+
+        var names = new List<string>(checked((int)entryCount));
+        var offset = 8;
+        for (var entryIndex = 0u; entryIndex < entryCount; entryIndex++)
+        {
+            if (!TryReadUInt32(map, ref offset, out var entryLength)
+                || entryLength < 12
+                || entryLength > int.MaxValue)
+            {
+                return [];
+            }
+
+            var entryStart = offset - sizeof(uint);
+            var entryEnd = checked(entryStart + (int)entryLength);
+            if (entryEnd > map.Length
+                || !TryReadUInt32(map, ref offset, out var componentCount)
+                || componentCount is 0 or > 64)
+            {
+                return [];
+            }
+
+            var hasStreamReference = false;
+            for (var componentIndex = 0u; componentIndex < componentCount; componentIndex++)
+            {
+                if (!TryReadUInt32(map[..entryEnd], ref offset, out var componentType)
+                    || !TryReadUnicodeLpP4(map[..entryEnd], ref offset, out _))
+                {
+                    return [];
+                }
+
+                hasStreamReference |= componentType == 0;
+            }
+
+            if (!TryReadUnicodeLpP4(map[..entryEnd], ref offset, out var dataSpaceName)
+                || offset != entryEnd)
+            {
+                return [];
+            }
+
+            if (hasStreamReference)
+            {
+                names.Add(dataSpaceName);
+            }
+        }
+
+        return names;
+    }
+
+    private static bool IsValidDataSpaceDefinition(ReadOnlySpan<byte> definition)
+    {
+        const int maximumTransformReferences = 64;
+        if (definition.Length < 8
+            || BinaryPrimitives.ReadUInt32LittleEndian(definition) != 8)
+        {
+            return false;
+        }
+
+        var transformCount = BinaryPrimitives.ReadUInt32LittleEndian(definition[4..]);
+        if (transformCount is 0 or > maximumTransformReferences)
+        {
+            return false;
+        }
+
+        var offset = 8;
+        for (var index = 0u; index < transformCount; index++)
+        {
+            if (!TryReadUnicodeLpP4(definition, ref offset, out var transformName)
+                || string.IsNullOrWhiteSpace(transformName))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryReadUnicodeLpP4(
+        ReadOnlySpan<byte> bytes,
+        ref int offset,
+        out string value)
+    {
+        value = string.Empty;
+        if (!TryReadUInt32(bytes, ref offset, out var byteLength)
+            || byteLength > int.MaxValue
+            || byteLength % 2 != 0
+            || byteLength > bytes.Length - offset)
+        {
+            return false;
+        }
+
+        value = Encoding.Unicode.GetString(
+            bytes.Slice(offset, checked((int)byteLength)));
+        offset += checked((int)byteLength);
+        var alignedOffset = checked((offset + 3) & ~3);
+        if (alignedOffset > bytes.Length)
+        {
+            return false;
+        }
+
+        offset = alignedOffset;
+        return true;
+    }
+
+    private static bool TryReadUInt32(
+        ReadOnlySpan<byte> bytes,
+        ref int offset,
+        out uint value)
+    {
+        value = 0;
+        if (offset < 0 || offset > bytes.Length - sizeof(uint))
+        {
+            return false;
+        }
+
+        value = BinaryPrimitives.ReadUInt32LittleEndian(bytes[offset..]);
+        offset += sizeof(uint);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates a standard OOXML workbook package without launching Excel.
+    /// Encrypted IRM/AIP compound documents require interactive Excel validation
+    /// and are intentionally not accepted by this preflight validator.
+    /// </summary>
+    public static bool HasValidWorkbookContainer(string filePath)
+    {
+        const string contentTypesNamespace =
+            "http://schemas.openxmlformats.org/package/2006/content-types";
+        const string packageRelationshipsNamespace =
+            "http://schemas.openxmlformats.org/package/2006/relationships";
+        const string spreadsheetNamespace =
+            "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        const string strictSpreadsheetNamespace =
+            "http://purl.oclc.org/ooxml/spreadsheetml/main";
+        const string officeDocumentRelationship =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
+        const string strictOfficeDocumentRelationship =
+            "http://purl.oclc.org/ooxml/officeDocument/relationships/officeDocument";
+        const string worksheetRelationship =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet";
+        const string strictWorksheetRelationship =
+            "http://purl.oclc.org/ooxml/officeDocument/relationships/worksheet";
+        const string chartSheetRelationship =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet";
+        const string strictChartSheetRelationship =
+            "http://purl.oclc.org/ooxml/officeDocument/relationships/chartsheet";
+        const string dialogSheetRelationship =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/dialogsheet";
+        const string strictDialogSheetRelationship =
+            "http://purl.oclc.org/ooxml/officeDocument/relationships/dialogsheet";
+        const string macroSheetRelationship =
+            "http://schemas.microsoft.com/office/2006/relationships/xlMacrosheet";
+        const string internationalMacroSheetRelationship =
+            "http://schemas.microsoft.com/office/2006/relationships/xlIntlMacrosheet";
+        const string macroSheetNamespace =
+            "http://schemas.microsoft.com/office/excel/2006/main";
+
+        try
+        {
+            using var stream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite);
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+            var contentTypes = LoadXmlPart(archive, "[Content_Types].xml");
+            var relationships = LoadXmlPart(archive, "_rels/.rels");
+            var workbook = LoadXmlPart(archive, "xl/workbook.xml");
+            var workbookRelationships = LoadXmlPart(archive, "xl/_rels/workbook.xml.rels");
+            if (contentTypes?.Root?.Name
+                    != XName.Get("Types", contentTypesNamespace)
+                || relationships?.Root?.Name
+                    != XName.Get("Relationships", packageRelationshipsNamespace)
+                || workbookRelationships?.Root?.Name
+                    != XName.Get("Relationships", packageRelationshipsNamespace)
+                || workbook?.Root?.Name.LocalName != "workbook"
+                || workbook.Root.Name.NamespaceName is not (
+                    spreadsheetNamespace or strictSpreadsheetNamespace))
+            {
+                return false;
+            }
+
+            var hasWorkbookContentType = contentTypes.Root.Elements()
+                .Any(element =>
+                    element.Name == XName.Get("Override", contentTypesNamespace)
+                    && string.Equals(
+                        element.Attribute("PartName")?.Value,
+                        "/xl/workbook.xml",
+                        StringComparison.OrdinalIgnoreCase)
+                    && element.Attribute("ContentType")?.Value is
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"
+                        or "application/vnd.ms-excel.sheet.macroEnabled.main+xml");
+            var hasWorkbookRelationship = relationships.Root.Elements()
+                .Any(element =>
+                    element.Name == XName.Get("Relationship", packageRelationshipsNamespace)
+                    && element.Attribute("Type")?.Value is
+                        officeDocumentRelationship or strictOfficeDocumentRelationship
+                    && string.Equals(
+                        element.Attribute("Target")?.Value.TrimStart('/'),
+                        "xl/workbook.xml",
+                        StringComparison.OrdinalIgnoreCase));
+            if (!hasWorkbookContentType || !hasWorkbookRelationship)
+            {
+                return false;
+            }
+
+            var workbookNamespace = workbook.Root.Name.NamespaceName;
+            var relationshipAttributeNamespace =
+                workbookNamespace == strictSpreadsheetNamespace
+                    ? "http://purl.oclc.org/ooxml/officeDocument/relationships"
+                    : "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+            var sheets = workbook.Root
+                .Element(XName.Get("sheets", workbookNamespace))?
+                .Elements(XName.Get("sheet", workbookNamespace))
+                .ToList();
+            if (sheets is not { Count: > 0 })
+            {
+                return false;
+            }
+
+            var relationshipElements = workbookRelationships.Root
+                .Elements(XName.Get("Relationship", packageRelationshipsNamespace))
+                .ToList();
+            foreach (var sheet in sheets)
+            {
+                var relationshipId = sheet
+                    .Attribute(XName.Get("id", relationshipAttributeNamespace))?
+                    .Value;
+                var sheetRelationship = relationshipElements.FirstOrDefault(element =>
+                    string.Equals(
+                        element.Attribute("Id")?.Value,
+                        relationshipId,
+                        StringComparison.Ordinal)
+                    && !string.Equals(
+                        element.Attribute("TargetMode")?.Value,
+                        "External",
+                        StringComparison.OrdinalIgnoreCase));
+                var sheetRelationshipType =
+                    sheetRelationship?.Attribute("Type")?.Value;
+                var sheetPart = sheetRelationshipType switch
+                {
+                    worksheetRelationship or strictWorksheetRelationship =>
+                        new SheetPartDescriptor(
+                            "worksheet",
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+                            workbookNamespace),
+                    chartSheetRelationship or strictChartSheetRelationship =>
+                        new SheetPartDescriptor(
+                            "chartsheet",
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.chartsheet+xml",
+                            workbookNamespace),
+                    dialogSheetRelationship or strictDialogSheetRelationship =>
+                        new SheetPartDescriptor(
+                            "dialogsheet",
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.dialogsheet+xml",
+                            workbookNamespace),
+                    macroSheetRelationship =>
+                        new SheetPartDescriptor(
+                            "macrosheet",
+                            "application/vnd.ms-excel.macrosheet+xml",
+                            macroSheetNamespace),
+                    internationalMacroSheetRelationship =>
+                        new SheetPartDescriptor(
+                            "macrosheet",
+                            "application/vnd.ms-excel.intlmacrosheet+xml",
+                            macroSheetNamespace),
+                    _ => null
+                };
+                var sheetTarget = sheetRelationship?.Attribute("Target")?.Value
+                    .Replace('\\', '/')
+                    .TrimStart('/');
+                if (sheetPart == null
+                    || string.IsNullOrWhiteSpace(sheetTarget)
+                    || sheetTarget.Split('/').Contains("..", StringComparer.Ordinal))
+                {
+                    return false;
+                }
+
+                var sheetEntryPath = sheetTarget.StartsWith(
+                    "xl/",
+                    StringComparison.OrdinalIgnoreCase)
+                    ? sheetTarget
+                    : $"xl/{sheetTarget}";
+                var hasSheetContentType = contentTypes.Root.Elements()
+                    .Any(element =>
+                        element.Name == XName.Get("Override", contentTypesNamespace)
+                        && string.Equals(
+                            element.Attribute("PartName")?.Value.TrimStart('/'),
+                            sheetEntryPath,
+                            StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(
+                            element.Attribute("ContentType")?.Value,
+                            sheetPart.ContentType,
+                            StringComparison.Ordinal));
+                if (!hasSheetContentType
+                    || !HasExpectedXmlRoot(
+                        archive,
+                        sheetEntryPath,
+                        sheetPart.RootElement,
+                        sheetPart.RootNamespace))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch (InvalidDataException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (XmlException)
+        {
+            return false;
+        }
+    }
+
+    private static XDocument? LoadXmlPart(ZipArchive archive, string name)
+    {
+        const long maximumMetadataPartBytes = 4 * 1024 * 1024;
+        var entry = archive.GetEntry(name);
+        if (entry == null || entry.Length > maximumMetadataPartBytes)
+        {
+            return null;
+        }
+
+        using var part = entry.Open();
+        using var reader = XmlReader.Create(part, CreateSafeXmlReaderSettings(maximumMetadataPartBytes));
+        return XDocument.Load(reader, LoadOptions.None);
+    }
+
+    private static bool HasExpectedXmlRoot(
+        ZipArchive archive,
+        string name,
+        string expectedLocalName,
+        string expectedNamespace)
+    {
+        const long maximumRootProbeCharacters = 1024 * 1024;
+        var entry = archive.GetEntry(name);
+        if (entry == null)
+        {
+            return false;
+        }
+
+        using var part = entry.Open();
+        using var reader = XmlReader.Create(
+            part,
+            CreateSafeXmlReaderSettings(maximumRootProbeCharacters));
+        reader.MoveToContent();
+        return reader.LocalName == expectedLocalName
+            && reader.NamespaceURI == expectedNamespace;
+    }
+
+    private static XmlReaderSettings CreateSafeXmlReaderSettings(long maximumCharacters) =>
+        new()
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = maximumCharacters
+        };
+
+    private sealed record SheetPartDescriptor(
+        string RootElement,
+        string ContentType,
+        string RootNamespace);
 
     /// <summary>
     /// Validates that a file is not locked by attempting to open it with exclusive access.
@@ -106,5 +557,3 @@ public static class FileAccessValidator
             innerException);
     }
 }
-
-

--- a/src/ExcelMcp.ComInterop/OleCompoundFileReader.cs
+++ b/src/ExcelMcp.ComInterop/OleCompoundFileReader.cs
@@ -1,0 +1,552 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Sbroenne.ExcelMcp.ComInterop;
+
+internal sealed class OleCompoundFileReader : IDisposable
+{
+    private const uint FreeSector = 0xFFFFFFFF;
+    private const uint EndOfChain = 0xFFFFFFFE;
+    private const uint FatSector = 0xFFFFFFFD;
+    private const uint DifatSector = 0xFFFFFFFC;
+    private const string DataSpacesStorage = "\u0006DataSpaces";
+    private const string DataSpaceMapStream = "DataSpaceMap";
+    private const string DataSpaceInfoStorage = "DataSpaceInfo";
+    private const string LegacyDrmDataSpace = "\tDRMDataSpace";
+    private const string ModernDrmDataSpace = "DRMEncryptedDataSpace";
+    private readonly FileStream _stream;
+    private readonly int _sectorSize;
+    private readonly int _miniSectorSize;
+    private readonly uint _miniStreamCutoff;
+    private readonly uint _firstMiniFatSector;
+    private readonly uint _miniFatSectorCount;
+    private readonly uint[] _fat;
+    private readonly DirectoryEntry[] _directoryEntries;
+    private readonly Dictionary<string, DirectoryEntry> _entriesByPath =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly DirectoryEntry _rootEntry;
+    private readonly ushort _majorVersion;
+    private byte[]? _miniStream;
+    private uint[]? _miniFat;
+
+    private OleCompoundFileReader(FileStream stream)
+    {
+        _stream = stream;
+        Span<byte> header = stackalloc byte[512];
+        stream.ReadExactly(header);
+        ReadOnlySpan<byte> signature =
+            [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
+        if (!header[..8].SequenceEqual(signature))
+        {
+            throw new InvalidDataException("The file is not an OLE compound file.");
+        }
+
+        _majorVersion = BinaryPrimitives.ReadUInt16LittleEndian(header[26..]);
+        var sectorShift = BinaryPrimitives.ReadUInt16LittleEndian(header[30..]);
+        var miniSectorShift = BinaryPrimitives.ReadUInt16LittleEndian(header[32..]);
+        if (BinaryPrimitives.ReadUInt16LittleEndian(header[28..]) != 0xFFFE
+            || _majorVersion is not (3 or 4)
+            || sectorShift != (_majorVersion == 3 ? 9 : 12)
+            || miniSectorShift != 6)
+        {
+            throw new InvalidDataException("The OLE compound header is invalid.");
+        }
+
+        _sectorSize = 1 << sectorShift;
+        _miniSectorSize = 1 << miniSectorShift;
+        var sectorCount = GetSectorCount(stream.Length, _sectorSize);
+        var fatSectorCount = BinaryPrimitives.ReadUInt32LittleEndian(header[44..]);
+        var firstDirectorySector = BinaryPrimitives.ReadUInt32LittleEndian(header[48..]);
+        _miniStreamCutoff = BinaryPrimitives.ReadUInt32LittleEndian(header[56..]);
+        _firstMiniFatSector = BinaryPrimitives.ReadUInt32LittleEndian(header[60..]);
+        _miniFatSectorCount = BinaryPrimitives.ReadUInt32LittleEndian(header[64..]);
+        var firstDifatSector = BinaryPrimitives.ReadUInt32LittleEndian(header[68..]);
+        var difatSectorCount = BinaryPrimitives.ReadUInt32LittleEndian(header[72..]);
+
+        var fatSectorIds = ReadFatSectorIds(
+            header,
+            fatSectorCount,
+            firstDifatSector,
+            difatSectorCount,
+            sectorCount);
+        _fat = ReadFat(fatSectorIds, sectorCount);
+        var directoryBytes = ReadRegularChain(firstDirectorySector, maximumSectors: sectorCount);
+        _directoryEntries = ReadDirectoryEntries(directoryBytes);
+        _rootEntry = _directoryEntries.FirstOrDefault(entry => entry.Type == 5)
+            ?? throw new InvalidDataException("The OLE root storage is missing.");
+        IndexRelevantChildren(
+            _rootEntry.Child,
+            DirectorySearchScope.Root,
+            new HashSet<int>());
+    }
+
+    internal static OleCompoundFileReader Open(string filePath)
+    {
+        var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite);
+        try
+        {
+            return new OleCompoundFileReader(stream);
+        }
+
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    internal static int GetSectorCount(long streamLength, int sectorSize)
+    {
+        if (sectorSize <= 0
+            || streamLength < sectorSize
+            || streamLength % sectorSize != 0)
+        {
+            throw new InvalidDataException("The OLE compound file length is invalid.");
+        }
+
+        var sectorCount = streamLength / sectorSize - 1;
+        if (sectorCount > int.MaxValue)
+        {
+            throw new InvalidDataException(
+                "The OLE compound file length exceeds the inspection limit.");
+        }
+
+        return (int)sectorCount;
+    }
+
+    internal bool TryReadStream(string path, out byte[] contents)
+    {
+        contents = [];
+        if (!_entriesByPath.TryGetValue(path, out var entry)
+            || entry.Type != 2
+            || entry.StreamSize < 0
+            || entry.StreamSize > int.MaxValue)
+        {
+            return false;
+        }
+
+        contents = entry.StreamSize < _miniStreamCutoff
+            ? ReadMiniStream(entry)
+            : ReadRegularStream(entry);
+        return true;
+    }
+
+    private List<uint> ReadFatSectorIds(
+        ReadOnlySpan<byte> header,
+        uint fatSectorCount,
+        uint firstDifatSector,
+        uint difatSectorCount,
+        int sectorCount)
+    {
+        if (fatSectorCount > sectorCount || difatSectorCount > sectorCount)
+        {
+            throw new InvalidDataException("The OLE FAT metadata is invalid.");
+        }
+
+        var ids = new List<uint>(checked((int)fatSectorCount));
+        for (var offset = 76; offset < 512 && ids.Count < fatSectorCount; offset += sizeof(uint))
+        {
+            AddFatSectorId(
+                BinaryPrimitives.ReadUInt32LittleEndian(header[offset..]),
+                ids,
+                sectorCount);
+        }
+
+        var difatSector = firstDifatSector;
+        var visited = new HashSet<uint>();
+        for (var index = 0u; index < difatSectorCount && ids.Count < fatSectorCount; index++)
+        {
+            if (!IsRegularSector(difatSector, sectorCount) || !visited.Add(difatSector))
+            {
+                throw new InvalidDataException("The OLE DIFAT chain is invalid.");
+            }
+
+            var sector = ReadSector(difatSector);
+            var entryCount = _sectorSize / sizeof(uint) - 1;
+            for (var entryIndex = 0; entryIndex < entryCount && ids.Count < fatSectorCount; entryIndex++)
+            {
+                AddFatSectorId(
+                    BinaryPrimitives.ReadUInt32LittleEndian(
+                        sector.AsSpan(entryIndex * sizeof(uint))),
+                    ids,
+                    sectorCount);
+            }
+
+            difatSector = BinaryPrimitives.ReadUInt32LittleEndian(
+                sector.AsSpan(entryCount * sizeof(uint)));
+        }
+
+        if (ids.Count != fatSectorCount)
+        {
+            throw new InvalidDataException("The OLE FAT sector list is incomplete.");
+        }
+
+        return ids;
+    }
+
+    private static void AddFatSectorId(uint id, List<uint> ids, int sectorCount)
+    {
+        if (id == FreeSector)
+        {
+            return;
+        }
+
+        if (!IsRegularSector(id, sectorCount))
+        {
+            throw new InvalidDataException("The OLE FAT contains an invalid sector.");
+        }
+
+        ids.Add(id);
+    }
+
+    private uint[] ReadFat(List<uint> fatSectorIds, int sectorCount)
+    {
+        var entries = new List<uint>(fatSectorIds.Count * (_sectorSize / sizeof(uint)));
+        foreach (var sectorId in fatSectorIds)
+        {
+            var sector = ReadSector(sectorId);
+            for (var offset = 0; offset < sector.Length; offset += sizeof(uint))
+            {
+                entries.Add(BinaryPrimitives.ReadUInt32LittleEndian(sector.AsSpan(offset)));
+            }
+        }
+
+        if (entries.Count < sectorCount)
+        {
+            throw new InvalidDataException("The OLE FAT does not cover the file.");
+        }
+
+        return [.. entries];
+    }
+
+    private DirectoryEntry[] ReadDirectoryEntries(byte[] bytes)
+    {
+        if (bytes.Length % 128 != 0)
+        {
+            throw new InvalidDataException("The OLE directory stream is invalid.");
+        }
+
+        var entries = new List<DirectoryEntry>(bytes.Length / 128);
+        for (var index = 0; index < bytes.Length / 128; index++)
+        {
+            var entry = bytes.AsSpan(index * 128, 128);
+            var nameLength = BinaryPrimitives.ReadUInt16LittleEndian(entry[64..]);
+            var type = entry[66];
+            string name;
+            if (type == 0)
+            {
+                name = string.Empty;
+            }
+            else
+            {
+                if (nameLength is < 2 or > 64 || nameLength % 2 != 0)
+                {
+                    throw new InvalidDataException("An OLE directory name is invalid.");
+                }
+
+                name = Encoding.Unicode.GetString(entry[..(nameLength - 2)]);
+            }
+
+            var rawSize = BinaryPrimitives.ReadInt64LittleEndian(entry[120..]);
+            var streamSize = _majorVersion == 3
+                ? unchecked((uint)rawSize)
+                : rawSize;
+            entries.Add(new DirectoryEntry(
+                index,
+                name,
+                type,
+                BinaryPrimitives.ReadInt32LittleEndian(entry[68..]),
+                BinaryPrimitives.ReadInt32LittleEndian(entry[72..]),
+                BinaryPrimitives.ReadInt32LittleEndian(entry[76..]),
+                BinaryPrimitives.ReadUInt32LittleEndian(entry[116..]),
+                streamSize));
+        }
+
+        return [.. entries];
+    }
+
+    private void IndexRelevantChildren(
+        int entryId,
+        DirectorySearchScope scope,
+        HashSet<int> visited)
+    {
+        var pending = new Stack<DirectoryTraversal>();
+        pending.Push(new DirectoryTraversal(
+            entryId,
+            scope,
+            DirectoryTraversalPhase.Enter));
+        while (pending.TryPop(out var traversal))
+        {
+            if (traversal.EntryId == -1)
+            {
+                continue;
+            }
+
+            var entry = GetDirectoryEntry(traversal.EntryId);
+            if (traversal.Phase == DirectoryTraversalPhase.Enter)
+            {
+                if (!visited.Add(traversal.EntryId))
+                {
+                    throw new InvalidDataException("The OLE directory tree contains a cycle.");
+                }
+
+                pending.Push(traversal with { Phase = DirectoryTraversalPhase.Visit });
+                pending.Push(new DirectoryTraversal(
+                    entry.LeftSibling,
+                    traversal.Scope,
+                    DirectoryTraversalPhase.Enter));
+                continue;
+            }
+
+            if (traversal.Phase == DirectoryTraversalPhase.Visit)
+            {
+                pending.Push(new DirectoryTraversal(
+                    entry.RightSibling,
+                    traversal.Scope,
+                    DirectoryTraversalPhase.Enter));
+
+                var childScope = GetChildSearchScope(traversal.Scope, entry);
+                var relevantPath = GetRelevantStreamPath(traversal.Scope, entry);
+                if (relevantPath != null
+                    && !_entriesByPath.TryAdd(relevantPath, entry))
+                {
+                    throw new InvalidDataException("The OLE directory contains duplicate paths.");
+                }
+
+                if (childScope is { } relevantChildScope)
+                {
+                    pending.Push(new DirectoryTraversal(
+                        entry.Child,
+                        relevantChildScope,
+                        DirectoryTraversalPhase.Enter));
+                }
+
+                continue;
+            }
+        }
+    }
+
+    private static DirectorySearchScope? GetChildSearchScope(
+        DirectorySearchScope scope,
+        DirectoryEntry entry)
+    {
+        if (entry.Type != 1)
+        {
+            return null;
+        }
+
+        return scope switch
+        {
+            DirectorySearchScope.Root
+                when entry.Name.Equals(DataSpacesStorage, StringComparison.OrdinalIgnoreCase) =>
+                DirectorySearchScope.DataSpaces,
+            DirectorySearchScope.DataSpaces
+                when entry.Name.Equals(DataSpaceInfoStorage, StringComparison.OrdinalIgnoreCase) =>
+                DirectorySearchScope.DataSpaceInfo,
+            _ => null
+        };
+    }
+
+    private static string? GetRelevantStreamPath(
+        DirectorySearchScope scope,
+        DirectoryEntry entry)
+    {
+        if (entry.Type != 2)
+        {
+            return null;
+        }
+
+        return scope switch
+        {
+            DirectorySearchScope.DataSpaces
+                when entry.Name.Equals(DataSpaceMapStream, StringComparison.OrdinalIgnoreCase) =>
+                $"{DataSpacesStorage}/{DataSpaceMapStream}",
+            DirectorySearchScope.DataSpaceInfo
+                when entry.Name.Equals(LegacyDrmDataSpace, StringComparison.OrdinalIgnoreCase) =>
+                $"{DataSpacesStorage}/{DataSpaceInfoStorage}/{LegacyDrmDataSpace}",
+            DirectorySearchScope.DataSpaceInfo
+                when entry.Name.Equals(ModernDrmDataSpace, StringComparison.OrdinalIgnoreCase) =>
+                $"{DataSpacesStorage}/{DataSpaceInfoStorage}/{ModernDrmDataSpace}",
+            _ => null
+        };
+    }
+
+    private DirectoryEntry GetDirectoryEntry(int entryId)
+    {
+        if ((uint)entryId >= _directoryEntries.Length)
+        {
+            throw new InvalidDataException("The OLE directory references an invalid entry.");
+        }
+
+        return _directoryEntries[entryId];
+    }
+
+    private byte[] ReadRegularStream(DirectoryEntry entry)
+    {
+        if (entry.StreamSize < 0 || entry.StreamSize > int.MaxValue)
+        {
+            throw new InvalidDataException("An OLE stream size exceeds the inspection limit.");
+        }
+
+        var bytes = ReadRegularChain(
+            entry.StartSector,
+            maximumSectors: (int)((entry.StreamSize + _sectorSize - 1) / _sectorSize));
+        if (bytes.Length < entry.StreamSize)
+        {
+            throw new InvalidDataException("An OLE stream chain is shorter than its declared size.");
+        }
+
+        return bytes[..checked((int)entry.StreamSize)];
+    }
+
+    private byte[] ReadRegularChain(uint startSector, int maximumSectors)
+    {
+        if (maximumSectors < 0)
+        {
+            throw new InvalidDataException("The OLE stream size is invalid.");
+        }
+
+        using var output = new MemoryStream();
+        var sectorId = startSector;
+        var visited = new HashSet<uint>();
+        while (sectorId != EndOfChain)
+        {
+            if (sectorId >= _fat.Length
+                || sectorId is FreeSector or FatSector or DifatSector
+                || !visited.Add(sectorId)
+                || visited.Count > maximumSectors)
+            {
+                throw new InvalidDataException("An OLE stream chain is invalid.");
+            }
+
+            output.Write(ReadSector(sectorId));
+            sectorId = _fat[sectorId];
+        }
+
+        return output.ToArray();
+    }
+
+    private byte[] ReadMiniStream(DirectoryEntry entry)
+    {
+        EnsureMiniStreamLoaded();
+        if (_miniFat == null || _miniStream == null)
+        {
+            throw new InvalidDataException("The OLE mini stream is unavailable.");
+        }
+
+        var expectedSectors = checked((int)((entry.StreamSize + _miniSectorSize - 1) / _miniSectorSize));
+        using var output = new MemoryStream();
+        var sectorId = entry.StartSector;
+        var visited = new HashSet<uint>();
+        while (sectorId != EndOfChain)
+        {
+            if (sectorId >= _miniFat.Length
+                || !visited.Add(sectorId)
+                || visited.Count > expectedSectors)
+            {
+                throw new InvalidDataException("An OLE mini stream chain is invalid.");
+            }
+
+            var offset = checked((long)sectorId * _miniSectorSize);
+            if (offset + _miniSectorSize > _miniStream.Length)
+            {
+                throw new InvalidDataException("An OLE mini stream sector is outside the root stream.");
+            }
+
+            output.Write(_miniStream, checked((int)offset), _miniSectorSize);
+            sectorId = _miniFat[sectorId];
+        }
+
+        var bytes = output.ToArray();
+        if (bytes.Length < entry.StreamSize)
+        {
+            throw new InvalidDataException("An OLE mini stream is shorter than its declared size.");
+        }
+
+        return bytes[..checked((int)entry.StreamSize)];
+    }
+
+    private void EnsureMiniStreamLoaded()
+    {
+        if (_miniFat != null)
+        {
+            return;
+        }
+
+        if (_miniFatSectorCount == 0
+            || _firstMiniFatSector == EndOfChain
+            || _rootEntry.StreamSize <= 0)
+        {
+            _miniFat = [];
+            _miniStream = [];
+            return;
+        }
+
+        var miniFatBytes = ReadRegularChain(
+            _firstMiniFatSector,
+            checked((int)_miniFatSectorCount));
+        var miniFat = new uint[miniFatBytes.Length / sizeof(uint)];
+        for (var index = 0; index < miniFat.Length; index++)
+        {
+            miniFat[index] = BinaryPrimitives.ReadUInt32LittleEndian(
+                miniFatBytes.AsSpan(index * sizeof(uint)));
+        }
+
+        _miniFat = miniFat;
+        _miniStream = ReadRegularStream(_rootEntry);
+    }
+
+    private byte[] ReadSector(uint sectorId)
+    {
+        var offset = checked(((long)sectorId + 1) * _sectorSize);
+        if (offset < _sectorSize || offset + _sectorSize > _stream.Length)
+        {
+            throw new InvalidDataException("An OLE sector is outside the file.");
+        }
+
+        var bytes = new byte[_sectorSize];
+        _stream.Position = offset;
+        _stream.ReadExactly(bytes);
+        return bytes;
+    }
+
+    private static bool IsRegularSector(uint sectorId, int sectorCount) =>
+        sectorId < sectorCount;
+
+    public void Dispose()
+    {
+        _stream.Dispose();
+    }
+
+    private sealed record DirectoryEntry(
+        int Id,
+        string Name,
+        byte Type,
+        int LeftSibling,
+        int RightSibling,
+        int Child,
+        uint StartSector,
+        long StreamSize);
+
+    private readonly record struct DirectoryTraversal(
+        int EntryId,
+        DirectorySearchScope Scope,
+        DirectoryTraversalPhase Phase);
+
+    private enum DirectoryTraversalPhase
+    {
+        Enter,
+        Visit
+    }
+
+    private enum DirectorySearchScope
+    {
+        Root,
+        DataSpaces,
+        DataSpaceInfo
+    }
+}

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -21,7 +21,7 @@ namespace Sbroenne.ExcelMcp.ComInterop.Session;
 /// </list>
 /// <para><b>Resource Cost:</b> Each ExcelBatch = one Excel.Application process (~50-100MB+ memory)</para>
 /// </remarks>
-internal sealed class ExcelBatch : IExcelBatch
+internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState
 {
     // P/Invoke for getting process ID from window handle
     [DllImport("user32.dll")]
@@ -39,6 +39,7 @@ internal sealed class ExcelBatch : IExcelBatch
     private readonly CancellationTokenSource _shutdownCts;
     private int _disposed; // 0 = not disposed, 1 = disposed (using int for Interlocked.CompareExchange)
     private int? _excelProcessId; // Excel.exe process ID for force-kill if needed
+    private ExcelProcessIdentity? _excelProcessIdentity;
     private volatile bool _isExcelVisible;
     private bool _operationTimedOut; // Track if an operation timed out for aggressive cleanup
     private bool _startupDetectedIrmProtectedWorkbook;
@@ -55,6 +56,10 @@ internal sealed class ExcelBatch : IExcelBatch
     /// Production code must leave this null.
     /// </summary>
     internal static Action<string, CancellationToken>? BeforeWorkbookOpenHook { get; set; }
+
+    internal static Func<ExcelProcessIdentity, bool>? FailedStartupTerminationHook { get; set; }
+
+    internal static Func<ExcelProcessIdentity, bool>? FailedStartupExitConfirmationHook { get; set; }
 
     // COM state (STA thread only)
     private Excel.Application? _excel;
@@ -177,7 +182,8 @@ internal sealed class ExcelBatch : IExcelBatch
                             if (processId != 0)
                             {
                                 _excelProcessId = (int)processId;
-                                SessionManager.TrackExcelProcess(_excelProcessId.Value);
+                                _excelProcessIdentity =
+                                    SessionManager.TrackExcelProcessIdentity(_excelProcessId.Value);
                                 _logger.LogDebug("Captured Excel process ID via Hwnd: {ProcessId} (attempt {Attempt})",
                                     _excelProcessId, attempt);
                                 break;
@@ -199,6 +205,11 @@ internal sealed class ExcelBatch : IExcelBatch
                             "Force-kill will be disabled for this session to avoid killing unrelated Excel instances.",
                             maxRetries);
                     }
+                }
+                catch (ExcelProcessPersistenceException ex)
+                {
+                    _excelProcessIdentity = ex.Identity;
+                    throw;
                 }
                 catch (Exception ex)
                 {
@@ -424,6 +435,26 @@ internal sealed class ExcelBatch : IExcelBatch
                             "[DIAG-SHUTDOWN-ENTER-PROCESS-DEAD] Excel PID {ProcessId} already dead BEFORE shutdown for {FileName}",
                             _excelProcessId.Value, Path.GetFileName(_workbookPath));
                     }
+                    catch (System.ComponentModel.Win32Exception ex)
+                    {
+                        SessionDiagnostics.WriteStdErr(
+                            $"[DIAG-SHUTDOWN-ENTER-PROCESS-INACCESSIBLE] Excel PID {_excelProcessId.Value} could not be queried before shutdown: {ex.Message}");
+                        _logger.LogWarning(
+                            ex,
+                            "[DIAG-SHUTDOWN-ENTER-PROCESS-INACCESSIBLE] Excel PID {ProcessId} could not be queried before shutdown for {FileName}",
+                            _excelProcessId.Value,
+                            Path.GetFileName(_workbookPath));
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        SessionDiagnostics.WriteStdErr(
+                            $"[DIAG-SHUTDOWN-ENTER-PROCESS-INACCESSIBLE] Excel PID {_excelProcessId.Value} state was unavailable before shutdown: {ex.Message}");
+                        _logger.LogWarning(
+                            ex,
+                            "[DIAG-SHUTDOWN-ENTER-PROCESS-INACCESSIBLE] Excel PID {ProcessId} state was unavailable before shutdown for {FileName}",
+                            _excelProcessId.Value,
+                            Path.GetFileName(_workbookPath));
+                    }
                 }
 
                 // Unified shutdown: use ExcelShutdownService for ALL workbook close/quit operations.
@@ -513,30 +544,38 @@ internal sealed class ExcelBatch : IExcelBatch
 
             started.Task.GetAwaiter().GetResult();
         }
-        catch
+        catch (Exception startupFailure)
         {
             if (_staThread.IsAlive)
             {
-                if (!_staThread.Join(TimeSpan.FromSeconds(10)) && _excelProcessId.HasValue)
-                {
-                    try
-                    {
-                        using var excelProcess = System.Diagnostics.Process.GetProcessById(_excelProcessId.Value);
-                        if (!excelProcess.HasExited)
-                        {
-                            excelProcess.Kill();
-                            excelProcess.WaitForExit(5000);
-                        }
-                    }
-                    catch (ArgumentException)
-                    {
-                        // Excel process already exited during startup cleanup.
-                    }
-                    catch (Exception)
-                    {
-                        // Best effort only — rethrow original startup failure below.
-                    }
+                _ = _staThread.Join(TimeSpan.FromSeconds(10));
+            }
 
+            if (_excelProcessIdentity is { } failedStartupIdentity)
+            {
+                try
+                {
+                    FinalizeFailedStartupOwnedProcess(
+                        failedStartupIdentity,
+                        FailedStartupTerminationHook
+                        ?? (identity => TryTerminateOwnedProcess(
+                            identity,
+                            TimeSpan.FromSeconds(5),
+                            TimeSpan.FromSeconds(3))),
+                        FailedStartupExitConfirmationHook
+                        ?? OwnedProcessGuard.TryConfirmExited);
+                }
+                catch (Exception teardownFailure)
+                {
+                    throw new InvalidOperationException(
+                        $"Excel startup failed and exact process teardown could not be confirmed for " +
+                        $"process {failedStartupIdentity.ProcessId}. The process identity remains tracked " +
+                        "for ProcessExit cleanup.",
+                        new AggregateException(startupFailure, teardownFailure));
+                }
+
+                if (_staThread.IsAlive)
+                {
                     _ = _staThread.Join(TimeSpan.FromSeconds(5));
                 }
             }
@@ -612,6 +651,11 @@ internal sealed class ExcelBatch : IExcelBatch
             // "unknown but assumed alive" so callers do not tear down a live session before the
             // first COM command runs; real COM failures still surface on the actual operation.
             return true;
+        }
+
+        if (_excelProcessIdentity is { } identity)
+        {
+            return OwnedProcessGuard.IsAlive(identity);
         }
 
         try
@@ -846,49 +890,46 @@ internal sealed class ExcelBatch : IExcelBatch
 
         // When operation timed out, the STA thread is stuck in IDispatch.Invoke (unmanaged COM call
         // that cannot be cancelled). Kill the Excel process FIRST to unblock the STA thread, then wait.
-        if (_operationTimedOut && _excelProcessId.HasValue && _staThread != null && _staThread.IsAlive)
+        if (_operationTimedOut
+            && _excelProcessIdentity is { } timedOutIdentity
+            && _staThread != null
+            && _staThread.IsAlive)
         {
             // INSTRUMENTATION: Track pre-emptive kill path entry
             _logger.LogWarning(
                 "[DIAG-DISPOSE-TIMEOUT-PREKILL] [Thread {CallingThread}] Operation timed out — force-killing Excel process {ProcessId} BEFORE waiting for STA thread to unblock IDispatch.Invoke for {FileName}",
-                callingThread, _excelProcessId.Value, Path.GetFileName(_workbookPath));
+                callingThread, timedOutIdentity.ProcessId, Path.GetFileName(_workbookPath));
             SessionDiagnostics.WriteStdErr(
-                $"[DIAG-DISPOSE-TIMEOUT-PREKILL] [Thread {callingThread}] Operation timed out — force-killing Excel process {_excelProcessId.Value} BEFORE waiting for STA thread to unblock IDispatch.Invoke for {Path.GetFileName(_workbookPath)}");
-            try
+                $"[DIAG-DISPOSE-TIMEOUT-PREKILL] [Thread {callingThread}] Operation timed out — force-killing Excel process {timedOutIdentity.ProcessId} BEFORE waiting for STA thread to unblock IDispatch.Invoke for {Path.GetFileName(_workbookPath)}");
+            if (OwnedProcessGuard.TryTerminate(
+                    timedOutIdentity,
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(5),
+                    out var preemptivelyTerminated))
             {
-                using var excelProcess = System.Diagnostics.Process.GetProcessById(_excelProcessId.Value);
-                if (!excelProcess.HasExited)
+                if (preemptivelyTerminated)
                 {
-                    excelProcess.Kill();
-                    excelProcess.WaitForExit(5000);
                     // INSTRUMENTATION: Track successful pre-emptive kill
                     _logger.LogInformation(
                         "[DIAG-DISPOSE-TIMEOUT-PREKILL-SUCCESS] [Thread {CallingThread}] Force-killed Excel process {ProcessId} (pre-emptive, before STA join)",
-                        callingThread, _excelProcessId.Value);
+                        callingThread, timedOutIdentity.ProcessId);
                     SessionDiagnostics.WriteStdErr(
-                        $"[DIAG-DISPOSE-TIMEOUT-PREKILL-SUCCESS] [Thread {callingThread}] Force-killed Excel process {_excelProcessId.Value} (pre-emptive, before STA join)");
+                        $"[DIAG-DISPOSE-TIMEOUT-PREKILL-SUCCESS] [Thread {callingThread}] Force-killed Excel process {timedOutIdentity.ProcessId} (pre-emptive, before STA join)");
                 }
                 else
                 {
-                    // INSTRUMENTATION: Process already gone
                     _logger.LogDebug(
-                        "[DIAG-DISPOSE-TIMEOUT-PREKILL-ALREADY-GONE] [Thread {CallingThread}] Excel process {ProcessId} already exited",
-                        callingThread, _excelProcessId.Value);
+                        "[DIAG-DISPOSE-TIMEOUT-PREKILL-ALREADY-GONE] [Thread {CallingThread}] Excel process {ProcessId} already exited or its PID was reused",
+                        callingThread, timedOutIdentity.ProcessId);
                     SessionDiagnostics.WriteStdErr(
-                        $"[DIAG-DISPOSE-TIMEOUT-PREKILL-ALREADY-GONE] [Thread {callingThread}] Excel process {_excelProcessId.Value} already exited");
+                        $"[DIAG-DISPOSE-TIMEOUT-PREKILL-ALREADY-GONE] [Thread {callingThread}] Excel process {timedOutIdentity.ProcessId} already exited or its PID was reused");
                 }
             }
-            catch (ArgumentException)
+            else
             {
-                _logger.LogDebug("[DIAG-DISPOSE-TIMEOUT-PREKILL-NOT-FOUND] [Thread {CallingThread}] Excel process {ProcessId} not found (already exited)", callingThread, _excelProcessId.Value);
+                _logger.LogWarning("[DIAG-DISPOSE-TIMEOUT-PREKILL-FAILED] [Thread {CallingThread}] Failed to force-kill Excel process {ProcessId}", callingThread, timedOutIdentity.ProcessId);
                 SessionDiagnostics.WriteStdErr(
-                    $"[DIAG-DISPOSE-TIMEOUT-PREKILL-NOT-FOUND] [Thread {callingThread}] Excel process {_excelProcessId.Value} not found (already exited)");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "[DIAG-DISPOSE-TIMEOUT-PREKILL-FAILED] [Thread {CallingThread}] Failed to force-kill Excel process {ProcessId}", callingThread, _excelProcessId.Value);
-                SessionDiagnostics.WriteStdErr(
-                    $"[DIAG-DISPOSE-TIMEOUT-PREKILL-FAILED] [Thread {callingThread}] Failed to force-kill Excel process {_excelProcessId.Value}: {ex.GetType().Name}: {ex.Message}");
+                    $"[DIAG-DISPOSE-TIMEOUT-PREKILL-FAILED] [Thread {callingThread}] Failed to force-kill Excel process {timedOutIdentity.ProcessId}");
             }
         }
 
@@ -920,40 +961,38 @@ internal sealed class ExcelBatch : IExcelBatch
                 SessionDiagnostics.WriteStdErr(
                     $"[DIAG-DISPOSE-STA-JOIN-TIMEOUT] [Thread {callingThread}] STA thread (Id={_staThread.ManagedThreadId}) did NOT exit within {joinTimeout} for {Path.GetFileName(_workbookPath)}. Excel cleanup is severely stuck{reasonForError}. Attempting force-kill.");
 
-                // Force-kill the hung Excel process
-                if (_excelProcessId.HasValue)
+                // Force-kill only the exact Excel identity captured for this batch.
+                if (_excelProcessIdentity is { } stuckIdentity)
                 {
-                    try
+                    _logger.LogWarning(
+                        "[DIAG-DISPOSE-FORCE-KILL-ATTEMPT] [Thread {CallingThread}] Force-killing Excel process {ProcessId} for {FileName}",
+                        callingThread, stuckIdentity.ProcessId, Path.GetFileName(_workbookPath));
+                    SessionDiagnostics.WriteStdErr(
+                        $"[DIAG-DISPOSE-FORCE-KILL-ATTEMPT] [Thread {callingThread}] Force-killing Excel process {stuckIdentity.ProcessId} for {Path.GetFileName(_workbookPath)}");
+
+                    if (OwnedProcessGuard.TryTerminate(
+                            stuckIdentity,
+                            TimeSpan.Zero,
+                            TimeSpan.FromSeconds(5),
+                            out var forceTerminated))
                     {
-                        using var excelProcess = System.Diagnostics.Process.GetProcessById(_excelProcessId.Value);
-                        // INSTRUMENTATION: Track force-kill attempt after STA join timeout
-                        _logger.LogWarning(
-                            "[DIAG-DISPOSE-FORCE-KILL-ATTEMPT] [Thread {CallingThread}] Force-killing Excel process {ProcessId} for {FileName}",
-                            callingThread, _excelProcessId.Value, Path.GetFileName(_workbookPath));
-                        SessionDiagnostics.WriteStdErr(
-                            $"[DIAG-DISPOSE-FORCE-KILL-ATTEMPT] [Thread {callingThread}] Force-killing Excel process {_excelProcessId.Value} for {Path.GetFileName(_workbookPath)}");
-
-                        excelProcess.Kill();
-                        excelProcess.WaitForExit(5000); // Wait up to 5 seconds for process to die
-
-                        // INSTRUMENTATION: Track successful force-kill
+                        var outcome = forceTerminated
+                            ? "force-killed"
+                            : "already exited or PID was reused";
                         _logger.LogInformation(
-                            "[DIAG-DISPOSE-FORCE-KILL-SUCCESS] [Thread {CallingThread}] Successfully force-killed Excel process {ProcessId}",
-                            callingThread, _excelProcessId.Value);
+                            "[DIAG-DISPOSE-FORCE-KILL-SUCCESS] [Thread {CallingThread}] Excel process {ProcessId} was {Outcome}",
+                            callingThread, stuckIdentity.ProcessId, outcome);
                         SessionDiagnostics.WriteStdErr(
-                            $"[DIAG-DISPOSE-FORCE-KILL-SUCCESS] [Thread {callingThread}] Successfully force-killed Excel process {_excelProcessId.Value}");
+                            $"[DIAG-DISPOSE-FORCE-KILL-SUCCESS] [Thread {callingThread}] Excel process {stuckIdentity.ProcessId} was {outcome}");
 
-                        // Now wait briefly for STA thread to exit after process killed
                         if (_staThread.Join(TimeSpan.FromSeconds(5)))
                         {
-                            // INSTRUMENTATION: Track STA thread exit after force-kill
                             _logger.LogDebug("[DIAG-DISPOSE-STA-EXIT-AFTER-KILL] [Thread {CallingThread}] STA thread exited after force-kill", callingThread);
                             SessionDiagnostics.WriteStdErr(
                                 $"[DIAG-DISPOSE-STA-EXIT-AFTER-KILL] [Thread {callingThread}] STA thread exited after force-kill");
                         }
                         else
                         {
-                            // INSTRUMENTATION: Track persistent STA thread leak
                             _logger.LogWarning(
                                 "[DIAG-DISPOSE-STA-LEAK] [Thread {CallingThread}] STA thread still stuck even after force-kill. Thread leak.",
                                 callingThread);
@@ -961,23 +1000,17 @@ internal sealed class ExcelBatch : IExcelBatch
                                 $"[DIAG-DISPOSE-STA-LEAK] [Thread {callingThread}] STA thread still stuck even after force-kill. Thread leak.");
                         }
                     }
-                    catch (ArgumentException)
+                    else
                     {
-                        _logger.LogWarning(
-                            "[Thread {CallingThread}] Excel process {ProcessId} not found (already exited?)",
-                            callingThread, _excelProcessId.Value);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex,
+                        _logger.LogError(
                             "[Thread {CallingThread}] Failed to force-kill Excel process {ProcessId}",
-                            callingThread, _excelProcessId.Value);
+                            callingThread, stuckIdentity.ProcessId);
                     }
                 }
                 else
                 {
                     _logger.LogError(
-                        "[Thread {CallingThread}] No Excel process ID captured - cannot force-kill. Process will leak.",
+                        "[Thread {CallingThread}] No Excel process identity captured - cannot force-kill. Process will leak.",
                         callingThread);
                 }
             }
@@ -987,105 +1020,120 @@ internal sealed class ExcelBatch : IExcelBatch
             _logger.LogDebug("[Thread {CallingThread}] STA thread was null or not alive for {FileName}", callingThread, Path.GetFileName(_workbookPath));
         }
 
-        // Wait for Excel process to fully terminate to prevent CO_E_SERVER_EXEC_FAILURE
-        // on subsequent Activator.CreateInstance calls. excel.Quit() + COM release doesn't
-        // guarantee the EXCEL.EXE process has exited — rapid create/destroy cycles can fail.
-        if (_excelProcessId.HasValue)
+        try
         {
-            try
+            // Wait for Excel process to fully terminate to prevent CO_E_SERVER_EXEC_FAILURE
+            // on subsequent Activator.CreateInstance calls. excel.Quit() + COM release doesn't
+            // guarantee the EXCEL.EXE process has exited — rapid create/destroy cycles can fail.
+            if (_excelProcessIdentity is { } lingeringIdentity)
             {
-                using var excelProc = System.Diagnostics.Process.GetProcessById(_excelProcessId.Value);
-                if (!excelProc.HasExited)
+                _logger.LogDebug(
+                    "[DIAG-DISPOSE-PROCESS-WAIT] [Thread {CallingThread}] Waiting for Excel process {ProcessId} to exit for {FileName}",
+                    callingThread, lingeringIdentity.ProcessId, Path.GetFileName(_workbookPath));
+                SessionDiagnostics.WriteStdErr(
+                    $"[DIAG-DISPOSE-PROCESS-WAIT] [Thread {callingThread}] Waiting for Excel process {lingeringIdentity.ProcessId} to exit for {Path.GetFileName(_workbookPath)}");
+
+                var lingeringProcessTerminated = false;
+                FinalizeOwnedProcessTeardown(
+                    lingeringIdentity,
+                    identity => OwnedProcessGuard.TryTerminate(
+                        identity,
+                        TimeSpan.FromSeconds(5),
+                        TimeSpan.FromSeconds(3),
+                        out lingeringProcessTerminated));
+
+                if (lingeringProcessTerminated)
                 {
-                    // INSTRUMENTATION: Track process linger detection
-                    _logger.LogDebug(
-                        "[DIAG-DISPOSE-PROCESS-WAIT] [Thread {CallingThread}] Waiting for Excel process {ProcessId} to exit for {FileName}",
-                        callingThread, _excelProcessId.Value, Path.GetFileName(_workbookPath));
+                    _logger.LogInformation(
+                        "[DIAG-DISPOSE-PROCESS-LINGER-KILLED] [Thread {CallingThread}] Force-killed lingering Excel process {ProcessId} for {FileName}",
+                        callingThread, lingeringIdentity.ProcessId, Path.GetFileName(_workbookPath));
                     SessionDiagnostics.WriteStdErr(
-                        $"[DIAG-DISPOSE-PROCESS-WAIT] [Thread {callingThread}] Waiting for Excel process {_excelProcessId.Value} to exit for {Path.GetFileName(_workbookPath)}");
-
-                    if (!excelProc.WaitForExit(5000))
-                    {
-                        // INSTRUMENTATION: Track process linger timeout (THE KEY SYMPTOM)
-                        _logger.LogWarning(
-                            "[DIAG-DISPOSE-PROCESS-LINGER] [Thread {CallingThread}] Excel process {ProcessId} did not exit within 5s for {FileName}. Force-killing to prevent zombie accumulation.",
-                            callingThread, _excelProcessId.Value, Path.GetFileName(_workbookPath));
-                        SessionDiagnostics.WriteStdErr(
-                            $"[DIAG-DISPOSE-PROCESS-LINGER] [Thread {callingThread}] Excel process {_excelProcessId.Value} did not exit within 5s for {Path.GetFileName(_workbookPath)}. Force-killing to prevent zombie accumulation.");
-
-                        // Force-kill: Excel was already told to Quit() and COM refs were released.
-                        // A process still running after 5s is hung and will leak desktop resources.
-                        try
-                        {
-                            excelProc.Kill();
-                            excelProc.WaitForExit(3000);
-                            // INSTRUMENTATION: Track final force-kill of lingering process
-                            _logger.LogInformation(
-                                "[DIAG-DISPOSE-PROCESS-LINGER-KILLED] [Thread {CallingThread}] Force-killed lingering Excel process {ProcessId} for {FileName}",
-                                callingThread, _excelProcessId.Value, Path.GetFileName(_workbookPath));
-                            SessionDiagnostics.WriteStdErr(
-                                $"[DIAG-DISPOSE-PROCESS-LINGER-KILLED] [Thread {callingThread}] Force-killed lingering Excel process {_excelProcessId.Value} for {Path.GetFileName(_workbookPath)}");
-                        }
-                        catch (Exception killEx)
-                        {
-                            // INSTRUMENTATION: Track final force-kill failure (CRITICAL - this is the leak)
-                            _logger.LogWarning(killEx,
-                                "[DIAG-DISPOSE-PROCESS-LINGER-KILL-FAILED] [Thread {CallingThread}] Failed to force-kill Excel process {ProcessId}",
-                                callingThread, _excelProcessId.Value);
-                            SessionDiagnostics.WriteStdErr(
-                                $"[DIAG-DISPOSE-PROCESS-LINGER-KILL-FAILED] [Thread {callingThread}] Failed to force-kill Excel process {_excelProcessId.Value}: {killEx.GetType().Name}: {killEx.Message}");
-                        }
-                    }
-                    else
-                    {
-                        // INSTRUMENTATION: Track normal process exit
-                        _logger.LogDebug(
-                            "[DIAG-DISPOSE-PROCESS-EXITED] [Thread {CallingThread}] Excel process {ProcessId} exited normally for {FileName}",
-                            callingThread, _excelProcessId.Value, Path.GetFileName(_workbookPath));
-                        SessionDiagnostics.WriteStdErr(
-                            $"[DIAG-DISPOSE-PROCESS-EXITED] [Thread {callingThread}] Excel process {_excelProcessId.Value} exited normally for {Path.GetFileName(_workbookPath)}");
-                    }
+                        $"[DIAG-DISPOSE-PROCESS-LINGER-KILLED] [Thread {callingThread}] Force-killed lingering Excel process {lingeringIdentity.ProcessId} for {Path.GetFileName(_workbookPath)}");
                 }
                 else
                 {
-                    // INSTRUMENTATION: Process already gone (fast path)
                     _logger.LogDebug(
-                        "[DIAG-DISPOSE-PROCESS-ALREADY-GONE] [Thread {CallingThread}] Excel process {ProcessId} already exited for {FileName}",
-                        callingThread, _excelProcessId.Value, Path.GetFileName(_workbookPath));
+                        "[DIAG-DISPOSE-PROCESS-EXITED] [Thread {CallingThread}] Excel process {ProcessId} exited normally or its PID was reused for {FileName}",
+                        callingThread, lingeringIdentity.ProcessId, Path.GetFileName(_workbookPath));
                     SessionDiagnostics.WriteStdErr(
-                        $"[DIAG-DISPOSE-PROCESS-ALREADY-GONE] [Thread {callingThread}] Excel process {_excelProcessId.Value} already exited for {Path.GetFileName(_workbookPath)}");
+                        $"[DIAG-DISPOSE-PROCESS-EXITED] [Thread {callingThread}] Excel process {lingeringIdentity.ProcessId} exited normally or its PID was reused for {Path.GetFileName(_workbookPath)}");
                 }
             }
-            catch (ArgumentException)
-            {
-                // Process already terminated — this is the expected fast path
-                _logger.LogDebug(
-                    "[DIAG-DISPOSE-PROCESS-NOT-FOUND] [Thread {CallingThread}] Excel process {ProcessId} not found (already exited)",
-                    callingThread, _excelProcessId.Value);
-                SessionDiagnostics.WriteStdErr(
-                    $"[DIAG-DISPOSE-PROCESS-NOT-FOUND] [Thread {callingThread}] Excel process {_excelProcessId.Value} not found (already exited)");
-            }
-            catch (InvalidOperationException ex)
-            {
-                // Process object is not associated with a running process
-                _logger.LogDebug(ex,
-                    "[DIAG-DISPOSE-PROCESS-INVALID] [Thread {CallingThread}] Excel process {ProcessId} object invalid",
-                    callingThread, _excelProcessId.Value);
-                SessionDiagnostics.WriteStdErr(
-                    $"[DIAG-DISPOSE-PROCESS-INVALID] [Thread {callingThread}] Excel process {_excelProcessId.Value} object invalid: {ex.Message}");
-            }
-        }
 
-        if (_excelProcessId.HasValue)
+            _logger.LogDebug("[Thread {CallingThread}] Dispose COMPLETED for {FileName}", callingThread, Path.GetFileName(_workbookPath));
+        }
+        catch (InvalidOperationException ex) when (_excelProcessIdentity is { })
         {
-            SessionManager.UntrackExcelProcess(_excelProcessId.Value);
+            _logger.LogError(
+                ex,
+                "[DIAG-DISPOSE-PROCESS-LINGER-KILL-FAILED] [Thread {CallingThread}] Excel teardown failed for {FileName}; the exact process identity remains tracked",
+                callingThread,
+                Path.GetFileName(_workbookPath));
+            SessionDiagnostics.WriteStdErr(
+                $"[DIAG-DISPOSE-PROCESS-LINGER-KILL-FAILED] [Thread {callingThread}] {ex.Message}");
+            throw;
+        }
+        finally
+        {
+            // COM cleanup runs on the STA thread; this local resource must also be
+            // released even when final process termination cannot be confirmed.
+            _logger.LogDebug("[Thread {CallingThread}] Disposing CancellationTokenSource for {FileName}", callingThread, Path.GetFileName(_workbookPath));
+            _shutdownCts.Dispose();
+        }
+    }
+
+    internal static void FinalizeOwnedProcessTeardown(
+        ExcelProcessIdentity identity,
+        Func<ExcelProcessIdentity, bool> confirmExit)
+    {
+        ArgumentNullException.ThrowIfNull(confirmExit);
+        if (!confirmExit(identity))
+        {
+            throw new InvalidOperationException(
+                $"Excel process {identity.ProcessId} did not exit or its exit could not be confirmed. " +
+                "Its exact PID/start-time identity remains tracked for later pipe-scoped cleanup.");
         }
 
-        // Dispose cancellation token source
-        _logger.LogDebug("[Thread {CallingThread}] Disposing CancellationTokenSource for {FileName}", callingThread, Path.GetFileName(_workbookPath));
-        _shutdownCts.Dispose();
+        SessionManager.UntrackExcelProcess(identity);
+    }
 
-        _logger.LogDebug("[Thread {CallingThread}] Dispose COMPLETED for {FileName}", callingThread, Path.GetFileName(_workbookPath));
+    internal static bool TryTerminateOwnedProcess(
+        ExcelProcessIdentity identity,
+        TimeSpan waitBeforeTermination,
+        TimeSpan waitAfterTermination) =>
+        OwnedProcessGuard.TryTerminate(
+            identity,
+            waitBeforeTermination,
+            waitAfterTermination,
+            out _);
+
+    internal static void FinalizeFailedStartupOwnedProcess(
+        ExcelProcessIdentity identity,
+        Func<ExcelProcessIdentity, bool> attemptTermination,
+        Func<ExcelProcessIdentity, bool> confirmExit)
+    {
+        ArgumentNullException.ThrowIfNull(attemptTermination);
+        ArgumentNullException.ThrowIfNull(confirmExit);
+        if (!attemptTermination(identity) && !confirmExit(identity))
+        {
+            throw new InvalidOperationException(
+                $"Excel process {identity.ProcessId} remained live or inaccessible after startup " +
+                "cleanup. Its exact PID/start-time identity remains tracked for ProcessExit cleanup.");
+        }
+
+        SessionManager.UntrackExcelProcess(identity);
+    }
+
+    bool IExcelBatchTeardownState.TryConfirmOwnedProcessTeardown()
+    {
+        if (_excelProcessIdentity is not { } identity
+            || !OwnedProcessGuard.TryConfirmExited(identity))
+        {
+            return false;
+        }
+
+        SessionManager.UntrackExcelProcess(identity);
+        return true;
     }
 
 }

--- a/src/ExcelMcp.ComInterop/Session/ExcelProcessIdentity.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelProcessIdentity.cs
@@ -1,0 +1,9 @@
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+/// <summary>
+/// Identifies an Excel process by PID and creation time so PID reuse cannot
+/// transfer ownership to an unrelated process.
+/// </summary>
+public readonly record struct ExcelProcessIdentity(
+    int ProcessId,
+    long StartedAtUtcFileTime);

--- a/src/ExcelMcp.ComInterop/Session/ExcelProcessPersistenceException.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelProcessPersistenceException.cs
@@ -1,0 +1,14 @@
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+internal sealed class ExcelProcessPersistenceException : InvalidOperationException
+{
+    public ExcelProcessPersistenceException(ExcelProcessIdentity identity, Exception innerException)
+        : base(
+            $"Failed to durably persist ownership for Excel process {identity.ProcessId}.",
+            innerException)
+    {
+        Identity = identity;
+    }
+
+    public ExcelProcessIdentity Identity { get; }
+}

--- a/src/ExcelMcp.ComInterop/Session/IExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/IExcelBatch.cs
@@ -158,3 +158,7 @@ public interface IExcelBatch : IDisposable
 
 }
 
+internal interface IExcelBatchTeardownState
+{
+    bool TryConfirmOwnedProcessTeardown();
+}

--- a/src/ExcelMcp.ComInterop/Session/OwnedProcessGuard.cs
+++ b/src/ExcelMcp.ComInterop/Session/OwnedProcessGuard.cs
@@ -1,0 +1,175 @@
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+/// <summary>
+/// Validates and operates on one owned process through the same native handle.
+/// </summary>
+internal static class OwnedProcessGuard
+{
+    private const uint ProcessTerminate = 0x0001;
+    private const uint Synchronize = 0x00100000;
+    private const uint ProcessQueryLimitedInformation = 0x1000;
+    private const uint WaitObject0 = 0x00000000;
+    private const uint WaitTimeout = 0x00000102;
+    private const int ErrorInvalidParameter = 87;
+
+    internal static bool IsAlive(ExcelProcessIdentity identity)
+    {
+        var probe = ProbeMatchingProcess(
+            identity,
+            ProcessQueryLimitedInformation | Synchronize,
+            out var handle);
+        using (handle)
+        {
+            return IsAlive(probe);
+        }
+    }
+
+    internal static bool IsAlive(ProcessIdentityProbe probe) =>
+        probe != ProcessIdentityProbe.ConfirmedExited;
+
+    internal static bool TryConfirmExited(ExcelProcessIdentity identity)
+    {
+        var probe = ProbeMatchingProcess(
+            identity,
+            ProcessQueryLimitedInformation | Synchronize,
+            out var handle);
+        using (handle)
+        {
+            return probe == ProcessIdentityProbe.ConfirmedExited;
+        }
+    }
+
+    internal static bool TryTerminate(
+        ExcelProcessIdentity identity,
+        TimeSpan waitBeforeTermination,
+        TimeSpan waitAfterTermination,
+        out bool terminated)
+    {
+        terminated = false;
+        var probe = ProbeMatchingProcess(
+            identity,
+            ProcessTerminate | ProcessQueryLimitedInformation | Synchronize,
+            out var handle);
+        if (probe == ProcessIdentityProbe.Indeterminate)
+        {
+            return false;
+        }
+
+        if (probe == ProcessIdentityProbe.ConfirmedExited)
+        {
+            return true;
+        }
+
+        if (handle == null)
+        {
+            return false;
+        }
+
+        using (handle)
+        {
+            var initialWait = WaitForSingleObject(
+                handle,
+                ToWaitMilliseconds(waitBeforeTermination));
+            if (initialWait == WaitObject0)
+            {
+                return true;
+            }
+
+            if (initialWait != WaitTimeout)
+            {
+                return false;
+            }
+
+            if (!TerminateProcess(handle, 1)
+                && WaitForSingleObject(handle, 0) != WaitObject0)
+            {
+                return false;
+            }
+
+            terminated = true;
+            return WaitForSingleObject(
+                handle,
+                ToWaitMilliseconds(waitAfterTermination)) == WaitObject0;
+        }
+    }
+
+    private static ProcessIdentityProbe ProbeMatchingProcess(
+        ExcelProcessIdentity identity,
+        uint desiredAccess,
+        out SafeProcessHandle? handle)
+    {
+        handle = OpenProcess(desiredAccess, inheritHandle: false, identity.ProcessId);
+        if (handle.IsInvalid)
+        {
+            var error = Marshal.GetLastWin32Error();
+            handle.Dispose();
+            handle = null;
+            return error == ErrorInvalidParameter
+                ? ProcessIdentityProbe.ConfirmedExited
+                : ProcessIdentityProbe.Indeterminate;
+        }
+
+        if (!GetProcessTimes(handle, out var creationTime, out _, out _, out _))
+        {
+            handle.Dispose();
+            handle = null;
+            return ProcessIdentityProbe.Indeterminate;
+        }
+
+        if (creationTime != identity.StartedAtUtcFileTime
+            || WaitForSingleObject(handle, 0) == WaitObject0)
+        {
+            handle.Dispose();
+            handle = null;
+            return ProcessIdentityProbe.ConfirmedExited;
+        }
+
+        return ProcessIdentityProbe.Alive;
+    }
+
+    internal enum ProcessIdentityProbe
+    {
+        Alive,
+        ConfirmedExited,
+        Indeterminate
+    }
+
+    private static uint ToWaitMilliseconds(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        return (uint)Math.Min(timeout.TotalMilliseconds, uint.MaxValue - 1);
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern SafeProcessHandle OpenProcess(
+        uint desiredAccess,
+        [MarshalAs(UnmanagedType.Bool)] bool inheritHandle,
+        int processId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetProcessTimes(
+        SafeProcessHandle processHandle,
+        out long creationTime,
+        out long exitTime,
+        out long kernelTime,
+        out long userTime);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool TerminateProcess(
+        SafeProcessHandle processHandle,
+        uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint WaitForSingleObject(
+        SafeProcessHandle handle,
+        uint milliseconds);
+}

--- a/src/ExcelMcp.ComInterop/Session/SessionManager.cs
+++ b/src/ExcelMcp.ComInterop/Session/SessionManager.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -26,7 +28,7 @@ namespace Sbroenne.ExcelMcp.ComInterop.Session;
 /// </remarks>
 public sealed class SessionManager : IDisposable
 {
-    private static readonly ConcurrentDictionary<int, byte> _trackedExcelPids = new();
+    private static readonly ConcurrentDictionary<ExcelProcessIdentity, byte> _trackedExcelProcesses = new();
     private static int _processExitRegistered;
 
     /// <summary>
@@ -36,12 +38,40 @@ public sealed class SessionManager : IDisposable
     public static event Action<IReadOnlyCollection<int>>? TrackedExcelProcessesChanged;
 
     /// <summary>
+    /// Raised with PID/start-time identities whenever owned Excel processes change.
+    /// </summary>
+    public static event Action<IReadOnlyCollection<ExcelProcessIdentity>>? TrackedExcelProcessIdentitiesChanged;
+
+    /// <summary>
+    /// Invoked synchronously when a new identity is first tracked so in-process
+    /// owners can durably persist it before session startup continues.
+    /// </summary>
+    internal static event Action<ExcelProcessIdentity>? ExcelProcessIdentityTracked;
+
+    /// <summary>
     /// Registers an Excel process ID for cleanup on unexpected process exit.
     /// Called from ExcelBatch when a PID is captured.
     /// </summary>
-    public static void TrackExcelProcess(int processId)
+    public static void TrackExcelProcess(int processId) =>
+        _ = TrackExcelProcessIdentity(processId);
+
+    /// <summary>
+    /// Registers an Excel process and returns its captured PID/start-time identity.
+    /// </summary>
+    public static ExcelProcessIdentity? TrackExcelProcessIdentity(int processId)
     {
-        _trackedExcelPids[processId] = 0;
+        if (!TryCaptureExcelProcessIdentity(processId, out var identity))
+        {
+            return null;
+        }
+
+        TrackExcelProcess(identity);
+        return identity;
+    }
+
+    internal static void TrackExcelProcess(ExcelProcessIdentity identity)
+    {
+        _trackedExcelProcesses[identity] = 0;
 
         // Register handler exactly once (thread-safe)
         if (Interlocked.CompareExchange(ref _processExitRegistered, 1, 0) == 0)
@@ -49,6 +79,7 @@ public sealed class SessionManager : IDisposable
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
         }
 
+        NotifyExcelProcessIdentityTracked(identity);
         NotifyTrackedExcelProcessesChanged();
     }
 
@@ -57,27 +88,56 @@ public sealed class SessionManager : IDisposable
     /// </summary>
     public static void UntrackExcelProcess(int processId)
     {
-        _trackedExcelPids.TryRemove(processId, out _);
+        foreach (var identity in _trackedExcelProcesses.Keys
+                     .Where(process => process.ProcessId == processId))
+        {
+            _trackedExcelProcesses.TryRemove(identity, out _);
+        }
+
         NotifyTrackedExcelProcessesChanged();
     }
 
     /// <summary>
-    /// Returns a snapshot of Excel process IDs currently owned by this process.
+    /// Marks one exact PID/start-time identity as no longer needing cleanup.
     /// </summary>
-    public static IReadOnlyCollection<int> GetTrackedExcelProcessIds() => _trackedExcelPids.Keys.ToArray();
+    public static void UntrackExcelProcess(ExcelProcessIdentity identity)
+    {
+        _trackedExcelProcesses.TryRemove(identity, out _);
+        NotifyTrackedExcelProcessesChanged();
+    }
+
+    /// <summary>
+    /// Returns a snapshot of Excel process identities currently owned by this process.
+    /// </summary>
+    public static IReadOnlyCollection<ExcelProcessIdentity> GetTrackedExcelProcesses() =>
+        _trackedExcelProcesses.Keys.ToArray();
+
+    /// <summary>
+    /// Returns the PIDs currently tracked for backward compatibility.
+    /// </summary>
+    public static IReadOnlyCollection<int> GetTrackedExcelProcessIds() =>
+        _trackedExcelProcesses.Keys
+            .Select(process => process.ProcessId)
+            .Distinct()
+            .ToArray();
 
     private static void NotifyTrackedExcelProcessesChanged()
     {
-        var subscribers = TrackedExcelProcessesChanged;
-        if (subscribers is null)
+        var legacySubscribers = TrackedExcelProcessesChanged;
+        var identitySubscribers = TrackedExcelProcessIdentitiesChanged;
+        if (legacySubscribers is null && identitySubscribers is null)
         {
             return;
         }
 
-        var processIds = GetTrackedExcelProcessIds();
+        var processes = GetTrackedExcelProcesses();
+        var processIds = processes
+            .Select(process => process.ProcessId)
+            .Distinct()
+            .ToArray();
         _ = Task.Run(() =>
         {
-            foreach (var subscriber in subscribers.GetInvocationList())
+            foreach (var subscriber in legacySubscribers?.GetInvocationList() ?? [])
             {
                 try
                 {
@@ -90,7 +150,42 @@ public sealed class SessionManager : IDisposable
                         ex.Message);
                 }
             }
+
+            foreach (var subscriber in identitySubscribers?.GetInvocationList() ?? [])
+            {
+                try
+                {
+                    ((Action<IReadOnlyCollection<ExcelProcessIdentity>>)subscriber)(processes);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning(
+                        "Tracked Excel process identity notification failed: {0}",
+                        ex.Message);
+                }
+            }
         });
+    }
+
+    private static void NotifyExcelProcessIdentityTracked(ExcelProcessIdentity identity)
+    {
+        var subscribers = ExcelProcessIdentityTracked;
+        if (subscribers is null)
+        {
+            return;
+        }
+
+        foreach (var subscriber in subscribers.GetInvocationList())
+        {
+            try
+            {
+                ((Action<ExcelProcessIdentity>)subscriber)(identity);
+            }
+            catch (Exception ex)
+            {
+                throw new ExcelProcessPersistenceException(identity, ex);
+            }
+        }
     }
 
     private static void OnProcessExit(object? sender, EventArgs e)
@@ -100,21 +195,29 @@ public sealed class SessionManager : IDisposable
         int alreadyExitedCount = 0;
         int failedCount = 0;
 
-        foreach (var pid in _trackedExcelPids.Keys)
+        foreach (var identity in _trackedExcelProcesses.Keys)
         {
             try
             {
-                using var proc = System.Diagnostics.Process.GetProcessById(pid);
-                if (!proc.HasExited)
+                var stopped = OwnedProcessGuard.TryTerminate(
+                        identity,
+                        TimeSpan.Zero,
+                        TimeSpan.FromSeconds(5),
+                        out var terminated);
+                if (stopped && terminated)
                 {
-                    proc.Kill();
                     killedCount++;
                     // Note: Cannot use ILogger here - ProcessExit handler runs during AppDomain teardown
-                    SessionDiagnostics.WriteStdErr($"[DIAG-PROCESSEXIT-KILLED] Force-killed Excel process {pid}");
+                    SessionDiagnostics.WriteStdErr($"[DIAG-PROCESSEXIT-KILLED] Force-killed Excel process {identity.ProcessId}");
+                }
+                else if (stopped)
+                {
+                    alreadyExitedCount++;
                 }
                 else
                 {
-                    alreadyExitedCount++;
+                    failedCount++;
+                    SessionDiagnostics.WriteStdErr($"[DIAG-PROCESSEXIT-FAILED] Failed to kill Excel process {identity.ProcessId}");
                 }
             }
             catch (ArgumentException)
@@ -126,14 +229,49 @@ public sealed class SessionManager : IDisposable
             {
                 // Process inaccessible
                 failedCount++;
-                SessionDiagnostics.WriteStdErr($"[DIAG-PROCESSEXIT-FAILED] Failed to kill Excel process {pid}: {ex.Message}");
+                SessionDiagnostics.WriteStdErr($"[DIAG-PROCESSEXIT-FAILED] Failed to kill Excel process {identity.ProcessId}: {ex.Message}");
             }
         }
 
         // Summary log
         if (killedCount > 0 || failedCount > 0)
         {
-            SessionDiagnostics.WriteStdErr($"[DIAG-PROCESSEXIT-SUMMARY] Killed={killedCount}, AlreadyExited={alreadyExitedCount}, Failed={failedCount}, Total={_trackedExcelPids.Count}");
+            SessionDiagnostics.WriteStdErr($"[DIAG-PROCESSEXIT-SUMMARY] Killed={killedCount}, AlreadyExited={alreadyExitedCount}, Failed={failedCount}, Total={_trackedExcelProcesses.Count}");
+        }
+    }
+
+    private static bool TryCaptureExcelProcessIdentity(
+        int processId,
+        out ExcelProcessIdentity identity)
+    {
+        identity = default;
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            if (process.HasExited)
+            {
+                return false;
+            }
+
+            identity = new ExcelProcessIdentity(
+                processId,
+                process.StartTime.ToUniversalTime().ToFileTimeUtc());
+            return true;
+        }
+        catch (ArgumentException ex)
+        {
+            Trace.TraceWarning("Could not track Excel process {0}: {1}", processId, ex.Message);
+            return false;
+        }
+        catch (InvalidOperationException ex)
+        {
+            Trace.TraceWarning("Could not track Excel process {0}: {1}", processId, ex.Message);
+            return false;
+        }
+        catch (Win32Exception ex)
+        {
+            Trace.TraceWarning("Could not track Excel process {0}: {1}", processId, ex.Message);
+            return false;
         }
     }
 
@@ -143,7 +281,7 @@ public sealed class SessionManager : IDisposable
     private readonly ConcurrentDictionary<string, int> _activeOperationCounts = new();
     private readonly ConcurrentDictionary<string, object> _sessionLocks = new();
     private readonly ConcurrentDictionary<string, byte> _closingSessions = new();
-    private readonly ConcurrentDictionary<string, string> _teardownFailures = new();
+    private readonly ConcurrentDictionary<string, ExceptionDispatchInfo> _teardownFailures = new();
     private readonly ConcurrentDictionary<string, bool> _showExcelFlags = new();
     private readonly ConcurrentDictionary<string, SessionOrigin> _sessionOrigins = new();
     private readonly ConcurrentDictionary<string, DateTime> _sessionCreatedAt = new();
@@ -212,23 +350,26 @@ public sealed class SessionManager : IDisposable
         // Normalize file path for comparison
         string normalizedPath = Path.GetFullPath(filePath);
 
-        // Reject external file-access failures before starting Excel. ExcelBatch
-        // repeats this check on its STA thread to cover locks acquired after preflight.
-        if (!FileAccessValidator.IsIrmProtected(normalizedPath))
-        {
-            FileAccessValidator.ValidateFileNotLocked(normalizedPath);
-        }
-
         // Generate unique session ID
         string sessionId = Guid.NewGuid().ToString("N");
         if (!TryClaimFilePath(normalizedPath, sessionId))
         {
-            throw new InvalidOperationException($"File '{filePath}' is already open or reserved by another session. Excel cannot open the same file multiple times.");
+            throw new InvalidOperationException(
+                $"File '{filePath}' is already open in another session or reserved for one. " +
+                "Excel cannot open the same file multiple times.");
         }
 
         IExcelBatch? batch = null;
         try
         {
+            // Reject external file-access failures after the in-process path claim,
+            // so a duplicate session reports its canonical ownership error instead
+            // of being mistaken for an unrelated OS-level file lock.
+            if (!FileAccessValidator.IsIrmProtected(normalizedPath))
+            {
+                FileAccessValidator.ValidateFileNotLocked(normalizedPath);
+            }
+
             // Create batch session using Core API with retry for transient COM failures
             // (e.g., CO_E_SERVER_EXEC_FAILURE when system resources are constrained)
             batch = _sessionCreationPipeline.Execute(() => ExcelSession.BeginBatch(show, operationTimeout, filePath));
@@ -407,6 +548,12 @@ public sealed class SessionManager : IDisposable
     /// </summary>
     private void CleanupDeadSession(string sessionId, IExcelBatch batch)
     {
+        if (_teardownFailures.ContainsKey(sessionId)
+            && !TryConfirmFailedTeardown(batch))
+        {
+            return;
+        }
+
         RemoveSessionTracking(sessionId, removeSessionLock: true);
 
         // Dispose the batch (best effort - process is already dead)
@@ -487,7 +634,8 @@ public sealed class SessionManager : IDisposable
         {
             if (_teardownFailures.TryGetValue(sessionId, out var teardownFailure))
             {
-                errorMessage = $"Session '{sessionId}' is quarantined after a failed close: {teardownFailure}";
+                errorMessage = $"Session '{sessionId}' is quarantined after a failed close: " +
+                               teardownFailure.SourceException.Message;
                 return false;
             }
 
@@ -605,6 +753,16 @@ public sealed class SessionManager : IDisposable
             return new CloseValidationResult(false, false, 0, $"Session '{sessionId}' not found");
         }
 
+        if (_teardownFailures.TryGetValue(sessionId, out var teardownFailure))
+        {
+            return new CloseValidationResult(
+                true,
+                false,
+                0,
+                $"Session '{sessionId}' is quarantined after a failed close: " +
+                teardownFailure.SourceException.Message);
+        }
+
         var activeOps = GetActiveOperationCount(sessionId);
         var isVisible = IsExcelVisible(sessionId);
 
@@ -637,10 +795,32 @@ public sealed class SessionManager : IDisposable
 
         var sessionLock = GetSessionLock(sessionId);
         IExcelBatch batch;
+        var resolvedFailedTeardown = false;
         lock (sessionLock)
         {
+            if (!_activeSessions.TryGetValue(sessionId, out batch!))
+            {
+                return false;
+            }
+
+            if (_teardownFailures.TryGetValue(sessionId, out var teardownFailure))
+            {
+                if (!TryConfirmFailedTeardown(batch))
+                {
+                    teardownFailure.Throw();
+                }
+
+                RemoveSessionTracking(sessionId, removeSessionLock: false);
+                resolvedFailedTeardown = true;
+            }
+
+            if (resolvedFailedTeardown)
+            {
+                _closingSessions.TryRemove(sessionId, out _);
+            }
+
             // Check for running operations (unless force is true)
-            if (!force)
+            if (!resolvedFailedTeardown && !force)
             {
                 var activeOps = GetActiveOperationCount(sessionId);
                 if (activeOps > 0)
@@ -651,12 +831,23 @@ public sealed class SessionManager : IDisposable
                 }
             }
 
-            if (!_activeSessions.TryGetValue(sessionId, out batch!))
+            if (!resolvedFailedTeardown && save && batch.HasTimedOutOperation)
             {
-                return false;
+                throw new InvalidOperationException(
+                    $"A previous operation on session '{sessionId}' timed out or was cancelled. " +
+                    "Close without saving and reopen the workbook before retrying.");
             }
 
-            _closingSessions[sessionId] = 0;
+            if (!resolvedFailedTeardown)
+            {
+                _closingSessions[sessionId] = 0;
+            }
+        }
+
+        if (resolvedFailedTeardown)
+        {
+            _sessionLocks.TryRemove(sessionId, out _);
+            return true;
         }
 
         var closeSucceeded = false;
@@ -701,8 +892,11 @@ public sealed class SessionManager : IDisposable
         }
         catch (Exception ex)
         {
-            _teardownFailures[sessionId] = ex.Message;
-            throw new InvalidOperationException($"Failed to dispose session '{sessionId}': {ex.Message}", ex);
+            var closeFailure = new InvalidOperationException(
+                $"Failed to dispose session '{sessionId}': {ex.Message}",
+                ex);
+            _teardownFailures[sessionId] = ExceptionDispatchInfo.Capture(closeFailure);
+            throw closeFailure;
         }
 
         var sessionLock = GetSessionLock(sessionId);
@@ -713,6 +907,10 @@ public sealed class SessionManager : IDisposable
 
         _sessionLocks.TryRemove(sessionId, out _);
     }
+
+    private static bool TryConfirmFailedTeardown(IExcelBatch batch) =>
+        batch is IExcelBatchTeardownState teardownState
+        && teardownState.TryConfirmOwnedProcessTeardown();
 
     /// <summary>
     /// Gets the number of active sessions.
@@ -1027,5 +1225,8 @@ public sealed record CloseValidationResult(
     /// <summary>
     /// Whether the session can be closed (no blocking conditions).
     /// </summary>
-    public bool CanClose => SessionExists && ActiveOperationCount == 0;
+    public bool CanClose =>
+        SessionExists
+        && ActiveOperationCount == 0
+        && BlockingReason == null;
 }

--- a/src/ExcelMcp.Core/Attributes/AllowEmptyStringAttribute.cs
+++ b/src/ExcelMcp.Core/Attributes/AllowEmptyStringAttribute.cs
@@ -1,0 +1,10 @@
+namespace Sbroenne.ExcelMcp.Core.Attributes;
+
+/// <summary>
+/// Marks a required string parameter whose empty value has defined semantics.
+/// The parameter must still be supplied by public callers.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class AllowEmptyStringAttribute : Attribute
+{
+}

--- a/src/ExcelMcp.Core/Attributes/EnumAliasAttribute.cs
+++ b/src/ExcelMcp.Core/Attributes/EnumAliasAttribute.cs
@@ -1,0 +1,24 @@
+namespace Sbroenne.ExcelMcp.Core.Attributes;
+
+/// <summary>
+/// Declares an additional case-insensitive external name for an enum member.
+/// Generated CLI, service, and MCP parsing accepts the alias explicitly.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+public sealed class EnumAliasAttribute : Attribute
+{
+    /// <summary>
+    /// Creates an alias for an enum member.
+    /// </summary>
+    /// <param name="alias">External enum value accepted by generated parsers.</param>
+    public EnumAliasAttribute(string alias)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(alias);
+        Alias = alias;
+    }
+
+    /// <summary>
+    /// External enum value accepted by generated parsers.
+    /// </summary>
+    public string Alias { get; }
+}

--- a/src/ExcelMcp.Core/Commands/ConditionalFormat/IConditionalFormattingCommands.cs
+++ b/src/ExcelMcp.Core/Commands/ConditionalFormat/IConditionalFormattingCommands.cs
@@ -89,7 +89,7 @@ public interface IConditionalFormattingCommands
     [ServiceAction("add-rule")]
     OperationResult AddRule(
         IExcelBatch batch,
-        [RequiredParameter, FromString("sheetName")] string sheetName,
+        [RequiredParameter, AllowEmptyString, FromString("sheetName")] string sheetName,
         [RequiredParameter, FromString("rangeAddress")] string rangeAddress,
         [RequiredParameter, FromString("ruleType")] string ruleType,
         [FromString("operatorType")] string? operatorType,
@@ -141,13 +141,13 @@ public interface IConditionalFormattingCommands
     /// Excel COM: Range.FormatConditions.Delete()
     /// </summary>
     /// <param name="batch">Excel batch session</param>
-    /// <param name="sheetName">Target worksheet name</param>
+    /// <param name="sheetName">Target worksheet name (empty for active sheet)</param>
     /// <param name="rangeAddress">Range address to clear rules from (e.g., A1:D10)</param>
     /// <exception cref="InvalidOperationException">Sheet or range not found</exception>
     [ServiceAction("clear-rules")]
     OperationResult ClearRules(
         IExcelBatch batch,
-        [RequiredParameter, FromString("sheetName")] string sheetName,
+        [RequiredParameter, AllowEmptyString, FromString("sheetName")] string sheetName,
         [RequiredParameter, FromString("rangeAddress")] string rangeAddress);
 
     /// <summary>
@@ -167,7 +167,7 @@ public interface IConditionalFormattingCommands
     [ServiceAction("list-rules")]
     ConditionalFormatListResult ListRules(
         IExcelBatch batch,
-        [RequiredParameter, FromString("sheetName")] string sheetName,
+        [RequiredParameter, AllowEmptyString, FromString("sheetName")] string sheetName,
         [RequiredParameter, FromString("rangeAddress")] string rangeAddress);
 
     /// <summary>
@@ -182,6 +182,5 @@ public interface IConditionalFormattingCommands
     [ServiceAction("list-worksheet-rules")]
     ConditionalFormatListResult ListWorksheetRules(
         IExcelBatch batch,
-        [RequiredParameter, FromString("sheetName")] string sheetName);
+        [RequiredParameter, AllowEmptyString, FromString("sheetName")] string sheetName);
 }
-

--- a/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.Lifecycle.cs
+++ b/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.Lifecycle.cs
@@ -86,7 +86,7 @@ public partial class ConnectionCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            Excel.WorkbookConnection? conn = ComUtilities.FindConnection(ctx.Book, connectionName);
+            Excel.WorkbookConnection? conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
 
             if (conn == null)
             {
@@ -167,7 +167,7 @@ public partial class ConnectionCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            Excel.WorkbookConnection? conn = ComUtilities.FindConnection(ctx.Book, connectionName);
+            Excel.WorkbookConnection? conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
 
             if (conn == null)
             {
@@ -355,34 +355,33 @@ public partial class ConnectionCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            Excel.WorkbookConnection? conn = ComUtilities.FindConnection(ctx.Book, connectionName);
-
-            if (conn == null)
+            Excel.WorkbookConnection? conn = null;
+            try
             {
-                throw new InvalidOperationException($"Connection '{connectionName}' not found.");
-            }
+                conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
 
-            // Check if this is a Power Query connection
-            if (PowerQueryHelpers.IsPowerQueryConnection(conn))
-            {
-                // Check if this is an orphaned Power Query connection (no corresponding query exists)
-                // Orphaned connections can be safely deleted via the connection API
-                if (!PowerQueryHelpers.IsOrphanedPowerQueryConnection(ctx.Book, conn))
+                if (conn == null)
                 {
-                    throw new InvalidOperationException($"Connection '{connectionName}' is a Power Query connection. Use powerquery with action 'Delete' instead.");
+                    throw new InvalidOperationException($"Connection '{connectionName}' not found.");
                 }
-                // Orphaned connection - allow deletion to proceed
+
+                if (PowerQueryHelpers.IsPowerQueryConnection(conn) &&
+                    !PowerQueryHelpers.IsOrphanedPowerQueryConnection(ctx.Book, conn))
+                {
+                    throw new InvalidOperationException(
+                        $"Connection '{connectionName}' is a Power Query connection. Use powerquery with action 'delete' instead.");
+                }
+
+                PowerQueryHelpers.RemoveQueryTables(ctx.Book, conn);
+                ComUtilities.Release(ref conn);
+                conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
+                conn?.Delete();
+                return new OperationResult { Success = true, FilePath = batch.WorkbookPath };
             }
-
-            // Remove associated QueryTables first
-            PowerQueryHelpers.RemoveQueryTables(ctx.Book, connectionName);
-
-            // Delete the connection
-            conn.Delete();
-            return new OperationResult { Success = true, FilePath = batch.WorkbookPath };
+            finally
+            {
+                ComUtilities.Release(ref conn);
+            }
         });
     }
 }
-
-
-

--- a/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.Operations.cs
+++ b/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.Operations.cs
@@ -26,7 +26,7 @@ public partial class ConnectionCommands
 
             try
             {
-                conn = ComUtilities.FindConnection(ctx.Book, connectionName);
+                conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
 
                 if (conn == null)
                 {
@@ -38,6 +38,19 @@ public partial class ConnectionCommands
                 {
                     throw new InvalidOperationException($"Connection '{connectionName}' is a Power Query connection. Use 'pq-loadto' command instead.");
                 }
+
+                var definition = new ConnectionDefinition
+                {
+                    Name = connectionName,
+                    Description = conn.Description,
+                    ConnectionString = GetConnectionString(conn),
+                    CommandText = GetCommandText(conn),
+                    CommandType = GetCommandType(conn),
+                    BackgroundQuery = GetBackgroundQuerySetting(conn),
+                    RefreshOnFileOpen = GetRefreshOnFileOpenSetting(conn),
+                    SavePassword = GetSavePasswordSetting(conn),
+                    RefreshPeriod = GetRefreshPeriod(conn)
+                };
 
                 // Find or create target sheet
                 sheets = ctx.Book.Worksheets;
@@ -68,7 +81,17 @@ public partial class ConnectionCommands
                 }
 
                 // Remove existing QueryTables first
-                PowerQueryHelpers.RemoveQueryTables(ctx.Book, connectionName);
+                PowerQueryHelpers.RemoveQueryTables(ctx.Book, conn);
+                ComUtilities.Release(ref conn);
+                conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
+                if (conn == null)
+                {
+                    CreateConnection(ctx.Book, connectionName, definition);
+                    conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName)
+                        ?? throw new InvalidOperationException(
+                            $"Connection '{connectionName}' could not be recreated after replacing its QueryTables.");
+                    UpdateConnectionProperties(conn, definition);
+                }
 
                 // Create QueryTable to load data
                 var options = new PowerQueryHelpers.QueryTableOptions
@@ -97,7 +120,7 @@ public partial class ConnectionCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            Excel.WorkbookConnection? conn = ComUtilities.FindConnection(ctx.Book, connectionName);
+            Excel.WorkbookConnection? conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
 
             if (conn == null)
             {
@@ -127,6 +150,3 @@ public partial class ConnectionCommands
         });
     }
 }
-
-
-

--- a/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.Properties.cs
+++ b/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.Properties.cs
@@ -1,4 +1,3 @@
-using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Models;
 using Sbroenne.ExcelMcp.Core.PowerQuery;
@@ -22,7 +21,7 @@ public partial class ConnectionCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            Excel.WorkbookConnection? conn = ComUtilities.FindConnection(ctx.Book, connectionName);
+            Excel.WorkbookConnection? conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
 
             if (conn == null)
             {
@@ -47,7 +46,7 @@ public partial class ConnectionCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            Excel.WorkbookConnection? conn = ComUtilities.FindConnection(ctx.Book, connectionName);
+            Excel.WorkbookConnection? conn = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
 
             if (conn == null)
             {
@@ -90,6 +89,4 @@ public partial class ConnectionCommands
         });
     }
 }
-
-
 

--- a/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.RefreshControl.cs
+++ b/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.RefreshControl.cs
@@ -1,6 +1,7 @@
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Models;
+using Sbroenne.ExcelMcp.Core.PowerQuery;
 using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.Core.Commands;
@@ -12,7 +13,7 @@ public partial class ConnectionCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            Excel.WorkbookConnection? connection = ComUtilities.FindConnection(ctx.Book, connectionName);
+            Excel.WorkbookConnection? connection = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
             try
             {
                 if (connection == null)
@@ -41,7 +42,7 @@ public partial class ConnectionCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            Excel.WorkbookConnection? connection = ComUtilities.FindConnection(ctx.Book, connectionName);
+            Excel.WorkbookConnection? connection = PowerQueryHelpers.FindConnectionByExactName(ctx.Book, connectionName);
             try
             {
                 if (connection == null)

--- a/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Connection/ConnectionCommands.cs
@@ -970,7 +970,7 @@ public partial class ConnectionCommands : IConnectionCommands
         {
             queryTables = targetSheet.QueryTables;
             range = targetSheet.Range["A1"];
-            queryTable = queryTables.Add(connectionString, range, commandText);
+            queryTable = queryTables.Add(conn, range, commandText);
 
             queryTable.Name = options.Name.Replace(" ", "_");
             queryTable.RefreshStyle = 1; // xlInsertDeleteCells
@@ -1023,5 +1023,4 @@ internal sealed class ConnectionDefinition
     public bool? SavePassword { get; set; }
     public int? RefreshPeriod { get; set; }
 }
-
 

--- a/src/ExcelMcp.Core/Commands/Connection/IConnectionCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Connection/IConnectionCommands.cs
@@ -12,7 +12,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 /// </summary>
 [ServiceCategory("connection", "Connection")]
 [McpTool("connection", Title = "Data Connection Operations", Destructive = true, Category = "query",
-    Description = "Data connections (OLEDB, ODBC, ODC import). TEXT/WEB/CSV: Use querytable for direct local imports or powerquery for transformations. Power Query connections redirect to powerquery. Typed OLEDB/ODBC refresh status and cancellation are available. TIMEOUT: 30 min auto-timeout for refresh/loadto.")]
+    Description = "Data connections (OLEDB, ODBC, ODC import). TEXT/WEB/CSV: Use querytable for direct local imports or powerquery for transformations. Power Query connections redirect to powerquery by exact mashup Location identity. Delete/load-to cleanup follows the exact WorkbookConnection and preserves unrelated similarly named QueryTables. Typed OLEDB/ODBC refresh status and cancellation are available. TIMEOUT: 30 min auto-timeout for refresh/loadto.")]
 public interface IConnectionCommands
 {
     /// <summary>
@@ -52,7 +52,7 @@ public interface IConnectionCommands
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="connectionName">Name of the connection to refresh</param>
-    /// <param name="timeout">Optional timeout for the refresh operation</param>
+    /// <param name="timeout">Optional public timeout in whole seconds from 1 through 2147483; converted to TimeSpan at shared dispatch</param>
     [ServiceAction("refresh")]
     OperationResult Refresh(
         IExcelBatch batch,
@@ -60,8 +60,10 @@ public interface IConnectionCommands
         [FromString("timeout")] TimeSpan? timeout = null);
 
     /// <summary>
-    /// Gets refresh status for OLEDB and ODBC connections.
+    /// Gets refresh status for OLEDB and ODBC background refreshes started
+    /// outside the synchronous connection refresh action.
     /// Excel PIA exposes status on the typed sub-connection, not WorkbookConnection.
+    /// The synchronous refresh action occupies the session queue until completion.
     /// </summary>
     [ServiceAction("get-refresh-status")]
     RefreshStatusResult GetRefreshStatus(
@@ -69,7 +71,8 @@ public interface IConnectionCommands
         [RequiredParameter, FromString("connectionName")] string connectionName);
 
     /// <summary>
-    /// Cancels an active OLEDB or ODBC refresh.
+    /// Cancels an active OLEDB or ODBC background refresh started outside the
+    /// synchronous connection refresh action.
     /// Returns an explicit unsupported result for connection types without a typed PIA cancellation API.
     /// </summary>
     [ServiceAction("cancel-refresh")]
@@ -78,7 +81,7 @@ public interface IConnectionCommands
         [RequiredParameter, FromString("connectionName")] string connectionName);
 
     /// <summary>
-    /// Deletes a connection
+    /// Deletes a connection and QueryTables owned by that exact WorkbookConnection.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="connectionName">Name of the connection to delete</param>
@@ -88,7 +91,8 @@ public interface IConnectionCommands
         [RequiredParameter, FromString("connectionName")] string connectionName);
 
     /// <summary>
-    /// Loads connection data to a worksheet
+    /// Loads connection data to a worksheet, replacing only QueryTables owned by
+    /// the exact WorkbookConnection.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="connectionName">Name of the connection</param>
@@ -143,4 +147,3 @@ public interface IConnectionCommands
         IExcelBatch batch,
         [RequiredParameter, FromString("connectionName")] string connectionName);
 }
-

--- a/src/ExcelMcp.Core/Commands/DataModel/DataModelCommands.RenameTable.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/DataModelCommands.RenameTable.cs
@@ -113,24 +113,23 @@ public partial class DataModelCommands
                     return result;
                 }
 
-                // Extract Power Query name from connection (format: "Query - {QueryName}")
                 string connectionName = sourceConnection.Name?.ToString() ?? string.Empty;
-                if (!connectionName.StartsWith("Query - ", StringComparison.OrdinalIgnoreCase))
+                if (!PowerQuery.PowerQueryHelpers.TryGetMashupLocation(
+                    sourceConnection,
+                    out var pqName))
                 {
                     result.Success = false;
                     result.ErrorMessage = $"Cannot rename table '{result.NormalizedOldName}': " +
-                        "Power Query connection name format is unexpected: '{connectionName}'.";
+                        $"Power Query connection '{connectionName}' has no exact mashup Location identity.";
                     return result;
                 }
-
-                string pqName = connectionName["Query - ".Length..];
 
                 // Find and rename the underlying Power Query
                 dynamic? targetQuery = null;
                 dynamic? oleDbConnection = null;
                 try
                 {
-                    targetQuery = ComUtilities.FindQuery(ctx.Book, pqName);
+                    targetQuery = PowerQuery.PowerQueryHelpers.FindQueryByExactName(ctx.Book, pqName);
                     if (targetQuery == null)
                     {
                         result.Success = false;
@@ -155,17 +154,12 @@ public partial class DataModelCommands
                         string? currentConnectionString = oleDbConnection.Connection?.ToString();
                         if (!string.IsNullOrEmpty(currentConnectionString))
                         {
-                            // Replace Location={oldName} with Location={newName}
-                            // Handle both exact match and partial match scenarios
-                            string oldLocation = $"Location={pqName}";
-                            string newLocation = $"Location={result.NormalizedNewName}";
-
-                            if (currentConnectionString.Contains(oldLocation, StringComparison.OrdinalIgnoreCase))
+                            if (PowerQuery.PowerQueryHelpers.TryReplaceMashupLocation(
+                                currentConnectionString,
+                                pqName,
+                                result.NormalizedNewName,
+                                out var newConnectionString))
                             {
-                                string newConnectionString = currentConnectionString.Replace(
-                                    oldLocation,
-                                    newLocation,
-                                    StringComparison.OrdinalIgnoreCase);
                                 oleDbConnection.Connection = newConnectionString;
                             }
                         }
@@ -219,18 +213,14 @@ public partial class DataModelCommands
                         if (oleDbConnection != null)
                         {
                             string? currentConnectionString = oleDbConnection.Connection?.ToString();
-                            if (!string.IsNullOrEmpty(currentConnectionString))
+                            if (!string.IsNullOrEmpty(currentConnectionString) &&
+                                PowerQuery.PowerQueryHelpers.TryReplaceMashupLocation(
+                                    currentConnectionString,
+                                    result.NormalizedNewName,
+                                    pqName,
+                                    out var restoredConnectionString))
                             {
-                                string newLocation = $"Location={result.NormalizedNewName}";
-                                string oldLocation = $"Location={pqName}";
-                                if (currentConnectionString.Contains(newLocation, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    string restoredConnectionString = currentConnectionString.Replace(
-                                        newLocation,
-                                        oldLocation,
-                                        StringComparison.OrdinalIgnoreCase);
-                                    oleDbConnection.Connection = restoredConnectionString;
-                                }
+                                oleDbConnection.Connection = restoredConnectionString;
                             }
                         }
                     }
@@ -263,4 +253,3 @@ public partial class DataModelCommands
         });
     }
 }
-

--- a/src/ExcelMcp.Core/Commands/DataModel/IDataModelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/IDataModelCommands.cs
@@ -143,7 +143,7 @@ public interface IDataModelCommands
     /// </summary>
     /// <param name="batch">Excel batch context for accessing workbook</param>
     /// <param name="tableName">Optional: Specific table to refresh (if null, refreshes entire model)</param>
-    /// <param name="timeout">Optional: Timeout for the refresh operation</param>
+    /// <param name="timeout">Optional public timeout in whole seconds from 1 through 2147483; converted to TimeSpan at shared dispatch</param>
     /// <exception cref="InvalidOperationException">Thrown when refresh operation fails</exception>
     [ServiceAction("refresh")]
     OperationResult Refresh(IExcelBatch batch, string? tableName = null, TimeSpan? timeout = null);
@@ -156,7 +156,7 @@ public interface IDataModelCommands
     /// <param name="batch">Excel batch context for accessing workbook</param>
     /// <param name="tableName">Name of the table to add the measure to</param>
     /// <param name="measureName">Name of the new measure</param>
-    /// <param name="daxFormula">DAX formula for the measure</param>
+    /// <param name="daxFormula">DAX formula. Public callers must supply either inline daxFormula or a readable daxFormulaFile, not both.</param>
     /// <param name="formatType">Optional: Format type (Currency, Decimal, Percentage, General)</param>
     /// <param name="description">Optional: Description of the measure</param>
     /// <param name="formatDax">Whether to send the DAX formula to the remote daxformatter.com service before saving. Defaults to false to preserve privacy.</param>
@@ -179,7 +179,7 @@ public interface IDataModelCommands
     /// </summary>
     /// <param name="batch">Excel batch context for accessing workbook</param>
     /// <param name="measureName">Name of the measure to update</param>
-    /// <param name="daxFormula">Optional: New DAX formula (null to keep existing)</param>
+    /// <param name="daxFormula">Optional new DAX formula. Public callers may supply inline daxFormula or a readable daxFormulaFile, not both.</param>
     /// <param name="formatType">Optional: New format type (null to keep existing)</param>
     /// <param name="description">Optional: New description (null to keep existing)</param>
     /// <param name="formatDax">Whether to send the DAX formula to the remote daxformatter.com service before saving. Defaults to false to preserve privacy.</param>
@@ -200,7 +200,7 @@ public interface IDataModelCommands
     /// The query should start with EVALUATE and return a table result.
     /// </summary>
     /// <param name="batch">Excel batch context for accessing workbook</param>
-    /// <param name="daxQuery">DAX EVALUATE query (e.g., "EVALUATE 'TableName'" or "EVALUATE SUMMARIZE(...)")</param>
+    /// <param name="daxQuery">DAX EVALUATE query. Public callers must supply either inline daxQuery or a readable daxQueryFile, not both.</param>
     /// <returns>Result containing column names and data rows from the DAX query</returns>
     /// <exception cref="ArgumentException">Thrown when daxQuery is empty</exception>
     /// <exception cref="InvalidOperationException">Thrown when workbook has no Data Model or query execution fails</exception>
@@ -213,7 +213,7 @@ public interface IDataModelCommands
     /// DMV queries retrieve metadata about the Data Model (tables, columns, measures, relationships, etc.).
     /// </summary>
     /// <param name="batch">Excel batch context for accessing workbook</param>
-    /// <param name="dmvQuery">DMV query in SQL-like syntax (e.g., "SELECT * FROM $SYSTEM.TMSCHEMA_TABLES")</param>
+    /// <param name="dmvQuery">DMV query in SQL-like syntax. Public callers must supply either inline dmvQuery or a readable dmvQueryFile, not both.</param>
     /// <returns>Result containing column names and data rows from the DMV query</returns>
     /// <exception cref="ArgumentException">Thrown when dmvQuery is empty</exception>
     /// <exception cref="InvalidOperationException">Thrown when workbook has no Data Model or query execution fails</exception>
@@ -228,5 +228,4 @@ public interface IDataModelCommands
     [ServiceAction("execute-dmv")]
     DmvQueryResult ExecuteDmv(IExcelBatch batch, [RequiredParameter, FileOrValue] string dmvQuery);
 }
-
 

--- a/src/ExcelMcp.Core/Commands/FileCommands.cs
+++ b/src/ExcelMcp.Core/Commands/FileCommands.cs
@@ -1,5 +1,6 @@
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.Core.Models;
+using Sbroenne.ExcelMcp.Core.Utilities;
 
 namespace Sbroenne.ExcelMcp.Core.Commands;
 
@@ -11,11 +12,14 @@ public class FileCommands : IFileCommands
     /// <inheritdoc />
     public FileValidationInfo Test(string filePath)
     {
-        filePath = Path.GetFullPath(filePath);
+        filePath = FilePathValidation.NormalizeAbsoluteWindowsPath(filePath);
 
         bool exists = File.Exists(filePath);
         string extension = Path.GetExtension(filePath).ToLowerInvariant();
         bool isValidExtension = extension is ".xlsx" or ".xlsm";
+        bool isIrmProtected = exists && isValidExtension && FileAccessValidator.IsIrmProtected(filePath);
+        bool isValid = false;
+        bool canOpen = false;
 
         long size = 0;
         DateTime lastModified = DateTime.MinValue;
@@ -31,6 +35,46 @@ public class FileCommands : IFileCommands
             ? $"File not found: {filePath}"
             : !isValidExtension ? $"Invalid file extension. Expected .xlsx or .xlsm, got {extension}" : null;
 
+        if (exists && isValidExtension)
+        {
+            try
+            {
+                if (isIrmProtected)
+                {
+                    using var readTest = new FileStream(
+                        filePath,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.ReadWrite);
+                    message =
+                        "IRM/AIP protection detected. Container validity and openability require " +
+                        "an interactive Excel open; use show=true. ExcelMcp will open this file read-only.";
+                }
+                else
+                {
+                    FileAccessValidator.ValidateFileNotLocked(filePath);
+                    isValid = FileAccessValidator.HasValidWorkbookContainer(filePath);
+                    canOpen = isValid;
+                    if (!isValid)
+                    {
+                        message = $"File is not a valid Excel workbook container: {filePath}";
+                    }
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                message = ex.Message;
+            }
+            catch (IOException ex)
+            {
+                message = $"Cannot read '{Path.GetFileName(filePath)}': {ex.Message}";
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                message = $"Cannot read '{Path.GetFileName(filePath)}': {ex.Message}";
+            }
+        }
+
         return new FileValidationInfo
         {
             FilePath = filePath,
@@ -38,14 +82,13 @@ public class FileCommands : IFileCommands
             Size = size,
             Extension = extension,
             LastModified = lastModified,
-            IsValid = exists && isValidExtension,
-            IsIrmProtected = exists && FileAccessValidator.IsIrmProtected(filePath),
+            IsValid = isValid,
+            CanOpen = canOpen,
+            IsIrmProtected = isIrmProtected,
+            WillOpenReadOnly = isIrmProtected,
+            RequiresVisibleSession = isIrmProtected,
             Message = message
         };
     }
 
 }
-
-
-
-

--- a/src/ExcelMcp.Core/Commands/IFileCommands.cs
+++ b/src/ExcelMcp.Core/Commands/IFileCommands.cs
@@ -8,12 +8,12 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 public interface IFileCommands
 {
     /// <summary>
-    /// Tests if a file exists and is a valid Excel file
+    /// Tests file existence, Excel extension validity, openability, and deterministic
+    /// IRM/AIP read-only and visible-session requirements without opening Excel
     /// </summary>
     /// <param name="filePath">Path to the Excel file to validate</param>
-    /// <returns>File validation details including existence, size, extension, and validity information</returns>
+    /// <returns>Canonical file metadata shared by CLI and MCP</returns>
     FileValidationInfo Test(string filePath);
 }
-
 
 

--- a/src/ExcelMcp.Core/Commands/PivotTable/IPivotTableCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PivotTable/IPivotTableCommands.cs
@@ -104,7 +104,7 @@ public interface IPivotTableCommands
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="pivotTableName">Name of the PivotTable to refresh</param>
-    /// <param name="timeout">Optional timeout for the refresh operation</param>
+    /// <param name="timeout">Optional public timeout in whole seconds from 1 through 2147483; converted to TimeSpan at shared dispatch</param>
     /// <returns>Refresh timestamp, record count, any structural changes</returns>
     [ServiceAction("refresh")]
     PivotTableRefreshResult Refresh(IExcelBatch batch, string pivotTableName, TimeSpan? timeout = null);
@@ -156,4 +156,3 @@ public interface IPivotTableCommands
         string pivotTableName,
         string cellAddress);
 }
-

--- a/src/ExcelMcp.Core/Commands/PowerQuery/IPowerQueryCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/IPowerQueryCommands.cs
@@ -20,28 +20,33 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 /// Without explicit types, dates may be stored as numbers and Data Model relationships may fail.
 ///
 /// DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'.
+/// Values are case-insensitive and unknown values are rejected.
 /// Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures.
 ///
 /// M-CODE: Preserved exactly by default. Set formatMCode=true only with explicit user consent;
 /// it sends M code to powerqueryformatter.com.
 ///
 /// TARGET CELL: targetCellAddress places tables without clearing sheet.
-/// TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60 or similar.
-/// timeout=0 or omitted uses the 30 min default.
+/// TIMEOUT: Refresh accepts a caller timeout; load-to uses the fixed 30-minute data-operation timeout.
+/// READS: list returns compact metadata, exact load state, and an M preview of at
+/// most 80 characters. Use view for one query's full M code.
 /// </summary>
 [ServiceCategory("powerquery", "PowerQuery")]
 [McpTool("powerquery", Title = "Power Query Operations", Destructive = true, Category = "query",
-    Description = "Power Query M code and data loading. TEST-FIRST WORKFLOW: 1. evaluate (test M code without persisting) 2. create/update (store validated query) 3. refresh/load-to (load data to destination). IF CREATE FAILS: Use evaluate for detailed M engine error. DATETIME: Always include Table.TransformColumnTypes() for explicit column types. DESTINATIONS: worksheet (default), data-model (for DAX), both, connection-only. M-CODE: Preserved exactly by default. Set formatMCode=true only with user consent; it sends M code to powerqueryformatter.com. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: 30 min auto-timeout for refresh and load-to. For quick queries, use timeout=60. timeout=0 or omitted uses the 30 min default.")]
+    Description = "Power Query M code and data loading. TEST-FIRST WORKFLOW: 1. evaluate (test M code without persisting) 2. create/update (store validated query) 3. refresh/load-to (load data to destination). IF CREATE FAILS: Use evaluate for detailed M engine error. READS: list returns compact metadata, exact load state, and an M preview of at most 80 characters; use view for one query's full M code. IDENTITY: Load detection, refresh, unload, and delete use the exact case-insensitive mashup Location, so prefix names remain isolated. EVALUATE: Temporary query, sheet, table, and connection cleanup is verified; cleanup failures return an error with recovery guidance. DATETIME: Always include Table.TransformColumnTypes() for explicit column types. DESTINATIONS: worksheet (default), data-model (for DAX), both, connection-only. Values are case-insensitive and unknown values are rejected. M-CODE: Preserved exactly by default. Set formatMCode=true only with user consent; it sends M code to powerqueryformatter.com. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: Refresh accepts a caller timeout; load-to uses the fixed 30-minute data-operation timeout.")]
 public interface IPowerQueryCommands
 {
     /// <summary>
-    /// Lists all Power Query queries in the workbook
+    /// Lists compact metadata for all Power Queries, including exact worksheet/Data Model
+    /// load state and an M formula preview bounded to 80 characters. Full M code is omitted;
+    /// use view for a single query's complete formula. Inspection failures fail the action
+    /// rather than silently omitting a query.
     /// </summary>
     [ServiceAction("list")]
     PowerQueryListResult List(IExcelBatch batch);
 
     /// <summary>
-    /// Views the M code of a Power Query
+    /// Views the full M code and exact worksheet/Data Model load state of a Power Query
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="queryName">Name of the query to view</param>
@@ -53,10 +58,10 @@ public interface IPowerQueryCommands
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="queryName">Name of the query to refresh</param>
-    /// <param name="timeout">Maximum time to wait for refresh</param>
+    /// <param name="timeout">Public input is whole seconds from 0 through 2147483. Omitted or 0 uses the 30-minute data-operation default.</param>
     /// <param name="progress">Optional progress reporter</param>
     [ServiceAction("refresh")]
-    PowerQueryRefreshResult Refresh(IExcelBatch batch, [RequiredParameter] string queryName, TimeSpan timeout, IProgress<ProgressInfo>? progress = null);
+    PowerQueryRefreshResult Refresh(IExcelBatch batch, [RequiredParameter] string queryName, TimeSpan timeout = default, IProgress<ProgressInfo>? progress = null);
 
     /// <summary>
     /// Gets the current load configuration of a Power Query
@@ -67,7 +72,7 @@ public interface IPowerQueryCommands
     PowerQueryLoadConfigResult GetLoadConfig(IExcelBatch batch, [RequiredParameter] string queryName);
 
     /// <summary>
-    /// Deletes a Power Query from the workbook
+    /// Deletes a Power Query and only the destinations with the exact mashup Location identity.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="queryName">Name of the query to delete</param>
@@ -81,7 +86,7 @@ public interface IPowerQueryCommands
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="queryName">Name for the new query</param>
-    /// <param name="mCode">Raw M code (inline string)</param>
+    /// <param name="mCode">Raw M code. Public callers must supply either inline mCode or a readable mCodeFile, not both.</param>
     /// <param name="loadMode">Load destination mode</param>
     /// <param name="targetSheet">Target worksheet name (required for LoadToTable and LoadToBoth; defaults to query name when omitted)</param>
     /// <param name="targetCellAddress">Optional target cell address for worksheet loads (e.g., "B5"). Required when loading to an existing worksheet with other data.</param>
@@ -101,7 +106,7 @@ public interface IPowerQueryCommands
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="queryName">Name of the query to update</param>
-    /// <param name="mCode">Raw M code (inline string)</param>
+    /// <param name="mCode">Raw M code. Public callers must supply either inline mCode or a readable mCodeFile, not both.</param>
     /// <param name="refresh">Whether to refresh data after update (default: true)</param>
     /// <param name="formatMCode">Whether to send M code to the remote powerqueryformatter.com service before saving. Defaults to false to preserve privacy.</param>
     /// <exception cref="InvalidOperationException">Thrown when the query is not found, M code is invalid, or refresh fails</exception>
@@ -132,7 +137,7 @@ public interface IPowerQueryCommands
     /// Batch refresh with error tracking.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
-    /// <param name="timeout">Maximum time to wait for all queries to refresh. Default: 30 minutes. Use a lower value for quick workbooks or higher for very large ones.</param>
+    /// <param name="timeout">Public input is whole seconds from 0 through 2147483. Omitted or 0 uses the 30-minute data-operation default.</param>
     /// <param name="progress">Optional progress reporter</param>
     /// <exception cref="InvalidOperationException">Thrown when any Power Query fails to refresh</exception>
     OperationResult RefreshAll(IExcelBatch batch, TimeSpan timeout = default, IProgress<ProgressInfo>? progress = null);
@@ -152,7 +157,7 @@ public interface IPowerQueryCommands
     RenameResult Rename(IExcelBatch batch, [RequiredParameter] string oldName, [RequiredParameter] string newName);
 
     /// <summary>
-    /// Converts query to connection-only by removing data from all destinations.
+    /// Converts query to connection-only by removing data from its exact destinations.
     /// Removes worksheet ListObjects AND Data Model connections, but keeps the query definition.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
@@ -163,11 +168,13 @@ public interface IPowerQueryCommands
 
     /// <summary>
     /// Evaluates M code and returns the result data without creating a permanent query.
-    /// Creates a temporary query, executes it, reads the results, then cleans up.
+    /// Creates a temporary query, executes it, reads the results, then cleans up every
+    /// exact temporary mashup connection regardless of Excel's display name.
+    /// Cleanup failures are surfaced and include recovery guidance.
     /// Useful for testing M code snippets and getting preview data.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
-    /// <param name="mCode">M code to evaluate</param>
+    /// <param name="mCode">M code to evaluate. Public callers must supply either inline mCode or a readable mCodeFile, not both.</param>
     /// <returns>Result containing evaluated data as columns/rows</returns>
     /// <exception cref="InvalidOperationException">Thrown when M code has errors</exception>
     [ServiceAction("evaluate")]

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Evaluate.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Evaluate.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Runtime.ExceptionServices;
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Models;
@@ -42,6 +43,7 @@ public partial class PowerQueryCommands
             dynamic? queryTable = null;
             dynamic? range = null;
             dynamic? usedRange = null;
+            Exception? operationError = null;
 
             try
             {
@@ -173,105 +175,119 @@ public partial class PowerQueryCommands
                     ComUtilities.Release(ref dataBodyRange);
                 }
 
-                result.Success = true;
             }
-            finally
+            catch (Exception ex)
             {
-                // STEP 6: Cleanup - delete temporary objects
-                // Order matters: delete table, sheet, query, connections
-
-                // Delete the ListObject (table)
-                try
-                {
-                    if (listObject != null)
-                    {
-                        listObject.Delete();
-                    }
-                }
-                catch (COMException) { /* ignore cleanup errors */ }
-
-                ComUtilities.Release(ref queryTable);
-                ComUtilities.Release(ref listObject);
-                ComUtilities.Release(ref listObjects);
-                ComUtilities.Release(ref range);
-                ComUtilities.Release(ref usedRange);
-
-                // Delete the temporary worksheet
-                try
-                {
-                    if (tempSheet != null)
-                    {
-                        // Suppress alerts to avoid "Are you sure you want to delete?" prompt
-                        dynamic? app = null;
-                        try
-                        {
-                            app = ctx.Book.Application;
-                            bool originalAlerts = app.DisplayAlerts;
-                            app.DisplayAlerts = false;
-                            try
-                            {
-                                tempSheet.Delete();
-                            }
-                            finally
-                            {
-                                app.DisplayAlerts = originalAlerts;
-                            }
-                        }
-                        finally
-                        {
-                            ComUtilities.Release(ref app);
-                        }
-                    }
-                }
-                catch (COMException) { /* ignore cleanup errors */ }
-
-                ComUtilities.Release(ref tempSheet);
-                ComUtilities.Release(ref worksheets);
-
-                // Delete the temporary query
-                try
-                {
-                    if (query != null)
-                    {
-                        query.Delete();
-                    }
-                }
-                catch (COMException) { /* ignore cleanup errors */ }
-
-                ComUtilities.Release(ref query);
-                ComUtilities.Release(ref queriesCollection);
-
-                // Clean up any lingering connections
-                dynamic? connections = null;
-                try
-                {
-                    connections = ctx.Book.Connections;
-                    for (int i = connections.Count; i >= 1; i--)
-                    {
-                        dynamic? conn = null;
-                        try
-                        {
-                            conn = connections.Item(i);
-                            string connName = conn.Name?.ToString() ?? "";
-                            if (connName.Contains(tempQueryName))
-                            {
-                                conn.Delete();
-                            }
-                        }
-                        catch (COMException) { /* ignore cleanup errors */ }
-                        finally
-                        {
-                            ComUtilities.Release(ref conn);
-                        }
-                    }
-                }
-                catch (COMException) { /* ignore cleanup errors */ }
-                finally
-                {
-                    ComUtilities.Release(ref connections);
-                }
+                operationError = ex;
             }
 
+            var cleanupErrors = new List<Exception>();
+            try
+            {
+                if (listObject != null)
+                {
+                    listObject.Delete();
+                }
+            }
+            catch (COMException ex)
+            {
+                cleanupErrors.Add(new InvalidOperationException(
+                    $"Failed to delete temporary evaluate table for '{tempQueryName}'.",
+                    ex));
+            }
+
+            ComUtilities.Release(ref queryTable);
+            ComUtilities.Release(ref listObject);
+            ComUtilities.Release(ref listObjects);
+            ComUtilities.Release(ref range);
+            ComUtilities.Release(ref usedRange);
+
+            try
+            {
+                if (tempSheet != null)
+                {
+                    // Suppress alerts to avoid "Are you sure you want to delete?" prompt
+                    dynamic? app = null;
+                    try
+                    {
+                        app = ctx.Book.Application;
+                        bool originalAlerts = app.DisplayAlerts;
+                        app.DisplayAlerts = false;
+                        try
+                        {
+                            tempSheet.Delete();
+                        }
+                        finally
+                        {
+                            app.DisplayAlerts = originalAlerts;
+                        }
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref app);
+                    }
+                }
+            }
+            catch (COMException ex)
+            {
+                cleanupErrors.Add(new InvalidOperationException(
+                    $"Failed to delete temporary evaluate worksheet '{tempSheetName}'.",
+                    ex));
+            }
+
+            ComUtilities.Release(ref tempSheet);
+            ComUtilities.Release(ref worksheets);
+
+            try
+            {
+                PowerQuery.PowerQueryHelpers.RemoveConnectionsByMashupLocation(
+                    ctx.Book,
+                    tempQueryName);
+            }
+            catch (Exception ex) when (ex is COMException or InvalidOperationException)
+            {
+                cleanupErrors.Add(new InvalidOperationException(
+                    $"Failed to delete temporary evaluate connections for '{tempQueryName}'.",
+                    ex));
+            }
+
+            try
+            {
+                if (query != null)
+                {
+                    query.Delete();
+                }
+            }
+            catch (COMException ex)
+            {
+                cleanupErrors.Add(new InvalidOperationException(
+                    $"Failed to delete temporary evaluate query '{tempQueryName}'.",
+                    ex));
+            }
+
+            ComUtilities.Release(ref query);
+            ComUtilities.Release(ref queriesCollection);
+
+            if (cleanupErrors.Count > 0)
+            {
+                if (operationError != null)
+                {
+                    cleanupErrors.Insert(0, operationError);
+                }
+
+                throw new PowerQueryCommandException(
+                    $"Power Query evaluate cleanup failed for temporary identity '{tempQueryName}'. " +
+                    "Inspect powerquery list and connection list before saving, or close without saving and retry.",
+                    "Cleanup",
+                    new AggregateException(cleanupErrors));
+            }
+
+            if (operationError != null)
+            {
+                ExceptionDispatchInfo.Capture(operationError).Throw();
+            }
+
+            result.Success = true;
             return result;
         });
     }

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Helpers.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Helpers.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using Microsoft.CSharp.RuntimeBinder;
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.Core.Commands;
 
@@ -17,23 +18,32 @@ public partial class PowerQueryCommands
     /// - Worksheet queries (InModel=false): Errors thrown via QueryTable.Refresh(false)
     /// - Data Model queries (InModel=true): Errors thrown via Connection.Refresh()
     ///
-    /// Strategy order ensures we use the appropriate method for each connection type:
-    /// 1. Try QueryTable.Refresh() first (handles worksheet queries)
-    /// 2. Fall back to Connection.Refresh() (handles Data Model queries)
+    /// Strategy order ensures every configured destination is refreshed:
+    /// 1. Refresh the worksheet QueryTable when present
+    /// 2. Refresh the Data Model source connection when present
+    /// 3. Fall back to a matching workbook connection for connection-only queries
     /// </summary>
     /// <returns>True if refresh was executed, false if no connection or table found</returns>
     /// <exception cref="Exception">Thrown if Power Query has formula errors</exception>
     private static bool RefreshConnectionByQueryName(dynamic workbook, string queryName, CancellationToken cancellationToken)
     {
-        // Strategy 1: Find and refresh QueryTable directly on worksheet
-        // For worksheet queries (InModel=false), errors are thrown by QueryTable.Refresh()
-        if (RefreshQueryTableByName(workbook, queryName, cancellationToken))
+        // A LoadToBoth query has independent worksheet and Data Model connections.
+        // Refresh both before reporting success so neither destination remains stale.
+        var worksheetRefreshed = RefreshQueryTableByName(
+            workbook,
+            queryName,
+            cancellationToken);
+        var dataModelRefreshed = RefreshDataModelConnectionByQueryName(
+            workbook,
+            queryName,
+            cancellationToken);
+        if (worksheetRefreshed || dataModelRefreshed)
         {
             return true;
         }
 
-        // Strategy 2: Find connection by name patterns and refresh
-        // For Data Model queries (InModel=true), errors are thrown by Connection.Refresh()
+        // Connection-only queries may expose a workbook connection without either
+        // a worksheet QueryTable or a Data Model table.
         dynamic? targetConnection = null;
         dynamic? connections = null;
         try
@@ -46,9 +56,10 @@ public partial class PowerQueryCommands
                 try
                 {
                     conn = connections.Item(i);
-                    string connName = conn.Name?.ToString() ?? "";
-                    if (connName.Equals(queryName, StringComparison.OrdinalIgnoreCase) ||
-                        connName.Equals($"Query - {queryName}", StringComparison.OrdinalIgnoreCase))
+                    if (PowerQuery.PowerQueryHelpers.TryGetMashupLocation(
+                        (Excel.WorkbookConnection)conn,
+                        out var location) &&
+                        string.Equals(location, queryName, StringComparison.OrdinalIgnoreCase))
                     {
                         targetConnection = conn;
                         conn = null; // Don't release - we're using it
@@ -80,6 +91,62 @@ public partial class PowerQueryCommands
         }
 
         return false;
+    }
+
+    private static bool RefreshDataModelConnectionByQueryName(
+        dynamic workbook,
+        string queryName,
+        CancellationToken cancellationToken)
+    {
+        dynamic? model = null;
+        dynamic? modelTables = null;
+        try
+        {
+            try
+            {
+                model = workbook.Model;
+                modelTables = model.ModelTables;
+            }
+            catch (COMException)
+            {
+                return false;
+            }
+
+            for (int i = 1; i <= modelTables.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                dynamic? modelTable = null;
+                Excel.WorkbookConnection? sourceConnection = null;
+                try
+                {
+                    modelTable = modelTables.Item(i);
+                    string tableName = modelTable.Name?.ToString() ?? string.Empty;
+                    sourceConnection = modelTable.SourceWorkbookConnection;
+                    if (string.Equals(
+                            tableName,
+                            queryName,
+                            StringComparison.OrdinalIgnoreCase) &&
+                        sourceConnection != null &&
+                        MatchesDataModelSourceConnection(sourceConnection, queryName))
+                    {
+                        RefreshWorkbookConnection(sourceConnection, cancellationToken);
+                        return true;
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref sourceConnection);
+                    ComUtilities.Release(ref modelTable);
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            ComUtilities.Release(ref modelTables);
+            ComUtilities.Release(ref model);
+        }
     }
 
     /// <summary>
@@ -131,8 +198,9 @@ public partial class PowerQueryCommands
                             // Check if this QueryTable is for our query by examining connection string
                             // Format: "OLEDB;...;Location=QueryName;..."
                             string? connection = queryTable.Connection?.ToString();
-                            if (connection != null &&
-                                connection.Contains($"Location={queryName}", StringComparison.OrdinalIgnoreCase))
+                            if (PowerQuery.PowerQueryHelpers.MatchesMashupLocation(
+                                connection,
+                                queryName))
                             {
                                 // Keep synchronous refresh semantics for worksheet queries.
                                 // QueryTable.Refresh(false) is the only reliable path that propagates
@@ -387,5 +455,3 @@ public partial class PowerQueryCommands
         }
     }
 }
-
-

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Lifecycle.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Lifecycle.cs
@@ -26,171 +26,31 @@ public partial class PowerQueryCommands
 
                 for (int i = 1; i <= count; i++)
                 {
+                    ct.ThrowIfCancellationRequested();
                     Excel.WorkbookQuery? query = null;
                     try
                     {
                         query = queriesCollection.Item(i);
-                        string name = query.Name ?? $"Query{i}";
-
-                        // Try to read formula - some queries may not have accessible formulas
-                        string formula = "";
-                        try
-                        {
-                            formula = query.Formula?.ToString() ?? "";
-                        }
-                        catch (COMException)
-                        {
-                            // Formula property not accessible (e.g., corrupted query, permission issue)
-                            // Don't fail the entire List operation - just mark this query
-                            formula = "";
-                        }
-
+                        string name = query.Name ??
+                            throw new InvalidOperationException(
+                                $"Power Query at index {i} did not expose a name.");
+                        string formula = query.Formula?.ToString() ?? string.Empty;
                         string preview = formula.Length > 80 ? formula[..77] + "..." : formula;
-                        if (string.IsNullOrEmpty(formula))
-                        {
-                            preview = "(formula not accessible)";
-                        }
-
-                        // Check if loaded to table (ListObject) - same pattern as GetLoadConfig
-                        bool isConnectionOnly = true;
-                        dynamic? worksheets = null;
-                        try
-                        {
-                            worksheets = ctx.Book.Worksheets;
-                            for (int ws = 1; ws <= worksheets.Count; ws++)
-                            {
-                                dynamic? worksheet = null;
-                                dynamic? listObjects = null;
-                                try
-                                {
-                                    worksheet = worksheets.Item(ws);
-                                    listObjects = worksheet.ListObjects;
-
-                                    for (int lo = 1; lo <= listObjects.Count; lo++)
-                                    {
-                                        dynamic? listObject = null;
-                                        dynamic? queryTable = null;
-                                        dynamic? wbConn = null;
-                                        dynamic? oledbConn = null;
-                                        try
-                                        {
-                                            listObject = listObjects.Item(lo);
-
-                                            // QueryTable property may throw 0x800A03EC if ListObject doesn't have a valid QueryTable
-                                            // This is normal - not all ListObjects have QueryTables (e.g., manually created tables)
-                                            try
-                                            {
-                                                queryTable = listObject.QueryTable;
-                                            }
-                                            catch (COMException ex)
-                                                when (ex.HResult == unchecked((int)0x800A03EC))
-                                            {
-                                                // ListObject doesn't have QueryTable - skip it
-                                                continue;
-                                            }
-
-                                            if (queryTable == null) continue;
-
-                                            wbConn = queryTable.WorkbookConnection;
-                                            if (wbConn == null) continue;
-
-                                            // Non-OLEDB connection types (Type=7, Type=8) throw COMException
-                                            try { oledbConn = wbConn.OLEDBConnection; }
-                                            catch (System.Runtime.InteropServices.COMException) { continue; }
-                                            if (oledbConn == null) continue;
-
-                                            string connString = oledbConn.Connection?.ToString() ?? "";
-                                            bool isMashup = connString.Contains("Provider=Microsoft.Mashup.OleDb.1", StringComparison.OrdinalIgnoreCase);
-                                            bool locationMatches = connString.Contains($"Location={name}", StringComparison.OrdinalIgnoreCase);
-
-                                            if (isMashup && locationMatches)
-                                            {
-                                                isConnectionOnly = false;
-                                                ComUtilities.Release(ref oledbConn!);
-                                                ComUtilities.Release(ref wbConn!);
-                                                ComUtilities.Release(ref queryTable!);
-                                                ComUtilities.Release(ref listObject!);
-                                                break;
-                                            }
-                                        }
-                                        finally
-                                        {
-                                            ComUtilities.Release(ref oledbConn!);
-                                            ComUtilities.Release(ref wbConn!);
-                                            ComUtilities.Release(ref queryTable!);
-                                            ComUtilities.Release(ref listObject!);
-                                        }
-                                    }
-                                }
-                                finally
-                                {
-                                    ComUtilities.Release(ref listObjects!);
-                                    ComUtilities.Release(ref worksheet!);
-                                }
-                                if (!isConnectionOnly) break;
-                            }
-                        }
-                        finally
-                        {
-                            ComUtilities.Release(ref worksheets!);
-                        }
-
-                        // Also check for Data Model connections
-                        // A query loaded ONLY to Data Model has no ListObjects but has a connection
-                        if (isConnectionOnly)
-                        {
-                            dynamic? connections = null;
-                            try
-                            {
-                                connections = ctx.Book.Connections;
-                                for (int c = 1; c <= connections.Count; c++)
-                                {
-                                    dynamic? conn = null;
-                                    try
-                                    {
-                                        conn = connections.Item(c);
-                                        string connName = conn.Name?.ToString() ?? "";
-
-                                        // Check if this is a Data Model connection for our query
-                                        // Patterns:
-                                        // - "Query - {queryName}" (worksheet connection)
-                                        // - "Query - {queryName} (Data Model)" (Data Model connection)
-                                        // - "Query - {queryName} - suffix" (legacy pattern)
-                                        if (connName.Equals($"Query - {name}", StringComparison.OrdinalIgnoreCase) ||
-                                            connName.StartsWith($"Query - {name} -", StringComparison.OrdinalIgnoreCase) ||
-                                            connName.StartsWith($"Query - {name} (", StringComparison.OrdinalIgnoreCase))
-                                        {
-                                            // Has Data Model connection - NOT connection-only
-                                            isConnectionOnly = false;
-                                            break;
-                                        }
-                                    }
-                                    finally
-                                    {
-                                        ComUtilities.Release(ref conn);
-                                    }
-                                }
-                            }
-                            finally
-                            {
-                                ComUtilities.Release(ref connections);
-                            }
-                        }
+                        var loadState = DetectLoadState(ctx.Book, name, ct);
 
                         result.Queries.Add(new PowerQueryInfo
                         {
                             Name = name,
+#pragma warning disable CS0618
                             Formula = formula,
+#pragma warning restore CS0618
                             FormulaPreview = preview,
-                            IsConnectionOnly = isConnectionOnly
+                            CharacterCount = formula.Length,
+                            LoadMode = loadState.LoadMode,
+                            TargetSheet = loadState.TargetSheet,
+                            IsConnectionOnly = loadState.IsConnectionOnly,
+                            IsLoadedToDataModel = loadState.IsLoadedToDataModel
                         });
-                    }
-                    catch (COMException)
-                    {
-                        // Skip query if COM error occurs during processing
-                        // This allows listing to continue for remaining queries
-                        // COM exceptions occur for corrupted queries or access issues
-                        continue;
                     }
                     finally
                     {
@@ -228,206 +88,24 @@ public partial class PowerQueryCommands
         return batch.Execute((ctx, ct) =>
         {
             Excel.WorkbookQuery? query = null;
-            dynamic? worksheets = null;
-            dynamic? connections = null;
             try
             {
-                query = ComUtilities.FindQuery(ctx.Book, queryName);
+                query = PowerQuery.PowerQueryHelpers.FindQueryByExactName(ctx.Book, queryName);
                 if (query == null)
                 {
                     throw new InvalidOperationException($"Query '{queryName}' not found.");
                 }
 
-                // Check for ListObjects first (Power Query loaded to table creates a ListObject)
-                bool hasTableConnection = false;
-                bool hasDataModelConnection = false;
-                string? targetSheet = null;
-
-                worksheets = ctx.Book.Worksheets;
-                for (int ws = 1; ws <= worksheets.Count; ws++)
-                {
-                    dynamic? worksheet = null;
-                    dynamic? listObjects = null;
-                    try
-                    {
-                        worksheet = worksheets.Item(ws);
-                        listObjects = worksheet.ListObjects;
-
-                        for (int lo = 1; lo <= listObjects.Count; lo++)
-                        {
-                            dynamic? listObject = null;
-                            dynamic? queryTable = null;
-                            dynamic? wbConn = null;
-                            dynamic? oledbConn = null;
-                            try
-                            {
-                                listObject = listObjects.Item(lo);
-
-                                // QueryTable property throws 0x800A03EC for regular tables
-                                // (i.e., tables not backed by an external data query). Skip them.
-                                try
-                                {
-                                    queryTable = listObject.QueryTable;
-                                }
-                                catch (System.Runtime.InteropServices.COMException ex)
-                                    when (ex.HResult == unchecked((int)0x800A03EC))
-                                {
-                                    continue;
-                                }
-
-                                if (queryTable == null) continue;
-
-                                wbConn = queryTable.WorkbookConnection;
-                                if (wbConn == null) continue;
-
-                                // Non-OLEDB connection types (Type=7, Type=8) throw COMException
-                                try { oledbConn = wbConn.OLEDBConnection; }
-                                catch (System.Runtime.InteropServices.COMException) { continue; }
-                                if (oledbConn == null) continue;
-
-                                string connString = oledbConn.Connection?.ToString() ?? "";
-                                bool isMashup = connString.Contains("Provider=Microsoft.Mashup.OleDb.1", StringComparison.OrdinalIgnoreCase);
-                                bool locationMatches = connString.Contains($"Location={queryName}", StringComparison.OrdinalIgnoreCase);
-
-                                // Also check CommandText as fallback
-                                string commandText = "";
-                                try
-                                {
-                                    if (queryTable.CommandText is object[] arr && arr.Length > 0)
-                                        commandText = arr[0]?.ToString() ?? "";
-                                    else
-                                        commandText = queryTable.CommandText?.ToString() ?? "";
-                                }
-                                catch (COMException)
-                                {
-                                    // CommandText property may not be accessible for certain QueryTable types
-                                }
-
-                                bool cmdMatches = commandText.Contains($"[{queryName}]", StringComparison.OrdinalIgnoreCase);
-
-                                if (isMashup && (locationMatches || cmdMatches))
-                                {
-                                    hasTableConnection = true;
-                                    targetSheet = worksheet.Name;
-                                    ComUtilities.Release(ref oledbConn!);
-                                    ComUtilities.Release(ref wbConn!);
-                                    ComUtilities.Release(ref queryTable!);
-                                    ComUtilities.Release(ref listObject!);
-                                    break;
-                                }
-                            }
-                            finally
-                            {
-                                ComUtilities.Release(ref oledbConn!);
-                                ComUtilities.Release(ref wbConn!);
-                                ComUtilities.Release(ref queryTable!);
-                                ComUtilities.Release(ref listObject!);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        ComUtilities.Release(ref listObjects!);
-                        ComUtilities.Release(ref worksheet!);
-                    }
-                    if (hasTableConnection) break;
-                }
-
-                // Check connections for Data Model membership using InModel property
-                connections = ctx.Book.Connections;
-                for (int i = 1; i <= connections.Count; i++)
-                {
-                    dynamic? conn = null;
-                    dynamic? oledbConn = null;
-                    try
-                    {
-                        conn = connections.Item(i);
-                        string connName = conn.Name?.ToString() ?? "";
-
-                        // Check if this connection is related to our query
-                        // Patterns:
-                        // - "{queryName}" (exact match)
-                        // - "Query - {queryName}" (worksheet connection)
-                        // - "Query - {queryName} (Data Model)" (Data Model connection)
-                        // - "Query - {queryName} - suffix" (legacy pattern)
-                        bool isQueryConnection = connName.Equals(queryName, StringComparison.OrdinalIgnoreCase) ||
-                            connName.Equals($"Query - {queryName}", StringComparison.OrdinalIgnoreCase) ||
-                            connName.StartsWith($"Query - {queryName} -", StringComparison.OrdinalIgnoreCase) ||
-                            connName.StartsWith($"Query - {queryName} (", StringComparison.OrdinalIgnoreCase);
-
-                        // Also check connection string for Power Query pattern
-                        if (!isQueryConnection)
-                        {
-                            try
-                            {
-                                oledbConn = conn.OLEDBConnection;
-                                if (oledbConn != null)
-                                {
-                                    string connString = oledbConn.Connection?.ToString() ?? "";
-                                    bool isPowerQuery = connString.Contains("Provider=Microsoft.Mashup.OleDb.1", StringComparison.OrdinalIgnoreCase);
-                                    bool matchesQuery = connString.Contains($"Location={queryName}", StringComparison.OrdinalIgnoreCase);
-                                    isQueryConnection = isPowerQuery && matchesQuery;
-                                }
-                            }
-                            catch (Exception ex) when (ex is COMException or System.Reflection.TargetInvocationException)
-                            {
-                                // Connection type doesn't have OLEDBConnection property - skip
-                            }
-                        }
-
-                        if (isQueryConnection)
-                        {
-                            result.HasConnection = true;
-
-                            // Check InModel property to detect Data Model connections
-                            try
-                            {
-                                bool inModel = conn.InModel;
-                                if (inModel)
-                                {
-                                    hasDataModelConnection = true;
-                                }
-                            }
-                            catch (Exception ex) when (ex is COMException or System.Reflection.TargetInvocationException)
-                            {
-                                // InModel property not available for this connection type
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        ComUtilities.Release(ref oledbConn!);
-                        ComUtilities.Release(ref conn);
-                    }
-                }
-
-                // Determine load mode
-                if (hasTableConnection && hasDataModelConnection)
-                {
-                    result.LoadMode = PowerQueryLoadMode.LoadToBoth;
-                }
-                else if (hasTableConnection)
-                {
-                    result.LoadMode = PowerQueryLoadMode.LoadToTable;
-                }
-                else if (hasDataModelConnection)
-                {
-                    result.LoadMode = PowerQueryLoadMode.LoadToDataModel;
-                }
-                else
-                {
-                    result.LoadMode = PowerQueryLoadMode.ConnectionOnly;
-                }
-
-                result.TargetSheet = targetSheet;
-                result.IsLoadedToDataModel = hasDataModelConnection;
+                var loadState = DetectLoadState(ctx.Book, queryName, ct);
+                result.HasConnection = loadState.HasConnection;
+                result.LoadMode = loadState.LoadMode;
+                result.TargetSheet = loadState.TargetSheet;
+                result.IsLoadedToDataModel = loadState.IsLoadedToDataModel;
                 result.Success = true;
                 return result;
             }
             finally
             {
-                ComUtilities.Release(ref connections);
-                ComUtilities.Release(ref worksheets);
                 ComUtilities.Release(ref query);
             }
         });
@@ -445,12 +123,11 @@ public partial class PowerQueryCommands
         return batch.Execute((ctx, ct) =>
         {
             Excel.WorkbookQuery? query = null;
-            Excel.Queries? queriesCollection = null;
             dynamic? worksheets = null;
 
             try
             {
-                query = ComUtilities.FindQuery(ctx.Book, queryName);
+                query = PowerQuery.PowerQueryHelpers.FindQueryByExactName(ctx.Book, queryName);
                 if (query == null)
                 {
                     throw new InvalidOperationException($"Query '{queryName}' not found.");
@@ -494,10 +171,9 @@ public partial class PowerQueryCommands
                                         if (oleDbConnection != null)
                                         {
                                             string? connString = oleDbConnection.Connection?.ToString() ?? "";
-                                            // Check if connection string references our query
-                                            // Format: "OLEDB;Provider=Microsoft.Mashup.OleDb.1;Data Source=$Workbook$;Location=QueryName"
-                                            if (connString.Contains("Microsoft.Mashup.OleDb") &&
-                                                connString.Contains($"Location={queryName}"))
+                                            if (PowerQuery.PowerQueryHelpers.MatchesMashupLocation(
+                                                connString,
+                                                queryName))
                                             {
                                                 // This table is associated with our query - delete it
                                                 table.Delete();
@@ -525,73 +201,17 @@ public partial class PowerQueryCommands
                     }
                 }
 
-                // STEP 2: Remove Data Model connections
-                // Data Model connections follow pattern: "Query - {queryName}" or "Query - {queryName} - suffix"
-                dynamic? connections = null;
-                try
-                {
-                    connections = ctx.Book.Connections;
-                    var connectionsToDelete = new List<string>();
+                PowerQuery.PowerQueryHelpers.RemoveConnectionsByMashupLocation(
+                    ctx.Book,
+                    queryName);
 
-                    for (int c = 1; c <= connections.Count; c++)
-                    {
-                        dynamic? conn = null;
-                        try
-                        {
-                            conn = connections.Item(c);
-                            string connName = conn.Name?.ToString() ?? "";
-
-                            // Check if this is a connection for our query
-                            // Patterns:
-                            // - "Query - {queryName}" (worksheet connection)
-                            // - "Query - {queryName} (Data Model)" (Data Model connection)
-                            // - "Query - {queryName} - suffix" (legacy pattern)
-                            if (connName.Equals($"Query - {queryName}", StringComparison.OrdinalIgnoreCase) ||
-                                connName.StartsWith($"Query - {queryName} -", StringComparison.OrdinalIgnoreCase) ||
-                                connName.StartsWith($"Query - {queryName} (", StringComparison.OrdinalIgnoreCase))
-                            {
-                                connectionsToDelete.Add(connName);
-                            }
-                        }
-                        finally
-                        {
-                            ComUtilities.Release(ref conn);
-                        }
-                    }
-
-                    // Delete connections
-                    foreach (var connName in connectionsToDelete)
-                    {
-                        dynamic? connToDelete = null;
-                        try
-                        {
-                            connToDelete = connections.Item(connName);
-                            connToDelete.Delete();
-                        }
-                        catch (COMException)
-                        {
-                            // Connection may have already been deleted - safe to ignore
-                        }
-                        finally
-                        {
-                            ComUtilities.Release(ref connToDelete);
-                        }
-                    }
-                }
-                finally
-                {
-                    ComUtilities.Release(ref connections);
-                }
-
-                queriesCollection = ctx.Book.Queries;
-                queriesCollection.Item(queryName).Delete();
+                query.Delete();
 
                 return new OperationResult { Success = true, FilePath = batch.WorkbookPath };
             }
             finally
             {
                 ComUtilities.Release(ref worksheets);
-                ComUtilities.Release(ref queriesCollection);
                 ComUtilities.Release(ref query);
             }
         });
@@ -625,7 +245,7 @@ public partial class PowerQueryCommands
 
             try
             {
-                query = ComUtilities.FindQuery(ctx.Book, queryName);
+                query = PowerQuery.PowerQueryHelpers.FindQueryByExactName(ctx.Book, queryName);
                 if (query == null)
                 {
                     throw new InvalidOperationException($"Query '{queryName}' not found.");
@@ -690,9 +310,9 @@ public partial class PowerQueryCommands
                                     if (oleDbConnection != null)
                                     {
                                         string? connString = oleDbConnection.Connection?.ToString() ?? "";
-                                        // Check if connection string references our query
-                                        if (connString.Contains("Microsoft.Mashup.OleDb") &&
-                                            connString.Contains($"Location={queryName}"))
+                                        if (PowerQuery.PowerQueryHelpers.MatchesMashupLocation(
+                                            connString,
+                                            queryName))
                                         {
                                             // This table is associated with our query - delete it
                                             table.Delete();
@@ -720,63 +340,9 @@ public partial class PowerQueryCommands
                 }
             }
 
-            // STEP 2: Remove Data Model connections
-            // Data Model connections follow pattern: "Query - {queryName}" or "Query - {queryName} - suffix"
-            dynamic? connections = null;
-            try
-            {
-                connections = workbook.Connections;
-                var connectionsToDelete = new List<string>();
-
-                for (int i = 1; i <= connections.Count; i++)
-                {
-                    dynamic? conn = null;
-                    try
-                    {
-                        conn = connections.Item(i);
-                        string connName = conn.Name?.ToString() ?? "";
-
-                        // Check if this is a connection for our query
-                        // Patterns:
-                        // - "Query - {queryName}" (worksheet connection)
-                        // - "Query - {queryName} (Data Model)" (Data Model connection)
-                        // - "Query - {queryName} - suffix" (legacy pattern)
-                        if (connName.Equals($"Query - {queryName}", StringComparison.OrdinalIgnoreCase) ||
-                            connName.StartsWith($"Query - {queryName} -", StringComparison.OrdinalIgnoreCase) ||
-                            connName.StartsWith($"Query - {queryName} (", StringComparison.OrdinalIgnoreCase))
-                        {
-                            connectionsToDelete.Add(connName);
-                        }
-                    }
-                    finally
-                    {
-                        ComUtilities.Release(ref conn);
-                    }
-                }
-
-                // Delete connections (must iterate separately to avoid modifying collection while enumerating)
-                foreach (var connName in connectionsToDelete)
-                {
-                    dynamic? connToDelete = null;
-                    try
-                    {
-                        connToDelete = connections.Item(connName);
-                        connToDelete.Delete();
-                    }
-                    catch (COMException)
-                    {
-                        // Connection may have already been deleted or is in use - safe to ignore
-                    }
-                    finally
-                    {
-                        ComUtilities.Release(ref connToDelete);
-                    }
-                }
-            }
-            finally
-            {
-                ComUtilities.Release(ref connections);
-            }
+            PowerQuery.PowerQueryHelpers.RemoveConnectionsByMashupLocation(
+                (Excel.Workbook)workbook,
+                queryName);
         }
         finally
         {

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Refresh.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Refresh.cs
@@ -47,7 +47,7 @@ public partial class PowerQueryCommands
                 Excel.WorkbookQuery? query = null;
                 try
                 {
-                    query = ComUtilities.FindQuery(ctx.Book, queryName);
+                    query = PowerQuery.PowerQueryHelpers.FindQueryByExactName(ctx.Book, queryName);
                     if (query == null)
                     {
                         throw new InvalidOperationException($"Query '{queryName}' not found.");
@@ -76,10 +76,9 @@ public partial class PowerQueryCommands
 
                     result.HasErrors = false;
                     result.Success = true;
-                    result.LoadedToSheet = DetermineLoadedSheet(ctx.Book, queryName);
-
-                    bool isLoadedToDataModel = IsQueryLoadedToDataModel(ctx.Book, queryName);
-                    result.IsConnectionOnly = string.IsNullOrEmpty(result.LoadedToSheet) && !isLoadedToDataModel;
+                    var loadState = DetectLoadState(ctx.Book, queryName, ct);
+                    result.LoadedToSheet = loadState.TargetSheet;
+                    result.IsConnectionOnly = loadState.IsConnectionOnly;
 
                     progress?.Report(new ProgressInfo { Current = 1, Total = 1, Message = $"Refreshed '{queryName}'" });
                     return result;
@@ -185,41 +184,4 @@ public partial class PowerQueryCommands
         }, timeoutCts.Token);
     }
 
-    /// <summary>
-    /// Helper method to find connection for a query
-    /// </summary>
-    private static dynamic? FindConnectionForQuery(dynamic workbook, string queryName)
-    {
-        dynamic? connections = null;
-        try
-        {
-            connections = workbook.Connections;
-            for (int i = 1; i <= connections.Count; i++)
-            {
-                dynamic? conn = null;
-                try
-                {
-                    conn = connections.Item(i);
-                    string connName = conn.Name;
-                    if (connName.Contains(queryName))
-                    {
-                        return conn;
-                    }
-                }
-                finally
-                {
-                    if (conn != null && conn != connections.Item(i))
-                    {
-                        ComUtilities.Release(ref conn!);
-                    }
-                }
-            }
-        }
-        finally
-        {
-            ComUtilities.Release(ref connections!);
-        }
-
-        return null;
-    }
 }

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Rename.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.Rename.cs
@@ -43,7 +43,9 @@ public partial class PowerQueryCommands
                 queries = ctx.Book.Queries;
 
                 // Find target query (case-sensitive exact match first)
-                targetQuery = ComUtilities.FindQuery(ctx.Book, result.NormalizedOldName);
+                targetQuery = PowerQuery.PowerQueryHelpers.FindQueryByExactName(
+                    ctx.Book,
+                    result.NormalizedOldName);
                 if (targetQuery == null)
                 {
                     result.Success = false;

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.View.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.View.cs
@@ -43,7 +43,6 @@ public partial class PowerQueryCommands
         {
             Excel.Queries? queries = null;
             Excel.WorkbookQuery? query = null;
-            dynamic? worksheets = null;
 
             try
             {
@@ -80,142 +79,18 @@ public partial class PowerQueryCommands
                 result.MCode = mCode;
                 result.CharacterCount = mCode.Length;
 
-                // STEP 3: Detect load configuration (QueryTable or ListObject pattern)
-                // Same detection logic as Update() - check BOTH patterns
-                bool isLoadedToWorksheet = false;
-
-                worksheets = ctx.Book.Worksheets;
-                for (int ws = 1; ws <= worksheets.Count; ws++)
-                {
-                    dynamic? worksheet = null;
-                    try
-                    {
-                        worksheet = worksheets.Item(ws);
-
-                        // FIRST: Check for QueryTable (Pattern 1 - from LoadTo/Create)
-                        dynamic? queryTables = null;
-                        try
-                        {
-                            queryTables = worksheet.QueryTables;
-                            for (int qt = 1; qt <= queryTables.Count; qt++)
-                            {
-                                dynamic? qTable = null;
-                                dynamic? wbConn = null;
-                                dynamic? oledbConn = null;
-                                try
-                                {
-                                    qTable = queryTables.Item(qt);
-                                    wbConn = qTable.WorkbookConnection;
-                                    if (wbConn == null) continue;
-
-                                    // Non-OLEDB connection types (Type=7, Type=8) throw COMException
-                                    try { oledbConn = wbConn.OLEDBConnection; }
-                                    catch (System.Runtime.InteropServices.COMException) { continue; }
-                                    if (oledbConn == null) continue;
-
-                                    string connString = oledbConn.Connection?.ToString() ?? "";
-                                    bool isMashup = connString.Contains("Provider=Microsoft.Mashup.OleDb.1", StringComparison.OrdinalIgnoreCase);
-                                    bool locationMatches = connString.Contains($"Location={queryName}", StringComparison.OrdinalIgnoreCase);
-
-                                    if (isMashup && locationMatches)
-                                    {
-                                        isLoadedToWorksheet = true;
-                                        break;
-                                    }
-                                }
-                                finally
-                                {
-                                    ComUtilities.Release(ref oledbConn!);
-                                    ComUtilities.Release(ref wbConn!);
-                                    ComUtilities.Release(ref qTable!);
-                                }
-                            }
-                        }
-                        finally
-                        {
-                            ComUtilities.Release(ref queryTables!);
-                        }
-
-                        if (isLoadedToWorksheet) break;
-
-                        // SECOND: Check for ListObject (Pattern 2 - from previous Update)
-                        dynamic? listObjects = null;
-                        try
-                        {
-                            listObjects = worksheet.ListObjects;
-                            for (int lo = 1; lo <= listObjects.Count; lo++)
-                            {
-                                dynamic? listObj = null;
-                                dynamic? queryTable = null;
-                                dynamic? wbConn = null;
-                                dynamic? oledbConn = null;
-                                try
-                                {
-                                    listObj = listObjects.Item(lo);
-
-                                    // NOTE: Accessing QueryTable on a regular Excel table (not from external data)
-                                    // throws COMException 0x800A03EC. We must catch and skip such tables.
-                                    try
-                                    {
-                                        queryTable = listObj.QueryTable;
-                                    }
-                                    catch (System.Runtime.InteropServices.COMException)
-                                    {
-                                        // Regular table without QueryTable - skip it
-                                        continue;
-                                    }
-
-                                    if (queryTable == null) continue;
-
-                                    wbConn = queryTable.WorkbookConnection;
-                                    if (wbConn == null) continue;
-
-                                    // Non-OLEDB connection types (Type=7, Type=8) throw COMException
-                                    try { oledbConn = wbConn.OLEDBConnection; }
-                                    catch (System.Runtime.InteropServices.COMException) { continue; }
-                                    if (oledbConn == null) continue;
-
-                                    string connString = oledbConn.Connection?.ToString() ?? "";
-                                    bool isMashup = connString.Contains("Provider=Microsoft.Mashup.OleDb.1", StringComparison.OrdinalIgnoreCase);
-                                    bool locationMatches = connString.Contains($"Location={queryName}", StringComparison.OrdinalIgnoreCase);
-
-                                    if (isMashup && locationMatches)
-                                    {
-                                        isLoadedToWorksheet = true;
-                                        break;
-                                    }
-                                }
-                                finally
-                                {
-                                    ComUtilities.Release(ref oledbConn!);
-                                    ComUtilities.Release(ref wbConn!);
-                                    ComUtilities.Release(ref queryTable!);
-                                    ComUtilities.Release(ref listObj!);
-                                }
-                            }
-                        }
-                        finally
-                        {
-                            ComUtilities.Release(ref listObjects!);
-                        }
-                    }
-                    finally
-                    {
-                        ComUtilities.Release(ref worksheet!);
-                    }
-
-                    if (isLoadedToWorksheet) break;
-                }
-
-                // STEP 4: Set load mode result
-                result.IsConnectionOnly = !isLoadedToWorksheet;
+                var loadState = DetectLoadState(ctx.Book, queryName, ct);
+                result.LoadMode = loadState.LoadMode;
+                result.TargetSheet = loadState.TargetSheet;
+                result.HasConnection = loadState.HasConnection;
+                result.IsLoadedToDataModel = loadState.IsLoadedToDataModel;
+                result.IsConnectionOnly = loadState.IsConnectionOnly;
 
                 result.Success = true;
                 return result;
             }
             finally
             {
-                ComUtilities.Release(ref worksheets!);
                 ComUtilities.Release(ref query!);
                 ComUtilities.Release(ref queries!);
             }

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryCommands.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using Sbroenne.ExcelMcp.ComInterop;
-
+using Sbroenne.ExcelMcp.Core.Models;
+using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.Core.Commands;
 
@@ -125,41 +126,87 @@ public partial class PowerQueryCommands : IPowerQueryCommands
         return match.Success ? match.Groups[1].Value : null;
     }
 
-    /// <summary>
-    /// Determine which worksheet a query is loaded to (if any).
-    /// Uses the same ListObjects + connection string matching as RefreshQueryTableByName
-    /// for reliable detection of modern Excel table (ListObject) queries.
-    /// </summary>
-    private static string? DetermineLoadedSheet(dynamic workbook, string queryName)
+    private static PowerQueryLoadState DetectLoadState(
+        Excel.Workbook workbook,
+        string queryName,
+        CancellationToken cancellationToken)
     {
-        dynamic? worksheets = null;
+        var targetSheet = DetermineLoadedSheet(workbook, queryName, cancellationToken);
+        var isLoadedToDataModel = IsQueryLoadedToDataModel(
+            workbook,
+            queryName,
+            cancellationToken);
+
+        var loadMode = (targetSheet != null, isLoadedToDataModel) switch
+        {
+            (true, true) => PowerQueryLoadMode.LoadToBoth,
+            (true, false) => PowerQueryLoadMode.LoadToTable,
+            (false, true) => PowerQueryLoadMode.LoadToDataModel,
+            _ => PowerQueryLoadMode.ConnectionOnly
+        };
+
+        return new PowerQueryLoadState(loadMode, targetSheet, isLoadedToDataModel);
+    }
+
+    /// <summary>
+    /// Determines which worksheet a query is loaded to by exact mashup Location identity.
+    /// </summary>
+    private static string? DetermineLoadedSheet(
+        Excel.Workbook workbook,
+        string queryName,
+        CancellationToken cancellationToken)
+    {
+        Excel.Sheets? worksheets = null;
         try
         {
             worksheets = workbook.Worksheets;
             for (int ws = 1; ws <= worksheets.Count; ws++)
             {
-                dynamic? worksheet = null;
-                dynamic? listObjects = null;
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.Worksheet? worksheet = null;
+                Excel.QueryTables? queryTables = null;
+                Excel.ListObjects? listObjects = null;
                 try
                 {
-                    worksheet = worksheets.Item(ws);
+                    worksheet = (Excel.Worksheet)worksheets.Item[ws];
+                    queryTables = worksheet.QueryTables;
+                    for (int qt = 1; qt <= queryTables.Count; qt++)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        Excel.QueryTable? queryTable = null;
+                        try
+                        {
+                            queryTable = queryTables.Item(qt);
+                            if (MatchesWorksheetQueryTable(queryTable, queryName))
+                            {
+                                return worksheet.Name;
+                            }
+                        }
+                        finally
+                        {
+                            ComUtilities.Release(ref queryTable);
+                        }
+                    }
+
                     listObjects = worksheet.ListObjects;
 
                     for (int lo = 1; lo <= listObjects.Count; lo++)
                     {
-                        dynamic? listObject = null;
-                        dynamic? queryTable = null;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        Excel.ListObject? listObject = null;
+                        Excel.QueryTable? queryTable = null;
                         try
                         {
-                            listObject = listObjects.Item(lo);
+                            listObject = listObjects.Item[lo];
 
                             try
                             {
                                 queryTable = listObject.QueryTable;
                             }
-                            catch (COMException)
+                            catch (COMException ex)
+                                when (ex.HResult == unchecked((int)0x800A03EC))
                             {
-                                // ListObject has no QueryTable — skip
+                                // A regular Excel table has no external QueryTable.
                                 continue;
                             }
 
@@ -168,19 +215,10 @@ public partial class PowerQueryCommands : IPowerQueryCommands
                                 continue;
                             }
 
-                            // Match by connection string: "OLEDB;...;Location=QueryName;..."
-                            // This is the same strategy as RefreshQueryTableByName and is
-                            // reliable regardless of what Excel assigns as the QueryTable.Name.
-                            string? connection = queryTable.Connection?.ToString();
-                            if (connection != null &&
-                                connection.Contains($"Location={queryName}", StringComparison.OrdinalIgnoreCase))
+                            if (MatchesWorksheetQueryTable(queryTable, queryName))
                             {
-                                return worksheet.Name?.ToString();
+                                return worksheet.Name;
                             }
-                        }
-                        catch (COMException)
-                        {
-                            continue;
                         }
                         finally
                         {
@@ -192,6 +230,7 @@ public partial class PowerQueryCommands : IPowerQueryCommands
                 finally
                 {
                     ComUtilities.Release(ref listObjects);
+                    ComUtilities.Release(ref queryTables);
                     ComUtilities.Release(ref worksheet);
                 }
             }
@@ -204,13 +243,37 @@ public partial class PowerQueryCommands : IPowerQueryCommands
         return null;
     }
 
-    /// <summary>
-    /// Determines if a query is loaded to the Data Model
-    /// </summary>
-    private static bool IsQueryLoadedToDataModel(dynamic workbook, string queryName)
+    private static bool MatchesWorksheetQueryTable(
+        Excel.QueryTable queryTable,
+        string queryName)
     {
-        dynamic? model = null;
-        dynamic? modelTables = null;
+        Excel.WorkbookConnection? connection = null;
+        try
+        {
+            connection = queryTable.WorkbookConnection;
+            return connection != null &&
+                PowerQuery.PowerQueryHelpers.TryGetMashupLocationForInspection(
+                    connection,
+                    out var location) &&
+                string.Equals(location, queryName, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            ComUtilities.Release(ref connection);
+        }
+    }
+
+    /// <summary>
+    /// Determines whether a query is loaded to the Data Model by requiring both
+    /// an exact table name and an exact mashup source Location identity.
+    /// </summary>
+    private static bool IsQueryLoadedToDataModel(
+        Excel.Workbook workbook,
+        string queryName,
+        CancellationToken cancellationToken)
+    {
+        Excel.Model? model = null;
+        Excel.ModelTables? modelTables = null;
         try
         {
             model = workbook.Model;
@@ -218,27 +281,30 @@ public partial class PowerQueryCommands : IPowerQueryCommands
 
             for (int i = 1; i <= modelTables.Count; i++)
             {
-                dynamic? table = null;
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.ModelTable? table = null;
+                Excel.WorkbookConnection? sourceConnection = null;
                 try
                 {
                     table = modelTables.Item(i);
-                    string tableName = table.Name?.ToString() ?? "";
-
-                    // Match by query name (Excel may add prefixes/suffixes)
-                    if (tableName.Contains(queryName, StringComparison.OrdinalIgnoreCase))
+                    string tableName = table.Name;
+                    sourceConnection = table.SourceWorkbookConnection;
+                    if (string.Equals(
+                            tableName,
+                            queryName,
+                            StringComparison.OrdinalIgnoreCase) &&
+                        sourceConnection != null &&
+                        MatchesDataModelSourceConnection(sourceConnection, queryName))
                     {
                         return true;
                     }
                 }
                 finally
                 {
+                    ComUtilities.Release(ref sourceConnection);
                     ComUtilities.Release(ref table);
                 }
             }
-        }
-        catch (System.Runtime.InteropServices.COMException)
-        {
-            // Data Model might not be available or accessible
         }
         finally
         {
@@ -248,6 +314,24 @@ public partial class PowerQueryCommands : IPowerQueryCommands
 
         return false;
     }
+
+    private static bool MatchesDataModelSourceConnection(
+        Excel.WorkbookConnection sourceConnection,
+        string queryName)
+    {
+        return PowerQuery.PowerQueryHelpers.TryGetMashupLocationForInspection(
+                sourceConnection,
+                out var location) &&
+            string.Equals(location, queryName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private readonly record struct PowerQueryLoadState(
+        PowerQueryLoadMode LoadMode,
+        string? TargetSheet,
+        bool IsLoadedToDataModel)
+    {
+        public bool IsConnectionOnly => LoadMode == PowerQueryLoadMode.ConnectionOnly;
+
+        public bool HasConnection => !IsConnectionOnly;
+    }
 }
-
-

--- a/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryHelpers.cs
+++ b/src/ExcelMcp.Core/Commands/PowerQuery/PowerQueryHelpers.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
 using Sbroenne.ExcelMcp.ComInterop;
 using Excel = Microsoft.Office.Interop.Excel;
 
@@ -8,57 +10,37 @@ namespace Sbroenne.ExcelMcp.Core.PowerQuery;
 /// </summary>
 public static class PowerQueryHelpers
 {
+    private const string MashupProvider = "Microsoft.Mashup.OleDb.1";
+
     /// <summary>
     /// Determines if a Power Query connection is orphaned (no corresponding query exists).
-    /// An orphaned connection is one that appears to be a Power Query connection (based on
-    /// connection string or naming pattern) but has no matching entry in the Queries collection.
+    /// Ownership comes from the exact mashup Location property, not the display name.
     /// This commonly occurs after query deletions, renames, or copy/paste operations in Excel.
     /// 
-    /// A connection is considered orphaned if:
-    /// 1. It's a Power Query connection (uses Microsoft.Mashup provider)
-    /// 2. AND EITHER:
-    ///    a. It doesn't follow the standard "Query - {queryName}" naming pattern (e.g., "Connection", "Connection1")
-    ///    b. OR it follows the pattern but the corresponding query no longer exists in Workbook.Queries
+    /// A mashup connection is orphaned when Location is absent or no exact
+    /// case-insensitive query name matches that Location.
     /// </summary>
     /// <param name="workbook">Excel workbook COM object</param>
     /// <param name="connection">Connection COM object</param>
     /// <returns>True if connection is a Power Query connection with no corresponding query</returns>
-    public static bool IsOrphanedPowerQueryConnection(dynamic workbook, dynamic connection)
+    public static bool IsOrphanedPowerQueryConnection(
+        Excel.Workbook workbook,
+        Excel.WorkbookConnection connection)
     {
-        // First check if this is even a Power Query connection
-        if (!IsPowerQueryConnection(connection))
+        if (!TryGetMashupIdentity(connection, out var identity))
         {
             return false;
         }
 
-        string connectionName = connection.Name?.ToString() ?? "";
-
-        // Check if connection follows the standard "Query - {queryName}" naming pattern
-        // Only connections with this pattern are considered "proper" Power Query connections
-        if (!connectionName.StartsWith("Query - ", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrWhiteSpace(identity.Location))
         {
-            // Generic names like "Connection", "Connection1", etc. are ALWAYS orphaned
-            // even if their Location= points to an existing query.
-            // The proper connection for a query is always named "Query - {queryName}".
             return true;
         }
 
-        // Extract the query name from the "Query - {queryName}" pattern
-        string expectedQueryName = connectionName["Query - ".Length..];
-
-        // Handle potential suffixes like "Query - Name - Model" (though rare)
-        int dashIndex = expectedQueryName.IndexOf(" -", StringComparison.Ordinal);
-        if (dashIndex > 0)
-        {
-            expectedQueryName = expectedQueryName[..dashIndex];
-        }
-
-        // Check if a query with this name exists
         Excel.WorkbookQuery? query = null;
         try
         {
-            query = ComUtilities.FindQuery(workbook, expectedQueryName);
-            // If query is null, the connection is orphaned
+            query = FindQueryByExactName(workbook, identity.Location);
             return query == null;
         }
         finally
@@ -68,81 +50,173 @@ public static class PowerQueryHelpers
     }
 
     /// <summary>
+    /// Compatibility overload for callers compiled against the object-based API.
+    /// </summary>
+    public static bool IsOrphanedPowerQueryConnection(object workbook, object connection)
+    {
+        return IsOrphanedPowerQueryConnection(
+            (Excel.Workbook)workbook,
+            (Excel.WorkbookConnection)connection);
+    }
+
+    /// <summary>
     /// Determines if a connection is a Power Query connection
     /// </summary>
     /// <param name="connection">Connection COM object</param>
     /// <returns>True if connection is a Power Query connection</returns>
-    public static bool IsPowerQueryConnection(dynamic connection)
+    public static bool IsPowerQueryConnection(Excel.WorkbookConnection connection)
     {
-        try
-        {
-            // Power Query connections use Microsoft.Mashup provider
-            // Check OLEDBConnection for Mashup provider
-            if (connection.Type == 1) // xlConnectionTypeOLEDB
-            {
-                string connectionString = connection.OLEDBConnection?.Connection?.ToString() ?? "";
-                if (connectionString.Contains("Microsoft.Mashup.OleDb", StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
+        return TryGetMashupIdentity(connection, out _);
+    }
 
-            // Also check connection name pattern (Power Query connections are named "Query - Name")
-            string name = connection.Name?.ToString() ?? "";
-            if (name.StartsWith("Query - ", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-        catch (System.Runtime.InteropServices.COMException)
+    /// <summary>
+    /// Compatibility overload for callers compiled against the object-based API.
+    /// </summary>
+    public static bool IsPowerQueryConnection(object connection)
+    {
+        return IsPowerQueryConnection((Excel.WorkbookConnection)connection);
+    }
+
+    /// <summary>
+    /// Determines whether a connection string belongs to the exact mashup query location.
+    /// </summary>
+    public static bool MatchesMashupLocation(string? connectionString, string queryName)
+    {
+        return TryParseMashupIdentity(connectionString, out var identity) &&
+            string.Equals(identity.Location, queryName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Reads the exact mashup query location from a workbook connection.
+    /// </summary>
+    public static bool TryGetMashupLocation(
+        Excel.WorkbookConnection connection,
+        out string location)
+    {
+        if (TryGetMashupIdentity(connection, out var identity) &&
+            !string.IsNullOrWhiteSpace(identity.Location))
         {
-            // If any error occurs, assume not a Power Query connection
+            location = identity.Location;
+            return true;
         }
 
+        location = string.Empty;
         return false;
     }
 
     /// <summary>
-    /// Removes QueryTables associated with a query or connection name from all worksheets
+    /// Reads mashup identity for read-contract inspection without converting an
+    /// unexpected OLEDB COM failure into a false "not loaded" result.
     /// </summary>
-    /// <param name="workbook">Excel workbook COM object</param>
-    /// <param name="name">Name of the query or connection (spaces will be replaced with underscores for QueryTable names)</param>
-    public static void RemoveQueryTables(dynamic workbook, string name)
+    internal static bool TryGetMashupLocationForInspection(
+        Excel.WorkbookConnection connection,
+        out string location)
     {
-        dynamic? worksheets = null;
+        if (Convert.ToInt32(connection.Type, CultureInfo.InvariantCulture) !=
+            (int)Excel.XlConnectionType.xlConnectionTypeOLEDB)
+        {
+            location = string.Empty;
+            return false;
+        }
 
+        Excel.OLEDBConnection? oleDbConnection = null;
+        try
+        {
+            oleDbConnection = connection.OLEDBConnection;
+            string? connectionString = oleDbConnection == null
+                ? null
+                : Convert.ToString(
+                    oleDbConnection.Connection,
+                    CultureInfo.InvariantCulture);
+            if (oleDbConnection != null &&
+                TryParseMashupIdentity(
+                    connectionString,
+                    out var identity) &&
+                !string.IsNullOrWhiteSpace(identity.Location))
+            {
+                location = identity.Location;
+                return true;
+            }
+
+            location = string.Empty;
+            return false;
+        }
+        finally
+        {
+            ComUtilities.Release(ref oleDbConnection);
+        }
+    }
+
+    /// <summary>
+    /// Replaces the exact Location property of a mashup connection string.
+    /// </summary>
+    public static bool TryReplaceMashupLocation(
+        string connectionString,
+        string expectedLocation,
+        string newLocation,
+        out string updatedConnectionString)
+    {
+        var parsed = ParseConnectionProperties(connectionString);
+        if (!parsed.TryGetValue("Provider", out var provider) ||
+            !string.Equals(provider.Value, MashupProvider, StringComparison.OrdinalIgnoreCase) ||
+            !parsed.TryGetValue("Location", out var location) ||
+            !string.Equals(location.Value, expectedLocation, StringComparison.OrdinalIgnoreCase))
+        {
+            updatedConnectionString = connectionString;
+            return false;
+        }
+
+        var encodedLocation = EncodePropertyValue(newLocation);
+        updatedConnectionString =
+            connectionString[..location.ValueStart] +
+            encodedLocation +
+            connectionString[location.ValueEnd..];
+        return true;
+    }
+
+    /// <summary>
+    /// Removes QueryTables owned by the exact workbook connection.
+    /// </summary>
+    public static void RemoveQueryTables(
+        Excel.Workbook workbook,
+        Excel.WorkbookConnection expectedConnection)
+    {
+        Excel.Sheets? worksheets = null;
+        var expectedConnectionName = expectedConnection.Name;
         try
         {
             worksheets = workbook.Worksheets;
-            string normalizedName = name.Replace(" ", "_");
-
             for (int ws = 1; ws <= worksheets.Count; ws++)
             {
-                dynamic? worksheet = null;
-                dynamic? queryTables = null;
-
+                Excel.Worksheet? worksheet = null;
+                Excel.QueryTables? queryTables = null;
                 try
                 {
-                    worksheet = worksheets.Item(ws);
+                    worksheet = (Excel.Worksheet)worksheets.Item[ws];
                     queryTables = worksheet.QueryTables;
-
-                    // Iterate backwards to safely delete items
                     for (int qt = queryTables.Count; qt >= 1; qt--)
                     {
-                        dynamic? queryTable = null;
+                        Excel.QueryTable? queryTable = null;
+                        Excel.WorkbookConnection? queryTableConnection = null;
                         try
                         {
                             queryTable = queryTables.Item(qt);
-                            string queryTableName = queryTable.Name?.ToString() ?? "";
-
-                            // Match QueryTable names that contain the normalized name
-                            if (queryTableName.Contains(normalizedName, StringComparison.OrdinalIgnoreCase))
+                            queryTableConnection = queryTable.WorkbookConnection;
+                            if (string.Equals(
+                                queryTableConnection.Name,
+                                expectedConnectionName,
+                                StringComparison.OrdinalIgnoreCase))
                             {
                                 queryTable.Delete();
                             }
                         }
+                        catch (COMException ex) when (ex.HResult == unchecked((int)0x800A03EC))
+                        {
+                            // The QueryTable has no accessible WorkbookConnection.
+                        }
                         finally
                         {
+                            ComUtilities.Release(ref queryTableConnection);
                             ComUtilities.Release(ref queryTable);
                         }
                     }
@@ -154,15 +228,343 @@ public static class PowerQueryHelpers
                 }
             }
         }
-        catch (System.Runtime.InteropServices.COMException)
-        {
-            // Ignore errors when removing QueryTables - they may not exist
-        }
         finally
         {
             ComUtilities.Release(ref worksheets);
         }
     }
+
+    /// <summary>
+    /// Compatibility overload that resolves an exact workbook connection name.
+    /// </summary>
+    public static void RemoveQueryTables(object workbook, string connectionName)
+    {
+        var typedWorkbook = (Excel.Workbook)workbook;
+        Excel.WorkbookConnection? connection = null;
+        try
+        {
+            connection = FindConnectionByExactName(typedWorkbook, connectionName);
+            if (connection != null)
+            {
+                RemoveQueryTables(typedWorkbook, connection);
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref connection);
+        }
+    }
+
+    /// <summary>
+    /// Removes workbook connections whose mashup Location exactly matches the query.
+    /// </summary>
+    public static void RemoveConnectionsByMashupLocation(
+        Excel.Workbook workbook,
+        string queryName)
+    {
+        Excel.Connections? connections = null;
+        var connectionNames = new List<string>();
+        try
+        {
+            connections = workbook.Connections;
+            for (int i = 1; i <= connections.Count; i++)
+            {
+                Excel.WorkbookConnection? connection = null;
+                try
+                {
+                    connection = connections.Item(i);
+                    if (TryGetMashupLocation(connection, out var location) &&
+                        string.Equals(location, queryName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        connectionNames.Add(connection.Name);
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref connection);
+                }
+            }
+
+            foreach (var connectionName in connectionNames)
+            {
+                Excel.WorkbookConnection? connection = null;
+                try
+                {
+                    connection = FindConnectionByExactName(workbook, connectionName);
+                    connection?.Delete();
+                }
+                finally
+                {
+                    ComUtilities.Release(ref connection);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref connections);
+        }
+    }
+
+    internal static Excel.WorkbookConnection? FindConnectionByExactName(
+        Excel.Workbook workbook,
+        string connectionName)
+    {
+        Excel.Connections? connections = null;
+        try
+        {
+            connections = workbook.Connections;
+            for (int i = 1; i <= connections.Count; i++)
+            {
+                Excel.WorkbookConnection? connection = null;
+                try
+                {
+                    connection = connections.Item(i);
+                    if (string.Equals(
+                        connection.Name,
+                        connectionName,
+                        StringComparison.OrdinalIgnoreCase))
+                    {
+                        var result = connection;
+                        connection = null;
+                        return result;
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref connection);
+                }
+            }
+
+            return null;
+        }
+        finally
+        {
+            ComUtilities.Release(ref connections);
+        }
+    }
+
+    internal static Excel.WorkbookQuery? FindQueryByExactName(
+        Excel.Workbook workbook,
+        string queryName)
+    {
+        Excel.Queries? queries = null;
+        try
+        {
+            queries = workbook.Queries;
+            for (int i = 1; i <= queries.Count; i++)
+            {
+                Excel.WorkbookQuery? query = null;
+                try
+                {
+                    query = queries.Item(i);
+                    if (string.Equals(
+                        query.Name,
+                        queryName,
+                        StringComparison.OrdinalIgnoreCase))
+                    {
+                        var result = query;
+                        query = null;
+                        return result;
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref query);
+                }
+            }
+
+            return null;
+        }
+        finally
+        {
+            ComUtilities.Release(ref queries);
+        }
+    }
+
+    private static bool TryGetMashupIdentity(
+        Excel.WorkbookConnection connection,
+        out MashupIdentity identity)
+    {
+        Excel.OLEDBConnection? oleDbConnection = null;
+        try
+        {
+            oleDbConnection = connection.OLEDBConnection;
+            return TryParseMashupIdentity(
+                Convert.ToString(oleDbConnection.Connection, CultureInfo.InvariantCulture),
+                out identity);
+        }
+        catch (COMException)
+        {
+            identity = default;
+            return false;
+        }
+        finally
+        {
+            ComUtilities.Release(ref oleDbConnection);
+        }
+    }
+
+    private static bool TryParseMashupIdentity(
+        string? connectionString,
+        out MashupIdentity identity)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            identity = default;
+            return false;
+        }
+
+        var properties = ParseConnectionProperties(connectionString);
+        if (!properties.TryGetValue("Provider", out var provider) ||
+            !string.Equals(provider.Value, MashupProvider, StringComparison.OrdinalIgnoreCase))
+        {
+            identity = default;
+            return false;
+        }
+
+        properties.TryGetValue("Location", out var location);
+        identity = new MashupIdentity(location.Value ?? string.Empty);
+        return true;
+    }
+
+    private static Dictionary<string, ConnectionProperty> ParseConnectionProperties(
+        string connectionString)
+    {
+        var properties = new Dictionary<string, ConnectionProperty>(
+            StringComparer.OrdinalIgnoreCase);
+        var segmentStart = 0;
+        var quote = '\0';
+        var seenEquals = false;
+        var valueStarted = false;
+
+        for (int index = 0; index <= connectionString.Length; index++)
+        {
+            var atEnd = index == connectionString.Length;
+            var current = atEnd ? ';' : connectionString[index];
+
+            if (!atEnd && quote != '\0')
+            {
+                if (current == quote)
+                {
+                    if (index + 1 < connectionString.Length &&
+                        connectionString[index + 1] == quote)
+                    {
+                        index++;
+                    }
+                    else
+                    {
+                        quote = '\0';
+                    }
+                }
+
+                continue;
+            }
+
+            if (!atEnd && current == '=' && !seenEquals)
+            {
+                seenEquals = true;
+                continue;
+            }
+
+            if (!atEnd && seenEquals && !valueStarted)
+            {
+                if (char.IsWhiteSpace(current))
+                {
+                    continue;
+                }
+
+                valueStarted = true;
+                if (current is '"' or '\'')
+                {
+                    quote = current;
+                    continue;
+                }
+            }
+
+            if (current != ';')
+            {
+                continue;
+            }
+
+            AddConnectionProperty(connectionString, segmentStart, index, properties);
+            segmentStart = index + 1;
+            seenEquals = false;
+            valueStarted = false;
+        }
+
+        return properties;
+    }
+
+    private static void AddConnectionProperty(
+        string connectionString,
+        int segmentStart,
+        int segmentEnd,
+        IDictionary<string, ConnectionProperty> properties)
+    {
+        var equalsIndex = connectionString.IndexOf('=', segmentStart, segmentEnd - segmentStart);
+        if (equalsIndex < 0)
+        {
+            return;
+        }
+
+        var key = connectionString[segmentStart..equalsIndex].Trim();
+        if (key.Length == 0)
+        {
+            return;
+        }
+
+        var valueStart = equalsIndex + 1;
+        while (valueStart < segmentEnd && char.IsWhiteSpace(connectionString[valueStart]))
+        {
+            valueStart++;
+        }
+
+        var valueEnd = segmentEnd;
+        while (valueEnd > valueStart &&
+            (char.IsWhiteSpace(connectionString[valueEnd - 1]) ||
+             connectionString[valueEnd - 1] == '\0'))
+        {
+            valueEnd--;
+        }
+
+        var rawValue = connectionString[valueStart..valueEnd];
+        var value = DecodePropertyValue(rawValue);
+        properties[key] = new ConnectionProperty(value, valueStart, valueEnd);
+    }
+
+    private static string DecodePropertyValue(string rawValue)
+    {
+        if (rawValue.Length >= 2 &&
+            rawValue[0] == rawValue[^1] &&
+            rawValue[0] is '"' or '\'')
+        {
+            var quote = rawValue[0];
+            return rawValue[1..^1].Replace(
+                new string(quote, 2),
+                quote.ToString(),
+                StringComparison.Ordinal);
+        }
+
+        return rawValue;
+    }
+
+    private static string EncodePropertyValue(string value)
+    {
+        if (value.IndexOfAny([';', '"', '\'']) < 0 &&
+            value.Length == value.Trim().Length)
+        {
+            return value;
+        }
+
+        return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+    }
+
+    private readonly record struct MashupIdentity(string Location);
+
+    private readonly record struct ConnectionProperty(
+        string? Value,
+        int ValueStart,
+        int ValueEnd);
 
     /// <summary>
     /// Options for creating QueryTable connections

--- a/src/ExcelMcp.Core/Commands/Vba/IVbaCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Vba/IVbaCommands.cs
@@ -42,7 +42,7 @@ public interface IVbaCommands
     /// Imports VBA code to create a new standard module
     /// </summary>
     /// <param name="moduleName">Name for the new module</param>
-    /// <param name="vbaCode">VBA code to import</param>
+    /// <param name="vbaCode">VBA code. Public callers must supply either inline vbaCode or a readable vbaCodeFile, not both.</param>
     [ServiceAction("import")]
     OperationResult Import(IExcelBatch batch, [RequiredParameter] string moduleName, [RequiredParameter][FileOrValue] string vbaCode);
 
@@ -50,7 +50,7 @@ public interface IVbaCommands
     /// Updates an existing VBA module with new code
     /// </summary>
     /// <param name="moduleName">Name of the module to update</param>
-    /// <param name="vbaCode">New VBA code</param>
+    /// <param name="vbaCode">New VBA code. Public callers must supply either inline vbaCode or a readable vbaCodeFile, not both.</param>
     [ServiceAction("update")]
     OperationResult Update(IExcelBatch batch, [RequiredParameter] string moduleName, [RequiredParameter][FileOrValue] string vbaCode);
 
@@ -58,7 +58,7 @@ public interface IVbaCommands
     /// Runs a VBA procedure with optional parameters
     /// </summary>
     /// <param name="procedureName">Name of the procedure to run (for example "Module1.MySub")</param>
-    /// <param name="timeout">Optional timeout for execution</param>
+    /// <param name="timeout">Optional public timeout in whole seconds from 1 through 2147483; converted to TimeSpan at shared dispatch</param>
     /// <param name="parameters">Optional parameters to pass to the procedure</param>
     [ServiceAction("run")]
     OperationResult Run(IExcelBatch batch, [RequiredParameter] string procedureName, TimeSpan? timeout, params string[] parameters);
@@ -70,6 +70,5 @@ public interface IVbaCommands
     [ServiceAction("delete")]
     OperationResult Delete(IExcelBatch batch, [RequiredParameter] string moduleName);
 }
-
 
 

--- a/src/ExcelMcp.Core/Commands/XmlMap/IXmlMapCommands.cs
+++ b/src/ExcelMcp.Core/Commands/XmlMap/IXmlMapCommands.cs
@@ -31,7 +31,7 @@ public interface IXmlMapCommands
     /// External XSD import/include dependencies are rejected.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
-    /// <param name="schema">Inline XSD schema content</param>
+    /// <param name="schema">XSD schema content. Public callers must supply either inline schema or a readable schemaFile, not both.</param>
     /// <param name="rootElementName">Optional root element when the schema has multiple roots</param>
     /// <param name="mapName">Optional name to assign to the created map</param>
     [ServiceAction("add")]
@@ -69,7 +69,7 @@ public interface IXmlMapCommands
     /// XML schema-location attributes are rejected to prevent implicit external access.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
-    /// <param name="xmlData">Inline XML data</param>
+    /// <param name="xmlData">XML data. Public callers must supply either inline xmlData or a readable xmlDataFile, not both.</param>
     /// <param name="mapName">Existing XML map name; omit for automatic mapping</param>
     /// <param name="sheetName">Destination worksheet for automatic mapping</param>
     /// <param name="startCell">Top-left destination cell for automatic mapping</param>

--- a/src/ExcelMcp.Core/Models/Actions/ActionExtensions.cs
+++ b/src/ExcelMcp.Core/Models/Actions/ActionExtensions.cs
@@ -12,7 +12,6 @@ public static class ActionExtensions
         FileAction.Open => "open",
         FileAction.Close => "close",
         FileAction.Create => "create",
-        FileAction.CloseWorkbook => "close-workbook",
         FileAction.Test => "test",
         _ => throw new ArgumentException($"Unknown FileAction: {action}")
     };
@@ -55,5 +54,4 @@ public static class ActionExtensions
     // CalculationModeAction.ToActionString() is now generated in ServiceRegistry.Calculation.ToActionString()
 }
 #pragma warning restore CS1591
-
 

--- a/src/ExcelMcp.Core/Models/Actions/ToolActions.cs
+++ b/src/ExcelMcp.Core/Models/Actions/ToolActions.cs
@@ -24,9 +24,6 @@ public enum FileAction
     [System.Text.Json.Serialization.JsonStringEnumMemberName("create")]
     Create,
 
-    [System.Text.Json.Serialization.JsonStringEnumMemberName("close-workbook")]
-    CloseWorkbook,
-
     [System.Text.Json.Serialization.JsonStringEnumMemberName("test")]
     Test
 }
@@ -81,5 +78,4 @@ public enum FileAction
 // CalculationModeAction is now generated from ICalculationModeCommands interface
 // See Sbroenne.ExcelMcp.Generated.CalculationAction in ServiceRegistry.Calculation.g.cs
 #pragma warning restore CS1591
-
 

--- a/src/ExcelMcp.Core/Models/ResultTypes.cs
+++ b/src/ExcelMcp.Core/Models/ResultTypes.cs
@@ -341,7 +341,8 @@ public class PowerQueryListResult : ResultBase
 }
 
 /// <summary>
-/// Information about a Power Query
+/// Compact metadata for a Power Query list item.
+/// Full M code is available only through the Power Query view action.
 /// </summary>
 public class PowerQueryInfo
 {
@@ -351,19 +352,44 @@ public class PowerQueryInfo
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
-    /// Full M code formula
+    /// Full M code retained for source and binary compatibility.
+    /// Use the Power Query view action for new code.
     /// </summary>
+    [Obsolete("Use the Power Query view action to retrieve full M code. This compatibility property is not serialized.")]
+    [JsonIgnore]
     public string Formula { get; set; } = string.Empty;
 
     /// <summary>
-    /// Preview of the formula (first 80 characters)
+    /// Bounded preview of the formula (at most 80 characters).
+    /// Use Power Query view to retrieve the full M code.
     /// </summary>
     public string FormulaPreview { get; set; } = string.Empty;
 
     /// <summary>
-    /// Whether the query is connection-only
+    /// Number of characters in the full M code
+    /// </summary>
+    public int CharacterCount { get; set; }
+
+    /// <summary>
+    /// Exact current load mode
+    /// </summary>
+    public PowerQueryLoadMode LoadMode { get; set; }
+
+    /// <summary>
+    /// Target worksheet name for worksheet and combined loads
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TargetSheet { get; set; }
+
+    /// <summary>
+    /// Whether the query has no worksheet or Data Model destination
     /// </summary>
     public bool IsConnectionOnly { get; set; }
+
+    /// <summary>
+    /// Whether the query is loaded to the Data Model
+    /// </summary>
+    public bool IsLoadedToDataModel { get; set; }
 }
 
 /// <summary>
@@ -387,7 +413,28 @@ public class PowerQueryViewResult : ResultBase
     public int CharacterCount { get; set; }
 
     /// <summary>
-    /// Whether the query is connection-only
+    /// Exact current load mode
+    /// </summary>
+    public PowerQueryLoadMode LoadMode { get; set; }
+
+    /// <summary>
+    /// Target worksheet name for worksheet and combined loads
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TargetSheet { get; set; }
+
+    /// <summary>
+    /// Whether the query has an active worksheet or Data Model destination
+    /// </summary>
+    public bool HasConnection { get; set; }
+
+    /// <summary>
+    /// Whether the query is loaded to the Data Model
+    /// </summary>
+    public bool IsLoadedToDataModel { get; set; }
+
+    /// <summary>
+    /// Whether the query has no worksheet or Data Model destination
     /// </summary>
     public bool IsConnectionOnly { get; set; }
 }
@@ -407,18 +454,23 @@ public enum PowerQueryLoadMode
     /// <summary>
     /// Load to table in worksheet
     /// </summary>
+    [Attributes.EnumAlias("worksheet")]
+    [Attributes.EnumAlias("table")]
     [JsonStringEnumMemberName("load-to-table")]
     LoadToTable,
 
     /// <summary>
     /// Load to Data Model (PowerPivot)
     /// </summary>
+    [Attributes.EnumAlias("data-model")]
+    [Attributes.EnumAlias("datamodel")]
     [JsonStringEnumMemberName("load-to-data-model")]
     LoadToDataModel,
 
     /// <summary>
     /// Load to both table and data model
     /// </summary>
+    [Attributes.EnumAlias("both")]
     [JsonStringEnumMemberName("load-to-both")]
     LoadToBoth
 }
@@ -445,7 +497,7 @@ public class PowerQueryLoadConfigResult : ResultBase
     public string? TargetSheet { get; set; }
 
     /// <summary>
-    /// Whether the query has an active connection
+    /// Whether the query has an active worksheet or Data Model destination
     /// </summary>
     public bool HasConnection { get; set; }
 
@@ -870,6 +922,11 @@ public class ScriptInfo
 public class FileValidationInfo
 {
     /// <summary>
+    /// Whether the file passed validation and can be opened
+    /// </summary>
+    public bool Success => CanOpen;
+
+    /// <summary>
     /// Full file path being validated
     /// </summary>
     public string FilePath { get; set; } = string.Empty;
@@ -895,9 +952,17 @@ public class FileValidationInfo
     public DateTime LastModified { get; set; }
 
     /// <summary>
-    /// Whether the file is a valid Excel workbook
+    /// Whether a standard OOXML file has a supported extension and valid package.
+    /// IRM/AIP containers require interactive Excel validation and report false.
     /// </summary>
     public bool IsValid { get; set; }
+
+    /// <summary>
+    /// Whether a standard OOXML workbook passes package validation and can be
+    /// accessed using ExcelMcp's required open mode. IRM/AIP openability requires
+    /// interactive authentication and reports false during preflight.
+    /// </summary>
+    public bool CanOpen { get; set; }
 
     /// <summary>
     /// Whether the file is IRM/AIP-protected (OLE2 compound document format).
@@ -908,10 +973,26 @@ public class FileValidationInfo
     public bool IsIrmProtected { get; set; }
 
     /// <summary>
+    /// Whether ExcelMcp will open the workbook read-only
+    /// </summary>
+    public bool WillOpenReadOnly { get; set; }
+
+    /// <summary>
+    /// Whether opening requires a visible Excel session for authentication
+    /// </summary>
+    public bool RequiresVisibleSession { get; set; }
+
+    /// <summary>
     /// Optional message describing validation outcome (missing file, invalid extension, etc.)
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Message { get; set; }
+
+    /// <summary>
+    /// Indicates a validation failure in CLI and MCP result envelopes
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IsError => Success ? null : true;
 }
 
 /// <summary>

--- a/src/ExcelMcp.Core/Utilities/FilePathValidation.cs
+++ b/src/ExcelMcp.Core/Utilities/FilePathValidation.cs
@@ -1,0 +1,23 @@
+namespace Sbroenne.ExcelMcp.Core.Utilities;
+
+/// <summary>
+/// Shared validation for public workbook path inputs.
+/// </summary>
+public static class FilePathValidation
+{
+    /// <summary>
+    /// Requires and normalizes an absolute Windows file path.
+    /// </summary>
+    public static string NormalizeAbsoluteWindowsPath(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        if (!Path.IsPathFullyQualified(filePath))
+        {
+            throw new ArgumentException(
+                $"File path must be an absolute Windows path: '{filePath}'.",
+                nameof(filePath));
+        }
+
+        return Path.GetFullPath(filePath);
+    }
+}

--- a/src/ExcelMcp.Core/Utilities/ParameterTransforms.cs
+++ b/src/ExcelMcp.Core/Utilities/ParameterTransforms.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Sbroenne.ExcelMcp.Core.Commands.Range;
@@ -11,6 +10,12 @@ namespace Sbroenne.ExcelMcp.Core.Utilities;
 /// </summary>
 public static class ParameterTransforms
 {
+    /// <summary>
+    /// Largest whole-second timeout that remains within the millisecond range accepted by
+    /// all supported cancellation APIs.
+    /// </summary>
+    public const int MaximumTimeoutSeconds = int.MaxValue / 1000;
+
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -255,22 +260,75 @@ public static class ParameterTransforms
 
     /// <summary>
     /// Resolves a value that can come from either a direct string or a file path.
-    /// If filePath is provided and exists, reads file content. Otherwise returns directValue.
+    /// Exactly one source may be supplied.
     /// </summary>
     /// <param name="directValue">The direct string value (e.g., M code inline)</param>
     /// <param name="filePath">Optional path to a file containing the value</param>
+    /// <param name="parameterName">Public inline parameter name used in validation errors</param>
     /// <returns>The resolved value (file content or direct value)</returns>
-    public static string? ResolveFileOrValue(string? directValue, string? filePath)
+    public static string? ResolveFileOrValue(
+        string? directValue,
+        string? filePath,
+        string parameterName = "value")
     {
+        ValidateFileOrValuePair(directValue, filePath, parameterName);
+
         if (!string.IsNullOrWhiteSpace(filePath))
         {
             if (!File.Exists(filePath))
             {
-                throw new FileNotFoundException($"File not found: {filePath}", filePath);
+                throw new FileNotFoundException(
+                    $"File for '{parameterName}' was not found: {filePath}",
+                    filePath);
             }
             return File.ReadAllText(filePath);
         }
         return directValue;
+    }
+
+    /// <summary>
+    /// Rejects ambiguous inline-plus-file inputs without reading the file.
+    /// </summary>
+    public static void ValidateFileOrValuePair(
+        string? directValue,
+        string? filePath,
+        string parameterName)
+    {
+        if (!string.IsNullOrWhiteSpace(directValue) &&
+            !string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentException(
+                $"Provide either {parameterName} or {parameterName}File, not both.",
+                parameterName);
+        }
+    }
+
+    /// <summary>
+    /// Validates file-or-value shape and file existence without reading content.
+    /// Content is resolved exactly once immediately before Core dispatch.
+    /// </summary>
+    public static void ValidateFileOrValueInput(
+        string? directValue,
+        string? filePath,
+        string parameterName,
+        bool required)
+    {
+        ValidateFileOrValuePair(directValue, filePath, parameterName);
+        if (!string.IsNullOrWhiteSpace(filePath) && !File.Exists(filePath))
+        {
+            throw new FileNotFoundException(
+                $"File for '{parameterName}' was not found: {filePath}",
+                filePath);
+        }
+
+        if (required
+            && string.IsNullOrWhiteSpace(directValue)
+            && string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentException(
+                $"{parameterName} is required.",
+                parameterName);
+        }
     }
 
     /// <summary>
@@ -280,13 +338,20 @@ public static class ParameterTransforms
     /// <returns>The corresponding PowerQueryLoadMode enum value</returns>
     public static Models.PowerQueryLoadMode ParseLoadMode(string? loadDestination)
     {
-        return loadDestination?.ToLowerInvariant() switch
+        if (string.IsNullOrWhiteSpace(loadDestination))
         {
-            "worksheet" or "table" => Models.PowerQueryLoadMode.LoadToTable,
-            "data-model" or "datamodel" => Models.PowerQueryLoadMode.LoadToDataModel,
-            "both" => Models.PowerQueryLoadMode.LoadToBoth,
+            return Models.PowerQueryLoadMode.LoadToTable;
+        }
+
+        return loadDestination.ToLowerInvariant() switch
+        {
+            "worksheet" or "table" or "load-to-table" or "loadtotable" => Models.PowerQueryLoadMode.LoadToTable,
+            "data-model" or "datamodel" or "load-to-data-model" or "loadtodatamodel" => Models.PowerQueryLoadMode.LoadToDataModel,
+            "both" or "load-to-both" or "loadtoboth" => Models.PowerQueryLoadMode.LoadToBoth,
             "connection-only" or "connectiononly" => Models.PowerQueryLoadMode.ConnectionOnly,
-            _ => Models.PowerQueryLoadMode.LoadToTable
+            _ => throw new ArgumentException(
+                $"Invalid load destination '{loadDestination}'. Valid values: worksheet, data-model, both, connection-only.",
+                nameof(loadDestination))
         };
     }
 
@@ -336,29 +401,45 @@ public static class ParameterTransforms
     }
 
     /// <summary>
-    /// Parses a timeout value supplied via CLI.
-    /// Plain numeric values are interpreted as seconds; TimeSpan-formatted values are preserved.
-    /// Returns null for null/empty input.
+    /// Converts a validated public whole-second timeout to the internal TimeSpan representation.
     /// </summary>
-    /// <param name="value">Timeout text from CLI</param>
+    /// <param name="value">Timeout in whole seconds</param>
     /// <param name="parameterName">Parameter name for error messages</param>
+    /// <param name="minimumSeconds">Smallest accepted value</param>
+    /// <param name="maximumSeconds">Largest accepted value</param>
     /// <returns>Parsed timeout or null</returns>
-    /// <exception cref="FormatException">Thrown when the timeout cannot be parsed</exception>
-    public static TimeSpan? ParseTimeSpanOrSeconds(string? value, string parameterName = "timeout")
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the timeout is outside the supported range</exception>
+    public static TimeSpan? ParseTimeoutSeconds(
+        int? value,
+        string parameterName = "timeout",
+        int minimumSeconds = 1,
+        int maximumSeconds = MaximumTimeoutSeconds)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (!value.HasValue)
             return null;
 
-        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
-            return TimeSpan.FromSeconds(seconds);
+        ValidateTimeoutSeconds(value, parameterName, minimumSeconds, maximumSeconds);
+        return TimeSpan.FromSeconds(value.Value);
+    }
 
-        if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var parsed)
-            || TimeSpan.TryParse(value, CultureInfo.CurrentCulture, out parsed))
+    /// <summary>
+    /// Validates a public whole-second timeout without converting its representation.
+    /// </summary>
+    public static void ValidateTimeoutSeconds(
+        int? value,
+        string parameterName = "timeout",
+        int minimumSeconds = 1,
+        int maximumSeconds = MaximumTimeoutSeconds)
+    {
+        if (!value.HasValue)
+            return;
+
+        if (value.Value < minimumSeconds || value.Value > maximumSeconds)
         {
-            return parsed;
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                value,
+                $"{parameterName} must be between {minimumSeconds} and {maximumSeconds} seconds.");
         }
-
-        throw new FormatException(
-            $"Invalid {parameterName} value '{value}'. Use seconds (for example 600) or TimeSpan format (for example 00:10:00).");
     }
 }

--- a/src/ExcelMcp.Generators.Mcp/McpToolGenerator.cs
+++ b/src/ExcelMcp.Generators.Mcp/McpToolGenerator.cs
@@ -125,6 +125,7 @@ public class McpToolGenerator : IIncrementalGenerator
         sb.AppendLine();
         sb.AppendLine("using System.ComponentModel;");
         sb.AppendLine("using System.Threading;");
+        sb.AppendLine("using ModelContextProtocol.Protocol;");
         sb.AppendLine("using ModelContextProtocol.Server;");
         sb.AppendLine("using Sbroenne.ExcelMcp.Generated;");
         if (hasProgress)
@@ -253,6 +254,7 @@ public class McpToolGenerator : IIncrementalGenerator
         {
             sb.AppendLine("        IProgress<ProgressNotificationValue> progress = default!,");
         }
+        sb.AppendLine("        RequestContext<CallToolRequestParams> requestContext = default!,");
         sb.AppendLine("        CancellationToken cancellationToken = default");
         sb.AppendLine("    )");
         sb.AppendLine("    {");
@@ -271,21 +273,6 @@ public class McpToolGenerator : IIncrementalGenerator
         var registryName = info.CategoryPascal;
         var toolName = info.McpToolName;
 
-        var hasPreProcessing = false;
-        foreach (var p in mcpParams)
-        {
-            if (p.PreProcessingCode != null)
-            {
-                if (!hasPreProcessing)
-                {
-                    sb.AppendLine("        // Pre-process parameters");
-                    hasPreProcessing = true;
-                }
-                sb.AppendLine($"        {p.PreProcessingCode}");
-            }
-        }
-        if (hasPreProcessing) sb.AppendLine();
-
         // Set ambient progress context so DispatchToCore can inject it into Core methods
         if (hasProgress)
         {
@@ -302,19 +289,44 @@ public class McpToolGenerator : IIncrementalGenerator
         sb.AppendLine($"{indent}return ExcelToolsBase.ExecuteToolAction(");
         sb.AppendLine($"{indent}    \"{toolName}\",");
         sb.AppendLine($"{indent}    ServiceRegistry.{registryName}.ToActionString(action),");
-        sb.AppendLine($"{indent}    () => ServiceRegistry.{registryName}.RouteAction(");
-        sb.AppendLine($"{indent}        action,");
+        sb.AppendLine($"{indent}    () =>");
+        sb.AppendLine($"{indent}    {{");
+        if (mcpParams.Count > 0)
+        {
+            sb.AppendLine($"{indent}        ServiceRegistry.{registryName}.ValidateActionParameters(");
+            sb.AppendLine($"{indent}            ServiceRegistry.{registryName}.ToActionString(action),");
+            sb.AppendLine($"{indent}            ServiceRegistry.GetSuppliedParameterNames(");
+            for (int i = 0; i < mcpParams.Count; i++)
+            {
+                var parameter = mcpParams[i];
+                var comma = i < mcpParams.Count - 1 ? "," : "),";
+                sb.AppendLine(
+                    $"{indent}                (\"{parameter.RouteActionParamName}\", requestContext.Params.Arguments?.ContainsKey(\"{parameter.Name}\") == true ? true : (bool?)null){comma}");
+            }
+            sb.AppendLine($"{indent}            allowFileParameters: true);");
+            sb.AppendLine();
+        }
+        foreach (var parameter in mcpParams.Where(parameter => parameter.PreProcessingCode != null))
+        {
+            sb.AppendLine($"{indent}        {parameter.PreProcessingCode}");
+        }
+        if (mcpParams.Any(parameter => parameter.PreProcessingCode != null))
+        {
+            sb.AppendLine();
+        }
+        sb.AppendLine($"{indent}        return ServiceRegistry.{registryName}.RouteAction(");
+        sb.AppendLine($"{indent}            action,");
 
         if (!info.NoSession)
         {
-            sb.AppendLine($"{indent}        session_id,");
+            sb.AppendLine($"{indent}            session_id,");
         }
         else
         {
-            sb.AppendLine($"{indent}        \"\",");
+            sb.AppendLine($"{indent}            \"\",");
         }
 
-        sb.AppendLine($"{indent}        ExcelToolsBase.ForwardToServiceFunc,");
+        sb.AppendLine($"{indent}            ExcelToolsBase.ForwardToServiceFunc,");
 
         // Named arguments to RouteAction
         for (int i = 0; i < mcpParams.Count; i++)
@@ -323,10 +335,11 @@ public class McpToolGenerator : IIncrementalGenerator
             var routeArgName = p.RouteActionParamName;
             var routeArgValue = p.RouteActionValue;
             var comma = i < mcpParams.Count - 1 ? "," : "";
-            sb.AppendLine($"{indent}        {routeArgName}: {routeArgValue}{comma}");
+            sb.AppendLine($"{indent}            {routeArgName}: {routeArgValue}{comma}");
         }
 
-        sb.AppendLine($"{indent}    ));");
+        sb.AppendLine($"{indent}        );");
+        sb.AppendLine($"{indent}    }});");
 
         // Close progress try/finally block
         if (hasProgress)
@@ -363,7 +376,6 @@ public class McpToolGenerator : IIncrementalGenerator
         {
             paramInfoByName.TryGetValue(ep.Name, out var pInfo);
             var snakeName = StringHelper.ToSnakeCase(ep.Name);
-            var defaultExpr = GetDefaultExpression(ep.TypeName, pInfo);
 
             // Determine MCP type and conversion
             if (pInfo != null && pInfo.IsEnum && pInfo.EnumTypeName != null)
@@ -386,10 +398,9 @@ public class McpToolGenerator : IIncrementalGenerator
                 else
                 {
                     var localVarName = $"_{ep.Name}Parsed";
-                    var parseExpression = $"System.Enum.TryParse<{pInfo.EnumTypeName}>({snakeName}?.Replace(\"-\", string.Empty).Replace(\"_\", string.Empty), ignoreCase: true, out var parsed{StringHelper.ToPascalCase(ep.Name)}) ? parsed{StringHelper.ToPascalCase(ep.Name)} : default";
-                    var preProcessingCode = defaultExpr == "null"
-                        ? $"var {localVarName} = !string.IsNullOrEmpty({snakeName}) ? ({pInfo.EnumTypeName}?)({parseExpression}) : null;"
-                        : $"var {localVarName} = !string.IsNullOrEmpty({snakeName}) ? {parseExpression} : {defaultExpr};";
+                    var aliasArguments = BuildEnumAliasArguments(pInfo);
+                    var preProcessingCode =
+                        $"var {localVarName} = !string.IsNullOrEmpty({snakeName}) ? ({pInfo.EnumTypeName}?)ServiceRegistry.ParseEnumValue<{pInfo.EnumTypeName}>({snakeName}, default, \"{ep.Name}\"{aliasArguments}) : null;";
 
                     result.Add(new McpParameter(
                         name: snakeName,
@@ -403,23 +414,20 @@ public class McpToolGenerator : IIncrementalGenerator
             }
             else if (ep.TypeName.Contains("TimeSpan"))
             {
-                // TimeSpan → int seconds in MCP
-                var secondsName = ep.Name.EndsWith("timeout", StringComparison.OrdinalIgnoreCase)
-                    ? ep.Name + "Seconds"
-                    : ep.Name + "Seconds";
+                // Public timeout inputs are whole seconds. Conversion happens once in service dispatch.
+                var secondsName = ep.Name + "Seconds";
                 var snakeSecondsName = StringHelper.ToSnakeCase(secondsName);
-                // Use the original name for MCP (the int seconds version)
-                var localVarName = $"_{ep.Name}";
+                var minimumSeconds = info.Category == "powerquery" ? 0 : 1;
                 result.Add(new McpParameter(
                     name: snakeSecondsName,
                     mcpTypeName: "int?",
                     routeActionParamName: ep.Name,
-                    routeActionValue: localVarName,
+                    routeActionValue: snakeSecondsName,
                     description: ep.DescriptionWithRequired != null
-                        ? ep.DescriptionWithRequired + " (in seconds)"
-                        : "Timeout in seconds",
+                        ? ep.DescriptionWithRequired + $" Accepted range: {minimumSeconds}-2147483 seconds."
+                        : $"Timeout in whole seconds; range {minimumSeconds}-2147483",
                     defaultExpression: "null",
-                    preProcessingCode: $"var {localVarName} = {snakeSecondsName}.HasValue ? System.TimeSpan.FromSeconds({snakeSecondsName}.Value) : (System.TimeSpan?)null;"));
+                    preProcessingCode: null));
             }
             else if (ep.TypeName.StartsWith("System.Collections.Generic.List<string>") ||
                      ep.TypeName.StartsWith("List<string>"))
@@ -443,8 +451,9 @@ public class McpToolGenerator : IIncrementalGenerator
                 var mcpType = ep.TypeName;
 
                 // All exposed params are optional in MCP (not all actions use every param).
-                // If the default is null, ensure the type is nullable to match RouteAction.
-                if (defaultExpr == "null" && !mcpType.EndsWith("?"))
+                // Use null as the category-wide omission sentinel, even when an individual action
+                // has a Core default. Core dispatch applies that default after action validation.
+                if (!mcpType.EndsWith("?"))
                     mcpType += "?";
 
                 result.Add(new McpParameter(
@@ -453,7 +462,7 @@ public class McpToolGenerator : IIncrementalGenerator
                     routeActionParamName: ep.Name,
                     routeActionValue: snakeName,
                     description: ep.DescriptionWithRequired,
-                    defaultExpression: defaultExpr,
+                    defaultExpression: "null",
                     preProcessingCode: null));
             }
         }
@@ -461,24 +470,15 @@ public class McpToolGenerator : IIncrementalGenerator
         return result;
     }
 
-    private static string GetDefaultExpression(string typeName, ParameterInfo? pInfo)
+    private static string BuildEnumAliasArguments(ParameterInfo parameter)
     {
-        if (pInfo?.DefaultValue != null)
-            return pInfo.DefaultValue;
+        if (parameter.EnumAliases.Count == 0 || parameter.EnumTypeName == null)
+            return string.Empty;
 
-        // All optional params default to null
-        if (typeName.EndsWith("?"))
-            return "null";
-
-        // Bool defaults
-        if (typeName == "bool")
-            return "false";
-
-        // Int defaults
-        if (typeName == "int")
-            return "0";
-
-        return "null";
+        return ", " + string.Join(
+            ", ",
+            parameter.EnumAliases.Select(alias =>
+                $"(\"{EscapeStringLiteral(alias.Alias)}\", {parameter.EnumTypeName}.{alias.MemberName})"));
     }
 
     private static string GetClassName(ServiceInfo info)

--- a/src/ExcelMcp.Generators.Shared/Models.cs
+++ b/src/ExcelMcp.Generators.Shared/Models.cs
@@ -91,6 +91,8 @@ public sealed class ParameterInfo
     public bool IsFromString { get; }
     public string? ExposedName { get; }
     public bool IsRequired { get; }
+    public bool AllowsEmptyString { get; }
+    public bool IsParams { get; }
     public bool IsEnum { get; }
     public string? XmlDocDescription { get; }
 
@@ -99,12 +101,15 @@ public sealed class ParameterInfo
     /// Used by MCP generator to emit typed enum parameters instead of strings.
     /// </summary>
     public string? EnumTypeName { get; }
+    public IReadOnlyList<EnumAliasInfo> EnumAliases { get; }
 
     public ParameterInfo(string name, string typeName, bool hasDefault, string? defaultValue,
         bool isFileOrValue = false, string? fileSuffix = null,
         bool isFromString = false, string? exposedName = null,
         bool isRequired = false, bool isEnum = false,
-        string? xmlDocDescription = null, string? enumTypeName = null)
+        string? xmlDocDescription = null, string? enumTypeName = null,
+        IReadOnlyList<EnumAliasInfo>? enumAliases = null, bool isParams = false,
+        bool allowsEmptyString = false)
     {
         Name = name;
         TypeName = typeName;
@@ -115,10 +120,25 @@ public sealed class ParameterInfo
         IsFromString = isFromString;
         ExposedName = exposedName;
         IsRequired = isRequired;
+        AllowsEmptyString = allowsEmptyString;
+        IsParams = isParams;
         IsEnum = isEnum;
         XmlDocDescription = xmlDocDescription;
         EnumTypeName = enumTypeName;
+        EnumAliases = enumAliases ?? [];
     }
+}
+
+public sealed class EnumAliasInfo
+{
+    public EnumAliasInfo(string alias, string memberName)
+    {
+        Alias = alias;
+        MemberName = memberName;
+    }
+
+    public string Alias { get; }
+    public string MemberName { get; }
 }
 
 /// <summary>
@@ -136,6 +156,7 @@ public sealed class ExposedParameter
 
     /// <summary>Total number of actions in the service (for computing "required for all" vs subset).</summary>
     public int TotalActionCount { get; set; }
+    public List<string> ApplicableByActions { get; } = new();
 
     public ExposedParameter(string name, string typeName, string? description = null, string? defaultValue = null)
     {
@@ -154,16 +175,23 @@ public sealed class ExposedParameter
     {
         get
         {
-            if (RequiredByActions.Count == 0)
+            var suffixes = new List<string>();
+            if (RequiredByActions.Count > 0)
+            {
+                suffixes.Add(RequiredByActions.Count == TotalActionCount
+                    ? "(required)"
+                    : $"(required for: {string.Join(", ", RequiredByActions)})");
+            }
+            if (ApplicableByActions.Count > 0 && ApplicableByActions.Count < TotalActionCount)
+            {
+                suffixes.Add($"(valid for: {string.Join(", ", ApplicableByActions)})");
+            }
+
+            if (suffixes.Count == 0)
                 return Description;
 
-            var suffix = RequiredByActions.Count == TotalActionCount
-                ? "(required)"
-                : $"(required for: {string.Join(", ", RequiredByActions)})";
-
-            return string.IsNullOrEmpty(Description)
-                ? suffix
-                : $"{Description} {suffix}";
+            var suffix = string.Join(" ", suffixes);
+            return string.IsNullOrEmpty(Description) ? suffix : $"{Description} {suffix}";
         }
     }
 }

--- a/src/ExcelMcp.Generators.Shared/ServiceInfoExtractor.cs
+++ b/src/ExcelMcp.Generators.Shared/ServiceInfoExtractor.cs
@@ -182,6 +182,7 @@ public static class ServiceInfoExtractor
         bool isFromString = false;
         string? exposedName = null;
         bool isRequired = false;
+        bool allowsEmptyString = false;
 
         foreach (var attr in param.GetAttributes())
         {
@@ -211,10 +212,15 @@ public static class ServiceInfoExtractor
             {
                 isRequired = true;
             }
+            else if (attrName == "AllowEmptyStringAttribute")
+            {
+                allowsEmptyString = true;
+            }
         }
 
         // Detect if this is an enum type (including Nullable<Enum>)
         bool isEnum = param.Type.TypeKind == TypeKind.Enum;
+        INamedTypeSymbol? enumTypeSymbol = isEnum ? param.Type as INamedTypeSymbol : null;
         string? enumTypeName = null;
         if (isEnum)
         {
@@ -227,7 +233,25 @@ public static class ServiceInfoExtractor
             isEnum = nullableType.TypeArguments[0].TypeKind == TypeKind.Enum;
             if (isEnum)
             {
+                enumTypeSymbol = nullableType.TypeArguments[0] as INamedTypeSymbol;
                 enumTypeName = TypeNameHelper.GetTypeName(nullableType.TypeArguments[0]);
+            }
+        }
+
+        var enumAliases = new List<EnumAliasInfo>();
+        if (enumTypeSymbol != null)
+        {
+            foreach (var field in enumTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(f => f.HasConstantValue))
+            {
+                foreach (var attribute in field.GetAttributes().Where(a => a.AttributeClass?.Name == "EnumAliasAttribute"))
+                {
+                    if (attribute.ConstructorArguments.Length > 0 &&
+                        attribute.ConstructorArguments[0].Value is string alias &&
+                        !string.IsNullOrWhiteSpace(alias))
+                    {
+                        enumAliases.Add(new EnumAliasInfo(alias, field.Name));
+                    }
+                }
             }
         }
 
@@ -250,7 +274,10 @@ public static class ServiceInfoExtractor
             isRequired,
             isEnum,
             paramDescription,
-            enumTypeName);
+            enumTypeName,
+            enumAliases,
+            param.IsParams,
+            allowsEmptyString);
     }
 
     private static XmlDocumentation? ExtractXmlDocumentation(IMethodSymbol method)
@@ -318,19 +345,32 @@ public static class ServiceInfoExtractor
                 }
 
                 // Track if this param is required for this action
-                var isRequired = p.IsRequired || (!p.HasDefault && !p.TypeName.EndsWith("?"));
+                var isRequired = p.IsRequired ||
+                                 (!p.HasDefault && !p.TypeName.EndsWith("?") && !p.IsParams);
                 if (isRequired)
                 {
                     existing.RequiredByActions.Add(method.ActionName);
+                }
+                if (!existing.ApplicableByActions.Contains(method.ActionName, StringComparer.OrdinalIgnoreCase))
+                {
+                    existing.ApplicableByActions.Add(method.ActionName);
                 }
 
                 // If FileOrValue, also add the file variant
                 if (p.IsFileOrValue && p.FileSuffix != null)
                 {
                     var fileParamName = exposedName + p.FileSuffix;
-                    if (!paramMap.ContainsKey(fileParamName))
+                    if (!paramMap.TryGetValue(fileParamName, out var fileParameter))
                     {
-                        paramMap[fileParamName] = new ExposedParameter(fileParamName, "string?", $"Path to file containing {exposedName}");
+                        fileParameter = new ExposedParameter(
+                            fileParamName,
+                            "string?",
+                            $"Path to a readable file containing {exposedName}; use instead of inline {exposedName}, not together");
+                        paramMap[fileParamName] = fileParameter;
+                    }
+                    if (!fileParameter.ApplicableByActions.Contains(method.ActionName, StringComparer.OrdinalIgnoreCase))
+                    {
+                        fileParameter.ApplicableByActions.Add(method.ActionName);
                     }
                 }
             }

--- a/src/ExcelMcp.Generators/ServiceRegistryGenerator.cs
+++ b/src/ExcelMcp.Generators/ServiceRegistryGenerator.cs
@@ -90,6 +90,9 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
             var skillManifestCode = GenerateSkillManifest(allCategories);
             context.AddSource("_SkillManifest.g.cs", SourceText.From(skillManifestCode, Encoding.UTF8));
 
+            var contractCode = GenerateContractRegistry(allCategories);
+            context.AddSource("ServiceRegistry.Contracts.g.cs", SourceText.From(contractCode, Encoding.UTF8));
+
             // Emit shared dispatch helper methods (DeserializeArgs, ParseEnumValue, etc.)
             var helpersCode = GenerateDispatchHelpers();
             context.AddSource("ServiceRegistry.DispatchHelpers.g.cs", SourceText.From(helpersCode, Encoding.UTF8));
@@ -280,10 +283,12 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         {
             var p = allExposedParams[i];
             var comma = i < allExposedParams.Count - 1 ? "," : ")";
-            sb.AppendLine($"            {p.TypeName} {p.Name} = {p.DefaultValue ?? "null"}{comma}");
+            sb.AppendLine($"            {p.TypeName} {p.Name} = null{comma}");
         }
 
         sb.AppendLine("        {");
+        GenerateSuppliedParameterValidationCall(sb, info, allExposedParams, "            ");
+        GenerateFileOrValuePairValidation(sb, info, "            ");
         sb.AppendLine("            return action switch");
         sb.AppendLine("            {");
         foreach (var method in info.Methods)
@@ -298,6 +303,7 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
 
         // Generate CLI RouteCliArgs method
         GenerateCliRouteMethod(sb, info);
+        GenerateActionContractMethods(sb, info, allExposedParams);
 
         sb.AppendLine("    }");
         sb.AppendLine("}");
@@ -324,11 +330,14 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         {
             var p = allExposedParams[i];
             var comma = i < allExposedParams.Count - 1 ? "," : ")";
-            sb.AppendLine($"            {p.TypeName} {p.Name} = {p.DefaultValue ?? "null"}{comma}");
+            sb.AppendLine($"            {p.TypeName} {p.Name} = null{comma}");
         }
 
         sb.AppendLine("        {");
         sb.AppendLine($"            var command = $\"{info.Category}.{{action}}\";");
+        sb.AppendLine();
+        GenerateSuppliedParameterValidationCall(sb, info, allExposedParams, "            ", actionExpression: "action");
+        GenerateFileOrValuePairValidation(sb, info, "            ");
         sb.AppendLine();
 
         // Generate switch statement with per-action validation
@@ -337,26 +346,30 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
 
         foreach (var method in info.Methods)
         {
-            bool hasFileOrValue = method.Parameters.Any(p => p.IsFileOrValue);
-
             sb.AppendLine($"                case \"{method.ActionName}\":");
-            // Use block scope when FileOrValue resolution generates local variables
-            // to avoid duplicate variable names across switch cases
-            if (hasFileOrValue)
+            if (method.Parameters.Any(p => p.IsFileOrValue))
                 sb.AppendLine("                {");
 
-            // Resolve FileOrValue parameters (read file content if file path provided)
-            foreach (var p in method.Parameters.Where(p => p.IsFileOrValue))
+            foreach (var parameter in method.Parameters.Where(p => p.IsEnum))
             {
-                sb.AppendLine($"                    var resolved{StringHelper.ToPascalCase(p.Name)} = Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ResolveFileOrValue({p.Name}, {p.Name}{p.FileSuffix});");
+                if (parameter.IsFromString)
+                {
+                    var exposedName = parameter.ExposedName ?? parameter.Name;
+                    GenerateEnumValidationStatement(sb, parameter, exposedName, exposedName, "                    ");
+                }
+                else
+                {
+                    GenerateTypedEnumValidationStatement(sb, parameter, parameter.Name, parameter.Name, "                    ");
+                }
             }
 
-            GenerateRequiredParameterValidation(sb, method, "                    ");
+            GenerateTimeoutValidation(sb, info, method, "                    ");
+            GenerateRequiredParameterValidation(sb, method, "                    ", includeFileOrValue: false);
 
             var argsExpr = BuildCliArgsExpression(method);
             sb.AppendLine($"                    return (command, {argsExpr});");
 
-            if (hasFileOrValue)
+            if (method.Parameters.Any(p => p.IsFileOrValue))
                 sb.AppendLine("                }");
         }
 
@@ -373,6 +386,230 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         GenerateCliSettings(sb, info, allExposedParams);
     }
 
+    private static void GenerateSuppliedParameterValidationCall(
+        StringBuilder sb,
+        ServiceInfo info,
+        List<ExposedParameter> allExposedParams,
+        string indent,
+        string? actionExpression = null)
+    {
+        if (allExposedParams.Count == 0)
+            return;
+
+        actionExpression ??= $"ToActionString(action)";
+        sb.AppendLine($"{indent}ValidateActionParameters(");
+        sb.AppendLine($"{indent}    {actionExpression},");
+        sb.AppendLine($"{indent}    ServiceRegistry.GetSuppliedParameterNames(");
+        for (int i = 0; i < allExposedParams.Count; i++)
+        {
+            var parameter = allExposedParams[i];
+            var comma = i < allExposedParams.Count - 1 ? "," : "),";
+            sb.AppendLine($"{indent}        (\"{parameter.Name}\", {parameter.Name}){comma}");
+        }
+        sb.AppendLine($"{indent}    allowFileParameters: true);");
+    }
+
+    private static void GenerateFileOrValuePairValidation(
+        StringBuilder sb,
+        ServiceInfo info,
+        string indent)
+    {
+        foreach (var parameter in info.Methods
+                     .SelectMany(method => method.Parameters)
+                     .Where(parameter => parameter.IsFileOrValue)
+                     .GroupBy(parameter => parameter.Name, StringComparer.OrdinalIgnoreCase)
+                     .Select(group => group.First()))
+        {
+            sb.AppendLine(
+                $"{indent}Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ValidateFileOrValuePair({parameter.Name}, {parameter.Name}{parameter.FileSuffix}, \"{parameter.Name}\");");
+        }
+    }
+
+    private static void GenerateTimeoutValidation(
+        StringBuilder sb,
+        ServiceInfo info,
+        MethodInfo method,
+        string indent,
+        string? argsPrefix = null)
+    {
+        var minimumSeconds = info.Category == "powerquery" ? 0 : 1;
+        foreach (var parameter in method.Parameters.Where(parameter => IsTimeSpanType(parameter.TypeName)))
+        {
+            var propertyName = parameter.ExposedName ?? parameter.Name;
+            var valueExpression = argsPrefix == null
+                ? propertyName
+                : $"{argsPrefix}.{StringHelper.ToPascalCase(propertyName)}";
+            sb.AppendLine(
+                $"{indent}Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ValidateTimeoutSeconds({valueExpression}, \"{propertyName}\", minimumSeconds: {minimumSeconds});");
+        }
+    }
+
+    private static void GenerateActionContractMethods(
+        StringBuilder sb,
+        ServiceInfo info,
+        List<ExposedParameter> allExposedParams)
+    {
+        sb.AppendLine("        /// <summary>Validates explicitly supplied parameters for an action.</summary>");
+        sb.AppendLine("        public static void ValidateActionParameters(");
+        sb.AppendLine("            string action,");
+        sb.AppendLine("            System.Collections.Generic.IEnumerable<string> suppliedParameters,");
+        sb.AppendLine("            bool allowFileParameters)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var validParameters = action switch");
+        sb.AppendLine("            {");
+        foreach (var method in info.Methods)
+        {
+            var serviceParameters = GetActionParameterNames(method, includeFileParameters: false);
+            var routeParameters = GetActionParameterNames(method, includeFileParameters: true);
+            if (serviceParameters.SequenceEqual(routeParameters, StringComparer.Ordinal))
+            {
+                sb.AppendLine($"                \"{method.ActionName}\" => {BuildStringArrayExpression(serviceParameters)},");
+            }
+            else
+            {
+                sb.AppendLine($"                \"{method.ActionName}\" => allowFileParameters");
+                sb.AppendLine($"                    ? {BuildStringArrayExpression(routeParameters)}");
+                sb.AppendLine($"                    : {BuildStringArrayExpression(serviceParameters)},");
+            }
+        }
+        sb.AppendLine("                _ => throw new System.ArgumentException($\"Unknown action: {action}\")");
+        sb.AppendLine("            };");
+        sb.AppendLine("            var validSet = new System.Collections.Generic.HashSet<string>(validParameters, System.StringComparer.Ordinal);");
+        sb.AppendLine("            var invalid = suppliedParameters");
+        sb.AppendLine("                .Where(parameter => !validSet.Contains(parameter))");
+        sb.AppendLine("                .Distinct(System.StringComparer.Ordinal)");
+        sb.AppendLine("                .OrderBy(parameter => parameter, System.StringComparer.Ordinal)");
+        sb.AppendLine("                .ToArray();");
+        sb.AppendLine("            if (invalid.Length > 0)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                throw new System.ArgumentException(");
+        sb.AppendLine("                    $\"Parameter(s) {string.Join(\", \", invalid)} are not valid for action '{action}'.\");");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+
+        sb.AppendLine("        /// <summary>Validates raw service arguments before Core dispatch.</summary>");
+        sb.AppendLine("        public static void ValidateActionArguments(string action, string? argsJson)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var rawPropertyNames = ServiceRegistry.GetJsonPropertyNames(argsJson, includeNullValues: true);");
+        sb.AppendLine(
+            $"            var canonicalPropertyNames = new System.Collections.Generic.HashSet<string>({BuildStringArrayExpression(allExposedParams.Select(parameter => parameter.Name).ToList())}, System.StringComparer.Ordinal);");
+        sb.AppendLine("            var invalidPropertyNames = rawPropertyNames");
+        sb.AppendLine("                .Where(parameter => !canonicalPropertyNames.Contains(parameter))");
+        sb.AppendLine("                .Distinct(System.StringComparer.Ordinal)");
+        sb.AppendLine("                .OrderBy(parameter => parameter, System.StringComparer.Ordinal)");
+        sb.AppendLine("                .ToArray();");
+        sb.AppendLine("            if (invalidPropertyNames.Length > 0)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                throw new System.ArgumentException(");
+        sb.AppendLine("                    $\"Unknown or non-canonical parameter(s): {string.Join(\", \", invalidPropertyNames)}.\");");
+        sb.AppendLine("            }");
+        sb.AppendLine("            ValidateActionParameters(action, rawPropertyNames, allowFileParameters: true);");
+        var validatedMethods = info.Methods
+            .Where(method => method.Parameters.Count > 0)
+            .ToList();
+        if (validatedMethods.Count > 0)
+        {
+            sb.AppendLine("            switch (action)");
+            sb.AppendLine("            {");
+            foreach (var method in validatedMethods)
+            {
+                sb.AppendLine($"                case \"{method.ActionName}\":");
+                sb.AppendLine("                {");
+                foreach (var parameter in method.Parameters.Where(parameter =>
+                             IsRequiredParameter(parameter) &&
+                             parameter.AllowsEmptyString))
+                {
+                    var propertyName = parameter.ExposedName ?? parameter.Name;
+                    sb.AppendLine(
+                        $"                    ServiceRegistry.RequireJsonStringArgument(argsJson, \"{propertyName}\", \"{method.ActionName}\");");
+                }
+                sb.AppendLine($"                    var args = DeserializeArgs<{method.MethodName}Args>(argsJson);");
+                foreach (var parameter in method.Parameters.Where(parameter => parameter.IsFileOrValue))
+                {
+                    var pascalName = StringHelper.ToPascalCase(parameter.Name);
+                    sb.AppendLine(
+                        $"                    Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ValidateFileOrValueInput(args.{pascalName}, args.{pascalName}{parameter.FileSuffix}, \"{parameter.Name}\", required: {(IsRequiredParameter(parameter) ? "true" : "false")});");
+                }
+                var requiredStringParameters = method.Parameters
+                    .Where(parameter =>
+                        !parameter.IsFileOrValue &&
+                        !parameter.IsEnum &&
+                        StringHelper.IsStringType(parameter.TypeName) &&
+                        IsRequiredParameter(parameter) &&
+                        !parameter.AllowsEmptyString)
+                    .ToList();
+                if (requiredStringParameters.Count > 0)
+                {
+                    sb.AppendLine(
+                        $"                    Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.RequireAllNotEmpty(\"{method.ActionName}\",");
+                    for (int i = 0; i < requiredStringParameters.Count; i++)
+                    {
+                        var parameter = requiredStringParameters[i];
+                        var propertyName = parameter.ExposedName ?? parameter.Name;
+                        var propertyExpression = $"args.{StringHelper.ToPascalCase(propertyName)}";
+                        var comma = i < requiredStringParameters.Count - 1 ? "," : ");";
+                        sb.AppendLine(
+                            $"                        ({propertyExpression}, \"{propertyName}\"){comma}");
+                    }
+                }
+                foreach (var parameter in method.Parameters.Where(parameter =>
+                             !parameter.IsFileOrValue &&
+                             !parameter.IsEnum &&
+                             !StringHelper.IsStringType(parameter.TypeName) &&
+                             IsRequiredParameter(parameter)))
+                {
+                    var propertyName = parameter.ExposedName ?? parameter.Name;
+                    var propertyExpression = $"args.{StringHelper.ToPascalCase(propertyName)}";
+                    sb.AppendLine($"                    if ({propertyExpression} is null)");
+                    sb.AppendLine(
+                        $"                        throw new System.ArgumentException(\"{propertyName} is required for {method.ActionName} action.\", \"{propertyName}\");");
+                }
+                foreach (var parameter in method.Parameters.Where(p => p.IsEnum))
+                {
+                    var propertyName = parameter.IsFromString && parameter.ExposedName != null
+                        ? parameter.ExposedName
+                        : parameter.Name;
+                    var propertyExpression = $"args.{StringHelper.ToPascalCase(propertyName)}";
+                    if (IsRequiredParameter(parameter))
+                    {
+                        sb.AppendLine($"                    if (string.IsNullOrWhiteSpace({propertyExpression}))");
+                        sb.AppendLine($"                        throw new System.ArgumentException(\"{propertyName} is required for {method.ActionName} action.\", \"{propertyName}\");");
+                    }
+                    GenerateEnumValidationStatement(sb, parameter, propertyExpression, propertyName, "                    ");
+                }
+                GenerateTimeoutValidation(sb, info, method, "                    ", argsPrefix: "args");
+                sb.AppendLine("                    break;");
+                sb.AppendLine("                }");
+            }
+            sb.AppendLine("                }");
+        }
+        sb.AppendLine("        }");
+        sb.AppendLine();
+    }
+
+    private static List<string> GetActionParameterNames(MethodInfo method, bool includeFileParameters)
+    {
+        var result = new List<string>();
+        foreach (var parameter in method.Parameters)
+        {
+            result.Add(parameter.ExposedName ?? parameter.Name);
+            if (includeFileParameters && parameter.IsFileOrValue && parameter.FileSuffix != null)
+            {
+                result.Add(parameter.Name + parameter.FileSuffix);
+            }
+        }
+        return result;
+    }
+
+    private static string BuildStringArrayExpression(List<string> values)
+    {
+        if (values.Count == 0)
+            return "System.Array.Empty<string>()";
+
+        return $"new[] {{ {string.Join(", ", values.Select(value => $"\"{value}\""))} }}";
+    }
+
     private static void GenerateRouteFromSettings(StringBuilder sb, ServiceInfo info, List<ExposedParameter> allExposedParams)
     {
         sb.AppendLine("        /// <summary>");
@@ -381,6 +618,20 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         sb.AppendLine("        /// </summary>");
         sb.AppendLine("        public static (string Command, object? Args) RouteFromSettings(string action, CliSettings settings)");
         sb.AppendLine("        {");
+        if (allExposedParams.Count > 0)
+        {
+            sb.AppendLine("            ValidateActionParameters(");
+            sb.AppendLine("                action,");
+            sb.AppendLine("                ServiceRegistry.GetSuppliedParameterNames(");
+            for (int i = 0; i < allExposedParams.Count; i++)
+            {
+                var parameter = allExposedParams[i];
+                var comma = i < allExposedParams.Count - 1 ? "," : "),";
+                sb.AppendLine(
+                    $"                    (\"{parameter.Name}\", settings.{StringHelper.ToPascalCase(parameter.Name)}){comma}");
+            }
+            sb.AppendLine("                allowFileParameters: true);");
+        }
         sb.AppendLine("            return RouteCliArgs(");
         sb.AppendLine("                action,");
 
@@ -388,8 +639,15 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         {
             var p = allExposedParams[i];
             var comma = i < allExposedParams.Count - 1 ? "," : ");";
+            var parameterInfo = FindParameterInfo(info, p.Name);
 
-            if (IsNestedCollectionType(p.TypeName))
+            if (parameterInfo is { IsEnum: true, IsFromString: false })
+            {
+                var enumType = parameterInfo.EnumTypeName ?? parameterInfo.TypeName.TrimEnd('?');
+                sb.AppendLine(
+                    $"                {p.Name}: !string.IsNullOrEmpty(settings.{StringHelper.ToPascalCase(p.Name)}) ? ({enumType}?)ServiceRegistry.ParseEnumValue<{enumType}>(settings.{StringHelper.ToPascalCase(p.Name)}, default, \"{p.Name}\"{BuildEnumAliasArguments(parameterInfo)}) : null{comma}");
+            }
+            else if (IsNestedCollectionType(p.TypeName))
             {
                 // CLI Settings stores nested collections as string (JSON).
                 // Deserialize back to the original type for RouteCliArgs.
@@ -405,10 +663,6 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
                 // Deserialize back to the original type for RouteCliArgs.
                 var nonNullableType = p.TypeName.TrimEnd('?');
                 sb.AppendLine($"                {p.Name}: !string.IsNullOrWhiteSpace(settings.{StringHelper.ToPascalCase(p.Name)}) ? ServiceRegistry.DeserializeList<{nonNullableType}>(settings.{StringHelper.ToPascalCase(p.Name)}) : null{comma}");
-            }
-            else if (IsTimeSpanType(p.TypeName))
-            {
-                sb.AppendLine($"                {p.Name}: Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ParseTimeSpanOrSeconds(settings.{StringHelper.ToPascalCase(p.Name)}, \"{p.Name}\"){comma}");
             }
             else
             {
@@ -506,11 +760,19 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
             // raw JSON. LLMs pass JSON arrays instead of repeated CLI flags.
             // Deserialized back to the original type in RouteFromSettings.
             var isCollectionForJson = IsNestedCollectionType(p.TypeName) || IsSimpleListType(p.TypeName);
-            var cliTypeName = isCollectionForJson || IsTimeSpanType(p.TypeName) ? "string?" : p.TypeName;
+            var parameterInfo = FindParameterInfo(info, p.Name);
+            var isTimeoutSeconds = parameterInfo != null && IsTimeSpanType(parameterInfo.TypeName);
+            var cliTypeName = isCollectionForJson ||
+                              parameterInfo is { IsEnum: true, IsFromString: false }
+                ? "string?"
+                : p.TypeName;
             if (isCollectionForJson && !escapedDescription.Contains("JSON"))
                 escapedDescription += " (JSON format)";
-            if (IsTimeSpanType(p.TypeName) && escapedDescription.IndexOf("seconds", StringComparison.OrdinalIgnoreCase) < 0)
-                escapedDescription += " Accepts seconds (e.g. 600) or TimeSpan format (e.g. 00:10:00).";
+            if (isTimeoutSeconds && escapedDescription.IndexOf("seconds", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                var minimumSeconds = info.Category == "powerquery" ? 0 : 1;
+                escapedDescription += $" Whole seconds only; range {minimumSeconds}-2147483.";
+            }
 
             // Add short aliases for backward compatibility with pre-generator CLI parameter names
             var shortAlias = GetShortAlias(p.Name);
@@ -533,6 +795,17 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         sb.AppendLine("        }");
     }
 
+    private static ParameterInfo? FindParameterInfo(ServiceInfo info, string exposedName)
+    {
+        return info.Methods
+            .SelectMany(method => method.Parameters)
+            .FirstOrDefault(parameter =>
+                string.Equals(
+                    parameter.ExposedName ?? parameter.Name,
+                    exposedName,
+                    StringComparison.OrdinalIgnoreCase));
+    }
+
     private static string BuildCliArgsExpression(MethodInfo method)
     {
         if (method.Parameters.Count == 0)
@@ -541,13 +814,16 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         var props = new List<string>();
         foreach (var p in method.Parameters)
         {
-            string valueName;
             if (p.IsFileOrValue)
             {
-                // Use resolved variable (ResolveFileOrValue applied in RouteCliArgs)
-                valueName = $"resolved{StringHelper.ToPascalCase(p.Name)}";
+                var fileValueJsonName = char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1);
+                props.Add($"{fileValueJsonName} = {p.Name}");
+                props.Add($"{fileValueJsonName}{p.FileSuffix} = {p.Name}{p.FileSuffix}");
+                continue;
             }
-            else if (p.IsFromString && p.ExposedName != null)
+
+            string valueName;
+            if (p.IsFromString && p.ExposedName != null)
             {
                 // CLI passes string directly to service using exposed name
                 valueName = p.ExposedName;
@@ -581,6 +857,11 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
                 methodParams.Add($"string? {p.Name} = null");
                 methodParams.Add($"string? {p.Name}{p.FileSuffix} = null");
             }
+            else if (IsTimeSpanType(p.TypeName))
+            {
+                var defaultStr = p.HasDefault ? " = null" : "";
+                methodParams.Add($"int? {p.Name}{defaultStr}");
+            }
             else if (p.IsFromString && p.IsEnum)
             {
                 // Expose as string
@@ -600,18 +881,22 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         sb.AppendLine($"        public static string Forward{method.MethodName}({string.Join(", ", methodParams)})");
         sb.AppendLine("        {");
 
-        // Generate transforms (only for FileOrValue parameters)
-        // Note: FromString enum parameters are passed as-is to the service (service does parsing)
+        // FromString enum parameters are passed as-is to the service (service does parsing).
         foreach (var p in method.Parameters)
         {
-            if (p.IsFileOrValue)
+            if (p.IsFromString && p.IsEnum)
             {
-                sb.AppendLine($"            var resolved{StringHelper.ToPascalCase(p.Name)} = Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ResolveFileOrValue({p.Name}, {p.Name}{p.FileSuffix});");
+                var exposedName = p.ExposedName ?? p.Name;
+                GenerateEnumValidationStatement(sb, p, exposedName, exposedName, "            ");
             }
-            // FromString enum parameters: pass raw string to service (no pre-parsing)
+            else if (p.IsEnum)
+            {
+                GenerateTypedEnumValidationStatement(sb, p, p.Name, p.Name, "            ");
+            }
         }
 
-        GenerateRequiredParameterValidation(sb, method, "            ");
+        GenerateTimeoutValidation(sb, info, method, "            ");
+        GenerateRequiredParameterValidation(sb, method, "            ", includeFileOrValue: false);
 
         // Build the request object - always use method-specific command constant
         if (method.Parameters.Count == 0)
@@ -624,12 +909,15 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
             sb.AppendLine("            {");
             foreach (var p in method.Parameters)
             {
-                string valueExpr;
                 if (p.IsFileOrValue)
                 {
-                    valueExpr = $"resolved{StringHelper.ToPascalCase(p.Name)}";
+                    sb.AppendLine($"                {StringHelper.ToPascalCase(p.Name)} = {p.Name},");
+                    sb.AppendLine($"                {StringHelper.ToPascalCase(p.Name)}{p.FileSuffix} = {p.Name}{p.FileSuffix},");
+                    continue;
                 }
-                else if (p.IsFromString && p.ExposedName != null)
+
+                string valueExpr;
+                if (p.IsFromString && p.ExposedName != null)
                 {
                     // FromString parameters: pass the exposed name (raw string) to service
                     valueExpr = p.ExposedName;
@@ -649,32 +937,130 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         sb.AppendLine();
     }
 
-    private static void GenerateRequiredParameterValidation(StringBuilder sb, MethodInfo method, string indent)
+    private static void GenerateEnumValidationStatement(
+        StringBuilder sb,
+        ParameterInfo parameter,
+        string valueExpression,
+        string exposedName,
+        string indent)
+    {
+        var enumType = parameter.EnumTypeName ?? parameter.TypeName.TrimEnd('?');
+        var defaultExpression = parameter.HasDefault &&
+                                parameter.DefaultValue != null &&
+                                parameter.DefaultValue != "null"
+            ? parameter.DefaultValue
+            : $"default({enumType})";
+        var parseCall =
+            $"ServiceRegistry.ParseEnumValue<{enumType}>({valueExpression}, {defaultExpression}, \"{exposedName}\"{BuildEnumAliasArguments(parameter)})";
+
+        if (parameter.TypeName.EndsWith("?"))
+        {
+            sb.AppendLine($"{indent}if (!string.IsNullOrEmpty({valueExpression}))");
+            sb.AppendLine($"{indent}    _ = {parseCall};");
+        }
+        else
+        {
+            sb.AppendLine($"{indent}_ = {parseCall};");
+        }
+    }
+
+    private static string BuildEnumAliasArguments(ParameterInfo parameter)
+    {
+        if (parameter.EnumAliases.Count == 0 || parameter.EnumTypeName == null)
+            return string.Empty;
+
+        return ", " + string.Join(
+            ", ",
+            parameter.EnumAliases.Select(alias =>
+                $"(\"{EscapeStringLiteral(alias.Alias)}\", {parameter.EnumTypeName}.{alias.MemberName})"));
+    }
+
+    private static void GenerateTypedEnumValidationStatement(
+        StringBuilder sb,
+        ParameterInfo parameter,
+        string valueExpression,
+        string parameterName,
+        string indent)
+    {
+        var enumType = parameter.EnumTypeName ?? parameter.TypeName.TrimEnd('?');
+        sb.AppendLine($"{indent}ServiceRegistry.ValidateEnumValue<{enumType}>({valueExpression}, \"{parameterName}\");");
+    }
+
+    private static string EscapeStringLiteral(string value)
+    {
+        return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+
+    private static void GenerateRequiredParameterValidation(
+        StringBuilder sb,
+        MethodInfo method,
+        string indent,
+        bool includeFileOrValue = true)
     {
         var requiredParameters = method.Parameters
             .Where(p =>
-                (p.IsRequired || (!p.HasDefault && !p.TypeName.EndsWith("?"))) &&
-                (p.IsFileOrValue || StringHelper.IsStringType(p.TypeName) || (p.IsFromString && p.IsEnum)))
+                IsRequiredParameter(p) &&
+                !p.AllowsEmptyString &&
+                ((includeFileOrValue && p.IsFileOrValue) ||
+                 (!p.IsFileOrValue && StringHelper.IsStringType(p.TypeName)) ||
+                 (p.IsFromString && p.IsEnum)))
             .ToList();
 
-        if (requiredParameters.Count == 0)
+        if (requiredParameters.Count > 0)
         {
-            return;
+            sb.AppendLine($"{indent}Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.RequireAllNotEmpty(\"{method.ActionName}\",");
+            for (int i = 0; i < requiredParameters.Count; i++)
+            {
+                var parameter = requiredParameters[i];
+                var parameterName = parameter.IsFromString && parameter.IsEnum
+                    ? parameter.ExposedName ?? parameter.Name
+                    : parameter.Name;
+                var valueExpression = parameter.IsFileOrValue
+                    ? $"resolved{StringHelper.ToPascalCase(parameter.Name)}"
+                    : parameterName;
+                var comma = i < requiredParameters.Count - 1 ? "," : ");";
+                sb.AppendLine($"{indent}    ({valueExpression}, \"{parameterName}\"){comma}");
+            }
         }
 
-        sb.AppendLine($"{indent}Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.RequireAllNotEmpty(\"{method.ActionName}\",");
-        for (int i = 0; i < requiredParameters.Count; i++)
+        foreach (var parameter in method.Parameters.Where(p =>
+                     IsRequiredParameter(p) &&
+                     p.AllowsEmptyString))
         {
-            var parameter = requiredParameters[i];
-            var parameterName = parameter.IsFromString && parameter.IsEnum
-                ? parameter.ExposedName ?? parameter.Name
-                : parameter.Name;
-            var valueExpression = parameter.IsFileOrValue
-                ? $"resolved{StringHelper.ToPascalCase(parameter.Name)}"
-                : parameterName;
-            var comma = i < requiredParameters.Count - 1 ? "," : ");";
-            sb.AppendLine($"{indent}    ({valueExpression}, \"{parameterName}\"){comma}");
+            var parameterName = parameter.ExposedName ?? parameter.Name;
+            sb.AppendLine($"{indent}if ({parameterName} is null)");
+            sb.AppendLine(
+                $"{indent}    throw new System.ArgumentException(\"{parameterName} is required for {method.ActionName} action.\", \"{parameterName}\");");
         }
+
+        foreach (var parameter in method.Parameters.Where(p =>
+                     IsRequiredParameter(p) &&
+                     !p.IsFileOrValue &&
+                     !StringHelper.IsStringType(p.TypeName) &&
+                     !(p.IsFromString && p.IsEnum)))
+        {
+            var parameterName = parameter.ExposedName ?? parameter.Name;
+            sb.AppendLine($"{indent}if ({parameterName} is null)");
+            sb.AppendLine(
+                $"{indent}    throw new System.ArgumentException(\"{parameterName} is required for {method.ActionName} action.\", \"{parameterName}\");");
+        }
+
+        foreach (var parameter in method.Parameters.Where(p =>
+                     p.IsEnum &&
+                     !p.IsFromString &&
+                     IsRequiredParameter(p)))
+        {
+            sb.AppendLine($"{indent}if (!{parameter.Name}.HasValue)");
+            sb.AppendLine($"{indent}    throw new System.ArgumentException(\"{parameter.Name} is required for {method.ActionName} action.\", \"{parameter.Name}\");");
+        }
+    }
+
+    private static bool IsRequiredParameter(ParameterInfo parameter)
+    {
+        return parameter.IsRequired ||
+               (!parameter.HasDefault &&
+                !parameter.TypeName.EndsWith("?") &&
+                !parameter.IsParams);
     }
 
     private static void GenerateArgsClass(StringBuilder sb, MethodInfo method)
@@ -692,6 +1078,11 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
             var pascalName = StringHelper.ToPascalCase(propertyName);
             var argsType = MakeArgsPropertyType(p);
             sb.AppendLine($"            public {argsType} {pascalName} {{ get; set; }}");
+            if (p.IsFileOrValue)
+            {
+                sb.AppendLine(
+                    $"            public string? {StringHelper.ToPascalCase(p.Name)}{p.FileSuffix} {{ get; set; }}");
+            }
         }
         sb.AppendLine("        }");
         sb.AppendLine();
@@ -704,7 +1095,10 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
     /// </summary>
     private static string MakeArgsPropertyType(ParameterInfo p)
     {
-        // Enums are kept as string? so service handlers can use existing Parse* methods
+        if (IsTimeSpanType(p.TypeName))
+            return "int?";
+
+        // Enums and FileOrValue inputs stay strings so service handlers can normalize them.
         if (p.IsFromString || p.IsFileOrValue || p.IsEnum)
             return "string?";
 
@@ -723,7 +1117,7 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         {
             foreach (var p in method.Parameters)
             {
-                var isRequired = p.IsRequired || (!p.HasDefault && !p.TypeName.EndsWith("?"));
+                var isRequired = IsRequiredParameter(p);
 
                 if (p.IsFileOrValue)
                 {
@@ -738,10 +1132,21 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
                     }
                     if (isRequired)
                         result[p.Name].RequiredByActions.Add(method.ActionName);
+                    if (!result[p.Name].ApplicableByActions.Contains(method.ActionName, StringComparer.OrdinalIgnoreCase))
+                        result[p.Name].ApplicableByActions.Add(method.ActionName);
 
                     var fileParamName = $"{p.Name}{p.FileSuffix}";
-                    if (!result.ContainsKey(fileParamName))
-                        result[fileParamName] = new ExposedParameter(fileParamName, "string?", $"Path to file containing {p.Name}", "null");
+                    if (!result.TryGetValue(fileParamName, out var fileParameter))
+                    {
+                        fileParameter = new ExposedParameter(
+                            fileParamName,
+                            "string?",
+                            $"Path to a readable file containing {p.Name}; use instead of inline {p.Name}, not together",
+                            "null");
+                        result[fileParamName] = fileParameter;
+                    }
+                    if (!fileParameter.ApplicableByActions.Contains(method.ActionName, StringComparer.OrdinalIgnoreCase))
+                        fileParameter.ApplicableByActions.Add(method.ActionName);
                 }
                 else if (p.IsFromString && p.IsEnum)
                 {
@@ -756,21 +1161,26 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
                     }
                     if (isRequired)
                         result[exposedName].RequiredByActions.Add(method.ActionName);
+                    if (!result[exposedName].ApplicableByActions.Contains(method.ActionName, StringComparer.OrdinalIgnoreCase))
+                        result[exposedName].ApplicableByActions.Add(method.ActionName);
                 }
                 else
                 {
                     if (!result.TryGetValue(p.Name, out var existing) ||
                         (string.IsNullOrEmpty(existing.Description) && !string.IsNullOrEmpty(p.XmlDocDescription)))
                     {
-                        var typeName = p.TypeName.EndsWith("?") ? p.TypeName : $"{p.TypeName}?";
-                        var defaultVal = p.HasDefault ? p.DefaultValue : "null";
-                        var ep = new ExposedParameter(p.Name, typeName, p.XmlDocDescription, defaultVal);
+                        var typeName = IsTimeSpanType(p.TypeName)
+                            ? "int?"
+                            : p.TypeName.EndsWith("?") ? p.TypeName : $"{p.TypeName}?";
+                        var ep = new ExposedParameter(p.Name, typeName, p.XmlDocDescription, "null");
                         if (result.TryGetValue(p.Name, out var prev))
                             ep.RequiredByActions.AddRange(prev.RequiredByActions);
                         result[p.Name] = ep;
                     }
                     if (isRequired)
                         result[p.Name].RequiredByActions.Add(method.ActionName);
+                    if (!result[p.Name].ApplicableByActions.Contains(method.ActionName, StringComparer.OrdinalIgnoreCase))
+                        result[p.Name].ApplicableByActions.Add(method.ActionName);
                 }
             }
         }
@@ -879,6 +1289,45 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         return sb.ToString();
     }
 
+    private static string GenerateContractRegistry(List<ServiceInfo> categories)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine("#pragma warning disable CS1591");
+        sb.AppendLine();
+        sb.AppendLine("namespace Sbroenne.ExcelMcp.Generated;");
+        sb.AppendLine();
+        sb.AppendLine("public static partial class ServiceRegistry");
+        sb.AppendLine("{");
+        sb.AppendLine("    /// <summary>Validates a generated service command before transport dispatch.</summary>");
+        sb.AppendLine("    public static void ValidateCommandArguments(string command, string? argsJson)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        var parts = command.Split('.', 2);");
+        sb.AppendLine("        if (parts.Length != 2) return;");
+        sb.AppendLine("        switch (parts[0])");
+        sb.AppendLine("        {");
+        foreach (var categoryGroup in categories
+                     .GroupBy(category => category.Category, StringComparer.Ordinal)
+                     .OrderBy(group => group.Key, StringComparer.Ordinal))
+        {
+            sb.AppendLine($"            case \"{categoryGroup.Key}\":");
+            foreach (var category in categoryGroup)
+            {
+                sb.AppendLine($"                if ({category.CategoryPascal}.ValidActions.Contains(parts[1], System.StringComparer.OrdinalIgnoreCase))");
+                sb.AppendLine("                {");
+                sb.AppendLine($"                    {category.CategoryPascal}.ValidateActionArguments(parts[1], argsJson);");
+                sb.AppendLine("                    break;");
+                sb.AppendLine("                }");
+            }
+            sb.AppendLine($"                throw new System.ArgumentException($\"Unknown action: {{parts[1]}}\");");
+        }
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
     private static string GenerateCliManifest(List<ServiceInfo> categories)
     {
         var sb = new StringBuilder();
@@ -979,13 +1428,21 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
 
             // Build required-by-actions map for each param
             var paramRequiredMap = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            var paramApplicableMap = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
             var totalActions = cat.Methods.Count;
             foreach (var method in cat.Methods)
             {
                 foreach (var p in method.Parameters)
                 {
-                    var pName = p.ExposedName ?? StringHelper.ToKebabCase(p.Name);
-                    var isRequired = p.IsRequired || (!p.HasDefault && !p.TypeName.EndsWith("?"));
+                    var pName = StringHelper.ToKebabCase(p.ExposedName ?? p.Name);
+                    if (!paramApplicableMap.TryGetValue(pName, out var applicableActions))
+                    {
+                        applicableActions = new List<string>();
+                        paramApplicableMap[pName] = applicableActions;
+                    }
+                    applicableActions.Add(method.ActionName);
+
+                    var isRequired = IsRequiredParameter(p);
                     if (isRequired)
                     {
                         if (!paramRequiredMap.TryGetValue(pName, out var reqActions))
@@ -1021,6 +1478,12 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
                     var suffix = requiredActions.Count == totalActions
                         ? "(required)"
                         : $"(required for: {string.Join(", ", requiredActions)})";
+                    baseDescription = string.IsNullOrEmpty(baseDescription) ? suffix : $"{baseDescription} {suffix}";
+                }
+                if (paramApplicableMap.TryGetValue(paramName, out var applicableActions) &&
+                    applicableActions.Count < totalActions)
+                {
+                    var suffix = $"(valid for: {string.Join(", ", applicableActions)})";
                     baseDescription = string.IsNullOrEmpty(baseDescription) ? suffix : $"{baseDescription} {suffix}";
                 }
 
@@ -1091,15 +1554,78 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         sb.AppendLine("        return System.Text.Json.JsonSerializer.Deserialize<T>(argsJson, DispatchJsonOptions) ?? new T();");
         sb.AppendLine("    }");
         sb.AppendLine();
+        sb.AppendLine("    /// <summary>Requires a named raw JSON argument to be present as a string; the empty string is valid.</summary>");
+        sb.AppendLine("    public static void RequireJsonStringArgument(string? argsJson, string parameterName, string action)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        using var document = System.Text.Json.JsonDocument.Parse(argsJson ?? \"{}\");");
+        sb.AppendLine("        if (document.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object");
+        sb.AppendLine("            || !document.RootElement.TryGetProperty(parameterName, out var value)");
+        sb.AppendLine("            || value.ValueKind != System.Text.Json.JsonValueKind.String)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            throw new System.ArgumentException(");
+        sb.AppendLine("                $\"{parameterName} is required as a JSON string for {action} action.\",");
+        sb.AppendLine("                parameterName);");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine();
         sb.AppendLine("    /// <summary>");
-        sb.AppendLine("    /// Parses an enum value from a string with kebab-case and snake_case support.");
-        sb.AppendLine("    /// Returns defaultValue if the string is null, empty, or cannot be parsed.");
+        sb.AppendLine("    /// Parses an enum value from a string with kebab-case, snake_case, and explicit alias support.");
+        sb.AppendLine("    /// Returns defaultValue only when the value is omitted; unknown supplied values are rejected.");
         sb.AppendLine("    /// </summary>");
-        sb.AppendLine("    internal static T ParseEnumValue<T>(string? value, T defaultValue) where T : struct, System.Enum");
+        sb.AppendLine("    public static T ParseEnumValue<T>(");
+        sb.AppendLine("        string? value,");
+        sb.AppendLine("        T defaultValue,");
+        sb.AppendLine("        string parameterName,");
+        sb.AppendLine("        params (string Alias, T Value)[] aliases) where T : struct, System.Enum");
         sb.AppendLine("    {");
         sb.AppendLine("        if (string.IsNullOrEmpty(value)) return defaultValue;");
         sb.AppendLine("        var cleaned = value.Replace(\"-\", \"\").Replace(\"_\", \"\");");
-        sb.AppendLine("        return System.Enum.TryParse<T>(cleaned, ignoreCase: true, out var result) ? result : defaultValue;");
+        sb.AppendLine("        foreach (var enumName in System.Enum.GetNames<T>())");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var cleanedName = enumName.Replace(\"_\", \"\");");
+        sb.AppendLine("            if (string.Equals(cleaned, cleanedName, System.StringComparison.OrdinalIgnoreCase))");
+        sb.AppendLine("                return System.Enum.Parse<T>(enumName);");
+        sb.AppendLine("        }");
+        sb.AppendLine("        foreach (var alias in aliases)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            if (string.Equals(value, alias.Alias, System.StringComparison.OrdinalIgnoreCase))");
+        sb.AppendLine("                return alias.Value;");
+        sb.AppendLine("        }");
+        sb.AppendLine("        var validValues = System.Enum.GetNames<T>().Concat(aliases.Select(alias => alias.Alias));");
+        sb.AppendLine("        throw new System.ArgumentException(");
+        sb.AppendLine("            $\"Invalid value '{value}' for parameter '{parameterName}'. Valid values: {string.Join(\", \", validValues)}.\",");
+        sb.AppendLine("            parameterName);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Rejects undefined values supplied through a typed enum transport.</summary>");
+        sb.AppendLine("    public static void ValidateEnumValue<T>(T? value, string parameterName) where T : struct, System.Enum");
+        sb.AppendLine("    {");
+        sb.AppendLine("        if (!value.HasValue || System.Enum.IsDefined(value.Value)) return;");
+        sb.AppendLine("        throw new System.ArgumentException(");
+        sb.AppendLine("            $\"Invalid value '{value.Value}' for parameter '{parameterName}'. Valid values: {string.Join(\", \", System.Enum.GetNames<T>())}.\",");
+        sb.AppendLine("            parameterName);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns parameter names whose category-wide values were explicitly supplied.</summary>");
+        sb.AppendLine("    public static System.Collections.Generic.IReadOnlyList<string> GetSuppliedParameterNames(");
+        sb.AppendLine("        params (string Name, object? Value)[] parameters)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        return parameters.Where(parameter => parameter.Value != null).Select(parameter => parameter.Name).ToArray();");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns property names explicitly present in a raw JSON arguments object.</summary>");
+        sb.AppendLine("    public static System.Collections.Generic.IReadOnlyList<string> GetJsonPropertyNames(");
+        sb.AppendLine("        string? argsJson,");
+        sb.AppendLine("        bool includeNullValues = false)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        if (string.IsNullOrWhiteSpace(argsJson)) return System.Array.Empty<string>();");
+        sb.AppendLine("        using var document = System.Text.Json.JsonDocument.Parse(argsJson);");
+        sb.AppendLine("        if (document.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)");
+        sb.AppendLine("            throw new System.ArgumentException(\"Command arguments must be a JSON object.\", nameof(argsJson));");
+        sb.AppendLine("        return document.RootElement.EnumerateObject()");
+        sb.AppendLine("            .Where(property => includeNullValues || property.Value.ValueKind != System.Text.Json.JsonValueKind.Null)");
+        sb.AppendLine("            .Select(property => property.Name)");
+        sb.AppendLine("            .ToArray();");
         sb.AppendLine("    }");
         sb.AppendLine();
         sb.AppendLine("    /// <summary>");
@@ -1187,6 +1713,7 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
             sb.AppendLine("            Sbroenne.ExcelMcp.ComInterop.Session.IExcelBatch batch,");
         sb.AppendLine("            string? argsJson)");
         sb.AppendLine("        {");
+        sb.AppendLine("            ValidateActionArguments(ToActionString(action), argsJson);");
         sb.AppendLine("            switch (action)");
         sb.AppendLine("            {");
 
@@ -1220,10 +1747,31 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
             sb.AppendLine($"                    var args = DeserializeArgs<{method.MethodName}Args>(argsJson);");
         }
 
+        foreach (var p in method.Parameters.Where(p => p.IsFileOrValue))
+        {
+            var pascalName = StringHelper.ToPascalCase(p.Name);
+            sb.AppendLine(
+                $"                    var resolved{pascalName} = Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ResolveFileOrValue(args.{pascalName}, args.{pascalName}{p.FileSuffix}, \"{p.Name}\");");
+            if (IsRequiredParameter(p))
+            {
+                sb.AppendLine(
+                    $"                    Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.RequireNotEmpty(resolved{pascalName}, \"{p.Name}\", \"{method.ActionName}\");");
+            }
+        }
+
+        foreach (var p in method.Parameters.Where(p => IsTimeSpanType(p.TypeName)))
+        {
+            var propName = p.ExposedName ?? p.Name;
+            var pascalProp = StringHelper.ToPascalCase(propName);
+            var minimumSeconds = info.Category == "powerquery" ? 0 : 1;
+            sb.AppendLine(
+                $"                    var {p.Name} = Sbroenne.ExcelMcp.Core.Utilities.ParameterTransforms.ParseTimeoutSeconds(args.{pascalProp}, \"{propName}\", minimumSeconds: {minimumSeconds});");
+        }
+
         foreach (var p in method.Parameters.Where(p =>
                      p.IsFromString &&
                      p.IsEnum &&
-                     (p.IsRequired || (!p.HasDefault && !p.TypeName.EndsWith("?")))))
+                     IsRequiredParameter(p)))
         {
             var propName = p.ExposedName ?? p.Name;
             var pascalProp = StringHelper.ToPascalCase(propName);
@@ -1240,18 +1788,22 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
 
             if (isNullableEnum)
             {
-                sb.AppendLine($"                    var {p.Name} = !string.IsNullOrEmpty(args.{pascalProp}) ? ({enumType}?)ParseEnumValue<{enumType}>(args.{pascalProp}, default) : null;");
+                sb.AppendLine($"                    var {p.Name} = !string.IsNullOrEmpty(args.{pascalProp}) ? ({enumType}?)ParseEnumValue<{enumType}>(args.{pascalProp}, default, \"{propName}\"{BuildEnumAliasArguments(p)}) : null;");
             }
             else
             {
                 var defaultExpr = (p.HasDefault && p.DefaultValue != null) ? p.DefaultValue : $"default({enumType})";
-                sb.AppendLine($"                    var {p.Name} = ParseEnumValue<{enumType}>(args.{pascalProp}, {defaultExpr});");
+                sb.AppendLine($"                    var {p.Name} = ParseEnumValue<{enumType}>(args.{pascalProp}, {defaultExpr}, \"{propName}\"{BuildEnumAliasArguments(p)});");
             }
         }
 
         // Parse [FromString] non-enum, non-string parameters into local variables
         // These are stored as string? in args but need type conversion (e.g., bool?, TimeSpan?)
-        foreach (var p in method.Parameters.Where(p => p.IsFromString && !p.IsEnum && !StringHelper.IsStringType(p.TypeName)))
+        foreach (var p in method.Parameters.Where(p =>
+                     p.IsFromString &&
+                     !p.IsEnum &&
+                     !StringHelper.IsStringType(p.TypeName) &&
+                     !IsTimeSpanType(p.TypeName)))
         {
             var propName = p.ExposedName ?? p.Name;
             var pascalProp = StringHelper.ToPascalCase(propName);
@@ -1280,7 +1832,18 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
 
         foreach (var p in method.Parameters)
         {
-            if (p.IsEnum || (p.IsFromString && !StringHelper.IsStringType(p.TypeName)))
+            if (p.IsFileOrValue)
+            {
+                var resolvedName = $"resolved{StringHelper.ToPascalCase(p.Name)}";
+                callArgs.Add(p.TypeName.EndsWith("?") ? resolvedName : resolvedName + "!");
+            }
+            else if (IsTimeSpanType(p.TypeName))
+            {
+                callArgs.Add(p.TypeName.EndsWith("?")
+                    ? p.Name
+                    : $"{p.Name} ?? default(System.TimeSpan)");
+            }
+            else if (p.IsEnum || (p.IsFromString && !StringHelper.IsStringType(p.TypeName)))
             {
                 // Already parsed to local variable
                 callArgs.Add(p.Name);

--- a/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
+++ b/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
@@ -336,7 +336,7 @@ internal static class TelemetryConfig
       <SkillManifestPath>$(MSBuildProjectDirectory)\..\ExcelMcp.Core\obj\GeneratedFiles\ExcelMcp.Generators\Sbroenne.ExcelMcp.Generators.ServiceRegistryGenerator\_SkillManifest.g.cs</SkillManifestPath>
     </PropertyGroup>
     <Message Text="Generating MCP Skill from template..." Importance="high" />
-    <GenerateSkillFile TemplatePath="$(SkillTemplatePath)" OutputPath="$(SkillOutputPath)" ManifestPath="$(SkillManifestPath)" ExcludeCommands="diag" ExtraOperationCount="6" ExtraToolCount="1" />
+    <GenerateSkillFile TemplatePath="$(SkillTemplatePath)" OutputPath="$(SkillOutputPath)" ManifestPath="$(SkillManifestPath)" ExcludeCommands="diag" ExtraOperationCount="5" ExtraToolCount="1" />
     <Message Text="Generated MCP Skill: $(SkillOutputPath)" Importance="high" />
   </Target>
 

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -63,9 +63,9 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**31 specialized tools with 326 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
+**31 specialized tools with 325 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
 
-📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 326 operations, grouped by category
+📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 325 operations, grouped by category
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/src/ExcelMcp.McpServer/ServiceBridge/ServiceBridge.cs
+++ b/src/ExcelMcp.McpServer/ServiceBridge/ServiceBridge.cs
@@ -243,7 +243,7 @@ public static class ServiceBridge
     /// </summary>
     public static async Task<ServiceResponse> CreateSessionAsync(
         string excelPath,
-        bool macroEnabled = false,
+        bool? macroEnabled = null,
         bool show = false,
         int? timeoutSeconds = null,
         CancellationToken cancellationToken = default)
@@ -262,7 +262,7 @@ public static class ServiceBridge
     /// </summary>
     public static async Task<ServiceResponse> CloseSessionAsync(
         string sessionId,
-        bool save = true,
+        bool save = false,
         CancellationToken cancellationToken = default)
     {
         return await SendAsync("session.close", sessionId, new { save }, cancellationToken: cancellationToken);
@@ -274,16 +274,6 @@ public static class ServiceBridge
     public static async Task<ServiceResponse> ListSessionsAsync(CancellationToken cancellationToken = default)
     {
         return await SendAsync("session.list", cancellationToken: cancellationToken);
-    }
-
-    /// <summary>
-    /// Saves a session via the service.
-    /// </summary>
-    public static async Task<ServiceResponse> SaveSessionAsync(
-        string sessionId,
-        CancellationToken cancellationToken = default)
-    {
-        return await SendAsync("session.save", sessionId, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using ModelContextProtocol.Server;
-using Sbroenne.ExcelMcp.Core.Commands;
 
 namespace Sbroenne.ExcelMcp.McpServer.Tools;
 
@@ -29,7 +28,9 @@ public static partial class ExcelFileTool
     ///
     /// IRM/AIP FILES: Files protected with Azure Information Protection are detected automatically.
     /// They are opened as read-only with Excel forced visible for credential authentication.
-    /// Use 'test' action first to check isIrmProtected before attempting to open.
+    /// Use 'test' first to inspect canOpen, isIrmProtected, willOpenReadOnly, and
+    /// requiresVisibleSession before attempting to open. IRM/AIP files report
+    /// canOpen=false until the required interactive Excel authentication occurs.
     /// </summary>
     /// <param name="action">The file operation to perform</param>
     /// <param name="path">Full Windows path to Excel file (.xlsx or .xlsm). ASK USER for the path - do not guess or use placeholder usernames. Required for: open, create, test</param>
@@ -77,7 +78,6 @@ public static partial class ExcelFileTool
                     FileAction.Open => OpenSessionAsync(path!, show, timeout),
                     FileAction.Close => CloseSessionAsync(session_id!, save),
                     FileAction.Create => CreateSessionAsync(path!, show, timeout),
-                    FileAction.CloseWorkbook => CloseWorkbook(path!),
                     FileAction.Test => TestFileAsync(path!),
                     _ => throw new ArgumentException($"Unknown action: {action} ({action.ToActionString()})", nameof(action))
                 };
@@ -174,9 +174,8 @@ public static partial class ExcelFileTool
     }
 
     /// <summary>
-    /// Closes an active session via the ExcelMCP Service with optional save.
-    /// By default, saves changes before closing to prevent data loss.
-    /// Set save=false to discard changes.
+    /// Closes an active session via the ExcelMCP Service with optional atomic save.
+    /// The default save=false discards changes; set save=true to persist before closing.
     /// </summary>
     private static string CloseSessionAsync(string sessionId, bool save)
     {
@@ -305,20 +304,6 @@ public static partial class ExcelFileTool
     }
 
     /// <summary>
-    /// Closes the workbook (no-op with new single-instance architecture).
-    /// LLM Pattern: This action is kept for backward compatibility but does nothing.
-    /// With single-instance sessions, workbooks are automatically closed after each operation.
-    /// </summary>
-    private static string CloseWorkbook(string path)
-    {
-        return JsonSerializer.Serialize(new
-        {
-            success = true,
-            filePath = path
-        }, ExcelToolsBase.JsonOptions);
-    }
-
-    /// <summary>
     /// Lists all active sessions with status info. Lightweight operation - no Excel COM calls.
     /// LLM Pattern: Use this to verify sessions and check for running operations before closing.
     /// </summary>
@@ -351,7 +336,8 @@ public static partial class ExcelFileTool
     }
 
     /// <summary>
-    /// Tests if an Excel file exists and is valid without opening it via Excel COM.
+    /// Tests file existence, validity, openability, and IRM/AIP read-only requirements
+    /// without opening it via Excel COM.
     /// LLM Pattern: Use this for discovery/connectivity testing before running operations.
     /// </summary>
     private static string TestFileAsync(string path)
@@ -361,33 +347,25 @@ public static partial class ExcelFileTool
             throw new ArgumentException("path is required for 'test' action", nameof(path));
         }
 
-        // Validate Windows path format before any file operations
-        var pathError = ExcelToolsBase.ValidateWindowsPath(path);
-        if (pathError != null)
+        var response = ServiceBridge.ServiceBridge.TestFileAsync(path).GetAwaiter().GetResult();
+        if (!response.Success)
         {
-            return pathError;
+            var errorMessage = response.ErrorMessage ?? "Failed to test file";
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = errorMessage,
+                errorMessage,
+                errorCategory = response.ErrorCategory,
+                exceptionType = response.ExceptionType,
+                hresult = response.HResult,
+                innerError = response.InnerError,
+                filePath = path,
+                isError = true
+            }, ExcelToolsBase.JsonOptions);
         }
 
-        var fileCommands = new FileCommands();
-        var info = fileCommands.Test(path);
-
-        return JsonSerializer.Serialize(new
-        {
-            success = info.IsValid,
-            filePath = info.FilePath,
-            exists = info.Exists,
-            isValid = info.IsValid,
-            extension = info.Extension,
-            size = info.Size,
-            lastModified = info.LastModified,
-            isIrmProtected = info.IsIrmProtected,
-            message = info.Message,
-            isError = info.IsValid ? (bool?)null : true
-        }, ExcelToolsBase.JsonOptions);
+        return response.Result ?? throw new InvalidOperationException(
+            "File test succeeded without returning validation metadata.");
     }
 }
-
-
-
-
-

--- a/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
@@ -311,6 +311,14 @@ public static class ExcelToolsBase
         string? exceptionType = ex.GetType().Name;
         string? hresult = null;
         string? innerError = null;
+        var errorCategory = ex switch
+        {
+            ArgumentException => "InvalidInput",
+            TimeoutException => "Timeout",
+            OperationCanceledException => "Cancelled",
+            System.Runtime.InteropServices.COMException => "ComInterop",
+            _ => null
+        };
 
         if (ex is System.Runtime.InteropServices.COMException comEx)
         {
@@ -332,6 +340,7 @@ public static class ExcelToolsBase
             success = false,
             error = errorMessage,
             errorMessage,
+            errorCategory,
             isError = true,
             exceptionType,
             hresult,
@@ -359,7 +368,6 @@ public static class ExcelToolsBase
         }, JsonOptions);
     }
 }
-
 
 
 

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -20,6 +20,7 @@ using Sbroenne.ExcelMcp.Core.Commands.Table;
 using Sbroenne.ExcelMcp.Core.Commands.Window;
 using Sbroenne.ExcelMcp.Core.Commands.Workbook;
 using Sbroenne.ExcelMcp.Core.Commands.XmlMap;
+using Sbroenne.ExcelMcp.Core.Utilities;
 using Sbroenne.ExcelMcp.Generated;
 
 namespace Sbroenne.ExcelMcp.Service;
@@ -65,6 +66,7 @@ public sealed class ExcelMcpService : IDisposable
     private readonly PythonInExcelCommands _pythonInExcelCommands = new();
     private readonly AnalysisCommands _analysisCommands = new();
     private readonly XmlMapCommands _xmlMapCommands = new();
+    private readonly FileCommands _fileCommands = new();
 
     public ExcelMcpService()
     {
@@ -259,6 +261,8 @@ public sealed class ExcelMcpService : IDisposable
             var category = parts[0];
             var action = parts.Length > 1 ? parts[1] : "";
 
+            ServiceRegistry.ValidateCommandArguments(request.Command, request.Args);
+
             ServiceResponse response = category switch
             {
                 "service" => HandleServiceCommand(action),
@@ -376,26 +380,61 @@ public sealed class ExcelMcpService : IDisposable
 
     private ServiceResponse HandleSessionCommand(string action, ServiceRequest request)
     {
+        if (action is not ("create" or "open" or "close" or "list" or "test"))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = $"Unknown session action: {action}" };
+        }
+
+        ValidateSessionActionArguments(action, request.Args);
         return action switch
         {
             "create" => HandleSessionCreate(request),
             "open" => HandleSessionOpen(request),
             "close" => HandleSessionClose(request),
-            "save" => HandleSessionSave(request),
             "list" => HandleSessionList(),
-            _ => new ServiceResponse { Success = false, ErrorMessage = $"Unknown session action: {action}" }
+            "test" => HandleSessionTest(request),
+            _ => throw new InvalidOperationException($"Unhandled session action: {action}")
         };
+    }
+
+    private static void ValidateSessionActionArguments(string action, string? argsJson)
+    {
+        var allowedParameters = action switch
+        {
+            "create" => new HashSet<string>(
+                ["filePath", "macroEnabled", "show", "timeoutSeconds"],
+                StringComparer.Ordinal),
+            "open" => new HashSet<string>(
+                ["filePath", "show", "timeoutSeconds"],
+                StringComparer.Ordinal),
+            "close" => new HashSet<string>(["save"], StringComparer.Ordinal),
+            "test" => new HashSet<string>(["filePath"], StringComparer.Ordinal),
+            _ => []
+        };
+        var unknownParameters = ServiceRegistry.GetJsonPropertyNames(argsJson, includeNullValues: true)
+            .Where(parameter => !allowedParameters.Contains(parameter))
+            .ToArray();
+        if (unknownParameters.Length > 0)
+        {
+            throw new ArgumentException(
+                $"Unknown parameter(s) for session.{action}: {string.Join(", ", unknownParameters)}.");
+        }
     }
 
     private ServiceResponse HandleSessionCreate(ServiceRequest request)
     {
         var args = ServiceRegistry.DeserializeArgs<SessionOpenArgs>(request.Args);
+        var timeout = ParameterTransforms.ParseTimeoutSeconds(
+            args.TimeoutSeconds,
+            "timeoutSeconds",
+            minimumSeconds: 10,
+            maximumSeconds: 3600);
         if (string.IsNullOrWhiteSpace(args?.FilePath))
         {
             return new ServiceResponse { Success = false, ErrorMessage = "filePath is required" };
         }
 
-        var fullPath = Path.GetFullPath(args.FilePath);
+        var fullPath = FilePathValidation.NormalizeAbsoluteWindowsPath(args.FilePath);
 
         if (File.Exists(fullPath))
         {
@@ -416,13 +455,16 @@ public sealed class ExcelMcpService : IDisposable
                 ErrorMessage = $"Invalid file extension '{extension}'. session create supports .xlsx and .xlsm only."
             };
         }
+        var extensionIsMacroEnabled = string.Equals(extension, ".xlsm", StringComparison.OrdinalIgnoreCase);
+        if (args.MacroEnabled.HasValue && args.MacroEnabled.Value != extensionIsMacroEnabled)
+        {
+            throw new ArgumentException(
+                $"macroEnabled must be {extensionIsMacroEnabled.ToString().ToLowerInvariant()} for a '{extension}' workbook.");
+        }
 
         try
         {
             // Use the combined create+open which starts Excel only once
-            TimeSpan? timeout = args.TimeoutSeconds.HasValue
-                ? TimeSpan.FromSeconds(args.TimeoutSeconds.Value)
-                : null;
             var sessionId = _sessionManager.CreateSessionForNewFile(fullPath, show: args.Show, operationTimeout: timeout, origin: SessionOrigin.CLI);
             _knownSessionIds.TryAdd(sessionId, 0);
 
@@ -441,22 +483,25 @@ public sealed class ExcelMcpService : IDisposable
     private ServiceResponse HandleSessionOpen(ServiceRequest request)
     {
         var args = ServiceRegistry.DeserializeArgs<SessionOpenArgs>(request.Args);
+        var timeout = ParameterTransforms.ParseTimeoutSeconds(
+            args.TimeoutSeconds,
+            "timeoutSeconds",
+            minimumSeconds: 10,
+            maximumSeconds: 3600);
         if (string.IsNullOrWhiteSpace(args?.FilePath))
         {
             return new ServiceResponse { Success = false, ErrorMessage = "filePath is required" };
         }
+        var fullPath = FilePathValidation.NormalizeAbsoluteWindowsPath(args.FilePath);
 
         try
         {
-            TimeSpan? timeout = args.TimeoutSeconds.HasValue
-                ? TimeSpan.FromSeconds(args.TimeoutSeconds.Value)
-                : null;
-            var sessionId = _sessionManager.CreateSession(args.FilePath, show: args.Show, operationTimeout: timeout, origin: SessionOrigin.CLI);
+            var sessionId = _sessionManager.CreateSession(fullPath, show: args.Show, operationTimeout: timeout, origin: SessionOrigin.CLI);
             _knownSessionIds.TryAdd(sessionId, 0);
             return new ServiceResponse
             {
                 Success = true,
-                Result = JsonSerializer.Serialize(new { success = true, sessionId, filePath = args.FilePath }, ServiceProtocol.JsonOptions)
+                Result = JsonSerializer.Serialize(new { success = true, sessionId, filePath = fullPath }, ServiceProtocol.JsonOptions)
             };
         }
         catch (Exception ex)
@@ -467,13 +512,14 @@ public sealed class ExcelMcpService : IDisposable
 
     private ServiceResponse HandleSessionClose(ServiceRequest request)
     {
+        var args = ServiceRegistry.DeserializeArgs<SessionCloseArgs>(request.Args);
+        var shouldSave = args?.Save ?? false;
+
         if (string.IsNullOrWhiteSpace(request.SessionId))
         {
             return new ServiceResponse { Success = false, ErrorMessage = "sessionId is required" };
         }
 
-        var args = ServiceRegistry.DeserializeArgs<SessionCloseArgs>(request.Args);
-        var shouldSave = args?.Save ?? false;
         bool closed;
         try
         {
@@ -506,33 +552,26 @@ public sealed class ExcelMcpService : IDisposable
         return new ServiceResponse { Success = false, ErrorMessage = $"Session '{request.SessionId}' not found" };
     }
 
-    private ServiceResponse HandleSessionSave(ServiceRequest request)
+    private ServiceResponse HandleSessionTest(ServiceRequest request)
     {
-        if (string.IsNullOrWhiteSpace(request.SessionId))
+        var args = ServiceRegistry.DeserializeArgs<SessionTestArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.FilePath))
         {
-            return new ServiceResponse { Success = false, ErrorMessage = "sessionId is required" };
-        }
-
-        var sessionError = TryBeginUsableSession(request.SessionId, out var batch);
-        if (sessionError != null)
-        {
-            return sessionError;
+            return new ServiceResponse { Success = false, ErrorMessage = "filePath is required" };
         }
 
         try
         {
-            batch!.Save();
-            return new ServiceResponse { Success = true };
+            var result = _fileCommands.Test(args.FilePath);
+            return new ServiceResponse
+            {
+                Success = true,
+                Result = JsonSerializer.Serialize(result, ServiceProtocol.JsonOptions)
+            };
         }
-        catch (Exception ex) when (IsFatalExcelDisconnect(ex))
+        catch (Exception ex)
         {
-            CleanupDeadSession(request.SessionId);
-            return CreateExcelDisconnectedResponse(request.SessionId, ex,
-                "Excel disconnected while saving. Session has been cleaned up; reopen the workbook and verify whether the save completed.");
-        }
-        finally
-        {
-            _sessionManager.EndOperation(request.SessionId);
+            return CreateErrorResponse(ex);
         }
     }
 
@@ -1039,7 +1078,7 @@ public sealed class ExcelMcpService : IDisposable
         {
             PowerQueryCommandException pqEx => pqEx.ErrorCategory,
             TimeoutException => "Timeout",
-            ArgumentException => "InvalidInput",
+            ArgumentException or JsonException => "InvalidInput",
             COMException => "ComInterop",
             _ => null
         };
@@ -1107,7 +1146,9 @@ public sealed class ExcelMcpService : IDisposable
 public sealed class SessionOpenArgs
 {
     public string? FilePath { get; set; }
+    public bool? MacroEnabled { get; set; }
     public bool Show { get; set; }
     public int? TimeoutSeconds { get; set; }
 }
 public sealed class SessionCloseArgs { public bool Save { get; set; } }
+public sealed class SessionTestArgs { public string? FilePath { get; set; } }

--- a/src/ExcelMcp.Service/ServiceClient.cs
+++ b/src/ExcelMcp.Service/ServiceClient.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.IO.Pipes;
+using Sbroenne.ExcelMcp.Core.Utilities;
 using Sbroenne.ExcelMcp.Service.Rpc;
 using StreamJsonRpc;
 
@@ -16,7 +18,8 @@ public sealed class ServiceClient : IDisposable
     private bool _disposed;
 
     public static readonly TimeSpan DefaultConnectTimeout = TimeSpan.FromSeconds(5);
-    public static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromHours(2); // Long enough that any --timeout value wins before the pipe does
+    public static readonly TimeSpan DefaultRequestTimeout =
+        TimeSpan.FromSeconds(ParameterTransforms.MaximumTimeoutSeconds + 60);
 
     public ServiceClient(string pipeName, TimeSpan? connectTimeout = null, TimeSpan? requestTimeout = null)
     {
@@ -28,25 +31,50 @@ public sealed class ServiceClient : IDisposable
     /// <summary>
     /// Sends a request to the service and waits for response via StreamJsonRpc.
     /// </summary>
-    public async Task<ServiceResponse> SendAsync(ServiceRequest request, CancellationToken cancellationToken = default)
+    public Task<ServiceResponse> SendAsync(
+        ServiceRequest request,
+        CancellationToken cancellationToken = default) =>
+        SendCoreAsync(request, totalTimeout: null, cancellationToken);
+
+    /// <summary>
+    /// Sends a request using one timeout across both pipe connection and response.
+    /// </summary>
+    public Task<ServiceResponse> SendAsync(
+        ServiceRequest request,
+        TimeSpan totalTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(totalTimeout, TimeSpan.Zero);
+        return SendCoreAsync(request, totalTimeout, cancellationToken);
+    }
+
+    private async Task<ServiceResponse> SendCoreAsync(
+        ServiceRequest request,
+        TimeSpan? totalTimeout,
+        CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        var startedAt = Stopwatch.GetTimestamp();
         using var pipe = ServiceSecurity.CreateClient(_pipeName);
+        var connectTimeout = GetStepTimeout(_connectTimeout, totalTimeout, startedAt);
         using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        connectCts.CancelAfter(_connectTimeout);
+        connectCts.CancelAfter(connectTimeout);
+        var connected = false;
 
         try
         {
-            await pipe.ConnectAsync((int)_connectTimeout.TotalMilliseconds, connectCts.Token);
+            await pipe.ConnectAsync(ToTimeoutMilliseconds(connectTimeout), connectCts.Token);
+            connected = true;
 
             // Use StreamJsonRpc typed proxy for the RPC call
             var proxy = JsonRpc.Attach<IExcelDaemonRpc>(pipe);
             try
             {
+                var requestTimeout = GetStepTimeout(_requestTimeout, totalTimeout, startedAt);
                 using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 using var disconnectMonitorCts = CancellationTokenSource.CreateLinkedTokenSource(requestCts.Token);
-                requestCts.CancelAfter(_requestTimeout);
+                requestCts.CancelAfter(requestTimeout);
 
                 var callTask = proxy.ProcessCommandAsync(request);
                 var disconnectTask = WaitForPipeDisconnectAsync(pipe, disconnectMonitorCts.Token);
@@ -70,39 +98,11 @@ public sealed class ServiceClient : IDisposable
         }
         catch (TimeoutException)
         {
-            return new ServiceResponse
-            {
-                Success = false,
-                Command = request.Command,
-                SessionId = request.SessionId,
-                ErrorCategory = "Timeout",
-                ErrorMessage = "Service connection timed out",
-                ExceptionType = nameof(TimeoutException)
-            };
-        }
-        catch (OperationCanceledException) when (connectCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-        {
-            return new ServiceResponse
-            {
-                Success = false,
-                Command = request.Command,
-                SessionId = request.SessionId,
-                ErrorCategory = "Timeout",
-                ErrorMessage = "Service connection timed out",
-                ExceptionType = nameof(OperationCanceledException)
-            };
+            return CreateTimeoutResponse(request, connected, nameof(TimeoutException));
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            return new ServiceResponse
-            {
-                Success = false,
-                Command = request.Command,
-                SessionId = request.SessionId,
-                ErrorCategory = "Timeout",
-                ErrorMessage = "Service request timed out",
-                ExceptionType = nameof(OperationCanceledException)
-            };
+            return CreateTimeoutResponse(request, connected, nameof(OperationCanceledException));
         }
         catch (ConnectionLostException)
         {
@@ -120,6 +120,46 @@ public sealed class ServiceClient : IDisposable
                 ExceptionType = nameof(IOException)
             };
         }
+    }
+
+    private static TimeSpan GetStepTimeout(
+        TimeSpan configuredTimeout,
+        TimeSpan? totalTimeout,
+        long startedAt)
+    {
+        if (totalTimeout is null)
+        {
+            return configuredTimeout;
+        }
+
+        var remaining = totalTimeout.Value - Stopwatch.GetElapsedTime(startedAt);
+        if (remaining <= TimeSpan.Zero)
+        {
+            throw new TimeoutException();
+        }
+
+        return configuredTimeout <= remaining ? configuredTimeout : remaining;
+    }
+
+    private static int ToTimeoutMilliseconds(TimeSpan timeout) =>
+        Math.Max(1, checked((int)Math.Ceiling(timeout.TotalMilliseconds)));
+
+    private static ServiceResponse CreateTimeoutResponse(
+        ServiceRequest request,
+        bool connected,
+        string exceptionType)
+    {
+        return new ServiceResponse
+        {
+            Success = false,
+            Command = request.Command,
+            SessionId = request.SessionId,
+            ErrorCategory = "Timeout",
+            ErrorMessage = connected
+                ? "Service request timed out"
+                : "Service connection timed out",
+            ExceptionType = exceptionType
+        };
     }
 
     private static async Task<bool> WaitForPipeDisconnectAsync(Stream pipe, CancellationToken cancellationToken)
@@ -166,16 +206,8 @@ public sealed class ServiceClient : IDisposable
     /// </summary>
     public async Task<bool> PingAsync(CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var response = await SendAsync(new ServiceRequest { Command = "service.ping" }, cancellationToken);
-            return response.Success;
-        }
-        catch (Exception)
-        {
-            // Any other communication failure — service is not reachable
-            return false;
-        }
+        var response = await SendAsync(new ServiceRequest { Command = "service.ping" }, cancellationToken);
+        return response.Success;
     }
 
     public void Dispose()
@@ -183,4 +215,3 @@ public sealed class ServiceClient : IDisposable
         _disposed = true;
     }
 }
-

--- a/tests/ExcelMcp.CLI.Tests/ExcelMcp.CLI.Tests.csproj
+++ b/tests/ExcelMcp.CLI.Tests/ExcelMcp.CLI.Tests.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="..\ExcelMcp.Core.Tests\Helpers\CoreTestHelper.cs" Link="Helpers\CoreTestHelper.cs" />
     <Compile Include="..\ExcelMcp.Core.Tests\Helpers\TempDirectoryFixture.cs" Link="Helpers\TempDirectoryFixture.cs" />
+    <Compile Include="..\Shared\OleDataSpaceTestFile.cs" Link="Helpers\OleDataSpaceTestFile.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ExcelMcp.CLI.Tests/Integration/CliDaemonTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/CliDaemonTests.cs
@@ -118,6 +118,61 @@ public sealed class CliDaemonTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ServiceStart_WhenDaemonStartupExceedsBusyTimeout_WaitsForStartupReadiness()
+    {
+        var result = await RunWithDelayedStartingDaemonAsync(TimeSpan.FromSeconds(18));
+        _output.WriteLine($"Slow startup response: {result.Stdout}");
+        _output.WriteLine($"Slow startup stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ServiceStart_WhenStartupMarkerAppearsDuringBusyWait_UsesOriginalStartupDeadline()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var result = await RunWithLateStartingMarkerAsync(
+            markerDelay: TimeSpan.FromSeconds(8),
+            startupDelay: TimeSpan.FromSeconds(33));
+        stopwatch.Stop();
+        _output.WriteLine($"Late startup marker response: {result.Stdout}");
+        _output.WriteLine($"Late startup marker stderr: {result.Stderr}");
+        _output.WriteLine($"Late startup marker elapsed: {stopwatch.Elapsed}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains("ready", json.RootElement.GetProperty("error").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.FromSeconds(29), TimeSpan.FromSeconds(37));
+    }
+
+    [Fact]
+    public async Task ServiceStart_WhenOnlyLifecycleLockIsHeld_UsesSingleStartupDeadline()
+    {
+        await using var startupLock = await HeldMutex.AcquireAsync(
+            DaemonAutoStart.GetDaemonStartupLockName(_testPipeName));
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = await CliProcessHelper.RunAsync(
+            "service start",
+            timeoutMs: 50000,
+            environmentVariables: TestEnv);
+        stopwatch.Stop();
+
+        _output.WriteLine($"Contended startup response: {result.Stdout}");
+        _output.WriteLine($"Contended startup stderr: {result.Stderr}");
+        _output.WriteLine($"Contended startup elapsed: {stopwatch.Elapsed}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains("ready", json.RootElement.GetProperty("error").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(36));
+    }
+
+    [Fact]
     public async Task ServiceStart_WhenDaemonMutexExistsButIsNotOwned_StartsDaemon()
     {
         var mutexName = DaemonAutoStart.GetDaemonMutexName(_testPipeName);
@@ -187,19 +242,124 @@ public sealed class CliDaemonTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ServiceStatus_WhenDaemonAcceptsConnectionButNeverReplies_FailsQuicklyWithTimeoutError()
+    public async Task ServiceStatus_WhenDaemonIsNotRunning_ReportsStoppedState()
     {
+        var result = await CliProcessHelper.RunAsync("service status", timeoutMs: 10000, environmentVariables: TestEnv);
+        _output.WriteLine($"Status response: {result.Stdout}");
+        _output.WriteLine($"Status stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("stopped", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.False(json.RootElement.GetProperty("running").GetBoolean());
+        Assert.False(json.RootElement.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public async Task SessionList_WhenDaemonIsNotRunning_ReturnsConfirmedEmptyList()
+    {
+        var result = await CliProcessHelper.RunAsync("session list", timeoutMs: 10000, environmentVariables: TestEnv);
+        _output.WriteLine($"Session list response: {result.Stdout}");
+        _output.WriteLine($"Session list stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("stopped", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.Equal(0, json.RootElement.GetProperty("count").GetInt32());
+        Assert.Empty(json.RootElement.GetProperty("sessions").EnumerateArray());
+        Assert.False(json.RootElement.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public async Task ServiceStatus_WhenStartupIsInProgressButNotReady_ReportsStartingState()
+    {
+        await using var daemonMutex = await HeldMutex.AcquireAsync(
+            DaemonAutoStart.GetDaemonMutexName(_testPipeName));
+        await using var startingMarker = await HeldMutex.AcquireAsync(
+            GetDaemonStartingMarkerName(_testPipeName));
+
+        var result = await CliProcessHelper.RunAsync("service status", timeoutMs: 20000, environmentVariables: TestEnv);
+        _output.WriteLine($"Starting status response: {result.Stdout}");
+        _output.WriteLine($"Starting status stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("starting", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.False(json.RootElement.GetProperty("running").GetBoolean());
+        Assert.False(json.RootElement.TryGetProperty("processId", out _));
+        Assert.Contains("timed out", json.RootElement.GetProperty("error").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SessionList_WhenStartupIsInProgressButNotReady_FailsWithoutEmptySessions()
+    {
+        await using var daemonMutex = await HeldMutex.AcquireAsync(
+            DaemonAutoStart.GetDaemonMutexName(_testPipeName));
+        await using var startingMarker = await HeldMutex.AcquireAsync(
+            GetDaemonStartingMarkerName(_testPipeName));
+
+        var result = await CliProcessHelper.RunAsync("session list", timeoutMs: 20000, environmentVariables: TestEnv);
+        _output.WriteLine($"Starting session list response: {result.Stdout}");
+        _output.WriteLine($"Starting session list stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("starting", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.False(json.RootElement.GetProperty("running").GetBoolean());
+        Assert.False(json.RootElement.TryGetProperty("sessions", out _));
+        Assert.Contains("timed out", json.RootElement.GetProperty("error").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ServiceStatus_WhenDaemonBecomesReadyAfterLegacyTimeout_WaitsAndSucceeds()
+    {
+        var result = await RunWithDelayedServiceAsync("service status", TimeSpan.FromSeconds(3));
+        _output.WriteLine($"Delayed status response: {result.Stdout}");
+        _output.WriteLine($"Delayed status stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("running", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.True(json.RootElement.GetProperty("running").GetBoolean());
+    }
+
+    [Fact]
+    public async Task SessionList_WhenDaemonBecomesReadyAfterLegacyTimeout_ReturnsGenuineEmptyList()
+    {
+        var result = await RunWithDelayedServiceAsync("session list", TimeSpan.FromSeconds(3));
+        _output.WriteLine($"Delayed session list response: {result.Stdout}");
+        _output.WriteLine($"Delayed session list stderr: {result.Stderr}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("running", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.Equal(0, json.RootElement.GetProperty("count").GetInt32());
+        Assert.Empty(json.RootElement.GetProperty("sessions").EnumerateArray());
+        Assert.False(json.RootElement.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public async Task ServiceStatus_WhenDaemonAcceptsConnectionButNeverReplies_ReportsUnresponsiveState()
+    {
+        await using var heldMutex = await HeldMutex.AcquireAsync(DaemonAutoStart.GetDaemonMutexName(_testPipeName));
         await using var stalledDaemon = new StalledPipeServer(_testPipeName, _output);
         await stalledDaemon.StartAsync();
 
-        var result = await CliProcessHelper.RunAsync("service status", timeoutMs: 10000, environmentVariables: TestEnv);
+        var result = await CliProcessHelper.RunAsync("service status", timeoutMs: 20000, environmentVariables: TestEnv);
         _output.WriteLine($"Status response: {result.Stdout}");
         _output.WriteLine($"Status stderr: {result.Stderr}");
 
         using var json = JsonDocument.Parse(result.Stdout);
         Assert.Equal(1, result.ExitCode);
         Assert.False(json.RootElement.GetProperty("success").GetBoolean());
-        Assert.False(json.RootElement.GetProperty("running").GetBoolean());
+        Assert.Equal("unresponsive", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.True(json.RootElement.GetProperty("running").GetBoolean());
 
         var error = json.RootElement.GetProperty("error").GetString();
         Assert.NotNull(error);
@@ -207,22 +367,95 @@ public sealed class CliDaemonTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ServiceStatus_WhenConnectConsumesPartOfDeadline_UsesOneControlTimeout()
+    {
+        await using var heldMutex = await HeldMutex.AcquireAsync(DaemonAutoStart.GetDaemonMutexName(_testPipeName));
+        await using var stalledDaemon = new StalledPipeServer(
+            _testPipeName,
+            _output,
+            TimeSpan.FromSeconds(6));
+
+        var stopwatch = Stopwatch.StartNew();
+        var commandTask = CliProcessHelper.RunAsync(
+            "service status",
+            timeoutMs: 20000,
+            environmentVariables: TestEnv);
+        await stalledDaemon.StartAsync();
+        var result = await commandTask;
+        stopwatch.Stop();
+
+        _output.WriteLine($"Deadline status response: {result.Stdout}");
+        _output.WriteLine($"Deadline status stderr: {result.Stderr}");
+        _output.WriteLine($"Deadline status elapsed: {stopwatch.Elapsed}");
+
+        using var json = JsonDocument.Parse(result.Stdout);
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("unresponsive", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.True(json.RootElement.GetProperty("running").GetBoolean());
+        Assert.Contains("timed out", json.RootElement.GetProperty("error").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(14));
+    }
+
+    [Fact]
     public async Task SessionList_WhenDaemonAcceptsConnectionButNeverReplies_FailsQuicklyWithTimeoutError()
     {
+        await using var heldMutex = await HeldMutex.AcquireAsync(DaemonAutoStart.GetDaemonMutexName(_testPipeName));
         await using var stalledDaemon = new StalledPipeServer(_testPipeName, _output);
         await stalledDaemon.StartAsync();
 
-        var result = await CliProcessHelper.RunAsync("session list", timeoutMs: 10000, environmentVariables: TestEnv);
+        var result = await CliProcessHelper.RunAsync("session list", timeoutMs: 20000, environmentVariables: TestEnv);
         _output.WriteLine($"Session list response: {result.Stdout}");
         _output.WriteLine($"Session list stderr: {result.Stderr}");
 
         using var json = JsonDocument.Parse(result.Stdout);
         Assert.Equal(1, result.ExitCode);
         Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("unresponsive", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.True(json.RootElement.GetProperty("running").GetBoolean());
+        Assert.False(json.RootElement.TryGetProperty("sessions", out _));
 
         var error = json.RootElement.GetProperty("error").GetString();
         Assert.NotNull(error);
         Assert.Contains("timed out", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SessionList_WhenDaemonDisappearsDuringRequest_ReturnsConfirmedStoppedEmptyList()
+    {
+        HeldMutex? heldMutex = await HeldMutex.AcquireAsync(DaemonAutoStart.GetDaemonMutexName(_testPipeName));
+        await using var stalledDaemon = new StalledPipeServer(_testPipeName, _output);
+        try
+        {
+            await stalledDaemon.StartAsync();
+            var commandTask = CliProcessHelper.RunAsync(
+                "session list",
+                timeoutMs: 20000,
+                environmentVariables: TestEnv);
+            await stalledDaemon.WaitForConnectionAsync();
+            await heldMutex.DisposeAsync();
+            heldMutex = null;
+
+            var result = await commandTask;
+            _output.WriteLine($"Disappeared daemon response: {result.Stdout}");
+            _output.WriteLine($"Disappeared daemon stderr: {result.Stderr}");
+
+            using var json = JsonDocument.Parse(result.Stdout);
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+            Assert.Equal("stopped", json.RootElement.GetProperty("daemonState").GetString());
+            Assert.Equal(0, json.RootElement.GetProperty("count").GetInt32());
+            Assert.Empty(json.RootElement.GetProperty("sessions").EnumerateArray());
+            Assert.False(json.RootElement.TryGetProperty("error", out _));
+            Assert.False(json.RootElement.TryGetProperty("isError", out _));
+        }
+        finally
+        {
+            if (heldMutex != null)
+            {
+                await heldMutex.DisposeAsync();
+            }
+        }
     }
 
     [Fact]
@@ -256,6 +489,23 @@ public sealed class CliDaemonTests : IAsyncLifetime
 
         Assert.Equal(0, result.ExitCode);
         Assert.Equal(0, json.RootElement.GetProperty("sessionCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task SessionList_WhenDaemonIsReadyAndEmpty_ReturnsEmptySuccess()
+    {
+        _daemonProcess = StartDaemon();
+        await WaitForDaemonReadyAsync();
+
+        var (result, json) = await CliProcessHelper.RunJsonAsync("session list", environmentVariables: TestEnv);
+        _output.WriteLine($"Session list response: {result.Stdout}");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("running", json.RootElement.GetProperty("daemonState").GetString());
+        Assert.Equal(0, json.RootElement.GetProperty("count").GetInt32());
+        Assert.Empty(json.RootElement.GetProperty("sessions").EnumerateArray());
+        Assert.False(json.RootElement.TryGetProperty("error", out _));
     }
 
     [Fact]
@@ -491,6 +741,86 @@ public sealed class CliDaemonTests : IAsyncLifetime
         throw new TimeoutException($"CLI daemon did not become ready within {maxRetries * delayMs}ms");
     }
 
+    private async Task<CliResult> RunWithDelayedServiceAsync(string command, TimeSpan startupDelay)
+    {
+        await using var heldMutex = await HeldMutex.AcquireAsync(DaemonAutoStart.GetDaemonMutexName(_testPipeName));
+        using var service = new ExcelMcpService();
+        var commandTask = CliProcessHelper.RunAsync(
+            command,
+            timeoutMs: 15000,
+            environmentVariables: TestEnv);
+
+        await Task.Delay(startupDelay);
+        var serviceTask = Task.Run(() => service.RunAsync(_testPipeName));
+        try
+        {
+            return await commandTask;
+        }
+        finally
+        {
+            service.RequestShutdown();
+            await serviceTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private async Task<CliResult> RunWithDelayedStartingDaemonAsync(TimeSpan startupDelay)
+    {
+        await using var daemonMutex = await HeldMutex.AcquireAsync(
+            DaemonAutoStart.GetDaemonMutexName(_testPipeName));
+        await using var startupLock = await HeldMutex.AcquireAsync(
+            DaemonAutoStart.GetDaemonStartupLockName(_testPipeName));
+        await using var startingMarker = await HeldMutex.AcquireAsync(
+            GetDaemonStartingMarkerName(_testPipeName));
+        using var service = new ExcelMcpService();
+        var commandTask = CliProcessHelper.RunAsync(
+            "service start",
+            timeoutMs: 25000,
+            environmentVariables: TestEnv);
+
+        await Task.Delay(startupDelay);
+        var serviceTask = Task.Run(() => service.RunAsync(_testPipeName));
+        try
+        {
+            return await commandTask;
+        }
+        finally
+        {
+            service.RequestShutdown();
+            await serviceTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private async Task<CliResult> RunWithLateStartingMarkerAsync(
+        TimeSpan markerDelay,
+        TimeSpan startupDelay)
+    {
+        await using var daemonMutex = await HeldMutex.AcquireAsync(
+            DaemonAutoStart.GetDaemonMutexName(_testPipeName));
+        using var service = new ExcelMcpService();
+        var commandTask = CliProcessHelper.RunAsync(
+            "service start",
+            timeoutMs: 42000,
+            environmentVariables: TestEnv);
+
+        await Task.Delay(markerDelay);
+        await using var startingMarker = await HeldMutex.AcquireAsync(
+            GetDaemonStartingMarkerName(_testPipeName));
+        await Task.Delay(startupDelay - markerDelay);
+        var serviceTask = Task.Run(() => service.RunAsync(_testPipeName));
+        try
+        {
+            return await commandTask;
+        }
+        finally
+        {
+            service.RequestShutdown();
+            await serviceTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private static string GetDaemonStartingMarkerName(string pipeName) =>
+        DaemonAutoStart.GetDaemonStartingMarkerName(pipeName);
+
     private void KillDaemon()
     {
         if (_daemonProcess is null || _daemonProcess.HasExited) return;
@@ -515,19 +845,27 @@ public sealed class CliDaemonTests : IAsyncLifetime
     {
         private readonly string _pipeName;
         private readonly ITestOutputHelper _output;
+        private readonly TimeSpan _listenDelay;
         private readonly CancellationTokenSource _cts = new();
         private readonly TaskCompletionSource _listeningTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _connectedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly Task _serverTask;
         private NamedPipeServerStream? _server;
 
-        public StalledPipeServer(string pipeName, ITestOutputHelper output)
+        public StalledPipeServer(
+            string pipeName,
+            ITestOutputHelper output,
+            TimeSpan? listenDelay = null)
         {
             _pipeName = pipeName;
             _output = output;
+            _listenDelay = listenDelay ?? TimeSpan.Zero;
             _serverTask = RunAsync();
         }
 
         public Task StartAsync() => _listeningTcs.Task;
+
+        public Task WaitForConnectionAsync() => _connectedTcs.Task;
 
         public async ValueTask DisposeAsync()
         {
@@ -559,11 +897,13 @@ public sealed class CliDaemonTests : IAsyncLifetime
         {
             try
             {
+                await Task.Delay(_listenDelay, _cts.Token);
                 _server = ServiceSecurity.CreateSecureServer(_pipeName);
                 _listeningTcs.TrySetResult();
                 _output.WriteLine($"Stalled pipe server listening on {_pipeName}");
 
                 await _server.WaitForConnectionAsync(_cts.Token);
+                _connectedTcs.TrySetResult();
                 _output.WriteLine("Stalled pipe server accepted a connection");
 
                 await Task.Delay(Timeout.InfiniteTimeSpan, _cts.Token);

--- a/tests/ExcelMcp.CLI.Tests/Integration/DaemonForcedStopRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/DaemonForcedStopRegressionTests.cs
@@ -1,13 +1,16 @@
 using System.Diagnostics;
 using System.Reflection;
+using System.Text.Json;
+using System.Xml.Linq;
 using Sbroenne.ExcelMcp.CLI.Commands;
 using Sbroenne.ExcelMcp.CLI.Infrastructure;
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
 
 /// <summary>
-/// Regression coverage for forced daemon shutdown reaping tracked Excel processes.
+/// Regression coverage for pipe-scoped daemon and orphaned Excel process cleanup.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "CLI")]
@@ -15,6 +18,786 @@ namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
 [Trait("RequiresExcel", "false")]
 public sealed class DaemonForcedStopRegressionTests
 {
+    public static TheoryData<string> AdversarialPipeNames
+    {
+        get
+        {
+            var data = new TheoryData<string>();
+            foreach (var pipeName in GetAdversarialPipeNames())
+            {
+                data.Add(pipeName);
+            }
+
+            return data;
+        }
+    }
+
+    [Fact]
+    public void MutexNames_UseDisjointHashedNamespaces()
+    {
+        const string daemonPrefix = "ExcelMcpCli_Daemon_";
+        const string startupPrefix = "ExcelMcpCli_Startup_";
+        const string trackerPrefix = "ExcelMcpCli_Tracker_";
+        var pipeNames = GetAdversarialPipeNames();
+        var names = pipeNames
+            .SelectMany(pipeName => new[]
+            {
+                DaemonAutoStart.GetDaemonMutexName(pipeName),
+                DaemonAutoStart.GetDaemonStartupLockName(pipeName),
+                DaemonProcessTracker.GetTrackingMutexName(pipeName)
+            })
+            .ToList();
+
+        Assert.Equal(
+            pipeNames.Distinct(StringComparer.OrdinalIgnoreCase).Count() * 3,
+            names.Distinct(StringComparer.Ordinal).Count());
+        foreach (var pipeName in pipeNames)
+        {
+            var daemonName = DaemonAutoStart.GetDaemonMutexName(pipeName);
+            var startupName = DaemonAutoStart.GetDaemonStartupLockName(pipeName);
+            var trackerName = DaemonProcessTracker.GetTrackingMutexName(pipeName);
+            Assert.StartsWith(daemonPrefix, daemonName, StringComparison.Ordinal);
+            Assert.StartsWith(startupPrefix, startupName, StringComparison.Ordinal);
+            Assert.StartsWith(trackerPrefix, trackerName, StringComparison.Ordinal);
+            Assert.Equal(64, daemonName[daemonPrefix.Length..].Length);
+            Assert.Equal(64, startupName[startupPrefix.Length..].Length);
+            Assert.Equal(64, trackerName[trackerPrefix.Length..].Length);
+            Assert.All(daemonName[daemonPrefix.Length..], character => Assert.True(char.IsAsciiHexDigit(character)));
+            Assert.All(startupName[startupPrefix.Length..], character => Assert.True(char.IsAsciiHexDigit(character)));
+            Assert.All(trackerName[trackerPrefix.Length..], character => Assert.True(char.IsAsciiHexDigit(character)));
+            Assert.Equal(daemonName, DaemonAutoStart.GetDaemonMutexName(pipeName));
+            Assert.Equal(startupName, DaemonAutoStart.GetDaemonStartupLockName(pipeName));
+            Assert.Equal(trackerName, DaemonProcessTracker.GetTrackingMutexName(pipeName));
+        }
+
+        Assert.Equal(
+            DaemonAutoStart.GetDaemonMutexName("foo"),
+            DaemonAutoStart.GetDaemonMutexName("FOO"));
+        Assert.Equal(
+            DaemonAutoStart.GetDaemonStartupLockName("foo"),
+            DaemonAutoStart.GetDaemonStartupLockName("FOO"));
+        Assert.Equal(
+            DaemonProcessTracker.GetTrackingMutexName("foo"),
+            DaemonProcessTracker.GetTrackingMutexName("FOO"));
+        Assert.Equal(
+            DaemonProcessTracker.GetTrackingFilePath("foo"),
+            DaemonProcessTracker.GetTrackingFilePath("FOO"));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task CaseVariantPipeNamesShareDaemonAndCleanupIdentity()
+    {
+        var cliPath = CliProcessHelper.GetExePath();
+        var pipeName = $"excelmcp-case-foo-{Guid.NewGuid():N}";
+        var caseVariantPipeName = pipeName.ToUpperInvariant();
+        using var daemon = StartDaemonProcess(cliPath, pipeName);
+        Process? duplicateDaemon = null;
+
+        try
+        {
+            await WaitForDaemonReadyAsync(cliPath, pipeName);
+            duplicateDaemon = StartDaemonProcess(cliPath, caseVariantPipeName);
+            Assert.True(
+                duplicateDaemon.WaitForExit(10000),
+                "A case-variant pipe name must not start a second daemon.");
+
+            var status = await GetServiceStatusAsync(cliPath, caseVariantPipeName);
+            Assert.Equal(0, status.ExitCode);
+            using var statusJson = JsonDocument.Parse(status.Stdout);
+            Assert.Equal(
+                daemon.Id,
+                statusJson.RootElement.GetProperty("processId").GetInt32());
+
+            var stopResult = await RunProcessAsync(
+                cliPath,
+                ["service", "stop", "--quiet"],
+                Path.GetDirectoryName(cliPath)!,
+                new Dictionary<string, string>
+                {
+                    ["EXCELMCP_CLI_PIPE"] = caseVariantPipeName
+                },
+                TimeSpan.FromSeconds(20));
+
+            Assert.Equal(0, stopResult.ExitCode);
+            Assert.True(daemon.WaitForExit(10000));
+            Assert.Equal(
+                DaemonProcessTracker.GetTrackingFilePath(pipeName),
+                DaemonProcessTracker.GetTrackingFilePath(caseVariantPipeName));
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            if (duplicateDaemon != null)
+            {
+                await StopDaemonBestEffortAsync(
+                    cliPath,
+                    caseVariantPipeName,
+                    duplicateDaemon);
+                duplicateDaemon.Dispose();
+            }
+            await StopDaemonBestEffortAsync(cliPath, pipeName, daemon);
+            DaemonProcessTracker.Clear(pipeName);
+            DaemonProcessTracker.Clear(caseVariantPipeName);
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task LegacyDaemonMutex_PreventsNewDaemonFromStarting()
+    {
+        var cliPath = CliProcessHelper.GetExePath();
+        var pipeName = $"excelmcp-legacy-mutex-{Guid.NewGuid():N}";
+        using var legacyMutex = new Mutex(
+            initiallyOwned: true,
+            $"ExcelMcpCli_{pipeName}",
+            out var createdNew);
+        Assert.True(createdNew);
+        using var daemon = StartDaemonProcess(cliPath, pipeName);
+
+        try
+        {
+            Assert.True(
+                daemon.WaitForExit(5000),
+                "A daemon must exit when a legacy daemon already owns the pipe lifetime mutex.");
+            Assert.Equal(0, daemon.ExitCode);
+        }
+        finally
+        {
+            if (!daemon.HasExited)
+            {
+                daemon.Kill(entireProcessTree: true);
+                await daemon.WaitForExitAsync();
+            }
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task StartupMutex_DoesNotCollideWithSuffixNamedDaemonMutex()
+    {
+        var cliPath = CliProcessHelper.GetExePath();
+        var pipeName = $"excelmcp-mutex-collision-{Guid.NewGuid():N}";
+        var suffixPipeName = $"{pipeName}_startup";
+        using var daemon = StartDaemonProcess(cliPath, pipeName);
+        using var suffixDaemon = StartDaemonProcess(cliPath, suffixPipeName);
+
+        try
+        {
+            await WaitForDaemonReadyAsync(cliPath, pipeName);
+            await WaitForDaemonReadyAsync(cliPath, suffixPipeName);
+
+            var stopResult = await RunProcessAsync(
+                cliPath,
+                ["service", "stop", "--quiet"],
+                Path.GetDirectoryName(cliPath)!,
+                new Dictionary<string, string>
+                {
+                    ["EXCELMCP_CLI_PIPE"] = pipeName
+                },
+                TimeSpan.FromSeconds(20));
+
+            Assert.True(
+                stopResult.ExitCode == 0,
+                $"service stop failed with exit code {stopResult.ExitCode}.{Environment.NewLine}" +
+                $"stdout: {stopResult.Stdout}{Environment.NewLine}stderr: {stopResult.Stderr}");
+            Assert.True(daemon.WaitForExit(10000));
+            Assert.False(suffixDaemon.HasExited);
+            Assert.True((await GetServiceStatusAsync(cliPath, suffixPipeName)).ExitCode == 0);
+        }
+        finally
+        {
+            await StopDaemonBestEffortAsync(cliPath, suffixPipeName, suffixDaemon);
+            await StopDaemonBestEffortAsync(cliPath, pipeName, daemon);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AdversarialPipeNames))]
+    public async Task ServiceStop_AdversarialPipeNamesRemainIsolated(string pipeName)
+    {
+        var controlPipeName = $"{pipeName}-control";
+        using var daemon = StartSleepingProcess();
+        using var excel = StartSleepingProcess();
+        using var controlDaemon = StartSleepingProcess();
+        using var controlExcel = StartSleepingProcess();
+
+        try
+        {
+            RegisterTrackedProcesses(pipeName, daemon, excel);
+            RegisterTrackedProcesses(controlPipeName, controlDaemon, controlExcel);
+
+            var result = await RunServiceStopAsync(pipeName);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(daemon.WaitForExit(5000));
+            Assert.True(excel.WaitForExit(5000));
+            Assert.False(controlDaemon.HasExited);
+            Assert.False(controlExcel.HasExited);
+            Assert.True(File.Exists(DaemonProcessTracker.GetTrackingFilePath(controlPipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(excel);
+            StopIfRunning(controlDaemon);
+            StopIfRunning(controlExcel);
+            DaemonProcessTracker.Clear(pipeName);
+            DaemonProcessTracker.Clear(controlPipeName);
+        }
+    }
+
+    [Fact]
+    public async Task StartupMutex_SamePipeSerializesCallers()
+    {
+        var pipeName = $"excelmcp-same-pipe-lock-{Guid.NewGuid():N}";
+        var firstEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var first = DaemonStartupLock.WithLockAsync(
+            pipeName,
+            async () =>
+            {
+                firstEntered.SetResult();
+                await releaseFirst.Task;
+                return true;
+            },
+            CancellationToken.None);
+        await firstEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var second = DaemonStartupLock.WithLockAsync(
+            pipeName,
+            () =>
+            {
+                secondEntered.SetResult();
+                return Task.FromResult(true);
+            },
+            CancellationToken.None);
+
+        await Task.Delay(250);
+        Assert.False(secondEntered.Task.IsCompleted);
+
+        releaseFirst.SetResult();
+        Assert.True(await first);
+        Assert.True(await second);
+        Assert.True(secondEntered.Task.IsCompleted);
+    }
+
+    [Fact]
+    public void PreBuildCleanup_RunsOnlyForCliProject()
+    {
+        var buildProperties = XDocument.Load(
+            Path.Combine(GetRepositoryRoot(), "Directory.Build.props"));
+        var cleanupTarget = buildProperties
+            .Descendants("Target")
+            .Single(element => string.Equals(
+                element.Attribute("Name")?.Value,
+                "StopExcelMcpProcesses",
+                StringComparison.Ordinal));
+
+        var condition = cleanupTarget.Attribute("Condition")?.Value;
+
+        Assert.Contains(
+            "'$(MSBuildProjectName)' == 'ExcelMcp.CLI'",
+            condition,
+            StringComparison.Ordinal);
+        Assert.Equal("BeforeBuild", cleanupTarget.Attribute("BeforeTargets")?.Value);
+    }
+
+    [Fact]
+    public void CleanupScript_StagesCurrentClientWhenExistingBinaryIsStale()
+    {
+        var cleanupScript = File.ReadAllText(
+            Path.Combine(GetRepositoryRoot(), "scripts", "Stop-ExcelMcpProcesses.ps1"));
+
+        Assert.Contains(
+            @"src\ExcelMcp.CLI\Infrastructure\DaemonAutoStart.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            @"src\ExcelMcp.CLI\Program.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            @"src\ExcelMcp.ComInterop\Session\SessionManager.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            @"src\ExcelMcp.ComInterop\Session\ExcelBatch.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            @"src\ExcelMcp.ComInterop\Session\ExcelProcessIdentity.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            @"src\ExcelMcp.ComInterop\Session\OwnedProcessGuard.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "-p:ExcelMcpCleanupRoot=$stagingRoot",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "-p:ExcelMcpSkipCleanup=true",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            @"src\ExcelMcp.Cleanup\ExcelMcp.Cleanup.csproj",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            @"src\ExcelMcp.Service\ServiceClient.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            @"src\ExcelMcp.Service\Rpc\IExcelDaemonRpc.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "if ($availableClis.Count -eq 0)",
+            cleanupScript,
+            StringComparison.Ordinal);
+    }
+
+    [Fact(Timeout = 300000)]
+    public async Task PreBuildCleanup_StaleBinaryStopsOwnedDaemonAndAllowsReleaseRebuild()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var releaseDirectory = Path.Combine(
+            repositoryRoot,
+            "src",
+            "ExcelMcp.CLI",
+            "bin",
+            "Release",
+            "net10.0-windows");
+        var releaseCli = Path.Combine(releaseDirectory, "excelcli.exe");
+        Assert.True(File.Exists(releaseCli), $"Release CLI is required for this regression: {releaseCli}");
+
+        var controlDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"excelmcp-stale-cleanup-control-{Guid.NewGuid():N}");
+        CopyDirectory(releaseDirectory, controlDirectory);
+        var controlCli = Path.Combine(controlDirectory, "excelcli.exe");
+        var ownedPipe = $"excelmcp-stale-build-owned-{Guid.NewGuid():N}";
+        var controlPipe = $"excelmcp-stale-build-control-{Guid.NewGuid():N}";
+        using var ownedDaemon = StartDaemonProcess(releaseCli, ownedPipe);
+        using var controlDaemon = StartDaemonProcess(controlCli, controlPipe);
+        var safetySource = Path.Combine(
+            repositoryRoot,
+            "src",
+            "ExcelMcp.CLI",
+            "Infrastructure",
+            "DaemonProcessTracker.cs");
+        var originalSourceWriteTime = File.GetLastWriteTimeUtc(safetySource);
+
+        try
+        {
+            await WaitForDaemonReadyAsync(releaseCli, ownedPipe);
+            await WaitForDaemonReadyAsync(controlCli, controlPipe);
+
+            File.SetLastWriteTimeUtc(safetySource, DateTime.UtcNow);
+            Assert.True(
+                File.GetLastWriteTimeUtc(safetySource) > File.GetLastWriteTimeUtc(releaseCli),
+                "The ownership source must be newer than the existing CLI for this regression.");
+
+            var buildResult = await RunProcessAsync(
+                "dotnet",
+                [
+                    "build",
+                    Path.Combine(
+                        repositoryRoot,
+                        "src",
+                        "ExcelMcp.CLI",
+                        "ExcelMcp.CLI.csproj"),
+                    "--configuration",
+                    "Release",
+                    "-p:NuGetAudit=false",
+                    "-maxcpucount:1",
+                    "-nodeReuse:false",
+                    "--verbosity",
+                    "quiet"
+                ],
+                repositoryRoot,
+                new Dictionary<string, string>
+                {
+                    ["EXCELMCP_CLI_PIPE"] = ownedPipe
+                },
+                TimeSpan.FromMinutes(3));
+
+            Assert.True(
+                buildResult.ExitCode == 0,
+                $"Release rebuild failed.{Environment.NewLine}" +
+                $"stdout: {buildResult.Stdout}{Environment.NewLine}" +
+                $"stderr: {buildResult.Stderr}");
+            Assert.DoesNotContain("warning ", buildResult.Stdout, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("warning ", buildResult.Stderr, StringComparison.OrdinalIgnoreCase);
+            Assert.True(
+                ownedDaemon.WaitForExit(10000),
+                $"Owned daemon {ownedDaemon.Id} was not stopped by the stale-binary pre-build target.");
+            Assert.False(controlDaemon.HasExited);
+            Assert.True((await GetServiceStatusAsync(controlCli, controlPipe)).ExitCode == 0);
+        }
+        finally
+        {
+            File.SetLastWriteTimeUtc(safetySource, originalSourceWriteTime);
+            await StopDaemonBestEffortAsync(releaseCli, ownedPipe, ownedDaemon);
+            await StopDaemonBestEffortAsync(controlCli, controlPipe, controlDaemon);
+            Directory.Delete(controlDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_StopsExcelTrackedAndUntrackedBetweenSnapshots()
+    {
+        var pipeName = $"excelmcp-between-snapshots-{Guid.NewGuid():N}";
+        using var daemon = StartSleepingProcess();
+        using var excel = StartSleepingProcess();
+
+        try
+        {
+            var daemonIdentity = DaemonProcessTracker.RegisterProcess(
+                pipeName,
+                daemon.Id,
+                daemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+            var preShutdownSnapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+
+            DaemonProcessTracker.UpdateExcelProcesses(pipeName, daemonIdentity, [excel.Id]);
+            DaemonProcessTracker.UpdateExcelProcesses(pipeName, daemonIdentity, []);
+            var trackedExcel = Assert.Single(
+                DaemonProcessTracker.GetTrackedExcelProcessIdentities(pipeName));
+            Assert.Equal(excel.Id, trackedExcel.ProcessId);
+
+            var cleanupResult = await OwnedProcessCleanup.CleanupAsync(
+                pipeName,
+                preShutdownSnapshot,
+                CancellationToken.None);
+
+            Assert.True(cleanupResult.Success);
+            Assert.True(daemon.WaitForExit(5000));
+            Assert.True(excel.WaitForExit(5000));
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(excel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_DelayedStaleExcelIdentityDoesNotCaptureReusedPid()
+    {
+        var pipeName = $"excelmcp-delayed-pid-reuse-{Guid.NewGuid():N}";
+        using var daemon = StartSleepingProcess();
+        using var replacement = StartSleepingProcess();
+
+        try
+        {
+            var daemonIdentity = DaemonProcessTracker.RegisterProcess(
+                pipeName,
+                daemon.Id,
+                daemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+            var preShutdownSnapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+            var staleExcelIdentity = new DaemonProcessTracker.ProcessIdentity(
+                replacement.Id,
+                replacement.StartTime.ToUniversalTime().ToFileTimeUtc() + 1);
+
+            DaemonProcessTracker.RecordExcelProcesses(
+                pipeName,
+                daemonIdentity,
+                [staleExcelIdentity]);
+
+            var trackedExcel = Assert.Single(
+                DaemonProcessTracker.GetTrackedExcelProcessIdentities(pipeName));
+            Assert.Equal(staleExcelIdentity, trackedExcel);
+
+            var cleanupResult = await OwnedProcessCleanup.CleanupAsync(
+                pipeName,
+                preShutdownSnapshot,
+                CancellationToken.None);
+
+            Assert.True(cleanupResult.Success);
+            Assert.True(daemon.WaitForExit(5000));
+            Assert.False(replacement.HasExited);
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(replacement);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_DoesNotStopUntrackedDaemonChildProcess()
+    {
+        var pipeName = $"excelmcp-child-isolation-{Guid.NewGuid():N}";
+        var childPidFile = Path.Combine(Path.GetTempPath(), $"excelmcp-child-{Guid.NewGuid():N}.pid");
+        using var daemon = StartSleepingProcessWithChild(childPidFile);
+        using var child = await WaitForChildProcessAsync(childPidFile);
+
+        try
+        {
+            DaemonProcessTracker.RegisterProcess(
+                pipeName,
+                daemon.Id,
+                daemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+
+            var cleanupResult = await OwnedProcessCleanup.CleanupAsync(pipeName, CancellationToken.None);
+
+            Assert.True(cleanupResult.Success);
+            Assert.True(daemon.WaitForExit(5000));
+            Assert.False(child.HasExited);
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(child);
+            DaemonProcessTracker.Clear(pipeName);
+            File.Delete(childPidFile);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_PreservesTrackedExcelWhenGracefulDaemonUntracksDuringShutdown()
+    {
+        var pipeName = $"excelmcp-graceful-tracking-loss-{Guid.NewGuid():N}";
+        using var daemon = StartShortLivedProcess();
+        using var excel = StartSleepingProcess();
+
+        try
+        {
+            var daemonIdentity = RegisterTrackedProcesses(pipeName, daemon, excel);
+            var preShutdownSnapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+
+            DaemonProcessTracker.UpdateExcelProcesses(pipeName, daemonIdentity, []);
+            var trackedExcel = Assert.Single(
+                DaemonProcessTracker.GetTrackedExcelProcessIdentities(pipeName));
+            Assert.Equal(excel.Id, trackedExcel.ProcessId);
+            await daemon.WaitForExitAsync();
+            Assert.Equal(0, daemon.ExitCode);
+            Assert.False(excel.HasExited);
+
+            var cleanupResult = await OwnedProcessCleanup.CleanupAsync(
+                pipeName,
+                preShutdownSnapshot,
+                CancellationToken.None);
+
+            Assert.True(cleanupResult.Success);
+            Assert.True(daemon.HasExited);
+            Assert.True(excel.WaitForExit(5000));
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(excel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_DoesNotStopOrClearReplacementDaemonGeneration()
+    {
+        var pipeName = $"excelmcp-replacement-generation-{Guid.NewGuid():N}";
+        using var oldDaemon = StartSleepingProcess();
+        using var oldExcel = StartSleepingProcess();
+        using var replacementDaemon = StartSleepingProcess();
+        using var replacementExcel = StartSleepingProcess();
+
+        try
+        {
+            RegisterTrackedProcesses(pipeName, oldDaemon, oldExcel);
+            var oldSnapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+            StopIfRunning(oldDaemon);
+
+            RegisterTrackedProcesses(pipeName, replacementDaemon, replacementExcel);
+
+            var cleanupResult = await OwnedProcessCleanup.CleanupAsync(
+                pipeName,
+                oldSnapshot,
+                CancellationToken.None);
+
+            Assert.True(cleanupResult.Success);
+            Assert.True(oldExcel.WaitForExit(5000));
+            Assert.False(replacementDaemon.HasExited);
+            Assert.False(replacementExcel.HasExited);
+            Assert.True(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(oldDaemon);
+            StopIfRunning(oldExcel);
+            StopIfRunning(replacementDaemon);
+            StopIfRunning(replacementExcel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public void UpdateExcelProcesses_DelayedOldGenerationDoesNotOverwriteReplacement()
+    {
+        var pipeName = $"excelmcp-delayed-tracking-{Guid.NewGuid():N}";
+        using var oldDaemon = StartSleepingProcess();
+        using var replacementDaemon = StartSleepingProcess();
+        using var oldExcel = StartSleepingProcess();
+
+        try
+        {
+            var oldDaemonIdentity = DaemonProcessTracker.RegisterProcess(
+                pipeName,
+                oldDaemon.Id,
+                oldDaemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+            DaemonProcessTracker.RegisterProcess(
+                pipeName,
+                replacementDaemon.Id,
+                replacementDaemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+
+            DaemonProcessTracker.UpdateExcelProcesses(
+                pipeName,
+                oldDaemonIdentity,
+                [oldExcel.Id]);
+
+            Assert.True(DaemonProcessTracker.TryGetProcessSnapshot(pipeName, out var snapshot));
+            Assert.Equal(replacementDaemon.Id, snapshot.DaemonProcess.ProcessId);
+            Assert.Empty(snapshot.ExcelProcesses);
+        }
+        finally
+        {
+            StopIfRunning(oldDaemon);
+            StopIfRunning(replacementDaemon);
+            StopIfRunning(oldExcel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task ServiceStop_CleansOnlyProcessesTrackedForSelectedPipe()
+    {
+        var pipeA = $"excelmcp-owned-cleanup-a-{Guid.NewGuid():N}";
+        var pipeB = $"excelmcp-owned-cleanup-b-{Guid.NewGuid():N}";
+        using var daemonA = StartSleepingProcess();
+        using var excelA = StartSleepingProcess();
+        using var daemonB = StartSleepingProcess();
+        using var excelB = StartSleepingProcess();
+
+        try
+        {
+            RegisterTrackedProcesses(pipeA, daemonA, excelA);
+            RegisterTrackedProcesses(pipeB, daemonB, excelB);
+
+            var result = await RunServiceStopAsync(pipeA);
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"service stop failed with exit code {result.ExitCode}.{Environment.NewLine}" +
+                $"stdout: {result.Stdout}{Environment.NewLine}stderr: {result.Stderr}");
+            Assert.True(daemonA.WaitForExit(5000));
+            Assert.True(excelA.WaitForExit(5000));
+            Assert.False(daemonB.HasExited);
+            Assert.False(excelB.HasExited);
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeA)));
+            Assert.True(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeB)));
+        }
+        finally
+        {
+            StopIfRunning(daemonA);
+            StopIfRunning(excelA);
+            StopIfRunning(daemonB);
+            StopIfRunning(excelB);
+            DaemonProcessTracker.Clear(pipeA);
+            DaemonProcessTracker.Clear(pipeB);
+        }
+    }
+
+    [Fact]
+    public async Task ServiceStop_CleansTrackedExcelAfterDaemonExited()
+    {
+        var pipeName = $"excelmcp-orphan-cleanup-{Guid.NewGuid():N}";
+        using var daemon = StartSleepingProcess();
+        using var excel = StartSleepingProcess();
+
+        try
+        {
+            RegisterTrackedProcesses(pipeName, daemon, excel);
+            StopIfRunning(daemon);
+
+            var result = await RunServiceStopAsync(pipeName);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(excel.WaitForExit(5000));
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(excel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task ServiceStop_IgnoresPidReusedTrackingRecords()
+    {
+        var pipeName = $"excelmcp-stale-cleanup-{Guid.NewGuid():N}";
+        using var daemon = StartSleepingProcess();
+        using var excel = StartSleepingProcess();
+
+        try
+        {
+            WriteStaleTrackingRecord(pipeName, daemon, excel);
+
+            var result = await RunServiceStopAsync(pipeName);
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"service stop failed with exit code {result.ExitCode}.{Environment.NewLine}" +
+                $"stdout: {result.Stdout}{Environment.NewLine}stderr: {result.Stderr}");
+            Assert.False(daemon.HasExited);
+            Assert.False(excel.HasExited);
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(excel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task ServiceStop_OwnedCleanupIsIdempotent()
+    {
+        var pipeName = $"excelmcp-idempotent-cleanup-{Guid.NewGuid():N}";
+        using var daemon = StartSleepingProcess();
+        using var excel = StartSleepingProcess();
+
+        try
+        {
+            RegisterTrackedProcesses(pipeName, daemon, excel);
+
+            var firstResult = await RunServiceStopAsync(pipeName);
+            var secondResult = await RunServiceStopAsync(pipeName);
+
+            Assert.Equal(0, firstResult.ExitCode);
+            Assert.Equal(0, secondResult.ExitCode);
+            Assert.True(daemon.WaitForExit(5000));
+            Assert.True(excel.WaitForExit(5000));
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(excel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
     [Fact]
     public async Task ForceStopTrackedDaemon_AlsoStopsTrackedExcelProcess()
     {
@@ -24,11 +807,12 @@ public sealed class DaemonForcedStopRegressionTests
 
         try
         {
-            DaemonProcessTracker.RegisterProcess(
+            var daemonIdentity = DaemonProcessTracker.RegisterProcess(
                 pipeName,
                 daemon.Id,
                 daemon.StartTime.ToUniversalTime().ToFileTimeUtc());
-            DaemonProcessTracker.UpdateExcelProcesses(pipeName, [excel.Id]);
+            DaemonProcessTracker.UpdateExcelProcesses(pipeName, daemonIdentity, [excel.Id]);
+            var preShutdownSnapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
 
             var method = typeof(ServiceStopCommand).GetMethod(
                 "TryForceStopTrackedDaemonAsync",
@@ -37,7 +821,7 @@ public sealed class DaemonForcedStopRegressionTests
 
             var stopTask = (Task<bool>)method!.Invoke(
                 null,
-                [pipeName, CancellationToken.None])!;
+                [pipeName, preShutdownSnapshot, CancellationToken.None])!;
             Assert.True(await stopTask);
 
             await daemon.WaitForExitAsync();
@@ -65,12 +849,7 @@ public sealed class DaemonForcedStopRegressionTests
         })!;
         process.WaitForExit();
 
-        var method = typeof(ServiceStopCommand).GetMethod(
-            "TryTerminateProcess",
-            BindingFlags.Static | BindingFlags.NonPublic);
-        Assert.NotNull(method);
-
-        var terminated = (bool)method!.Invoke(null, [process, false])!;
+        var terminated = OwnedProcessCleanup.TryTerminateProcess(process, entireProcessTree: false);
         Assert.True(terminated);
     }
 
@@ -104,9 +883,16 @@ public sealed class DaemonForcedStopRegressionTests
         {
             Directory.CreateDirectory(Path.GetDirectoryName(trackingFile)!);
             File.WriteAllText(trackingFile, """{"processId":""");
+            using var currentProcess = Process.GetCurrentProcess();
+            var daemonIdentity = new DaemonProcessTracker.ProcessIdentity(
+                currentProcess.Id,
+                currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc());
 
             var exception = Record.Exception(() =>
-                DaemonProcessTracker.UpdateExcelProcesses(pipeName, [Environment.ProcessId]));
+                DaemonProcessTracker.UpdateExcelProcesses(
+                    pipeName,
+                    daemonIdentity,
+                    [Environment.ProcessId]));
 
             Assert.Null(exception);
             Assert.True(File.Exists(trackingFile));
@@ -114,6 +900,361 @@ public sealed class DaemonForcedStopRegressionTests
         finally
         {
             DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public void RecordExcelProcesses_InvalidRecord_FailsStrictPersistence()
+    {
+        var pipeName = $"excelmcp-tracker-strict-test-{Guid.NewGuid():N}";
+        var trackingFile = DaemonProcessTracker.GetTrackingFilePath(pipeName);
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(trackingFile)!);
+            File.WriteAllText(trackingFile, """{"processId":""");
+            using var currentProcess = Process.GetCurrentProcess();
+            var daemonIdentity = new DaemonProcessTracker.ProcessIdentity(
+                currentProcess.Id,
+                currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc());
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                DaemonProcessTracker.RecordExcelProcesses(
+                    pipeName,
+                    daemonIdentity,
+                    [new DaemonProcessTracker.ProcessIdentity(
+                        Environment.ProcessId,
+                        currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc())]));
+            Assert.Contains("malformed", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_MissingTrackingRecord_IsSafeNoOp()
+    {
+        var pipeName = $"excelmcp-tracker-missing-{Guid.NewGuid():N}";
+
+        var result = await OwnedProcessCleanup.CleanupAsync(
+            pipeName,
+            CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.False(result.DaemonMatched);
+    }
+
+    [Fact]
+    public async Task Cleanup_MalformedTrackingRecord_FailsAndPreservesEvidence()
+    {
+        var pipeName = $"excelmcp-tracker-malformed-{Guid.NewGuid():N}";
+        var trackingFile = DaemonProcessTracker.GetTrackingFilePath(pipeName);
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(trackingFile)!);
+            await File.WriteAllTextAsync(trackingFile, """{"processId":""");
+
+            var result = await OwnedProcessCleanup.CleanupAsync(
+                pipeName,
+                CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.False(result.DaemonMatched);
+            Assert.True(File.Exists(trackingFile));
+            Assert.Equal("""{"processId":""", await File.ReadAllTextAsync(trackingFile));
+        }
+        finally
+        {
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_UnreadableTrackingRecord_FailsAndPreservesEvidence()
+    {
+        var pipeName = $"excelmcp-tracker-unreadable-{Guid.NewGuid():N}";
+        var trackingFile = DaemonProcessTracker.GetTrackingFilePath(pipeName);
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(trackingFile)!);
+            await File.WriteAllTextAsync(trackingFile, """{"processId":1}""");
+            await using (var exclusiveLease = new FileStream(
+                trackingFile,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None))
+            {
+                var result = await OwnedProcessCleanup.CleanupAsync(
+                    pipeName,
+                    CancellationToken.None);
+
+                Assert.False(result.Success);
+                Assert.False(result.DaemonMatched);
+                Assert.True(File.Exists(trackingFile));
+            }
+        }
+        finally
+        {
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task ServiceStop_MalformedTrackingRecord_ReportsFailureAndPreservesEvidence()
+    {
+        var pipeName = $"excelmcp-tracker-service-stop-{Guid.NewGuid():N}";
+        var trackingFile = DaemonProcessTracker.GetTrackingFilePath(pipeName);
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(trackingFile)!);
+            await File.WriteAllTextAsync(trackingFile, """{"processId":""");
+
+            var result = await RunServiceStopAsync(pipeName);
+
+            Assert.Equal(1, result.ExitCode);
+            using var response = JsonDocument.Parse(result.Stdout);
+            Assert.False(response.RootElement.GetProperty("success").GetBoolean());
+            Assert.Contains(
+                "malformed",
+                response.RootElement.GetProperty("error").GetString(),
+                StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(trackingFile));
+        }
+        finally
+        {
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact(Timeout = 180000)]
+    public async Task PreBuildCleanup_MalformedTrackingRecordPropagatesFailure()
+    {
+        var pipeName = $"excelmcp-tracker-prebuild-{Guid.NewGuid():N}";
+        var trackingFile = DaemonProcessTracker.GetTrackingFilePath(pipeName);
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(trackingFile)!);
+            await File.WriteAllTextAsync(trackingFile, """{"processId":""");
+
+            var result = await RunProcessAsync(
+                "powershell.exe",
+                [
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    Path.Combine(
+                        GetRepositoryRoot(),
+                        "scripts",
+                        "Stop-ExcelMcpProcesses.ps1"),
+                    "-PipeName",
+                    pipeName,
+                    "-Verbose"
+                ],
+                GetRepositoryRoot(),
+                environmentVariables: null,
+                TimeSpan.FromMinutes(2));
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains(
+                "cleanup failed",
+                result.Stdout + result.Stderr,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(trackingFile));
+        }
+        finally
+        {
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact(Timeout = 180000)]
+    public async Task PreBuildCleanup_UnresponsiveFallbackRemainsPipeScoped()
+    {
+        var selectedPipe = $"excelmcp-prebuild-unresponsive-{Guid.NewGuid():N}";
+        var unrelatedPipe = $"excelmcp-prebuild-control-{Guid.NewGuid():N}";
+        using var selectedDaemon = StartSleepingProcess();
+        using var selectedExcel = StartSleepingProcess();
+        using var unrelatedDaemon = StartSleepingProcess();
+        using var unrelatedExcel = StartSleepingProcess();
+        var repositoryRoot = GetRepositoryRoot();
+        var protocolSource = Path.Combine(
+            repositoryRoot,
+            "src",
+            "ExcelMcp.Service",
+            "ServiceClient.cs");
+        var originalSourceWriteTime = File.GetLastWriteTimeUtc(protocolSource);
+
+        try
+        {
+            RegisterTrackedProcesses(selectedPipe, selectedDaemon, selectedExcel);
+            RegisterTrackedProcesses(unrelatedPipe, unrelatedDaemon, unrelatedExcel);
+            File.SetLastWriteTimeUtc(protocolSource, DateTime.UtcNow.AddSeconds(2));
+
+            var result = await RunProcessAsync(
+                "powershell.exe",
+                [
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    Path.Combine(
+                        repositoryRoot,
+                        "scripts",
+                        "Stop-ExcelMcpProcesses.ps1"),
+                    "-PipeName",
+                    selectedPipe,
+                    "-Verbose"
+                ],
+                repositoryRoot,
+                environmentVariables: null,
+                TimeSpan.FromMinutes(2));
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(selectedDaemon.WaitForExit(5000));
+            Assert.True(selectedExcel.WaitForExit(5000));
+            Assert.False(unrelatedDaemon.HasExited);
+            Assert.False(unrelatedExcel.HasExited);
+            Assert.True(File.Exists(DaemonProcessTracker.GetTrackingFilePath(unrelatedPipe)));
+        }
+        finally
+        {
+            File.SetLastWriteTimeUtc(protocolSource, originalSourceWriteTime);
+            StopIfRunning(selectedDaemon);
+            StopIfRunning(selectedExcel);
+            StopIfRunning(unrelatedDaemon);
+            StopIfRunning(unrelatedExcel);
+            DaemonProcessTracker.Clear(selectedPipe);
+            DaemonProcessTracker.Clear(unrelatedPipe);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_LegacyCaseSensitiveRecordUsesCaseInsensitivePipeIdentity()
+    {
+        var legacyPipeName = $"excelmcp-legacy-tracker-{Guid.NewGuid():N}".ToLowerInvariant();
+        var callerPipeName = legacyPipeName.ToUpperInvariant();
+        var legacyTrackingFile = GetLegacyTrackingFilePath(legacyPipeName);
+        using var daemon = StartSleepingProcess();
+        using var excel = StartSleepingProcess();
+
+        try
+        {
+            WriteTrackingRecord(legacyTrackingFile, daemon, excel);
+
+            var result = await OwnedProcessCleanup.CleanupAsync(
+                callerPipeName,
+                CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.True(result.DaemonMatched);
+            Assert.True(daemon.WaitForExit(5000));
+            Assert.True(excel.WaitForExit(5000));
+            Assert.False(File.Exists(legacyTrackingFile));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
+            StopIfRunning(excel);
+            DaemonProcessTracker.Clear(legacyPipeName);
+            DaemonProcessTracker.Clear(callerPipeName);
+            File.Delete(legacyTrackingFile);
+        }
+    }
+
+    [Fact]
+    public async Task Cleanup_LegacyCaseSensitiveRecordKeepsUnrelatedPipeIsolated()
+    {
+        var selectedPipe = $"excelmcp-legacy-selected-{Guid.NewGuid():N}".ToLowerInvariant();
+        var unrelatedPipe = $"excelmcp-legacy-unrelated-{Guid.NewGuid():N}".ToLowerInvariant();
+        var selectedTrackingFile = GetLegacyTrackingFilePath(selectedPipe);
+        var unrelatedTrackingFile = GetLegacyTrackingFilePath(unrelatedPipe);
+        using var selectedDaemon = StartSleepingProcess();
+        using var selectedExcel = StartSleepingProcess();
+        using var unrelatedDaemon = StartSleepingProcess();
+        using var unrelatedExcel = StartSleepingProcess();
+
+        try
+        {
+            WriteTrackingRecord(selectedTrackingFile, selectedDaemon, selectedExcel);
+            WriteTrackingRecord(unrelatedTrackingFile, unrelatedDaemon, unrelatedExcel);
+
+            var result = await OwnedProcessCleanup.CleanupAsync(
+                selectedPipe.ToUpperInvariant(),
+                CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.True(selectedDaemon.WaitForExit(5000));
+            Assert.True(selectedExcel.WaitForExit(5000));
+            Assert.False(unrelatedDaemon.HasExited);
+            Assert.False(unrelatedExcel.HasExited);
+            Assert.True(File.Exists(unrelatedTrackingFile));
+        }
+        finally
+        {
+            StopIfRunning(selectedDaemon);
+            StopIfRunning(selectedExcel);
+            StopIfRunning(unrelatedDaemon);
+            StopIfRunning(unrelatedExcel);
+            DaemonProcessTracker.Clear(selectedPipe);
+            DaemonProcessTracker.Clear(selectedPipe.ToUpperInvariant());
+            DaemonProcessTracker.Clear(unrelatedPipe);
+            File.Delete(selectedTrackingFile);
+            File.Delete(unrelatedTrackingFile);
+        }
+    }
+
+    [Fact]
+    public async Task TrackingMutex_LegacyCaseVariantSerializesCanonicalCaller()
+    {
+        var legacyPipeName = $"excelmcp-legacy-lock-{Guid.NewGuid():N}".ToLowerInvariant();
+        var callerPipeName = legacyPipeName.ToUpperInvariant();
+        var legacyMutexName =
+            $"ExcelMcpCliTracker_{DaemonPipeIdentity.GetCaseSensitiveHash(legacyPipeName)}";
+        using var acquired = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var holder = Task.Run(() =>
+        {
+            using var legacyMutex = new Mutex(
+                initiallyOwned: false,
+                legacyMutexName,
+                out var createdNew);
+            Assert.True(createdNew);
+            legacyMutex.WaitOne();
+            try
+            {
+                acquired.Set();
+                release.Wait();
+            }
+            finally
+            {
+                legacyMutex.ReleaseMutex();
+            }
+        });
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(5)));
+        var registration = Task.Run(() =>
+            DaemonProcessTracker.RegisterProcess(
+                callerPipeName,
+                Environment.ProcessId,
+                Process.GetCurrentProcess().StartTime.ToUniversalTime().ToFileTimeUtc()));
+        try
+        {
+            await Task.Delay(250);
+            Assert.False(registration.IsCompleted);
+        }
+        finally
+        {
+            release.Set();
+            await holder;
+            await registration;
+            DaemonProcessTracker.Clear(callerPipeName);
         }
     }
 
@@ -128,6 +1269,122 @@ public sealed class DaemonForcedStopRegressionTests
         })!;
     }
 
+    private static Process StartShortLivedProcess()
+    {
+        return Process.Start(new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = "-NoProfile -Command \"Start-Sleep -Seconds 2\"",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        })!;
+    }
+
+    private static Process StartSleepingProcessWithChild(string childPidFile)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-Command");
+        startInfo.ArgumentList.Add(
+            "$child = Start-Process powershell.exe " +
+            "-ArgumentList '-NoProfile','-Command','Start-Sleep -Seconds 60' -PassThru; " +
+            $"Set-Content -LiteralPath '{childPidFile.Replace("'", "''", StringComparison.Ordinal)}' -Value $child.Id; " +
+            "Start-Sleep -Seconds 60");
+        return Process.Start(startInfo)!;
+    }
+
+    private static async Task<Process> WaitForChildProcessAsync(string childPidFile)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(childPidFile)
+                && int.TryParse(await File.ReadAllTextAsync(childPidFile), out var childProcessId))
+            {
+                return Process.GetProcessById(childProcessId);
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException("The daemon test process did not report its child PID.");
+    }
+
+    private static DaemonProcessTracker.ProcessIdentity RegisterTrackedProcesses(
+        string pipeName,
+        Process daemon,
+        Process excel)
+    {
+        var daemonIdentity = DaemonProcessTracker.RegisterProcess(
+            pipeName,
+            daemon.Id,
+            daemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+        DaemonProcessTracker.UpdateExcelProcesses(pipeName, daemonIdentity, [excel.Id]);
+        return daemonIdentity;
+    }
+
+    private static async Task<CliResult> RunServiceStopAsync(string pipeName)
+    {
+        return await CliProcessHelper.RunAsync(
+            "service stop",
+            timeoutMs: 15000,
+            environmentVariables: new Dictionary<string, string>
+            {
+                ["EXCELMCP_CLI_PIPE"] = pipeName
+            });
+    }
+
+    private static void WriteStaleTrackingRecord(string pipeName, Process daemon, Process excel)
+    {
+        var trackingFile = DaemonProcessTracker.GetTrackingFilePath(pipeName);
+        Directory.CreateDirectory(Path.GetDirectoryName(trackingFile)!);
+        var record = new
+        {
+            processId = daemon.Id,
+            startedAtUtcFileTime = daemon.StartTime.ToUniversalTime().ToFileTimeUtc() + 1,
+            excelProcesses = new[]
+            {
+                new
+                {
+                    processId = excel.Id,
+                    startedAtUtcFileTime = excel.StartTime.ToUniversalTime().ToFileTimeUtc() + 1
+                }
+            }
+        };
+        File.WriteAllText(trackingFile, JsonSerializer.Serialize(record));
+    }
+
+    private static string GetLegacyTrackingFilePath(string pipeName) =>
+        Path.Combine(
+            Path.GetDirectoryName(DaemonProcessTracker.GetTrackingFilePath(pipeName))!,
+            $"{DaemonPipeIdentity.GetCaseSensitiveHash(pipeName)}.json");
+
+    private static void WriteTrackingRecord(
+        string trackingFile,
+        Process daemon,
+        Process excel)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(trackingFile)!);
+        File.WriteAllText(trackingFile, JsonSerializer.Serialize(new
+        {
+            processId = daemon.Id,
+            startedAtUtcFileTime = daemon.StartTime.ToUniversalTime().ToFileTimeUtc(),
+            excelProcesses = new[]
+            {
+                new
+                {
+                    processId = excel.Id,
+                    startedAtUtcFileTime = excel.StartTime.ToUniversalTime().ToFileTimeUtc()
+                }
+            }
+        }));
+    }
+
     private static void StopIfRunning(Process process)
     {
         if (!process.HasExited)
@@ -136,4 +1393,165 @@ public sealed class DaemonForcedStopRegressionTests
             process.WaitForExit(5000);
         }
     }
+
+    private static string GetRepositoryRoot() =>
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+
+    private static IReadOnlyList<string> GetAdversarialPipeNames() =>
+    [
+        "foo",
+        "FOO",
+        "foo_startup",
+        @"pipe/segment\with:separators?and spaces",
+        $"excelmcp-{new string('x', 4096)}"
+    ];
+
+    private static Process StartDaemonProcess(string cliPath, string pipeName)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = cliPath,
+            WorkingDirectory = Path.GetDirectoryName(cliPath)!,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("service");
+        startInfo.ArgumentList.Add("run");
+        startInfo.ArgumentList.Add("--pipe-name");
+        startInfo.ArgumentList.Add(pipeName);
+        startInfo.ArgumentList.Add("--quiet");
+        return Process.Start(startInfo)!;
+    }
+
+    private static async Task WaitForDaemonReadyAsync(string cliPath, string pipeName)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            var status = await GetServiceStatusAsync(cliPath, pipeName);
+            if (status.ExitCode == 0
+                && status.Stdout.Contains("\"running\":true", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            await Task.Delay(250);
+        }
+
+        throw new TimeoutException($"Daemon for pipe '{pipeName}' did not become ready.");
+    }
+
+    private static Task<ProcessResult> GetServiceStatusAsync(string cliPath, string pipeName) =>
+        RunProcessAsync(
+            cliPath,
+            ["service", "status", "--quiet"],
+            Path.GetDirectoryName(cliPath)!,
+            new Dictionary<string, string>
+            {
+                ["EXCELMCP_CLI_PIPE"] = pipeName
+            },
+            TimeSpan.FromSeconds(10));
+
+    private static async Task StopDaemonBestEffortAsync(
+        string cliPath,
+        string pipeName,
+        Process daemon)
+    {
+        if (!daemon.HasExited)
+        {
+            _ = await RunProcessAsync(
+                cliPath,
+                ["service", "stop", "--quiet"],
+                Path.GetDirectoryName(cliPath)!,
+                new Dictionary<string, string>
+                {
+                    ["EXCELMCP_CLI_PIPE"] = pipeName
+                },
+                TimeSpan.FromSeconds(15));
+        }
+
+        if (!daemon.HasExited)
+        {
+            daemon.Kill(entireProcessTree: true);
+        }
+
+        daemon.WaitForExit(5000);
+    }
+
+    private static async Task<ProcessResult> RunProcessAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string>? environmentVariables,
+        TimeSpan timeout)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        if (environmentVariables != null)
+        {
+            foreach (var (key, value) in environmentVariables)
+            {
+                startInfo.Environment[key] = value;
+            }
+        }
+
+        using var process = Process.Start(startInfo)!;
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync();
+            }
+
+            throw new TimeoutException(
+                $"Process '{fileName}' exceeded {timeout.TotalSeconds:0} seconds.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            await stdoutTask,
+            await stderrTask);
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+        foreach (var directory in Directory.GetDirectories(
+                     source,
+                     "*",
+                     SearchOption.AllDirectories))
+        {
+            Directory.CreateDirectory(
+                Path.Combine(destination, Path.GetRelativePath(source, directory)));
+        }
+
+        foreach (var file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
+        {
+            File.Copy(
+                file,
+                Path.Combine(destination, Path.GetRelativePath(source, file)));
+        }
+    }
+
+    private sealed record ProcessResult(int ExitCode, string Stdout, string Stderr);
 }

--- a/tests/ExcelMcp.CLI.Tests/Integration/DataModelRefreshTimeoutRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/DataModelRefreshTimeoutRegressionTests.cs
@@ -39,11 +39,11 @@ public sealed class DataModelRefreshTimeoutRegressionTests
         Assert.Equal("datamodel.refresh", json.RootElement.GetProperty("command").GetString());
 
         using var argsJson = JsonDocument.Parse(json.RootElement.GetProperty("argsJson").GetString()!);
-        Assert.Equal("00:10:00", argsJson.RootElement.GetProperty("timeout").GetString());
+        Assert.Equal(600, argsJson.RootElement.GetProperty("timeout").GetInt32());
     }
 
     [Fact]
-    public async Task Refresh_TimeSpanTimeout_ForwardsRequestedBudget()
+    public async Task Refresh_TimeSpanTimeout_IsRejectedBeforeDaemonDispatch()
     {
         var pipeName = $"excelmcp-cli-test-{Guid.NewGuid():N}";
 
@@ -59,11 +59,11 @@ public sealed class DataModelRefreshTimeoutRegressionTests
             },
             diagnosticLabel: "issue-640-datamodel-refresh-timespan-timeout");
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
-
-        using var argsJson = JsonDocument.Parse(json.RootElement.GetProperty("argsJson").GetString()!);
-        Assert.Equal("00:10:00", argsJson.RootElement.GetProperty("timeout").GetString());
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        var error = json.RootElement.GetProperty("error").GetString();
+        Assert.Contains("00:10:00", error, StringComparison.Ordinal);
+        Assert.Contains("Nullable", error, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public sealed class DataModelRefreshTimeoutRegressionTests
         Assert.Equal("powerquery.refresh", json.RootElement.GetProperty("command").GetString());
 
         using var argsJson = JsonDocument.Parse(json.RootElement.GetProperty("argsJson").GetString()!);
-        Assert.Equal("00:10:00", argsJson.RootElement.GetProperty("timeout").GetString());
+        Assert.Equal(600, argsJson.RootElement.GetProperty("timeout").GetInt32());
     }
 
     private sealed class EchoDaemon : IAsyncDisposable

--- a/tests/ExcelMcp.CLI.Tests/Integration/DataModelRefreshTimeoutRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/DataModelRefreshTimeoutRegressionTests.cs
@@ -61,9 +61,10 @@ public sealed class DataModelRefreshTimeoutRegressionTests
 
         Assert.NotEqual(0, result.ExitCode);
         Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(json.RootElement.GetProperty("isError").GetBoolean());
         var error = json.RootElement.GetProperty("error").GetString();
         Assert.Contains("00:10:00", error, StringComparison.Ordinal);
-        Assert.Contains("Nullable", error, StringComparison.Ordinal);
+        Assert.Equal(error, json.RootElement.GetProperty("errorMessage").GetString());
     }
 
     [Fact]

--- a/tests/ExcelMcp.CLI.Tests/Integration/DiagCommandTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/DiagCommandTests.cs
@@ -183,16 +183,14 @@ public sealed class DiagCommandTests
     [Fact]
     public async Task ValidateParams_MissingCount_ReturnsValidationError()
     {
-        // count is int with no default → should be required
-        // But int can't be "empty" — Spectre.Console may handle differently
-        // This test documents the actual behavior
-        var result = await CliProcessHelper.RunAsync("diag validate-params --name \"test\"");
+        var (result, json) = await CliProcessHelper.RunJsonAsync(
+            "diag validate-params --name \"test\"");
         _output.WriteLine($"Exit: {result.ExitCode}, Stdout: {result.Stdout}");
 
-        // int without default gets default(int) = 0 from Spectre.Console
-        // So this should succeed with count=0
-        var json = JsonDocument.Parse(result.Stdout);
-        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains("count", json.RootElement.GetProperty("error").GetString());
+        Assert.Contains("required", json.RootElement.GetProperty("error").GetString());
     }
 
     // ============================================

--- a/tests/ExcelMcp.CLI.Tests/Integration/GeneratedActionContractCliTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/GeneratedActionContractCliTests.cs
@@ -1,0 +1,412 @@
+using System.Globalization;
+using System.Text.Json;
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Collection("Service")]
+[Trait("Layer", "CLI")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "GeneratedContracts")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class GeneratedActionContractCliTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _tempDirectory;
+
+    public GeneratedActionContractCliTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _tempDirectory = Path.Join(Path.GetTempPath(), $"GeneratedActionContractCliTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        "calculationmode calculate --session missing-session --scope workbook --mode manual",
+        "mode",
+        "calculate")]
+    [InlineData(
+        "powerquery delete --session missing-session --query-name Probe --m-code \"let Source = 1 in Source\"",
+        "mCode",
+        "delete")]
+    [InlineData(
+        "powerquery load-to --session missing-session --query-name Probe --load-destination not-a-destination",
+        "loadDestination",
+        "not-a-destination")]
+    [InlineData(
+        "powerquery load-to --session missing-session --query-name Probe --load-destination work_sheet",
+        "loadDestination",
+        "work_sheet")]
+    [InlineData(
+        "powerquery load-to --session missing-session --query-name Probe --load-destination work-sheet",
+        "loadDestination",
+        "work-sheet")]
+    [InlineData(
+        "powerquery load-to --session missing-session --query-name Probe --load-destination worksheet --timeout 30",
+        "timeout",
+        "load-to")]
+    [InlineData(
+        "powerquery refresh --session missing-session --query-name Probe --timeout -1",
+        "timeout",
+        "2147483")]
+    [InlineData(
+        "connection refresh --session missing-session --connection-name Probe --timeout 0",
+        "timeout",
+        "2147483")]
+    [InlineData(
+        "chart create-from-range --session missing-session --sheet Model --source-range-address A1:B2 --chart-type 999",
+        "chartType",
+        "999")]
+    [InlineData(
+        "chart create-from-range --session missing-session --sheet Model --source-range-address A1:B2 --chart-type 51",
+        "chartType",
+        "51")]
+    [InlineData(
+        "chart create-from-range --session missing-session --sheet Model --source-range-address A1:B2",
+        "chartType",
+        "required")]
+    public async Task DirectCommand_RejectsInvalidGeneratedContractBeforeDaemonDispatch(
+        string arguments,
+        string expectedParameter,
+        string expectedDetail)
+    {
+        var result = await CliProcessHelper.RunAsync(arguments);
+        _output.WriteLine($"stdout: {result.Stdout}");
+        _output.WriteLine($"stderr: {result.Stderr}");
+
+        Assert.Equal(1, result.ExitCode);
+        var combinedOutput = result.Stdout + result.Stderr;
+        Assert.Contains(expectedParameter, combinedOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(expectedDetail, combinedOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("session", combinedOutput, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(
+        """{"command":"calculation.calculate","sessionId":"missing-session","args":{"scope":"workbook","mode":"manual"}}""",
+        "mode",
+        "calculate")]
+    [InlineData(
+        """{"command":"powerquery.load-to","sessionId":"missing-session","args":{"queryName":"Probe","loadDestination":"not-a-destination"}}""",
+        "loadDestination",
+        "not-a-destination")]
+    [InlineData(
+        """{"command":"powerquery.load-to","sessionId":"missing-session","args":{"queryName":"Probe","loadDestination":"0"}}""",
+        "loadDestination",
+        "0")]
+    [InlineData(
+        """{"command":"powerquery.load-to","sessionId":"missing-session","args":{"queryName":"Probe","loadDestination":"work_sheet"}}""",
+        "loadDestination",
+        "work_sheet")]
+    [InlineData(
+        """{"command":"powerquery.load-to","sessionId":"missing-session","args":{"queryName":"Probe","loadDestination":"work-sheet"}}""",
+        "loadDestination",
+        "work-sheet")]
+    [InlineData(
+        """{"command":"calculation.calculate","sessionId":"missing-session","args":{"scope":5}}""",
+        "scope",
+        "String")]
+    [InlineData(
+        """{"command":"chart.create-from-range","sessionId":"missing-session","args":{"sheetName":"Model","sourceRangeAddress":"A1:B2"}}""",
+        "chartType",
+        "required")]
+    [InlineData(
+        """{"command":"powerquery.refresh","sessionId":"missing-session","args":{"queryName":"Probe","timeout":-1}}""",
+        "timeout",
+        "2147483")]
+    [InlineData(
+        """{"command":"connection.refresh","sessionId":"missing-session","args":{"connectionName":"Probe","timeout":0}}""",
+        "timeout",
+        "2147483")]
+    [InlineData(
+        """{"command":"powerquery.refresh","sessionId":"missing-session","args":{"queryName":"Probe","timeout":"600"}}""",
+        "timeout",
+        "Int32")]
+    public async Task RawBatch_RejectsInvalidGeneratedContractBeforeDaemonDispatch(
+        string entryJson,
+        string expectedParameter,
+        string expectedDetail)
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(inputPath, $"[{entryJson}]");
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+        _output.WriteLine($"stdout: {result.Stdout}");
+        _output.WriteLine($"stderr: {result.Stderr}");
+
+        Assert.Equal(1, result.ExitCode);
+        using var output = JsonDocument.Parse(result.Stdout.Trim());
+        var error = output.RootElement.GetProperty("error").GetString();
+        Assert.Contains(expectedParameter, error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(expectedDetail, error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("session", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("42")]
+    [InlineData("true")]
+    public async Task RawBatch_AllowEmptyRequiredStringRejectsNonStringBeforeDispatch(
+        string jsonValue)
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            inputPath,
+            $"[{{\"command\":\"conditionalformat.clear-rules\",\"sessionId\":\"missing-session\"," +
+            $"\"args\":{{\"sheetName\":{jsonValue},\"rangeAddress\":\"A1\"}}}}]");
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("sheetName", result.Stdout + result.Stderr, StringComparison.Ordinal);
+        Assert.Contains("JSON string", result.Stdout + result.Stderr, StringComparison.Ordinal);
+        Assert.DoesNotContain("session", result.Stdout + result.Stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RawBatch_AllowEmptyRequiredStringAcceptsEmptyStringBeforeDispatch()
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            inputPath,
+            """
+            [{"command":"conditionalformat.clear-rules","sessionId":"missing-session","args":{"sheetName":"","rangeAddress":"A1"}}]
+            """);
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("session", result.Stdout + result.Stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sheetName", result.Stdout + result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RawBatch_ReportsMissingFileAliasesAsIndexedValidationErrors()
+    {
+        var firstMissingPath = Path.Join(_tempDirectory, "missing-first.m");
+        var secondMissingPath = Path.Join(_tempDirectory, "missing-second.m");
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            inputPath,
+            JsonSerializer.Serialize(new object[]
+            {
+                new
+                {
+                    command = "powerquery.evaluate",
+                    args = new { mCodeFile = firstMissingPath }
+                },
+                new
+                {
+                    command = "powerquery.evaluate",
+                    args = new { mCodeFile = secondMissingPath }
+                }
+            }));
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        var outputLines = result.Stdout.Split(
+            Environment.NewLine,
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Equal(2, outputLines.Length);
+        for (var index = 0; index < outputLines.Length; index++)
+        {
+            using var output = JsonDocument.Parse(outputLines[index]);
+            Assert.Equal(index, output.RootElement.GetProperty("index").GetInt32());
+            Assert.Equal("powerquery.evaluate", output.RootElement.GetProperty("command").GetString());
+            Assert.False(output.RootElement.GetProperty("success").GetBoolean());
+            Assert.Contains("not found", output.RootElement.GetProperty("error").GetString(), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        "powerquery load-to --session missing-session --query-name Probe --load-destination worksheet")]
+    [InlineData(
+        "powerquery load-to --session missing-session --query-name Probe --load-destination WORKSHEET")]
+    public async Task DirectCommand_AcceptsExactAliasIgnoringCase(string arguments)
+    {
+        var result = await CliProcessHelper.RunAsync(arguments);
+
+        Assert.Equal(1, result.ExitCode);
+        var combinedOutput = result.Stdout + result.Stderr;
+        Assert.Contains("session", combinedOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Invalid value", combinedOutput, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("worksheet")]
+    [InlineData("WORKSHEET")]
+    public async Task RawBatch_AcceptsExactAliasIgnoringCase(string loadDestination)
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(inputPath, JsonSerializer.Serialize(new[]
+        {
+            new
+            {
+                command = "powerquery.load-to",
+                sessionId = "missing-session",
+                args = new { queryName = "Probe", loadDestination }
+            }
+        }));
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        using var output = JsonDocument.Parse(result.Stdout.Trim());
+        var error = output.RootElement.GetProperty("error").GetString();
+        Assert.Contains("session", error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Invalid value", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("create", 9)]
+    [InlineData("create", 3601)]
+    [InlineData("open", 9)]
+    [InlineData("open", 3601)]
+    public async Task ManualSessionCommand_RejectsTimeoutOutsideDocumentedRange(
+        string action,
+        int timeoutSeconds)
+    {
+        var workbookPath = Path.Join(_tempDirectory, "timeout-contract.xlsx");
+        var result = await CliProcessHelper.RunAsync(
+            ["session", action, workbookPath, "--timeout", timeoutSeconds.ToString(CultureInfo.InvariantCulture)]);
+
+        Assert.Equal(1, result.ExitCode);
+        var combinedOutput = result.Stdout + result.Stderr;
+        Assert.Contains("timeout", combinedOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("10", combinedOutput, StringComparison.Ordinal);
+        Assert.Contains("3600", combinedOutput, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("""{"command":"session.open","args":{"filePath":"missing.xlsx","timeoutSeconds":9}}""")]
+    [InlineData("""{"command":"session.create","args":{"filePath":"missing.xlsx","timeoutSeconds":3601}}""")]
+    [InlineData("""{"command":"session.open","args":{"filePath":"missing.xlsx","timeoutSeconds":"120"}}""")]
+    public async Task RawBatchSessionCommand_RejectsNonCanonicalTimeout(string request)
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(inputPath, $"[{request}]");
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("timeout", result.Stdout + result.Stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RawBatchSessionCommand_RejectsUnknownArgument()
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            inputPath,
+            """[{"command":"session.open","args":{"filePath":"missing.xlsx","unexpected":true}}]""");
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("unexpected", result.Stdout + result.Stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RawBatch_RejectsUnknownTopLevelProperty()
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            inputPath,
+            """[{"command":"diag.ping","args":{},"unexpected":true}]""");
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("unexpected", result.Stderr + result.Stdout, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(
+        """{"command":"powerquery.refresh","sessionId":"missing-session","args":{"queryName":"Probe","Timeout":60}}""",
+        "Timeout")]
+    [InlineData(
+        """{"command":"session.open","args":{"filePath":"missing.xlsx","TimeoutSeconds":120}}""",
+        "TimeoutSeconds")]
+    [InlineData(
+        """{"command":"powerquery.evaluate","sessionId":"missing-session","args":{"MCodeFile":"query.m"}}""",
+        "MCodeFile")]
+    [InlineData(
+        """{"command":"vba.import","sessionId":"missing-session","args":{"moduleName":"Module1","VbaCodeFile":"module.bas"}}""",
+        "VbaCodeFile")]
+    [InlineData(
+        """{"command":"datamodel.create-measure","sessionId":"missing-session","args":{"tableName":"Sales","measureName":"Total","DaxFormulaFile":"measure.dax"}}""",
+        "DaxFormulaFile")]
+    [InlineData(
+        """{"command":"datamodel.evaluate","sessionId":"missing-session","args":{"DaxQueryFile":"query.dax"}}""",
+        "DaxQueryFile")]
+    [InlineData(
+        """{"command":"datamodel.execute-dmv","sessionId":"missing-session","args":{"DmvQueryFile":"query.dmv"}}""",
+        "DmvQueryFile")]
+    [InlineData(
+        """{"command":"xmlmap.add","sessionId":"missing-session","args":{"SchemaFile":"schema.xsd"}}""",
+        "SchemaFile")]
+    [InlineData(
+        """{"command":"xmlmap.import-xml","sessionId":"missing-session","args":{"XmlDataFile":"data.xml"}}""",
+        "XmlDataFile")]
+    public async Task RawBatch_RejectsNonCanonicalArgumentCasing(
+        string entryJson,
+        string suppliedProperty)
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(inputPath, $"[{entryJson}]");
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(suppliedProperty, result.Stdout + result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RawBatch_RejectsNonCanonicalTopLevelCasing()
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            inputPath,
+            """[{"Command":"diag.ping","args":{}}]""");
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Command", result.Stdout + result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RawBatch_RejectsUnknownActionArgument()
+    {
+        var inputPath = Path.Join(_tempDirectory, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            inputPath,
+            """[{"command":"powerquery.refresh","sessionId":"missing-session","args":{"queryName":"Probe","timeout":60,"unexpected":true}}]""");
+
+        var result = await CliProcessHelper.RunAsync(["batch", "--input", inputPath]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("unexpected", result.Stdout, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("session", result.Stdout, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/ExcelMcp.CLI.Tests/Integration/IrmProtectedWorkbookRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/IrmProtectedWorkbookRegressionTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
 using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -25,7 +26,7 @@ public sealed class IrmProtectedWorkbookRegressionTests : IDisposable
     {
         _output = output;
         _fakeIrmFile = Path.Combine(Path.GetTempPath(), $"CliFakeIrm_{Guid.NewGuid():N}.xlsx");
-        File.WriteAllBytes(_fakeIrmFile, [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+        OleDataSpaceTestFile.Write(_fakeIrmFile, "\tDRMDataSpace");
     }
 
     private static string? GetConfiguredIrmTestFilePath()

--- a/tests/ExcelMcp.CLI.Tests/Integration/PowerQueryReadContractTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/PowerQueryReadContractTests.cs
@@ -1,0 +1,100 @@
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Collection("Service")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "PowerQuery")]
+[Trait("Layer", "CLI")]
+[Trait("RequiresExcel", "true")]
+[Trait("Speed", "Medium")]
+public sealed class PowerQueryReadContractTests : IDisposable
+{
+    private readonly string _testFile =
+        Path.Combine(Path.GetTempPath(), $"PqReadContract_{Guid.NewGuid():N}.xlsx");
+    private string? _sessionId;
+
+    [Fact]
+    public async Task List_IsCompactAndViewReturnsFullM_ViaCliProtocol()
+    {
+        const string queryName = "CliCompactRead";
+        var mCode = BuildLongMCode();
+        var (sessionResult, sessionJson) = await CliProcessHelper.RunJsonAsync(
+            ["session", "create", _testFile],
+            timeoutMs: 60_000,
+            diagnosticLabel: "pq-read-contract-session-create");
+
+        Assert.Equal(0, sessionResult.ExitCode);
+        _sessionId = sessionJson.RootElement.GetProperty("sessionId").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(_sessionId));
+
+        var (createResult, createJson) = await CliProcessHelper.RunJsonAsync(
+            [
+                "powerquery", "create",
+                "--session", _sessionId!,
+                "--query-name", queryName,
+                "--m-code", mCode,
+                "--load-destination", "connection-only"
+            ],
+            timeoutMs: 120_000,
+            diagnosticLabel: "pq-read-contract-create");
+
+        Assert.Equal(0, createResult.ExitCode);
+        Assert.True(createJson.RootElement.GetProperty("success").GetBoolean());
+
+        var (listResult, listJson) = await CliProcessHelper.RunJsonAsync(
+            ["powerquery", "list", "--session", _sessionId!],
+            timeoutMs: 60_000,
+            diagnosticLabel: "pq-read-contract-list");
+
+        Assert.Equal(0, listResult.ExitCode);
+        Assert.True(listJson.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(listResult.Stdout.Length < 1_000);
+        var serializedQuery = Assert.Single(
+            listJson.RootElement.GetProperty("queries").EnumerateArray(),
+            item => item.GetProperty("name").GetString() == queryName);
+        Assert.False(serializedQuery.TryGetProperty("formula", out _));
+        Assert.InRange(serializedQuery.GetProperty("formulaPreview").GetString()!.Length, 1, 80);
+        Assert.Equal(mCode.Length, serializedQuery.GetProperty("characterCount").GetInt32());
+        Assert.Equal("connection-only", serializedQuery.GetProperty("loadMode").GetString());
+
+        var (viewResult, viewJson) = await CliProcessHelper.RunJsonAsync(
+            [
+                "powerquery", "view",
+                "--session", _sessionId!,
+                "--query-name", queryName
+            ],
+            timeoutMs: 60_000,
+            diagnosticLabel: "pq-read-contract-view");
+
+        Assert.Equal(0, viewResult.ExitCode);
+        Assert.True(viewJson.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(mCode, viewJson.RootElement.GetProperty("mCode").GetString());
+        Assert.Equal("connection-only", viewJson.RootElement.GetProperty("loadMode").GetString());
+    }
+
+    public void Dispose()
+    {
+        if (!string.IsNullOrWhiteSpace(_sessionId))
+        {
+            CliProcessHelper.RunAsync(
+                ["session", "close", "--session", _sessionId, "--save", "false"],
+                timeoutMs: 60_000,
+                diagnosticLabel: "pq-read-contract-close").GetAwaiter().GetResult();
+        }
+
+        if (File.Exists(_testFile))
+        {
+            File.Delete(_testFile);
+        }
+    }
+
+    private static string BuildLongMCode()
+    {
+        var padding = string.Join(
+            Environment.NewLine,
+            Enumerable.Repeat("// CLI list must not serialize this padding", 250));
+        return $"let{Environment.NewLine}{padding}{Environment.NewLine}    Source = #table({{\"Value\"}}, {{{{1}}}}){Environment.NewLine}in{Environment.NewLine}    Source";
+    }
+}

--- a/tests/ExcelMcp.CLI.Tests/Integration/PreBuildGracefulSaveAcceptanceTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/PreBuildGracefulSaveAcceptanceTests.cs
@@ -1,0 +1,305 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Trait("Layer", "CLI")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "ServiceDaemon")]
+[Trait("RequiresExcel", "true")]
+[Trait("Speed", "Slow")]
+public sealed class PreBuildGracefulSaveAcceptanceTests : IClassFixture<TempDirectoryFixture>
+{
+    private readonly TempDirectoryFixture _fixture;
+
+    public PreBuildGracefulSaveAcceptanceTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(Timeout = 360000)]
+    public async Task StaleLockedBuildCleanup_GracefullySavesDirtySession_AndPreservesOtherPipe()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var releaseDirectory = Path.Combine(
+            repositoryRoot,
+            "src",
+            "ExcelMcp.CLI",
+            "bin",
+            "Release",
+            "net10.0-windows");
+        var releaseCli = Path.Combine(releaseDirectory, "excelcli.exe");
+        Assert.True(File.Exists(releaseCli), $"Release CLI is required: {releaseCli}");
+
+        var controlDirectory = Path.Combine(
+            _fixture.TempDir,
+            $"control-cli-{Guid.NewGuid():N}");
+        CopyDirectory(releaseDirectory, controlDirectory);
+        var controlCli = Path.Combine(controlDirectory, "excelcli.exe");
+        var selectedPipe = $"excelmcp-stale-save-{Guid.NewGuid():N}";
+        var controlPipe = $"excelmcp-stale-save-control-{Guid.NewGuid():N}";
+        var workbookPath = Path.Combine(
+            _fixture.TempDir,
+            $"stale-save-{Guid.NewGuid():N}.xlsx");
+        const string marker = "graceful-stale-cleanup-persisted";
+        using var selectedDaemon = StartDaemonProcess(releaseCli, selectedPipe);
+        using var controlDaemon = StartDaemonProcess(controlCli, controlPipe);
+        var safetySource = Path.Combine(
+            repositoryRoot,
+            "src",
+            "ExcelMcp.Service",
+            "ServiceClient.cs");
+        var originalSourceWriteTime = File.GetLastWriteTimeUtc(safetySource);
+
+        try
+        {
+            await WaitForDaemonReadyAsync(releaseCli, selectedPipe);
+            await WaitForDaemonReadyAsync(controlCli, controlPipe);
+
+            var create = await RunCliAsync(
+                releaseCli,
+                selectedPipe,
+                ["session", "create", workbookPath, "--quiet"],
+                TimeSpan.FromSeconds(45));
+            Assert.Equal(0, create.ExitCode);
+            using var createJson = JsonDocument.Parse(create.Stdout);
+            var sessionId = createJson.RootElement.GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(sessionId));
+
+            var write = await RunCliAsync(
+                releaseCli,
+                selectedPipe,
+                [
+                    "range", "set-values",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "A1",
+                    "--values", JsonSerializer.Serialize(new[] { new[] { marker } }),
+                    "--quiet"
+                ],
+                TimeSpan.FromSeconds(30));
+            Assert.Equal(0, write.ExitCode);
+
+            File.SetLastWriteTimeUtc(safetySource, DateTime.UtcNow.AddSeconds(2));
+            Assert.True(
+                File.GetLastWriteTimeUtc(safetySource) > File.GetLastWriteTimeUtc(releaseCli),
+                "The current protocol source must be newer than the locked CLI.");
+
+            var build = await RunProcessAsync(
+                "dotnet",
+                [
+                    "build",
+                    Path.Combine(
+                        repositoryRoot,
+                        "src",
+                        "ExcelMcp.CLI",
+                        "ExcelMcp.CLI.csproj"),
+                    "--configuration", "Release",
+                    "-p:NuGetAudit=false",
+                    "-maxcpucount:1",
+                    "-nodeReuse:false",
+                    "--verbosity", "quiet"
+                ],
+                repositoryRoot,
+                new Dictionary<string, string>
+                {
+                    ["EXCELMCP_CLI_PIPE"] = selectedPipe
+                },
+                TimeSpan.FromMinutes(4));
+
+            Assert.Equal(0, build.ExitCode);
+            Assert.True(
+                selectedDaemon.WaitForExit(15000),
+                $"Selected daemon {selectedDaemon.Id} did not exit.");
+            Assert.False(controlDaemon.HasExited);
+            Assert.Equal(0, (await GetServiceStatusAsync(controlCli, controlPipe)).ExitCode);
+
+            var reopen = await RunCliAsync(
+                releaseCli,
+                selectedPipe,
+                ["session", "open", workbookPath, "--quiet"],
+                TimeSpan.FromSeconds(45));
+            Assert.Equal(0, reopen.ExitCode);
+            using var reopenJson = JsonDocument.Parse(reopen.Stdout);
+            var reopenedSessionId = reopenJson.RootElement.GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(reopenedSessionId));
+
+            var read = await RunCliAsync(
+                releaseCli,
+                selectedPipe,
+                [
+                    "range", "get-values",
+                    "--session", reopenedSessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "A1",
+                    "--quiet"
+                ],
+                TimeSpan.FromSeconds(30));
+            Assert.Equal(0, read.ExitCode);
+            using var readJson = JsonDocument.Parse(read.Stdout);
+            Assert.Equal(marker, readJson.RootElement.GetProperty("values")[0][0].GetString());
+
+            _ = await RunCliAsync(
+                releaseCli,
+                selectedPipe,
+                ["session", "close", "--session", reopenedSessionId!, "--quiet"],
+                TimeSpan.FromSeconds(45));
+        }
+        finally
+        {
+            File.SetLastWriteTimeUtc(safetySource, originalSourceWriteTime);
+            await StopDaemonBestEffortAsync(releaseCli, selectedPipe, selectedDaemon);
+            await StopDaemonBestEffortAsync(controlCli, controlPipe, controlDaemon);
+        }
+    }
+
+    private static Process StartDaemonProcess(string cliPath, string pipeName)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = cliPath,
+            WorkingDirectory = Path.GetDirectoryName(cliPath)!,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("service");
+        startInfo.ArgumentList.Add("run");
+        startInfo.ArgumentList.Add("--pipe-name");
+        startInfo.ArgumentList.Add(pipeName);
+        startInfo.ArgumentList.Add("--quiet");
+        return Process.Start(startInfo)!;
+    }
+
+    private static async Task WaitForDaemonReadyAsync(string cliPath, string pipeName)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
+        while (DateTime.UtcNow < deadline)
+        {
+            var status = await GetServiceStatusAsync(cliPath, pipeName);
+            if (status.ExitCode == 0
+                && status.Stdout.Contains("\"running\":true", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            await Task.Delay(250);
+        }
+
+        throw new TimeoutException($"Daemon for pipe '{pipeName}' did not become ready.");
+    }
+
+    private static Task<ProcessResult> GetServiceStatusAsync(string cliPath, string pipeName) =>
+        RunCliAsync(
+            cliPath,
+            pipeName,
+            ["service", "status", "--quiet"],
+            TimeSpan.FromSeconds(10));
+
+    private static Task<ProcessResult> RunCliAsync(
+        string cliPath,
+        string pipeName,
+        IReadOnlyList<string> arguments,
+        TimeSpan timeout) =>
+        RunProcessAsync(
+            cliPath,
+            arguments,
+            Path.GetDirectoryName(cliPath)!,
+            new Dictionary<string, string>
+            {
+                ["EXCELMCP_CLI_PIPE"] = pipeName
+            },
+            timeout);
+
+    private static async Task StopDaemonBestEffortAsync(
+        string cliPath,
+        string pipeName,
+        Process daemon)
+    {
+        _ = await RunCliAsync(
+            cliPath,
+            pipeName,
+            ["service", "stop", "--quiet"],
+            TimeSpan.FromSeconds(20));
+
+        if (!daemon.HasExited)
+        {
+            daemon.Kill(entireProcessTree: true);
+        }
+
+        daemon.WaitForExit(5000);
+    }
+
+    private static async Task<ProcessResult> RunProcessAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string>? environmentVariables,
+        TimeSpan timeout)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        if (environmentVariables != null)
+        {
+            foreach (var (key, value) in environmentVariables)
+            {
+                startInfo.Environment[key] = value;
+            }
+        }
+
+        using var process = Process.Start(startInfo)!;
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync();
+            throw new TimeoutException(
+                $"Process '{fileName}' timed out after {timeout}.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            await stdoutTask,
+            await stderrTask);
+    }
+
+    private static void CopyDirectory(string sourceDirectory, string destinationDirectory)
+    {
+        Directory.CreateDirectory(destinationDirectory);
+        foreach (var file in Directory.EnumerateFiles(sourceDirectory))
+        {
+            File.Copy(file, Path.Combine(destinationDirectory, Path.GetFileName(file)));
+        }
+
+        foreach (var directory in Directory.EnumerateDirectories(sourceDirectory))
+        {
+            CopyDirectory(
+                directory,
+                Path.Combine(destinationDirectory, Path.GetFileName(directory)));
+        }
+    }
+
+    private static string GetRepositoryRoot() =>
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+
+    private sealed record ProcessResult(int ExitCode, string Stdout, string Stderr);
+}

--- a/tests/ExcelMcp.CLI.Tests/Integration/SessionCloseRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/SessionCloseRegressionTests.cs
@@ -31,7 +31,8 @@ public sealed class SessionCloseRegressionTests : IClassFixture<TempDirectoryFix
         var batch = new FakeBatch
         {
             WorkbookPath = CreateFakeWorkbookPath(),
-            DisposeException = new InvalidOperationException("synthetic teardown failure")
+            DisposeException = new InvalidOperationException(
+                "Excel process 4321 did not exit and remains tracked for pipe cleanup")
         };
         const string sessionId = "dispose-failure-quarantine";
         RegisterSession(service, sessionId, batch, addKnownSessionId: true);
@@ -41,7 +42,7 @@ public sealed class SessionCloseRegressionTests : IClassFixture<TempDirectoryFix
         Assert.False(firstClose.Success);
         Assert.NotNull(firstClose.ErrorMessage);
         Assert.Contains("Failed to dispose session", firstClose.ErrorMessage, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("synthetic teardown failure", firstClose.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("remains tracked", firstClose.ErrorMessage, StringComparison.OrdinalIgnoreCase);
 
         var listAfterFailedClose = await service.ProcessAsync(new ServiceRequest { Command = "session.list" });
         Assert.True(listAfterFailedClose.Success);
@@ -50,7 +51,7 @@ public sealed class SessionCloseRegressionTests : IClassFixture<TempDirectoryFix
 
         var quarantinedUse = await service.ProcessAsync(new ServiceRequest
         {
-            Command = "session.save",
+            Command = "sheet.list",
             SessionId = sessionId
         });
         Assert.False(quarantinedUse.Success);
@@ -68,20 +69,12 @@ public sealed class SessionCloseRegressionTests : IClassFixture<TempDirectoryFix
     public async Task SessionClose_DuringInFlightOperation_ReturnsBusyAndKeepsSessionUsable()
     {
         using var service = new ExcelMcpService();
-        var batch = new FakeBatch
-        {
-            WorkbookPath = CreateFakeWorkbookPath(),
-            BlockSaveUntilReleased = true
-        };
+        var batch = new FakeBatch { WorkbookPath = CreateFakeWorkbookPath() };
         const string sessionId = "in-flight-close-race";
         RegisterSession(service, sessionId, batch, addKnownSessionId: true);
 
-        var inFlightSave = Task.Run(async () => await service.ProcessAsync(new ServiceRequest
-        {
-            Command = "session.save",
-            SessionId = sessionId
-        }));
-        Assert.True(await batch.WaitForSaveStartedAsync(TimeSpan.FromSeconds(10)));
+        var sessionManager = GetSessionManager(service);
+        sessionManager.BeginOperation(sessionId);
 
         var closeWhileBusy = await CloseSessionAsync(service, sessionId);
 
@@ -102,17 +95,8 @@ public sealed class SessionCloseRegressionTests : IClassFixture<TempDirectoryFix
             Assert.False(session.GetProperty("canClose").GetBoolean());
         }
 
-        batch.ReleaseSave();
-        var saveResponse = await inFlightSave;
-        Assert.True(saveResponse.Success);
-        Assert.Equal(0, GetSessionManager(service).GetActiveOperationCount(sessionId));
-
-        var secondSave = await service.ProcessAsync(new ServiceRequest
-        {
-            Command = "session.save",
-            SessionId = sessionId
-        });
-        Assert.True(secondSave.Success);
+        sessionManager.EndOperation(sessionId);
+        Assert.Equal(0, sessionManager.GetActiveOperationCount(sessionId));
 
         var finalClose = await CloseSessionAsync(service, sessionId);
         Assert.True(finalClose.Success);
@@ -174,9 +158,6 @@ public sealed class SessionCloseRegressionTests : IClassFixture<TempDirectoryFix
 
     private sealed class FakeBatch : IExcelBatch
     {
-        private readonly TaskCompletionSource _saveStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource _releaseSave = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
         public string WorkbookPath { get; init; } = string.Empty;
         public Microsoft.Extensions.Logging.ILogger Logger { get; } = NullLogger.Instance;
         public IReadOnlyDictionary<string, Excel.Workbook> Workbooks { get; } = new Dictionary<string, Excel.Workbook>();
@@ -184,9 +165,7 @@ public sealed class SessionCloseRegressionTests : IClassFixture<TempDirectoryFix
         public int? ExcelProcessId => 1234;
         public TimeSpan OperationTimeout => TimeSpan.FromSeconds(5);
         public bool IsExcelVisible => false;
-        public bool BlockSaveUntilReleased { get; init; }
         public Exception? DisposeException { get; init; }
-        public int SaveCalls { get; private set; }
         public int DisposeCalls { get; private set; }
 
         public Excel.Workbook GetWorkbook(string filePath) => throw new NotSupportedException();
@@ -205,28 +184,9 @@ public sealed class SessionCloseRegressionTests : IClassFixture<TempDirectoryFix
 
         public void Save(CancellationToken cancellationToken = default)
         {
-            SaveCalls++;
-            if (!BlockSaveUntilReleased)
-            {
-                return;
-            }
-
-            _saveStarted.TrySetResult();
-            _releaseSave.Task.Wait(cancellationToken);
         }
 
         public bool IsExcelProcessAlive() => true;
-
-        public async Task<bool> WaitForSaveStartedAsync(TimeSpan timeout)
-        {
-            var completed = await Task.WhenAny(_saveStarted.Task, Task.Delay(timeout));
-            return completed == _saveStarted.Task;
-        }
-
-        public void ReleaseSave()
-        {
-            _releaseSave.TrySetResult();
-        }
 
         public void Dispose()
         {

--- a/tests/ExcelMcp.CLI.Tests/Integration/SessionLifecycleContractTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/SessionLifecycleContractTests.cs
@@ -1,0 +1,237 @@
+using System.IO.Compression;
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Sbroenne.ExcelMcp.Service;
+using Sbroenne.ExcelMcp.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Collection("Service")]
+[Trait("Layer", "CLI")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "File")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class SessionLifecycleContractTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _tempDirectory;
+
+    public SessionLifecycleContractTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _tempDirectory = Path.Join(Path.GetTempPath(), $"SessionLifecycleContractTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public async Task SessionHelp_AdvertisesOnlyCanonicalLifecycleActions()
+    {
+        var result = await CliProcessHelper.RunAsync(["session", "--help"], timeoutMs: 10_000);
+        var output = result.Stdout + result.Stderr;
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("create", output, StringComparison.Ordinal);
+        Assert.Contains("open", output, StringComparison.Ordinal);
+        Assert.Contains("close", output, StringComparison.Ordinal);
+        Assert.Contains("list", output, StringComparison.Ordinal);
+        Assert.Contains("test", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("save a session", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("session save", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ServiceStatus_ResponsiveServiceWithoutDaemonMutex_ReportsRunning()
+    {
+        var (result, json) = await CliProcessHelper.RunJsonAsync(
+            ["service", "status"],
+            timeoutMs: 15_000,
+            diagnosticLabel: "service-status-in-process-host");
+        using (json)
+        {
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+            Assert.True(json.RootElement.GetProperty("running").GetBoolean());
+            Assert.Equal(
+                "running",
+                json.RootElement.GetProperty("daemonState").GetString());
+        }
+    }
+
+    [Fact]
+    public async Task SessionSave_IsRejectedAsAnUnknownCommand()
+    {
+        var result = await CliProcessHelper.RunAsync(
+            ["session", "save", "--session", "missing-session"],
+            timeoutMs: 10_000);
+        var output = result.Stdout + result.Stderr;
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Unknown command", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("save", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SessionSave_ServiceProtocol_IsRejectedAsUnknown()
+    {
+        using var service = new ExcelMcpService();
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.save",
+            SessionId = "missing-session"
+        });
+
+        Assert.False(response.Success);
+        Assert.Contains("Unknown session action", response.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SessionTest_RelativePath_ReturnsSharedValidationError()
+    {
+        var result = await CliProcessHelper.RunAsync(
+            ["session", "test", @"relative\book.xlsx"],
+            timeoutMs: 10_000);
+        var output = result.Stdout + result.Stderr;
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("absolute Windows path", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("open")]
+    [InlineData("create")]
+    public async Task SessionOpenAndCreate_RelativePath_ReturnSharedValidationError(
+        string action)
+    {
+        var result = await CliProcessHelper.RunAsync(
+            ["session", action, @"relative\book.txt"],
+            timeoutMs: 10_000);
+        var output = result.Stdout + result.Stderr;
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("absolute Windows path", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("session.open")]
+    [InlineData("session.create")]
+    public async Task SessionService_RelativePath_ReturnsSharedValidationError(
+        string command)
+    {
+        using var service = new ExcelMcpService();
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = command,
+            Args = """{"filePath":"relative\\book.txt"}"""
+        });
+
+        Assert.False(response.Success);
+        Assert.Contains(
+            "absolute Windows path",
+            response.ErrorMessage,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("missing.xlsx", false, false, false, false, false, false)]
+    [InlineData("invalid.txt", true, false, false, false, false, false)]
+    [InlineData("corrupt.xlsx", true, false, false, false, false, false)]
+    [InlineData("normal.xlsx", true, false, true, true, false, false)]
+    [InlineData("protected.xlsx", true, true, false, false, true, true)]
+    [InlineData("protected-modern.xlsx", true, true, false, false, true, true)]
+    public async Task SessionTest_ReturnsCanonicalFileMetadata(
+        string fileName,
+        bool createFile,
+        bool irmSignature,
+        bool expectedValid,
+        bool expectedCanOpen,
+        bool expectedReadOnly,
+        bool expectedVisible)
+    {
+        var path = Path.Join(_tempDirectory, fileName);
+        if (createFile)
+        {
+            if (irmSignature)
+            {
+                OleDataSpaceTestFile.Write(
+                    path,
+                    fileName.Contains("modern", StringComparison.Ordinal)
+                        ? "DRMEncryptedDataSpace"
+                        : "\tDRMDataSpace");
+            }
+            else
+            {
+                if (string.Equals(fileName, "normal.xlsx", StringComparison.Ordinal))
+                {
+                    CreateMinimalWorkbook(path);
+                }
+                else
+                {
+                    await File.WriteAllTextAsync(path, "not an Excel workbook");
+                }
+            }
+        }
+
+        var (result, json) = await CliProcessHelper.RunJsonAsync(
+            ["session", "test", path],
+            timeoutMs: 30_000,
+            diagnosticLabel: $"session-test-{fileName}");
+        using (json)
+        {
+            _output.WriteLine(result.Stdout);
+            Assert.Equal(expectedCanOpen ? 0 : 1, result.ExitCode);
+            Assert.Equal(expectedCanOpen, json.RootElement.GetProperty("success").GetBoolean());
+            Assert.Equal(createFile, json.RootElement.GetProperty("exists").GetBoolean());
+            Assert.Equal(expectedValid, json.RootElement.GetProperty("isValid").GetBoolean());
+            Assert.Equal(expectedCanOpen, json.RootElement.GetProperty("canOpen").GetBoolean());
+            Assert.Equal(irmSignature, json.RootElement.GetProperty("isIrmProtected").GetBoolean());
+            Assert.Equal(expectedReadOnly, json.RootElement.GetProperty("willOpenReadOnly").GetBoolean());
+            Assert.Equal(expectedVisible, json.RootElement.GetProperty("requiresVisibleSession").GetBoolean());
+            Assert.Equal(Path.GetFullPath(path), json.RootElement.GetProperty("filePath").GetString());
+            Assert.Equal(Path.GetExtension(path), json.RootElement.GetProperty("extension").GetString());
+            Assert.True(json.RootElement.TryGetProperty("size", out _));
+            Assert.True(json.RootElement.TryGetProperty("lastModified", out _));
+            Assert.Equal(!expectedCanOpen, json.RootElement.TryGetProperty("isError", out var isError)
+                && isError.GetBoolean());
+        }
+    }
+
+    private static void CreateMinimalWorkbook(string path)
+    {
+        using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
+        WriteEntry(archive, "[Content_Types].xml",
+            """<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>""");
+        WriteEntry(archive, "_rels/.rels",
+            """<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>""");
+        WriteEntry(archive, "xl/workbook.xml",
+            """<?xml version="1.0" encoding="UTF-8"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>""");
+        WriteEntry(archive, "xl/_rels/workbook.xml.rels",
+            """<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>""");
+        WriteEntry(archive, "xl/worksheets/sheet1.xml",
+            """<?xml version="1.0" encoding="UTF-8"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>""");
+    }
+
+    private static void WriteEntry(ZipArchive archive, string name, string content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(content);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tests/ExcelMcp.CLI.Tests/Unit/DaemonStateObservationTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/DaemonStateObservationTests.cs
@@ -1,0 +1,307 @@
+using Sbroenne.ExcelMcp.CLI.Infrastructure;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Unit;
+
+[Trait("Layer", "CLI")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "ServiceDaemon")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class DaemonStateObservationTests
+{
+    [Fact]
+    public async Task IsDaemonMutexHeld_LegacyDaemonMutexIsHeld_ReturnsTrue()
+    {
+        var pipeName = $"legacy-daemon-{Guid.NewGuid():N}";
+        using var acquired = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var holder = Task.Run(() =>
+        {
+            using var legacyMutex = new Mutex(
+                initiallyOwned: false,
+                $"ExcelMcpCli_{pipeName}",
+                out var createdNew);
+            Assert.True(createdNew);
+            legacyMutex.WaitOne();
+            try
+            {
+                acquired.Set();
+                release.Wait();
+            }
+            finally
+            {
+                legacyMutex.ReleaseMutex();
+            }
+        });
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(5)));
+        try
+        {
+            Assert.True(DaemonAutoStart.IsDaemonMutexHeld(pipeName));
+        }
+        finally
+        {
+            release.Set();
+            await holder;
+        }
+    }
+
+    [Fact]
+    public async Task IsDaemonMutexHeld_LegacyDaemonMutexUsesCaseInsensitivePipeIdentity()
+    {
+        var legacyPipeName = $"legacy-daemon-case-{Guid.NewGuid():N}".ToLowerInvariant();
+        var callerPipeName = legacyPipeName.ToUpperInvariant();
+        using var acquired = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var holder = Task.Run(() =>
+        {
+            using var legacyMutex = new Mutex(
+                initiallyOwned: false,
+                $"ExcelMcpCli_{legacyPipeName}",
+                out var createdNew);
+            Assert.True(createdNew);
+            legacyMutex.WaitOne();
+            try
+            {
+                acquired.Set();
+                release.Wait();
+            }
+            finally
+            {
+                legacyMutex.ReleaseMutex();
+            }
+        });
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(5)));
+        try
+        {
+            Assert.True(DaemonAutoStart.IsDaemonMutexHeld(callerPipeName));
+        }
+        finally
+        {
+            release.Set();
+            await holder;
+        }
+    }
+
+    [Fact]
+    public void RecheckStartupAfterDaemonObservation_MarkerAppearsAfterInitialCheck_ReturnsStarting()
+    {
+        var observations = new Queue<(string Name, bool Value)>(
+        [
+            ("marker", false),
+            ("daemon", true),
+            ("marker", true)
+        ]);
+
+        var observation = DaemonConnectionPolicy.Observe(
+            () => DequeueObservation(observations, "marker"),
+            () => DequeueObservation(observations, "daemon"));
+
+        Assert.True(observation.DaemonRunning);
+        Assert.True(observation.StartupInProgress);
+        Assert.Empty(observations);
+    }
+
+    [Fact]
+    public void RecheckStartupAfterDaemonObservation_MarkerAppearsAfterStoppedObservation_ReturnsStarting()
+    {
+        var observations = new Queue<(string Name, bool Value)>(
+        [
+            ("marker", false),
+            ("daemon", false),
+            ("marker", true)
+        ]);
+
+        var observation = DaemonConnectionPolicy.Observe(
+            () => DequeueObservation(observations, "marker"),
+            () => DequeueObservation(observations, "daemon"));
+
+        Assert.False(observation.DaemonRunning);
+        Assert.True(observation.StartupInProgress);
+        Assert.Empty(observations);
+    }
+
+    [Fact]
+    public void Observe_InitialStartupMarkerDisappearsAfterDaemonObservation_UsesCompleteObservation()
+    {
+        var observations = new Queue<(string Name, bool Value)>(
+        [
+            ("marker", true),
+            ("daemon", true),
+            ("marker", false)
+        ]);
+
+        var observation = DaemonConnectionPolicy.Observe(
+            () => DequeueObservation(observations, "marker"),
+            () => DequeueObservation(observations, "daemon"));
+
+        Assert.True(observation.DaemonRunning);
+        Assert.True(observation.StartupInProgress);
+        Assert.Empty(observations);
+    }
+
+    [Fact]
+    public void Observe_InitialStartupMarkerPersistsAfterDaemonObservation_UsesCompleteObservation()
+    {
+        var observations = new Queue<(string Name, bool Value)>(
+        [
+            ("marker", true),
+            ("daemon", false),
+            ("marker", true)
+        ]);
+
+        var observation = DaemonConnectionPolicy.Observe(
+            () => DequeueObservation(observations, "marker"),
+            () => DequeueObservation(observations, "daemon"));
+
+        Assert.False(observation.DaemonRunning);
+        Assert.True(observation.StartupInProgress);
+        Assert.Empty(observations);
+    }
+
+    [Fact]
+    public void ShouldContinueStartupWait_DaemonReappearsAfterMutexGap_ReturnsTrue()
+    {
+        var daemonObservations = new Queue<bool>([false, true]);
+        var startupObserved = true;
+
+        Assert.False(daemonObservations.Dequeue());
+        var daemonObservedAfterGap = daemonObservations.Dequeue();
+        var closingMarkerProbeCount = 0;
+        startupObserved = DaemonAutoStart.RecheckStartupAfterDaemonObservation(
+            startupObserved,
+            () =>
+            {
+                closingMarkerProbeCount++;
+                return false;
+            });
+        var shouldWait = DaemonAutoStart.ShouldContinueStartupWait(
+            startupObserved,
+            daemonObservedAfterGap,
+            startupDeadlineExpired: false);
+
+        Assert.True(shouldWait);
+        Assert.Equal(1, closingMarkerProbeCount);
+        Assert.Empty(daemonObservations);
+    }
+
+    [Fact]
+    public async Task EnsureAndConnectCoreAsync_FinalDaemonAndMarkerAppearAfterMutexGap_WaitsForStartup()
+    {
+        var daemonObservations = new Queue<bool>([true, false, true]);
+        var markerObservations = new Queue<bool>([false, false, false, true]);
+        var waitedForStartup = false;
+        var runtime = new DaemonAutoStart.Runtime(
+            PingAsync: (_, _) => Task.FromResult(false),
+            IsDaemonMutexHeld: () => daemonObservations.Dequeue(),
+            IsStartupInProgress: () => markerObservations.Dequeue(),
+            TryStartDaemonAsync: (_, _) => throw new InvalidOperationException("The observer must not start another daemon."),
+            WaitForResponsiveDaemonAsync: (deadline, _) =>
+            {
+                waitedForStartup = true;
+                Assert.False(deadline.IsExpired);
+                return Task.FromResult(true);
+            });
+
+        using var client = await DaemonAutoStart.EnsureAndConnectCoreAsync(
+            $"race-test-{Guid.NewGuid():N}",
+            OperationDeadline.Start(TimeSpan.FromSeconds(5)),
+            runtime,
+            CancellationToken.None);
+
+        Assert.True(waitedForStartup);
+        Assert.Empty(daemonObservations);
+        Assert.Empty(markerObservations);
+    }
+
+    [Fact]
+    public async Task EnsureAndConnectCoreAsync_SpawnedDaemonReadinessUsesOriginalDeadline()
+    {
+        TimeSpan? remainingBeforeLaunch = null;
+        TimeSpan? remainingAfterLaunch = null;
+        var runtime = new DaemonAutoStart.Runtime(
+            PingAsync: async (_, cancellationToken) =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
+                return false;
+            },
+            IsDaemonMutexHeld: () => false,
+            IsStartupInProgress: () => throw new InvalidOperationException("No daemon was observed."),
+            TryStartDaemonAsync: async (deadline, cancellationToken) =>
+            {
+                remainingBeforeLaunch = deadline.Remaining;
+                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+                return DaemonAutoStart.StartOutcome.ObserveReadiness;
+            },
+            WaitForResponsiveDaemonAsync: (deadline, _) =>
+            {
+                remainingAfterLaunch = deadline.Remaining;
+                return Task.FromResult(false);
+            });
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            DaemonAutoStart.EnsureAndConnectCoreAsync(
+                $"deadline-test-{Guid.NewGuid():N}",
+                OperationDeadline.Start(TimeSpan.FromMilliseconds(700)),
+                runtime,
+                CancellationToken.None));
+
+        Assert.NotNull(remainingBeforeLaunch);
+        Assert.NotNull(remainingAfterLaunch);
+        Assert.True(remainingAfterLaunch.Value < remainingBeforeLaunch.Value);
+        Assert.InRange(
+            remainingAfterLaunch.Value,
+            TimeSpan.Zero,
+            TimeSpan.FromMilliseconds(400));
+    }
+
+    [Fact]
+    public async Task EnsureAndConnectCoreAsync_StartedDaemonAlreadyResponsive_DoesNotProbeAgain()
+    {
+        var runtime = new DaemonAutoStart.Runtime(
+            PingAsync: (_, _) => Task.FromResult(false),
+            IsDaemonMutexHeld: () => false,
+            IsStartupInProgress: () => throw new InvalidOperationException("No daemon was observed."),
+            TryStartDaemonAsync: (_, _) => Task.FromResult(DaemonAutoStart.StartOutcome.Ready),
+            WaitForResponsiveDaemonAsync: (_, _) =>
+                throw new InvalidOperationException("A ready daemon must not be probed again."));
+
+        using var client = await DaemonAutoStart.EnsureAndConnectCoreAsync(
+            $"ready-test-{Guid.NewGuid():N}",
+            OperationDeadline.Start(TimeSpan.FromSeconds(1)),
+            runtime,
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartDaemonProcess_ExpiredStartupDeadline_DoesNotLaunchProcess()
+    {
+        var deadline = OperationDeadline.Start(TimeSpan.FromMilliseconds(20));
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        var launchAttempted = false;
+
+        Assert.Throws<TimeoutException>(() =>
+            DaemonAutoStart.StartDaemonProcess(
+                deadline,
+                CancellationToken.None,
+                "test-daemon.exe",
+                () =>
+                {
+                    launchAttempted = true;
+                    return null;
+                }));
+
+        Assert.False(launchAttempted);
+    }
+
+    private static bool DequeueObservation(
+        Queue<(string Name, bool Value)> observations,
+        string expectedName)
+    {
+        var observation = observations.Dequeue();
+        Assert.Equal(expectedName, observation.Name);
+        return observation.Value;
+    }
+}

--- a/tests/ExcelMcp.CLI.Tests/Unit/ExcelMcpServiceErrorTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/ExcelMcpServiceErrorTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Utilities;
 using Sbroenne.ExcelMcp.Service;
 using Xunit;
 using Excel = Microsoft.Office.Interop.Excel;
@@ -106,6 +107,142 @@ public sealed class ExcelMcpServiceErrorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_SessionCloseValidatesArgumentsBeforeSessionId()
+    {
+        using var service = new ExcelMcpService();
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.close",
+            Args = """{"save":"invalid"}"""
+        });
+
+        Assert.False(response.Success);
+        Assert.Equal("InvalidInput", response.ErrorCategory);
+        Assert.Contains("save", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sessionId", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(
+        "powerquery.refresh",
+        """{"queryName":"Probe","Timeout":null}""",
+        "Timeout")]
+    [InlineData(
+        "powerquery.refresh",
+        """{"queryName":"Probe","unexpected":true}""",
+        "unexpected")]
+    [InlineData(
+        "connection.refresh",
+        """{"connectionName":"Probe","timeout":0}""",
+        "timeout")]
+    [InlineData(
+        "powerquery.load-to",
+        """{"queryName":"Probe","loadDestination":"worksheet","timeout":60}""",
+        "timeout")]
+    [InlineData(
+        "powerquery.refresh",
+        """{"queryName":null}""",
+        "queryName")]
+    [InlineData(
+        "powerquery.evaluate",
+        """{}""",
+        "mCode")]
+    [InlineData(
+        "powerquery.evaluate",
+        """{"mCode":"let Source = 1 in Source","mCodeFile":"missing.m"}""",
+        "mCode")]
+    [InlineData(
+        "chartconfig.remove-series",
+        """{"chartName":"Chart 1"}""",
+        "seriesIndex")]
+    [InlineData(
+        "analysis.create-scenario",
+        """{"sheetName":"Model","scenarioName":"Base","changingCells":"A1"}""",
+        "values")]
+    [InlineData(
+        "table.toggle-totals",
+        """{"tableName":"Probe"}""",
+        "showTotals")]
+    [InlineData(
+        "powerquery.load-to",
+        """{"queryName":"Probe","loadDestination":"worksheet","timeout":null}""",
+        "timeout")]
+    [InlineData(
+        "window.set-position",
+        """{"left":"not-a-number"}""",
+        "left")]
+    public async Task ProcessAsync_ValidatesGeneratedArgumentsBeforeSessionLookup(
+        string command,
+        string argsJson,
+        string expectedParameter)
+    {
+        using var service = new ExcelMcpService();
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = command,
+            SessionId = "missing-session",
+            Args = argsJson
+        });
+
+        Assert.False(response.Success);
+        Assert.Equal("InvalidInput", response.ErrorCategory);
+        Assert.Contains(expectedParameter, response.ErrorMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("session", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(
+        """{"filePath":"C:\\missing-parent\\probe.xlsx","macroEnabled":"true"}""",
+        "macroEnabled")]
+    [InlineData(
+        """{"filePath":"C:\\missing-parent\\probe.xlsx","macroEnabled":true}""",
+        "macroEnabled")]
+    public async Task ProcessAsync_ValidatesSessionCreateMacroEnabledBeforeFileCreation(
+        string argsJson,
+        string expectedParameter)
+    {
+        using var service = new ExcelMcpService();
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.create",
+            Args = argsJson
+        });
+
+        Assert.False(response.Success);
+        Assert.Equal("InvalidInput", response.ErrorCategory);
+        Assert.Contains(expectedParameter, response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ServiceClient_DefaultRequestTimeout_ExceedsLargestPublicOperationTimeout()
+    {
+        Assert.True(
+            ServiceClient.DefaultRequestTimeout > TimeSpan.FromSeconds(ParameterTransforms.MaximumTimeoutSeconds));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ValidatesFileInputBeforeSessionLookup()
+    {
+        using var service = new ExcelMcpService();
+        var missingPath = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}.m");
+
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "powerquery.evaluate",
+            SessionId = "missing-session",
+            Args = JsonSerializer.Serialize(new { mCodeFile = missingPath })
+        });
+
+        Assert.False(response.Success);
+        Assert.Contains("not found", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(missingPath, response.ErrorMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("session", response.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task ProcessAsync_SessionCommandOnTimedOutSession_FailsFastBeforeExecutingBatch()
     {
         using var service = new ExcelMcpService();
@@ -128,18 +265,19 @@ public sealed class ExcelMcpServiceErrorTests
     }
 
     [Fact]
-    public async Task ProcessAsync_SessionSaveOnTimedOutSession_FailsFastBeforeSaving()
+    public async Task ProcessAsync_SessionCloseSaveOnTimedOutSession_FailsFastBeforeSaving()
     {
         using var service = new ExcelMcpService();
         var batch = new FakeBatch { HasTimedOutOperation = true };
-        const string sessionId = "timed-out-save";
+        const string sessionId = "timed-out-close-save";
 
         RegisterSession(service, sessionId, batch);
 
         var response = await service.ProcessAsync(new ServiceRequest
         {
-            Command = "session.save",
-            SessionId = sessionId
+            Command = "session.close",
+            SessionId = sessionId,
+            Args = JsonSerializer.Serialize(new { save = true }, ServiceProtocol.JsonOptions)
         });
 
         Assert.False(response.Success);
@@ -149,18 +287,19 @@ public sealed class ExcelMcpServiceErrorTests
     }
 
     [Fact]
-    public async Task ProcessAsync_SessionSaveOnHealthySession_StillSavesNormally()
+    public async Task ProcessAsync_SessionCloseSaveOnHealthySession_SavesNormally()
     {
         using var service = new ExcelMcpService();
         var batch = new FakeBatch();
-        const string sessionId = "healthy-save";
+        const string sessionId = "healthy-close-save";
 
         RegisterSession(service, sessionId, batch);
 
         var response = await service.ProcessAsync(new ServiceRequest
         {
-            Command = "session.save",
-            SessionId = sessionId
+            Command = "session.close",
+            SessionId = sessionId,
+            Args = JsonSerializer.Serialize(new { save = true }, ServiceProtocol.JsonOptions)
         });
 
         Assert.True(response.Success);

--- a/tests/ExcelMcp.ComInterop.Tests/ExcelMcp.ComInterop.Tests.csproj
+++ b/tests/ExcelMcp.ComInterop.Tests/ExcelMcp.ComInterop.Tests.csproj
@@ -39,6 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\OleDataSpaceTestFile.cs" Link="Helpers\OleDataSpaceTestFile.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/ExcelMcp.ComInterop.Tests/Helpers/TempDirectoryFixture.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Helpers/TempDirectoryFixture.cs
@@ -1,0 +1,25 @@
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Helpers;
+
+public sealed class TempDirectoryFixture : IDisposable
+{
+    public TempDirectoryFixture()
+    {
+        DirectoryPath = Path.Combine(
+            Path.GetTempPath(),
+            $"ExcelMcpFileValidation_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(DirectoryPath);
+    }
+
+    public string DirectoryPath { get; }
+
+    public string CreateFilePath() =>
+        Path.Combine(DirectoryPath, $"{Guid.NewGuid():N}.xlsx");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(DirectoryPath))
+        {
+            Directory.Delete(DirectoryPath, recursive: true);
+        }
+    }
+}

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -415,7 +416,7 @@ public class ExcelBatchTests : IAsyncLifetime
     public void BeginBatch_IrmWorkbook_ShowFalse_FailsFastBeforeOpen()
     {
         string fakeIrmFile = Path.Join(Path.GetTempPath(), $"batch-irm-headless-{Guid.NewGuid():N}.xlsx");
-        File.WriteAllBytes(fakeIrmFile, [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+        OleDataSpaceTestFile.Write(fakeIrmFile, "\tDRMDataSpace");
 
         bool openAttempted = false;
         ExcelBatch.BeforeWorkbookOpenHook = (_, _) => openAttempted = true;
@@ -436,6 +437,88 @@ public class ExcelBatchTests : IAsyncLifetime
 #pragma warning disable CA1031 // Intentional: best-effort test cleanup
             try { File.Delete(fakeIrmFile); } catch (Exception) { }
 #pragma warning restore CA1031
+        }
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    [Trait("RequiresExcel", "true")]
+    public void BeginBatch_StartupFailureWithConfirmedExit_UntracksExactIdentity()
+    {
+        ExcelProcessIdentity? capturedIdentity = null;
+        void CaptureIdentity(ExcelProcessIdentity identity) => capturedIdentity = identity;
+
+        SessionManager.ExcelProcessIdentityTracked += CaptureIdentity;
+        ExcelBatch.BeforeWorkbookOpenHook = (_, _) =>
+            throw new InvalidOperationException("synthetic startup failure");
+        ExcelBatch.FailedStartupTerminationHook = _ => false;
+        ExcelBatch.FailedStartupExitConfirmationHook = _ => true;
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => ExcelSession.BeginBatch(_testFileCopy!));
+
+            Assert.Equal("synthetic startup failure", exception.Message);
+            var identity = Assert.IsType<ExcelProcessIdentity>(capturedIdentity);
+            Assert.DoesNotContain(identity, SessionManager.GetTrackedExcelProcesses());
+        }
+        finally
+        {
+            SessionManager.ExcelProcessIdentityTracked -= CaptureIdentity;
+            ExcelBatch.BeforeWorkbookOpenHook = null;
+            ExcelBatch.FailedStartupTerminationHook = null;
+            ExcelBatch.FailedStartupExitConfirmationHook = null;
+            if (capturedIdentity is { } identity)
+            {
+                _ = ExcelBatch.TryTerminateOwnedProcess(
+                    identity,
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(5));
+                SessionManager.UntrackExcelProcess(identity);
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("RunType", "OnDemand")]
+    [Trait("RequiresExcel", "true")]
+    public void BeginBatch_StartupFailureWithUnconfirmedLiveIdentity_RetainsOwnership()
+    {
+        ExcelProcessIdentity? capturedIdentity = null;
+        void CaptureIdentity(ExcelProcessIdentity identity) => capturedIdentity = identity;
+
+        SessionManager.ExcelProcessIdentityTracked += CaptureIdentity;
+        ExcelBatch.BeforeWorkbookOpenHook = (_, _) =>
+            throw new InvalidOperationException("synthetic startup failure");
+        ExcelBatch.FailedStartupTerminationHook = _ => false;
+        ExcelBatch.FailedStartupExitConfirmationHook = _ => false;
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => ExcelSession.BeginBatch(_testFileCopy!));
+
+            var identity = Assert.IsType<ExcelProcessIdentity>(capturedIdentity);
+            Assert.Contains(identity, SessionManager.GetTrackedExcelProcesses());
+            Assert.Contains("remains tracked", exception.Message, StringComparison.OrdinalIgnoreCase);
+            var failures = Assert.IsType<AggregateException>(exception.InnerException);
+            Assert.Contains(
+                failures.InnerExceptions,
+                failure => failure.Message == "synthetic startup failure");
+        }
+        finally
+        {
+            SessionManager.ExcelProcessIdentityTracked -= CaptureIdentity;
+            ExcelBatch.BeforeWorkbookOpenHook = null;
+            ExcelBatch.FailedStartupTerminationHook = null;
+            ExcelBatch.FailedStartupExitConfirmationHook = null;
+            if (capturedIdentity is { } identity)
+            {
+                _ = ExcelBatch.TryTerminateOwnedProcess(
+                    identity,
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(5));
+                SessionManager.UntrackExcelProcess(identity);
+            }
         }
     }
 
@@ -618,8 +701,6 @@ public class ExcelBatchTests : IAsyncLifetime
     //
     // Keeping this comment as documentation that the scenario is handled in production code.
 }
-
-
 
 
 

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTimeoutTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTimeoutTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -128,7 +129,7 @@ public class ExcelBatchTimeoutTests : IAsyncLifetime
     public void BeginBatch_IrmStartupOpenBlocks_TimeoutMessageIncludesInteractiveGuidance()
     {
         string fakeIrmFile = Path.Join(Path.GetTempPath(), $"batch-timeout-irm-{Guid.NewGuid():N}.xlsx");
-        File.WriteAllBytes(fakeIrmFile, [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+        OleDataSpaceTestFile.Write(fakeIrmFile, "\tDRMDataSpace");
 
         ExcelBatch.BeforeWorkbookOpenHook = (_, cancellationToken) =>
         {

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/SessionManagerOperationTrackingTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/SessionManagerOperationTrackingTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Xunit;
 using Xunit.Abstractions;
@@ -215,28 +216,337 @@ public class SessionManagerOperationTrackingTests : IDisposable
     }
 
     [Fact]
+    public void TrackExcelProcess_SynchronousPersistenceRunsBeforeReturn()
+    {
+        var persistenceObserved = false;
+        void PersistIdentity(ExcelProcessIdentity identity)
+        {
+            if (identity.ProcessId == Environment.ProcessId)
+            {
+                persistenceObserved = true;
+            }
+        }
+
+        ExcelProcessIdentity? trackedIdentity = null;
+        SessionManager.ExcelProcessIdentityTracked += PersistIdentity;
+        try
+        {
+            trackedIdentity = SessionManager.TrackExcelProcessIdentity(Environment.ProcessId);
+
+            Assert.True(persistenceObserved);
+        }
+        finally
+        {
+            SessionManager.ExcelProcessIdentityTracked -= PersistIdentity;
+            if (trackedIdentity is { } identity)
+            {
+                SessionManager.UntrackExcelProcess(identity);
+            }
+        }
+    }
+
+    [Fact]
+    public void TrackExcelProcess_SynchronousPersistenceFailurePropagates()
+    {
+        using var process = Process.GetCurrentProcess();
+        var identity = new ExcelProcessIdentity(
+            process.Id,
+            process.StartTime.ToUniversalTime().ToFileTimeUtc());
+        void FailPersistence(ExcelProcessIdentity _) =>
+            throw new IOException("synthetic durable persistence failure");
+
+        SessionManager.ExcelProcessIdentityTracked += FailPersistence;
+        try
+        {
+            var exception = Assert.ThrowsAny<InvalidOperationException>(() =>
+                SessionManager.TrackExcelProcess(identity));
+
+            Assert.Contains("persist", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.IsType<IOException>(exception.InnerException);
+            var persistenceException = Assert.IsType<ExcelProcessPersistenceException>(exception);
+            Assert.Equal(identity, persistenceException.Identity);
+        }
+        finally
+        {
+            SessionManager.ExcelProcessIdentityTracked -= FailPersistence;
+            SessionManager.UntrackExcelProcess(identity);
+        }
+    }
+
+    [Fact]
+    public void LegacyProcessTrackingMembers_RemainUsable()
+    {
+        using var notificationReceived = new ManualResetEventSlim();
+        void LegacySubscriber(IReadOnlyCollection<int> processIds)
+        {
+            if (processIds.Contains(Environment.ProcessId))
+            {
+                notificationReceived.Set();
+            }
+        }
+
+        SessionManager.TrackedExcelProcessesChanged += LegacySubscriber;
+        try
+        {
+            SessionManager.TrackExcelProcess(Environment.ProcessId);
+
+            Assert.True(notificationReceived.Wait(TimeSpan.FromSeconds(5)));
+            Assert.Contains(Environment.ProcessId, SessionManager.GetTrackedExcelProcessIds());
+        }
+        finally
+        {
+            SessionManager.TrackedExcelProcessesChanged -= LegacySubscriber;
+            SessionManager.UntrackExcelProcess(Environment.ProcessId);
+        }
+    }
+
+    [Fact]
+    public void TryTerminateOwnedProcess_MismatchedStartTime_DoesNotTerminateReusedPid()
+    {
+        using var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+        var staleIdentity = new ExcelProcessIdentity(
+            currentProcess.Id,
+            currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc() + 1);
+
+        var terminated = ExcelBatch.TryTerminateOwnedProcess(
+            staleIdentity,
+            waitBeforeTermination: TimeSpan.Zero,
+            waitAfterTermination: TimeSpan.FromSeconds(1));
+
+        Assert.True(terminated);
+        Assert.False(currentProcess.HasExited);
+    }
+
+    [Fact]
+    public void FinalizeOwnedProcessTeardown_TerminationFailureRetainsExactIdentity()
+    {
+        using var currentProcess = Process.GetCurrentProcess();
+        var identity = new ExcelProcessIdentity(
+            currentProcess.Id,
+            currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc());
+        var unrelatedIdentity = identity with
+        {
+            StartedAtUtcFileTime = identity.StartedAtUtcFileTime - 1
+        };
+        SessionManager.TrackExcelProcess(identity);
+        SessionManager.TrackExcelProcess(unrelatedIdentity);
+        ExcelProcessIdentity? observedIdentity = null;
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                ExcelBatch.FinalizeOwnedProcessTeardown(
+                    identity,
+                    candidate =>
+                    {
+                        observedIdentity = candidate;
+                        return false;
+                    }));
+
+            Assert.Equal(identity, observedIdentity);
+            Assert.Contains(identity, SessionManager.GetTrackedExcelProcesses());
+            Assert.Contains(unrelatedIdentity, SessionManager.GetTrackedExcelProcesses());
+            Assert.Contains(
+                identity.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                exception.Message,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            SessionManager.UntrackExcelProcess(identity);
+            SessionManager.UntrackExcelProcess(unrelatedIdentity);
+        }
+    }
+
+    [Fact]
+    public void FinalizeOwnedProcessTeardown_ConfirmedExitUntracksOnlyExactIdentity()
+    {
+        using var currentProcess = Process.GetCurrentProcess();
+        var identity = new ExcelProcessIdentity(
+            currentProcess.Id,
+            currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc());
+        var unrelatedIdentity = identity with
+        {
+            StartedAtUtcFileTime = identity.StartedAtUtcFileTime - 1
+        };
+        SessionManager.TrackExcelProcess(identity);
+        SessionManager.TrackExcelProcess(unrelatedIdentity);
+
+        try
+        {
+            ExcelBatch.FinalizeOwnedProcessTeardown(identity, candidate => candidate == identity);
+
+            Assert.DoesNotContain(identity, SessionManager.GetTrackedExcelProcesses());
+            Assert.Contains(unrelatedIdentity, SessionManager.GetTrackedExcelProcesses());
+            Assert.False(currentProcess.HasExited);
+        }
+        finally
+        {
+            SessionManager.UntrackExcelProcess(identity);
+            SessionManager.UntrackExcelProcess(unrelatedIdentity);
+        }
+    }
+
+    [Fact]
+    public void FinalizeFailedStartupOwnedProcess_ConfirmedExitUntracksExactIdentity()
+    {
+        using var currentProcess = Process.GetCurrentProcess();
+        var identity = new ExcelProcessIdentity(
+            currentProcess.Id,
+            currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc());
+        var unrelatedIdentity = identity with
+        {
+            StartedAtUtcFileTime = identity.StartedAtUtcFileTime - 1
+        };
+        SessionManager.TrackExcelProcess(identity);
+        SessionManager.TrackExcelProcess(unrelatedIdentity);
+
+        try
+        {
+            ExcelBatch.FinalizeFailedStartupOwnedProcess(
+                identity,
+                _ => false,
+                candidate => candidate == identity);
+
+            Assert.DoesNotContain(identity, SessionManager.GetTrackedExcelProcesses());
+            Assert.Contains(unrelatedIdentity, SessionManager.GetTrackedExcelProcesses());
+            Assert.False(currentProcess.HasExited);
+        }
+        finally
+        {
+            SessionManager.UntrackExcelProcess(identity);
+            SessionManager.UntrackExcelProcess(unrelatedIdentity);
+        }
+    }
+
+    [Fact]
+    public void FinalizeFailedStartupOwnedProcess_LiveUnkillableIdentityRemainsTracked()
+    {
+        using var currentProcess = Process.GetCurrentProcess();
+        var identity = new ExcelProcessIdentity(
+            currentProcess.Id,
+            currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc());
+        SessionManager.TrackExcelProcess(identity);
+        ExcelProcessIdentity? terminationCandidate = null;
+        ExcelProcessIdentity? confirmationCandidate = null;
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                ExcelBatch.FinalizeFailedStartupOwnedProcess(
+                    identity,
+                    candidate =>
+                    {
+                        terminationCandidate = candidate;
+                        return false;
+                    },
+                    candidate =>
+                    {
+                        confirmationCandidate = candidate;
+                        return false;
+                    }));
+
+            Assert.Equal(identity, terminationCandidate);
+            Assert.Equal(identity, confirmationCandidate);
+            Assert.Contains(identity, SessionManager.GetTrackedExcelProcesses());
+            Assert.Contains("remains tracked", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.False(currentProcess.HasExited);
+        }
+        finally
+        {
+            SessionManager.UntrackExcelProcess(identity);
+        }
+    }
+
+    [Fact]
+    public void UntrackExcelProcess_OldIdentityDoesNotRemoveReusedPidIdentity()
+    {
+        using var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+        var replacementIdentity = new ExcelProcessIdentity(
+            currentProcess.Id,
+            currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc());
+        var oldIdentity = replacementIdentity with
+        {
+            StartedAtUtcFileTime = replacementIdentity.StartedAtUtcFileTime - 1
+        };
+
+        SessionManager.TrackExcelProcess(oldIdentity);
+        SessionManager.TrackExcelProcess(replacementIdentity);
+        try
+        {
+            SessionManager.UntrackExcelProcess(oldIdentity);
+
+            Assert.DoesNotContain(oldIdentity, SessionManager.GetTrackedExcelProcesses());
+            Assert.Contains(replacementIdentity, SessionManager.GetTrackedExcelProcesses());
+        }
+        finally
+        {
+            SessionManager.UntrackExcelProcess(oldIdentity);
+            SessionManager.UntrackExcelProcess(replacementIdentity);
+        }
+    }
+
+    [Fact]
+    public void TrackExcelProcess_NotificationIncludesCapturedStartTime()
+    {
+        using var notificationReceived = new ManualResetEventSlim();
+        ExcelProcessIdentity? observedIdentity = null;
+        void CaptureSubscriber(IReadOnlyCollection<ExcelProcessIdentity> processes)
+        {
+            observedIdentity = processes.Single(process => process.ProcessId == Environment.ProcessId);
+            notificationReceived.Set();
+        }
+
+        using var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+        var expectedStartTime = currentProcess.StartTime.ToUniversalTime().ToFileTimeUtc();
+        ExcelProcessIdentity? trackedIdentity = null;
+        SessionManager.TrackedExcelProcessIdentitiesChanged += CaptureSubscriber;
+        try
+        {
+            trackedIdentity = SessionManager.TrackExcelProcessIdentity(Environment.ProcessId);
+
+            Assert.True(notificationReceived.Wait(TimeSpan.FromSeconds(5)));
+            Assert.Equal(
+                new ExcelProcessIdentity(Environment.ProcessId, expectedStartTime),
+                observedIdentity);
+        }
+        finally
+        {
+            SessionManager.TrackedExcelProcessIdentitiesChanged -= CaptureSubscriber;
+            if (trackedIdentity is { } identity)
+            {
+                SessionManager.UntrackExcelProcess(identity);
+            }
+        }
+    }
+
+    [Fact]
     public void TrackExcelProcess_SubscriberFailure_DoesNotBreakSessionLifecycle()
     {
         using var notificationReceived = new ManualResetEventSlim();
-        void ThrowingSubscriber(IReadOnlyCollection<int> _)
+        void ThrowingSubscriber(IReadOnlyCollection<ExcelProcessIdentity> _)
         {
             notificationReceived.Set();
             throw new InvalidOperationException("Simulated tracker failure.");
         }
 
-        SessionManager.TrackedExcelProcessesChanged += ThrowingSubscriber;
+        SessionManager.TrackedExcelProcessIdentitiesChanged += ThrowingSubscriber;
+        ExcelProcessIdentity? trackedIdentity = null;
         try
         {
             var exception = Record.Exception(() =>
-                SessionManager.TrackExcelProcess(Environment.ProcessId));
+                trackedIdentity = SessionManager.TrackExcelProcessIdentity(Environment.ProcessId));
 
             Assert.Null(exception);
             Assert.True(notificationReceived.Wait(TimeSpan.FromSeconds(5)));
         }
         finally
         {
-            SessionManager.TrackedExcelProcessesChanged -= ThrowingSubscriber;
-            SessionManager.UntrackExcelProcess(Environment.ProcessId);
+            SessionManager.TrackedExcelProcessIdentitiesChanged -= ThrowingSubscriber;
+            if (trackedIdentity is { } identity)
+            {
+                SessionManager.UntrackExcelProcess(identity);
+            }
         }
     }
 
@@ -427,4 +737,3 @@ public class SessionManagerOperationTrackingTests : IDisposable
 
     #endregion
 }
-

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/SessionManagerTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/SessionManagerTests.cs
@@ -670,9 +670,9 @@ public class SessionManagerTests : IDisposable
     }
 
     [Fact]
-    public void CloseSession_DefaultSaveTrue_PersistsChanges()
+    public void CloseSession_SaveTrue_PersistsChanges()
     {
-        var testFile = CreateTestFile(nameof(CloseSession_DefaultSaveTrue_PersistsChanges));
+        var testFile = CreateTestFile(nameof(CloseSession_SaveTrue_PersistsChanges));
         using var manager = new SessionManager();
         var sessionId = manager.CreateSession(testFile);
 
@@ -704,7 +704,6 @@ public class SessionManagerTests : IDisposable
 
     #endregion
 }
-
 
 
 

--- a/tests/ExcelMcp.ComInterop.Tests/Unit/FileAccessValidatorTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Unit/FileAccessValidatorTests.cs
@@ -1,0 +1,331 @@
+using System.IO.Compression;
+using Sbroenne.ExcelMcp.ComInterop.Tests.Helpers;
+using Sbroenne.ExcelMcp.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Unit;
+
+[Trait("Layer", "ComInterop")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "File")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class FileAccessValidatorTests(
+    TempDirectoryFixture fixture) : IClassFixture<TempDirectoryFixture>
+{
+    private const string SpreadsheetNamespace =
+        "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    private const string StrictSpreadsheetNamespace =
+        "http://purl.oclc.org/ooxml/spreadsheetml/main";
+    private const string MacroSheetNamespace =
+        "http://schemas.microsoft.com/office/excel/2006/main";
+    private const string WorksheetRelationship =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet";
+    private const string StrictWorksheetRelationship =
+        "http://purl.oclc.org/ooxml/officeDocument/relationships/worksheet";
+    private const string ChartSheetRelationship =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet";
+    private const string StrictChartSheetRelationship =
+        "http://purl.oclc.org/ooxml/officeDocument/relationships/chartsheet";
+    private const string MacroSheetRelationship =
+        "http://schemas.microsoft.com/office/2006/relationships/xlMacrosheet";
+    private const string InternationalMacroSheetRelationship =
+        "http://schemas.microsoft.com/office/2006/relationships/xlIntlMacrosheet";
+    private const string DialogSheetRelationship =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/dialogsheet";
+    private const string StrictDialogSheetRelationship =
+        "http://purl.oclc.org/ooxml/officeDocument/relationships/dialogsheet";
+    private const string MacroSheetContentType =
+        "application/vnd.ms-excel.macrosheet+xml";
+    private const string InternationalMacroSheetContentType =
+        "application/vnd.ms-excel.intlmacrosheet+xml";
+    private const string DialogSheetContentType =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.dialogsheet+xml";
+
+    [Theory]
+    [InlineData(
+        WorksheetRelationship,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+        "worksheet",
+        SpreadsheetNamespace,
+        SpreadsheetNamespace)]
+    [InlineData(
+        StrictWorksheetRelationship,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+        "worksheet",
+        StrictSpreadsheetNamespace,
+        StrictSpreadsheetNamespace)]
+    [InlineData(
+        ChartSheetRelationship,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.chartsheet+xml",
+        "chartsheet",
+        SpreadsheetNamespace,
+        SpreadsheetNamespace)]
+    [InlineData(
+        StrictChartSheetRelationship,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.chartsheet+xml",
+        "chartsheet",
+        StrictSpreadsheetNamespace,
+        StrictSpreadsheetNamespace)]
+    [InlineData(
+        MacroSheetRelationship,
+        MacroSheetContentType,
+        "macrosheet",
+        MacroSheetNamespace,
+        SpreadsheetNamespace)]
+    [InlineData(
+        InternationalMacroSheetRelationship,
+        InternationalMacroSheetContentType,
+        "macrosheet",
+        MacroSheetNamespace,
+        SpreadsheetNamespace)]
+    [InlineData(
+        DialogSheetRelationship,
+        DialogSheetContentType,
+        "dialogsheet",
+        SpreadsheetNamespace,
+        SpreadsheetNamespace)]
+    [InlineData(
+        StrictDialogSheetRelationship,
+        DialogSheetContentType,
+        "dialogsheet",
+        StrictSpreadsheetNamespace,
+        StrictSpreadsheetNamespace)]
+    public void HasValidWorkbookContainer_ValidExcelSheetType_ReturnsTrue(
+        string relationshipType,
+        string contentType,
+        string sheetRoot,
+        string sheetNamespace,
+        string workbookNamespace)
+    {
+        var filePath = CreateWorkbookPackage(
+            relationshipType,
+            contentType,
+            sheetRoot,
+            sheetNamespace,
+            workbookNamespace);
+
+        Assert.True(FileAccessValidator.HasValidWorkbookContainer(filePath));
+    }
+
+    [Fact]
+    public void HasValidWorkbookContainer_MacroSheetWithWorksheetRelationship_ReturnsFalse()
+    {
+        var filePath = CreateWorkbookPackage(
+            WorksheetRelationship,
+            MacroSheetContentType,
+            "macrosheet",
+            MacroSheetNamespace,
+            SpreadsheetNamespace);
+
+        Assert.False(FileAccessValidator.HasValidWorkbookContainer(filePath));
+    }
+
+    [Fact]
+    public void HasValidWorkbookContainer_DialogSheetWithWorksheetContentType_ReturnsFalse()
+    {
+        var filePath = CreateWorkbookPackage(
+            DialogSheetRelationship,
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+            "dialogsheet",
+            SpreadsheetNamespace,
+            SpreadsheetNamespace);
+
+        Assert.False(FileAccessValidator.HasValidWorkbookContainer(filePath));
+    }
+
+    [Fact]
+    public void HasValidWorkbookContainer_MacroSheetWithSpreadsheetRootNamespace_ReturnsFalse()
+    {
+        var filePath = CreateWorkbookPackage(
+            MacroSheetRelationship,
+            MacroSheetContentType,
+            "macrosheet",
+            SpreadsheetNamespace,
+            SpreadsheetNamespace);
+
+        Assert.False(FileAccessValidator.HasValidWorkbookContainer(filePath));
+    }
+
+    [Fact]
+    public void IsIrmProtected_PasswordEncryptionMarkersWithoutDrmDataSpace_ReturnsFalse()
+    {
+        var filePath = fixture.CreateFilePath();
+        var bytes = new byte[2048];
+        new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 }
+            .CopyTo(bytes, 0);
+        System.Text.Encoding.Unicode.GetBytes("EncryptionInfo")
+            .CopyTo(bytes, 512);
+        System.Text.Encoding.Unicode.GetBytes("EncryptedPackage")
+            .CopyTo(bytes, 1024);
+        File.WriteAllBytes(filePath, bytes);
+
+        Assert.False(FileAccessValidator.IsIrmProtected(filePath));
+    }
+
+    [Fact]
+    public void IsIrmProtected_LegacyDrmDataSpaceMetadata_ReturnsTrue()
+    {
+        var filePath = OleDataSpaceTestFile.Write(
+            fixture.CreateFilePath(),
+            "\tDRMDataSpace");
+
+        Assert.True(FileAccessValidator.IsIrmProtected(filePath));
+    }
+
+    [Fact]
+    public void IsIrmProtected_ModernDrmEncryptedDataSpaceMetadata_ReturnsTrue()
+    {
+        var filePath = OleDataSpaceTestFile.Write(
+            fixture.CreateFilePath(),
+            "DRMEncryptedDataSpace");
+
+        Assert.True(FileAccessValidator.IsIrmProtected(filePath));
+    }
+
+    [Fact]
+    public void IsIrmProtected_SimilarDataSpaceName_ReturnsFalse()
+    {
+        var filePath = OleDataSpaceTestFile.Write(
+            fixture.CreateFilePath(),
+            "DRMEncryptedDataSpacePreview");
+
+        Assert.False(FileAccessValidator.IsIrmProtected(filePath));
+    }
+
+    [Fact]
+    public void IsIrmProtected_MapWithoutMatchingDefinition_ReturnsFalse()
+    {
+        var filePath = OleDataSpaceTestFile.Write(
+            fixture.CreateFilePath(),
+            "\tDRMDataSpace",
+            "DifferentDataSpace");
+
+        Assert.False(FileAccessValidator.IsIrmProtected(filePath));
+    }
+
+    [Fact]
+    public void IsIrmProtected_DeepDirectoryTree_ReturnsFalseWithoutRecursionFailure()
+    {
+        var filePath = OleDataSpaceTestFile.WriteDeepDirectory(
+            fixture.CreateFilePath(),
+            entryCount: 10_000);
+
+        Assert.False(FileAccessValidator.IsIrmProtected(filePath));
+    }
+
+    [Fact]
+    public void IsIrmProtected_ThousandsOfNestedMaximumLengthStorages_HasBoundedAllocation()
+    {
+        var filePath = OleDataSpaceTestFile.WriteDeepNestedStorages(
+            fixture.CreateFilePath(),
+            entryCount: 2_000);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        var isIrmProtected = FileAccessValidator.IsIrmProtected(filePath);
+
+        var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.False(isIrmProtected);
+        Assert.True(
+            allocatedBytes < 32 * 1024 * 1024,
+            $"Nested OLE inspection allocated {allocatedBytes:N0} bytes.");
+    }
+
+    [Fact]
+    public void IsIrmProtected_OversizedVersion4RootMiniStream_ReturnsFalse()
+    {
+        var filePath = OleDataSpaceTestFile.WriteOversizedVersion4RootMiniStream(
+            fixture.CreateFilePath());
+
+        Assert.False(FileAccessValidator.IsIrmProtected(filePath));
+    }
+
+    [Fact]
+    public void GetSectorCount_SparseFileBeyondInspectionLimit_ThrowsInvalidDataException()
+    {
+        var oversizedLength = checked(((long)int.MaxValue + 2) * 512);
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => OleCompoundFileReader.GetSectorCount(oversizedLength, 512));
+
+        Assert.Contains("length", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string CreateWorkbookPackage(
+        string relationshipType,
+        string sheetContentType,
+        string sheetRoot,
+        string sheetNamespace,
+        string workbookNamespace)
+    {
+        const string contentTypesNamespace =
+            "http://schemas.openxmlformats.org/package/2006/content-types";
+        const string packageRelationshipsNamespace =
+            "http://schemas.openxmlformats.org/package/2006/relationships";
+        var strict = workbookNamespace == StrictSpreadsheetNamespace;
+        var officeRelationshipNamespace = strict
+            ? "http://purl.oclc.org/ooxml/officeDocument/relationships"
+            : "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        var officeDocumentRelationship =
+            $"{officeRelationshipNamespace}/officeDocument";
+        var sheetPath = sheetRoot switch
+        {
+            "dialogsheet" => "dialogsheets/sheet1.xml",
+            "macrosheet" => "macrosheets/sheet1.xml",
+            "chartsheet" => "chartsheets/sheet1.xml",
+            _ => "worksheets/sheet1.xml"
+        };
+        var filePath = fixture.CreateFilePath();
+
+        using var archive = ZipFile.Open(filePath, ZipArchiveMode.Create);
+        WriteEntry(
+            archive,
+            "[Content_Types].xml",
+            $"""
+             <Types xmlns="{contentTypesNamespace}">
+               <Override PartName="/xl/workbook.xml" ContentType="application/vnd.ms-excel.sheet.macroEnabled.main+xml"/>
+               <Override PartName="/xl/{sheetPath}" ContentType="{sheetContentType}"/>
+             </Types>
+             """);
+        WriteEntry(
+            archive,
+            "_rels/.rels",
+            $"""
+             <Relationships xmlns="{packageRelationshipsNamespace}">
+               <Relationship Id="rId1" Type="{officeDocumentRelationship}" Target="xl/workbook.xml"/>
+             </Relationships>
+             """);
+        WriteEntry(
+            archive,
+            "xl/workbook.xml",
+            $"""
+             <workbook xmlns="{workbookNamespace}" xmlns:r="{officeRelationshipNamespace}">
+               <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+             </workbook>
+             """);
+        WriteEntry(
+            archive,
+            "xl/_rels/workbook.xml.rels",
+            $"""
+             <Relationships xmlns="{packageRelationshipsNamespace}">
+               <Relationship Id="rId1" Type="{relationshipType}" Target="{sheetPath}"/>
+             </Relationships>
+             """);
+        WriteEntry(
+            archive,
+            $"xl/{sheetPath}",
+            $"""<{sheetRoot} xmlns="{sheetNamespace}"/>""");
+
+        return filePath;
+    }
+
+    private static void WriteEntry(
+        ZipArchive archive,
+        string path,
+        string content)
+    {
+        var entry = archive.CreateEntry(path);
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(content);
+    }
+}

--- a/tests/ExcelMcp.ComInterop.Tests/Unit/OwnedProcessGuardTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Unit/OwnedProcessGuardTests.cs
@@ -1,0 +1,24 @@
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Unit;
+
+[Trait("Layer", "ComInterop")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "SessionManager")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class OwnedProcessGuardTests
+{
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(2, true)]
+    public void IsAlive_ProbeResult_FailsOpenUnlessExitIsConfirmed(
+        int probeValue,
+        bool expected)
+    {
+        var probe = (OwnedProcessGuard.ProcessIdentityProbe)probeValue;
+        Assert.Equal(expected, OwnedProcessGuard.IsAlive(probe));
+    }
+}

--- a/tests/ExcelMcp.ComInterop.Tests/Unit/SessionManagerTeardownFailureTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Unit/SessionManagerTeardownFailureTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Excel = Microsoft.Office.Interop.Excel;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Unit;
+
+[Trait("Layer", "ComInterop")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "SessionManager")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class SessionManagerTeardownFailureTests
+{
+    [Fact]
+    public void CloseSession_OneShotDisposeFailure_RemainsQuarantinedUntilCleanupConfirmed()
+    {
+        using var manager = new SessionManager();
+        var batch = new OneShotFailingBatch();
+        const string sessionId = "one-shot-dispose-failure";
+        var filePath = Path.GetFullPath("one-shot-dispose-failure.xlsx");
+        RegisterSession(manager, sessionId, filePath, batch);
+
+        var firstFailure = Assert.Throws<InvalidOperationException>(
+            () => manager.CloseSession(sessionId));
+        var retryFailure = Assert.Throws<InvalidOperationException>(
+            () => manager.CloseSession(sessionId));
+
+        Assert.Same(firstFailure, retryFailure);
+        Assert.Equal(1, batch.DisposeCallCount);
+        Assert.Equal(1, manager.ActiveSessionCount);
+        Assert.Contains(sessionId, manager.ActiveSessionIds);
+        Assert.True(manager.TryGetFilePath(sessionId, out var retainedPath));
+        Assert.Equal(filePath, retainedPath);
+        Assert.False(manager.TryBeginOperation(sessionId, out _, out var errorMessage));
+        Assert.Contains("quarantined", errorMessage, StringComparison.OrdinalIgnoreCase);
+
+        batch.ConfirmOwnedCleanup();
+
+        Assert.True(manager.CloseSession(sessionId));
+        Assert.Equal(0, manager.ActiveSessionCount);
+        Assert.False(manager.TryGetFilePath(sessionId, out _));
+    }
+
+    private static void RegisterSession(
+        SessionManager manager,
+        string sessionId,
+        string filePath,
+        IExcelBatch batch)
+    {
+        GetField<ConcurrentDictionary<string, IExcelBatch>>(manager, "_activeSessions")
+            [sessionId] = batch;
+        GetField<ConcurrentDictionary<string, string>>(manager, "_activeFilePaths")
+            [filePath] = sessionId;
+        GetField<ConcurrentDictionary<string, string>>(manager, "_sessionFilePaths")
+            [sessionId] = filePath;
+        GetField<ConcurrentDictionary<string, int>>(manager, "_activeOperationCounts")
+            [sessionId] = 0;
+    }
+
+    private static T GetField<T>(SessionManager manager, string name) where T : class =>
+        Assert.IsType<T>(
+            typeof(SessionManager)
+                .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(manager));
+
+    private sealed class OneShotFailingBatch : IExcelBatch, IExcelBatchTeardownState
+    {
+        private bool _cleanupConfirmed;
+
+        public int DisposeCallCount { get; private set; }
+
+        public string WorkbookPath => Path.GetFullPath("one-shot-dispose-failure.xlsx");
+
+        public Microsoft.Extensions.Logging.ILogger Logger => NullLogger.Instance;
+
+        public IReadOnlyDictionary<string, Excel.Workbook> Workbooks =>
+            new Dictionary<string, Excel.Workbook>();
+
+        public bool HasTimedOutOperation => false;
+
+        public int? ExcelProcessId => Environment.ProcessId;
+
+        public TimeSpan OperationTimeout => TimeSpan.FromSeconds(1);
+
+        public bool IsExcelVisible => false;
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
+            if (DisposeCallCount == 1)
+            {
+                throw new InvalidOperationException("synthetic teardown failure");
+            }
+        }
+
+        public void ConfirmOwnedCleanup() => _cleanupConfirmed = true;
+
+        public bool TryConfirmOwnedProcessTeardown() => _cleanupConfirmed;
+
+        public bool IsExcelProcessAlive() => !_cleanupConfirmed;
+
+        public void UpdateWorkbookPath(string workbookPath) =>
+            throw new NotSupportedException();
+
+        public Excel.Workbook GetWorkbook(string filePath) =>
+            throw new NotSupportedException();
+
+        public void Execute(
+            Action<ExcelContext, CancellationToken> operation,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public T Execute<T>(
+            Func<ExcelContext, CancellationToken, T> operation,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public void Save(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/ExcelMcp.Core.Tests.csproj
+++ b/tests/ExcelMcp.Core.Tests/ExcelMcp.Core.Tests.csproj
@@ -35,6 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\OleDataSpaceTestFile.cs" Link="Helpers\OleDataSpaceTestFile.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <!-- Copy TestAssets to output directory for test execution -->
     <None Include="TestAssets\**\*" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.ExactIdentity.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Connection/ConnectionCommandsTests.ExactIdentity.cs
@@ -1,0 +1,105 @@
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Sbroenne.ExcelMcp.Core.Models;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Connection;
+
+public partial class ConnectionCommandsTests
+{
+    [Fact]
+    public void Delete_Connection_PreservesUnrelatedConnectionDataQueryTable()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var sourceFile = CreateTextSource();
+        var queryTableCommands = new QueryTableCommands();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _commands.Create(batch, "Connection", "ODBC;DSN=DeleteIdentityTest");
+        queryTableCommands.CreateText(
+            batch,
+            "ConnectionData",
+            sourceFile,
+            "Sheet1",
+            "A1");
+
+        var result = _commands.Delete(batch, "Connection");
+
+        Assert.True(result.Success);
+        Assert.Contains(
+            queryTableCommands.List(batch).QueryTables,
+            queryTable => queryTable.Name == "ConnectionData");
+    }
+
+    [Fact]
+    public void LoadTo_Connection_PreservesUnrelatedConnectionDataQueryTable()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var textSourceFile = CreateTextSource();
+        var aceSourceFile = Path.Join(_fixture.TempDir, $"ACE_{Guid.NewGuid():N}.xlsx");
+        var queryTableCommands = new QueryTableCommands();
+
+        AceOleDbTestHelper.CreateExcelDataSource(aceSourceFile);
+        ConnectionTestHelper.CreateAceOleDbConnection(testFile, "Connection", aceSourceFile);
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        queryTableCommands.CreateText(
+            batch,
+            "ConnectionData",
+            textSourceFile,
+            "Sheet1",
+            "A1");
+
+        var result = _commands.LoadTo(batch, "Connection", "ConnectionLoad");
+
+        Assert.True(result.Success);
+        var queryTables = queryTableCommands.List(batch);
+        Assert.Contains(queryTables.QueryTables, queryTable => queryTable.Name == "ConnectionData");
+        Assert.Contains(queryTables.QueryTables, queryTable => queryTable.Name == "Connection");
+
+        _commands.Delete(batch, "Connection");
+
+        var queryTablesAfterDelete = queryTableCommands.List(batch);
+        Assert.Contains(
+            queryTablesAfterDelete.QueryTables,
+            queryTable => queryTable.Name == "ConnectionData");
+        Assert.DoesNotContain(
+            queryTablesAfterDelete.QueryTables,
+            queryTable => queryTable.Name == "Connection");
+    }
+
+    [Fact]
+    public void Delete_ExactConnection_PreservesPowerQueryAlias()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var powerQueryCommands = new PowerQueryCommands(new DataModelCommands());
+        const string mCode = "let Source = #table({\"Value\"}, {{1}}) in Source";
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        powerQueryCommands.Create(
+            batch,
+            "Connection",
+            mCode,
+            PowerQueryLoadMode.LoadToTable,
+            "QueryData");
+        _commands.Create(batch, "Connection", "ODBC;DSN=ExactConnectionTest");
+
+        var result = _commands.Delete(batch, "Connection");
+
+        Assert.True(result.Success);
+        Assert.Contains(
+            _commands.List(batch).Connections,
+            connection => connection.Name == "Query - Connection");
+        Assert.Equal(
+            PowerQueryLoadMode.LoadToTable,
+            powerQueryCommands.GetLoadConfig(batch, "Connection").LoadMode);
+    }
+
+    private string CreateTextSource()
+    {
+        var sourceFile = Path.Join(_fixture.TempDir, $"ConnectionData_{Guid.NewGuid():N}.csv");
+        System.IO.File.WriteAllText(sourceFile, "Name,Value\r\nPreserved,1\r\n");
+        return sourceFile;
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.IrmDetection.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.IrmDetection.cs
@@ -1,4 +1,5 @@
 using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Sbroenne.ExcelMcp.Tests.Helpers;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.File;
@@ -36,25 +37,56 @@ public partial class FileCommandsTests
         // Assert
         Assert.True(info.Exists);
         Assert.True(info.IsValid);
+        Assert.True(info.Success);
+        Assert.True(info.CanOpen);
         Assert.False(info.IsIrmProtected);
+        Assert.False(info.WillOpenReadOnly);
+        Assert.False(info.RequiresVisibleSession);
         Assert.Null(info.Message);
     }
 
-    [Fact]
-    public void Test_IrmSignatureFile_DetectsProtection()
+    [Theory]
+    [InlineData("\tDRMDataSpace")]
+    [InlineData("DRMEncryptedDataSpace")]
+    public void Test_IrmDataSpaceFile_DetectsProtection(string dataSpaceName)
     {
-        // Arrange - deterministic OLE2 header seam for IRM detection logic
         var testFile = Path.Join(_fixture.TempDir, $"FakeIrm_{Guid.NewGuid():N}.xlsx");
-        System.IO.File.WriteAllBytes(testFile, Ole2Signature);
+        OleDataSpaceTestFile.Write(testFile, dataSpaceName);
 
         // Act
         var info = _fileCommands.Test(testFile);
 
         // Assert
         Assert.True(info.Exists);
-        Assert.True(info.IsValid);
+        Assert.False(info.IsValid);
+        Assert.False(info.Success);
+        Assert.False(info.CanOpen);
         Assert.True(info.IsIrmProtected);
-        Assert.Null(info.Message);
+        Assert.True(info.WillOpenReadOnly);
+        Assert.True(info.RequiresVisibleSession);
+        Assert.NotNull(info.Message);
+    }
+
+    [Fact]
+    public void Test_PasswordEncryptionMarkersWithoutDrmDataSpace_AreNotIrm()
+    {
+        var testFile = Path.Join(_fixture.TempDir, $"FakeIrmMarkers_{Guid.NewGuid():N}.xlsx");
+        var bytes = new byte[1536];
+        Ole2Signature.CopyTo(bytes, 0);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(26, 2), 3);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(28, 2), 0xFFFE);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(30, 2), 9);
+        System.Text.Encoding.Unicode.GetBytes("EncryptionInfo").CopyTo(bytes, 600);
+        System.Text.Encoding.Unicode.GetBytes("EncryptedPackage").CopyTo(bytes, 700);
+        System.IO.File.WriteAllBytes(testFile, bytes);
+
+        var info = _fileCommands.Test(testFile);
+
+        Assert.False(info.IsIrmProtected);
+        Assert.False(info.IsValid);
+        Assert.False(info.CanOpen);
+        Assert.False(info.WillOpenReadOnly);
+        Assert.False(info.RequiresVisibleSession);
     }
 
     [Fact]

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.TestFile.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.TestFile.cs
@@ -20,6 +20,10 @@ public partial class FileCommandsTests
         // Assert
         Assert.True(info.Exists);
         Assert.True(info.IsValid);
+        Assert.True(info.Success);
+        Assert.True(info.CanOpen);
+        Assert.False(info.WillOpenReadOnly);
+        Assert.False(info.RequiresVisibleSession);
         Assert.Equal(".xlsx", info.Extension);
         Assert.True(info.Size > 0);
         Assert.Null(info.Message);
@@ -36,9 +40,157 @@ public partial class FileCommandsTests
         // Assert
         Assert.False(info.Exists);
         Assert.False(info.IsValid);
+        Assert.False(info.Success);
+        Assert.False(info.CanOpen);
         Assert.NotNull(info.Message);
         Assert.Contains("not found", info.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void Test_CorruptSupportedExtension_IsNotValidOrOpenable()
+    {
+        var testFile = Path.Join(_fixture.TempDir, $"Corrupt_{Guid.NewGuid():N}.xlsx");
+        System.IO.File.WriteAllText(testFile, "not an Excel workbook");
+
+        var info = _fileCommands.Test(testFile);
+
+        Assert.True(info.Exists);
+        Assert.False(info.IsValid);
+        Assert.False(info.Success);
+        Assert.False(info.CanOpen);
+        Assert.NotNull(info.Message);
+        Assert.Contains("valid Excel workbook", info.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_ZipWithWorkbookEntryNamesButInvalidXml_IsNotValidOrOpenable()
+    {
+        var testFile = Path.Join(_fixture.TempDir, $"CorruptParts_{Guid.NewGuid():N}.xlsx");
+        using (var archive = System.IO.Compression.ZipFile.Open(
+                   testFile,
+                   System.IO.Compression.ZipArchiveMode.Create))
+        {
+            foreach (var name in new[] { "[Content_Types].xml", "_rels/.rels", "xl/workbook.xml" })
+            {
+                var entry = archive.CreateEntry(name);
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write("<invalid");
+            }
+        }
+
+        var info = _fileCommands.Test(testFile);
+
+        Assert.True(info.Exists);
+        Assert.False(info.IsValid);
+        Assert.False(info.CanOpen);
+    }
+
+    [Fact]
+    public void Test_ZipWithFabricatedWorkbookNamespaces_IsNotValidOrOpenable()
+    {
+        var testFile = Path.Join(_fixture.TempDir, $"FabricatedParts_{Guid.NewGuid():N}.xlsx");
+        using (var archive = System.IO.Compression.ZipFile.Open(
+                   testFile,
+                   System.IO.Compression.ZipArchiveMode.Create))
+        {
+            WriteZipEntry(archive, "[Content_Types].xml", "<Types/>");
+            WriteZipEntry(archive, "_rels/.rels",
+                """<Relationships><Relationship Id="rId1" Type="x/officeDocument" Target="xl/workbook.xml"/></Relationships>""");
+            WriteZipEntry(archive, "xl/workbook.xml",
+                """<workbook><sheets><sheet name="Sheet1" sheetId="1" id="rId1"/></sheets></workbook>""");
+            WriteZipEntry(archive, "xl/_rels/workbook.xml.rels",
+                """<Relationships><Relationship Id="rId1" Type="x/worksheet" Target="worksheets/sheet1.xml"/></Relationships>""");
+            WriteZipEntry(archive, "xl/worksheets/sheet1.xml", "<worksheet/>");
+        }
+
+        var info = _fileCommands.Test(testFile);
+
+        Assert.False(info.IsValid);
+        Assert.False(info.CanOpen);
+    }
+
+    [Fact]
+    public void Test_OoxmlPackageWithInvalidWorksheetPart_IsNotValidOrOpenable()
+    {
+        var testFile = Path.Join(_fixture.TempDir, $"InvalidWorksheet_{Guid.NewGuid():N}.xlsx");
+        using (var archive = System.IO.Compression.ZipFile.Open(
+                   testFile,
+                   System.IO.Compression.ZipArchiveMode.Create))
+        {
+            WriteZipEntry(archive, "[Content_Types].xml",
+                """<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>""");
+            WriteZipEntry(archive, "_rels/.rels",
+                """<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>""");
+            WriteZipEntry(archive, "xl/workbook.xml",
+                """<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>""");
+            WriteZipEntry(archive, "xl/_rels/workbook.xml.rels",
+                """<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>""");
+            WriteZipEntry(archive, "xl/worksheets/sheet1.xml",
+                """<notWorksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>""");
+        }
+
+        var info = _fileCommands.Test(testFile);
+
+        Assert.False(info.IsValid);
+        Assert.False(info.CanOpen);
+    }
+
+    [Fact]
+    public void Test_OoxmlPackageWithInvalidSecondSheet_IsNotValidOrOpenable()
+    {
+        var testFile = Path.Join(_fixture.TempDir, $"InvalidSecondSheet_{Guid.NewGuid():N}.xlsx");
+        using (var archive = System.IO.Compression.ZipFile.Open(
+                   testFile,
+                   System.IO.Compression.ZipArchiveMode.Create))
+        {
+            WriteZipEntry(archive, "[Content_Types].xml",
+                """<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>""");
+            WriteZipEntry(archive, "_rels/.rels",
+                """<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>""");
+            WriteZipEntry(archive, "xl/workbook.xml",
+                """<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/><sheet name="Sheet2" sheetId="2" r:id="rId2"/></sheets></workbook>""");
+            WriteZipEntry(archive, "xl/_rels/workbook.xml.rels",
+                """<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" TargetMode="External" Target="https://example.invalid/sheet2.xml"/></Relationships>""");
+            WriteZipEntry(archive, "xl/worksheets/sheet1.xml",
+                """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>""");
+        }
+
+        var info = _fileCommands.Test(testFile);
+
+        Assert.False(info.IsValid);
+        Assert.False(info.CanOpen);
+    }
+
+    private static void WriteZipEntry(
+        System.IO.Compression.ZipArchive archive,
+        string name,
+        string content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(content);
+    }
+
+    [Fact]
+    public void Test_LockedSupportedFile_ReportsNotOpenable()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var lockStream = new FileStream(
+            testFile,
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.None);
+
+        var info = _fileCommands.Test(testFile);
+
+        Assert.True(info.Exists);
+        Assert.False(info.IsValid);
+        Assert.False(info.Success);
+        Assert.False(info.CanOpen);
+        Assert.NotNull(info.Message);
+        Assert.Contains("already open", info.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("TestFile.xls", ".xls")]
     [InlineData("TestFile.csv", ".csv")]
@@ -57,12 +209,10 @@ public partial class FileCommandsTests
         // Assert
         Assert.True(info.Exists);
         Assert.False(info.IsValid);
+        Assert.False(info.Success);
+        Assert.False(info.CanOpen);
         Assert.Equal(expectedExt, info.Extension);
         Assert.NotNull(info.Message);
         Assert.Contains("Invalid file extension", info.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
-
-
-
-

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.DataModelLoading.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.DataModelLoading.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Commands;
 using Sbroenne.ExcelMcp.Core.Models;
@@ -298,6 +299,7 @@ in
 
         // Create with LoadToBoth
         _ = _powerQueryCommands.Create(batch, queryName, initialMCode, PowerQueryLoadMode.LoadToBoth);
+        AssertDataModelValue(batch, queryName, 1);
 
         // Verify initial state
         var loadConfigBefore = _powerQueryCommands.GetLoadConfig(batch, queryName);
@@ -307,6 +309,7 @@ in
 
         // Update
         _ = _powerQueryCommands.Update(batch, queryName, updatedMCode);
+        AssertDataModelValue(batch, queryName, 2);
 
         // Verify LoadToBoth preserved
         var loadConfigAfter = _powerQueryCommands.GetLoadConfig(batch, queryName);
@@ -330,20 +333,27 @@ in
         var testExcelFile = _fixture.CreateTestFile();
         var queryName = "PQ_RefreshBoth_" + Guid.NewGuid().ToString("N")[..8];
 
-        var mCode = @"let Source = #table({""Val""}, {{99}}) in Source";
+        var initialMCode = @"let Source = #table({""Val""}, {{1}}) in Source";
+        var updatedMCode = @"let Source = #table({""Val""}, {{2}}) in Source";
 
         using var batch = ExcelSession.BeginBatch(testExcelFile);
 
         // Create with LoadToBoth
-        _ = _powerQueryCommands.Create(batch, queryName, mCode, PowerQueryLoadMode.LoadToBoth);
+        _ = _powerQueryCommands.Create(batch, queryName, initialMCode, PowerQueryLoadMode.LoadToBoth);
+        AssertDataModelValue(batch, queryName, 1);
 
         // Verify initial state
         var loadConfigBefore = _powerQueryCommands.GetLoadConfig(batch, queryName);
         Assert.Equal(PowerQueryLoadMode.LoadToBoth, loadConfigBefore.LoadMode);
 
-        // Refresh
+        // Change the query without refreshing either destination.
+        _ = _powerQueryCommands.Update(batch, queryName, updatedMCode, refresh: false);
+        AssertDataModelValue(batch, queryName, 1);
+
+        // Refresh both worksheet and Data Model destinations.
         var refreshResult = _powerQueryCommands.Refresh(batch, queryName, TimeSpan.FromMinutes(5));
         Assert.True(refreshResult.Success, $"Refresh failed: {refreshResult.ErrorMessage}");
+        AssertDataModelValue(batch, queryName, 2);
 
         // Verify LoadToBoth preserved
         var loadConfigAfter = _powerQueryCommands.GetLoadConfig(batch, queryName);
@@ -358,6 +368,23 @@ in
     }
 
     #endregion
+
+    private void AssertDataModelValue(
+        IExcelBatch batch,
+        string queryName,
+        int expectedValue)
+    {
+        var result = _dataModelCommands.Evaluate(
+            batch,
+            $"EVALUATE '{queryName}'");
+
+        Assert.True(result.Success, $"Data Model evaluation failed: {result.ErrorMessage}");
+        var row = Assert.Single(result.Rows);
+        var value = Assert.Single(row);
+        Assert.Equal(
+            expectedValue,
+            Convert.ToInt32(value, CultureInfo.InvariantCulture));
+    }
 
     #region Multiple Queries Tests
 
@@ -1055,7 +1082,5 @@ in
 
     #endregion
 }
-
-
 
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.ExactIdentity.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.ExactIdentity.cs
@@ -1,0 +1,319 @@
+using System.Runtime.InteropServices;
+using System.Globalization;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
+using Sbroenne.ExcelMcp.Core.Commands.Table;
+using Sbroenne.ExcelMcp.Core.Models;
+using Xunit;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PowerQuery;
+
+public partial class PowerQueryCommandsTests
+{
+    private const string PrefixQueryMCode = "let Source = #table({\"Value\"}, {{1}}) in Source";
+
+    [Fact]
+    public void ExactIdentity_ReadAndRefreshPaths_DoNotTreatAAAsA()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        CreatePrefixQueries(batch, PowerQueryLoadMode.LoadToTable);
+
+        var listResult = _powerQueryCommands.List(batch);
+        Assert.True(listResult.Queries.Single(query => query.Name == "A").IsConnectionOnly);
+        Assert.False(listResult.Queries.Single(query => query.Name == "AA").IsConnectionOnly);
+
+        var viewResult = _powerQueryCommands.View(batch, "a");
+        Assert.True(viewResult.IsConnectionOnly);
+
+        var loadConfig = _powerQueryCommands.GetLoadConfig(batch, "a");
+        Assert.Equal(PowerQueryLoadMode.ConnectionOnly, loadConfig.LoadMode);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _powerQueryCommands.Refresh(batch, "a", TimeSpan.FromSeconds(30)));
+        Assert.Contains("Could not find connection or table for query 'a'", exception.Message);
+
+        AssertWorksheetLoadPreserved(batch, "AA");
+    }
+
+    [Fact]
+    public void LoadTo_PrefixQuery_PreservesAAWorksheetDestination()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        CreatePrefixQueries(batch, PowerQueryLoadMode.LoadToTable);
+
+        var result = _powerQueryCommands.LoadTo(
+            batch,
+            "A",
+            PowerQueryLoadMode.LoadToTable,
+            "AData",
+            "A1");
+
+        Assert.True(result.Success);
+        Assert.Equal(PowerQueryLoadMode.LoadToTable, _powerQueryCommands.GetLoadConfig(batch, "A").LoadMode);
+        AssertWorksheetLoadPreserved(batch, "AA");
+    }
+
+    [Fact]
+    public void Unload_PrefixQuery_PreservesAAWorksheetDestination()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        CreatePrefixQueries(batch, PowerQueryLoadMode.LoadToTable);
+
+        var result = _powerQueryCommands.Unload(batch, "A");
+
+        Assert.True(result.Success);
+        AssertWorksheetLoadPreserved(batch, "AA");
+    }
+
+    [Fact]
+    public void Delete_PrefixQuery_PreservesAAWorksheetDestination()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        CreatePrefixQueries(batch, PowerQueryLoadMode.LoadToTable);
+
+        var result = _powerQueryCommands.Delete(batch, "a");
+
+        Assert.True(result.Success);
+        Assert.DoesNotContain(_powerQueryCommands.List(batch).Queries, query => query.Name == "A");
+        AssertWorksheetLoadPreserved(batch, "AA");
+    }
+
+    [Fact]
+    public void Unload_PrefixQuery_PreservesAADataModelDestination()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var dataModelCommands = new DataModelCommands();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        CreatePrefixQueries(batch, PowerQueryLoadMode.LoadToDataModel);
+
+        var result = _powerQueryCommands.Unload(batch, "A");
+
+        Assert.True(result.Success);
+        var tables = dataModelCommands.ListTables(batch);
+        Assert.Contains(tables.Tables, table => table.Name == "AA");
+        Assert.Equal(
+            PowerQueryLoadMode.LoadToDataModel,
+            _powerQueryCommands.GetLoadConfig(batch, "AA").LoadMode);
+    }
+
+    [Fact]
+    public void ConnectionOnlyQuery_DoesNotClaimUnrelatedSameNamedDataModelTable()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var rangeCommands = new RangeCommands();
+        var tableCommands = new TableCommands();
+        var dataModelCommands = new DataModelCommands();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        rangeCommands.SetValues(batch, "Sheet1", "A1:A2", [["Value"], [1]]);
+        tableCommands.Create(batch, "Sheet1", "A", "A1:A2");
+        tableCommands.AddToDataModel(batch, "A");
+        _powerQueryCommands.Create(batch, "A", PrefixQueryMCode, PowerQueryLoadMode.ConnectionOnly);
+
+        var query = _powerQueryCommands.List(batch).Queries.Single(item => item.Name == "A");
+        Assert.True(query.IsConnectionOnly);
+        Assert.Equal(
+            PowerQueryLoadMode.ConnectionOnly,
+            _powerQueryCommands.GetLoadConfig(batch, "A").LoadMode);
+        Assert.Throws<InvalidOperationException>(
+            () => _powerQueryCommands.Refresh(batch, "A", TimeSpan.FromSeconds(30)));
+        Assert.Contains(dataModelCommands.ListTables(batch).Tables, table => table.Name == "A");
+    }
+
+    [Fact]
+    public void Evaluate_Success_SaveAndReopen_PersistsNoTemporaryArtifacts()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var connectionCommands = new ConnectionCommands();
+
+        using (var batch = ExcelSession.BeginBatch(testFile))
+        {
+            connectionCommands.Create(batch, "Connection", "ODBC;DSN=PreservedGenericConnection");
+            var result = _powerQueryCommands.Evaluate(batch, PrefixQueryMCode);
+            Assert.True(result.Success);
+            batch.Save();
+        }
+
+        AssertNoEvaluateArtifactsAfterReopen(testFile, connectionCommands);
+    }
+
+    [Fact]
+    public void Evaluate_Failure_SaveAndReopen_PersistsNoTemporaryArtifacts()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var connectionCommands = new ConnectionCommands();
+        const string invalidMCode = "let Source = UndefinedFunction() in Source";
+
+        using (var batch = ExcelSession.BeginBatch(testFile))
+        {
+            connectionCommands.Create(batch, "Connection", "ODBC;DSN=PreservedGenericConnection");
+            Assert.ThrowsAny<Exception>(() => _powerQueryCommands.Evaluate(batch, invalidMCode));
+            batch.Save();
+        }
+
+        AssertNoEvaluateArtifactsAfterReopen(testFile, connectionCommands);
+    }
+
+    [Fact]
+    public void Evaluate_PreservesQueryConnectionAliasedByTemporaryDisplayName()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _powerQueryCommands.Create(
+            batch,
+            "Connection",
+            PrefixQueryMCode,
+            PowerQueryLoadMode.LoadToTable,
+            "QueryData");
+
+        var result = _powerQueryCommands.Evaluate(batch, PrefixQueryMCode);
+
+        Assert.True(result.Success);
+        Assert.Equal(
+            PowerQueryLoadMode.LoadToTable,
+            _powerQueryCommands.GetLoadConfig(batch, "Connection").LoadMode);
+        Assert.Equal(
+            "QueryData",
+            _powerQueryCommands.GetLoadConfig(batch, "Connection").TargetSheet);
+    }
+
+    private void CreatePrefixQueries(IExcelBatch batch, PowerQueryLoadMode aaLoadMode)
+    {
+        _powerQueryCommands.Create(batch, "A", PrefixQueryMCode, PowerQueryLoadMode.ConnectionOnly);
+        _powerQueryCommands.Create(
+            batch,
+            "AA",
+            PrefixQueryMCode,
+            aaLoadMode,
+            aaLoadMode is PowerQueryLoadMode.LoadToTable or PowerQueryLoadMode.LoadToBoth
+                ? "AAData"
+                : null);
+    }
+
+    private void AssertWorksheetLoadPreserved(IExcelBatch batch, string queryName)
+    {
+        var config = _powerQueryCommands.GetLoadConfig(batch, queryName);
+        Assert.Equal(PowerQueryLoadMode.LoadToTable, config.LoadMode);
+        Assert.Equal("AAData", config.TargetSheet);
+
+        var view = _powerQueryCommands.View(batch, queryName);
+        Assert.False(view.IsConnectionOnly);
+    }
+
+    private static void AssertNoEvaluateArtifactsAfterReopen(
+        string testFile,
+        ConnectionCommands connectionCommands)
+    {
+        using var reopenedBatch = ExcelSession.BeginBatch(testFile);
+        var artifacts = FindEvaluateArtifacts(reopenedBatch);
+
+        Assert.Empty(artifacts);
+        Assert.Contains(
+            connectionCommands.List(reopenedBatch).Connections,
+            connection => connection.Name == "Connection");
+    }
+
+    private static List<string> FindEvaluateArtifacts(IExcelBatch batch)
+    {
+        return batch.Execute((ctx, ct) =>
+        {
+            var artifacts = new List<string>();
+            Excel.Queries? queries = null;
+            Excel.Sheets? worksheets = null;
+            Excel.Connections? connections = null;
+
+            try
+            {
+                queries = ctx.Book.Queries;
+                for (int i = 1; i <= queries.Count; i++)
+                {
+                    Excel.WorkbookQuery? query = null;
+                    try
+                    {
+                        query = queries.Item(i);
+                        if (query.Name.StartsWith("__pq_eval_", StringComparison.OrdinalIgnoreCase))
+                        {
+                            artifacts.Add($"query:{query.Name}");
+                        }
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref query);
+                    }
+                }
+
+                worksheets = ctx.Book.Worksheets;
+                for (int i = 1; i <= worksheets.Count; i++)
+                {
+                    Excel.Worksheet? worksheet = null;
+                    try
+                    {
+                        worksheet = (Excel.Worksheet)worksheets.Item[i];
+                        if (worksheet.Name.StartsWith("__pq_eval_", StringComparison.OrdinalIgnoreCase))
+                        {
+                            artifacts.Add($"worksheet:{worksheet.Name}");
+                        }
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref worksheet);
+                    }
+                }
+
+                connections = ctx.Book.Connections;
+                for (int i = 1; i <= connections.Count; i++)
+                {
+                    Excel.WorkbookConnection? connection = null;
+                    Excel.OLEDBConnection? oleDbConnection = null;
+                    try
+                    {
+                        connection = connections.Item(i);
+                        if (Convert.ToInt32(connection.Type, CultureInfo.InvariantCulture) != 1)
+                        {
+                            continue;
+                        }
+
+                        oleDbConnection = connection.OLEDBConnection;
+                        var connectionString = Convert.ToString(oleDbConnection.Connection) ?? string.Empty;
+                        if (connectionString.Contains(
+                            "Location=__pq_eval_",
+                            StringComparison.OrdinalIgnoreCase))
+                        {
+                            artifacts.Add($"connection:{connection.Name}");
+                        }
+                    }
+                    catch (COMException)
+                    {
+                        // Non-OLEDB connection subtype.
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref oleDbConnection);
+                        ComUtilities.Release(ref connection);
+                    }
+                }
+
+                return artifacts;
+            }
+            finally
+            {
+                ComUtilities.Release(ref connections);
+                ComUtilities.Release(ref worksheets);
+                ComUtilities.Release(ref queries);
+            }
+        });
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.ManualTable.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.ManualTable.cs
@@ -105,7 +105,7 @@ in
         // Verify the actual query is present
         var query = Assert.Single(result.Queries);
         Assert.Equal(queryName, query.Name);
-        Assert.NotEmpty(query.Formula);
+        Assert.NotEmpty(query.FormulaPreview);
         Assert.DoesNotContain("Error:", query.FormulaPreview);
 
         // Query should be connection-only (manual table shouldn't affect this)
@@ -294,7 +294,6 @@ in
         Assert.DoesNotContain("Column1", viewResult.MCode);
     }
 }
-
 
 
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.ReadContract.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/PowerQuery/PowerQueryCommandsTests.ReadContract.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Models;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.PowerQuery;
+
+public partial class PowerQueryCommandsTests
+{
+    [Fact]
+    public void List_LongFormula_ReturnsBoundedCompactMetadataWhileViewReturnsFullM()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var queryName = $"CompactRead_{Guid.NewGuid():N}";
+        var mCode = BuildLongReadContractMCode();
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _powerQueryCommands.Create(batch, queryName, mCode, PowerQueryLoadMode.ConnectionOnly);
+
+        var list = _powerQueryCommands.List(batch);
+        var query = Assert.Single(list.Queries, item => item.Name == queryName);
+        var listJson = JsonSerializer.Serialize(list, JsonSerializerOptions.Web);
+
+        Assert.True(list.Success);
+#pragma warning disable CS0618
+        Assert.Equal(mCode, query.Formula);
+#pragma warning restore CS0618
+        Assert.InRange(query.FormulaPreview.Length, 1, 80);
+        Assert.Equal(mCode.Length, query.CharacterCount);
+        Assert.Equal(PowerQueryLoadMode.ConnectionOnly, query.LoadMode);
+        Assert.True(listJson.Length < 1_000, $"Compact list payload was {listJson.Length} characters.");
+
+        using (var document = JsonDocument.Parse(listJson))
+        {
+            var serializedQuery = Assert.Single(
+                document.RootElement.GetProperty("queries").EnumerateArray());
+            Assert.False(serializedQuery.TryGetProperty("formula", out _));
+        }
+
+        var view = _powerQueryCommands.View(batch, queryName);
+
+        Assert.True(view.Success);
+        Assert.Equal(mCode, view.MCode);
+        Assert.Equal(mCode.Length, view.CharacterCount);
+    }
+
+    [Fact]
+    public void ReadActions_AllLoadModes_ReturnTheSameTruthfulLoadState()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var scenarios = new[]
+        {
+            new ReadLoadStateScenario(
+                $"ReadConnectionOnly_{suffix}",
+                PowerQueryLoadMode.ConnectionOnly,
+                null,
+                true,
+                false),
+            new ReadLoadStateScenario(
+                $"ReadWorksheet_{suffix}",
+                PowerQueryLoadMode.LoadToTable,
+                $"ReadWorksheet_{suffix}",
+                false,
+                false),
+            new ReadLoadStateScenario(
+                $"ReadDataModel_{suffix}",
+                PowerQueryLoadMode.LoadToDataModel,
+                null,
+                false,
+                true),
+            new ReadLoadStateScenario(
+                $"ReadBoth_{suffix}",
+                PowerQueryLoadMode.LoadToBoth,
+                $"ReadBoth_{suffix}",
+                false,
+                true)
+        };
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        foreach (var scenario in scenarios)
+        {
+            _powerQueryCommands.Create(
+                batch,
+                scenario.QueryName,
+                "let Source = #table({\"Value\"}, {{1}}) in Source",
+                scenario.LoadMode,
+                scenario.TargetSheet);
+        }
+
+        var list = _powerQueryCommands.List(batch);
+
+        foreach (var scenario in scenarios)
+        {
+            var query = Assert.Single(list.Queries, item => item.Name == scenario.QueryName);
+            var view = _powerQueryCommands.View(batch, scenario.QueryName);
+            var loadConfig = _powerQueryCommands.GetLoadConfig(batch, scenario.QueryName);
+
+            Assert.Equal(scenario.IsConnectionOnly, query.IsConnectionOnly);
+            Assert.Equal(scenario.IsConnectionOnly, view.IsConnectionOnly);
+            Assert.Equal(scenario.LoadMode, query.LoadMode);
+            Assert.Equal(scenario.LoadMode, view.LoadMode);
+            Assert.Equal(scenario.TargetSheet, query.TargetSheet);
+            Assert.Equal(scenario.TargetSheet, view.TargetSheet);
+            Assert.Equal(scenario.IsLoadedToDataModel, query.IsLoadedToDataModel);
+            Assert.Equal(scenario.IsLoadedToDataModel, view.IsLoadedToDataModel);
+            Assert.Equal(!scenario.IsConnectionOnly, view.HasConnection);
+            Assert.Equal(scenario.LoadMode, loadConfig.LoadMode);
+            Assert.Equal(scenario.TargetSheet, loadConfig.TargetSheet);
+            Assert.Equal(scenario.IsLoadedToDataModel, loadConfig.IsLoadedToDataModel);
+            Assert.Equal(!scenario.IsConnectionOnly, loadConfig.HasConnection);
+        }
+    }
+
+    [Fact]
+    public void List_UnexecutedInvalidMQuery_ReturnsCompactMetadata()
+    {
+        var testFile = _fixture.CreateTestFile();
+        var queryName = $"InvalidRead_{Guid.NewGuid():N}";
+        const string invalidMCode = "let Source = MissingFunction() in Source";
+
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _powerQueryCommands.Create(
+            batch,
+            queryName,
+            invalidMCode,
+            PowerQueryLoadMode.ConnectionOnly);
+
+        var result = _powerQueryCommands.List(batch);
+        var query = Assert.Single(result.Queries, item => item.Name == queryName);
+
+        Assert.True(result.Success);
+        Assert.Equal(invalidMCode, query.FormulaPreview);
+        Assert.Equal(invalidMCode.Length, query.CharacterCount);
+        Assert.Equal(PowerQueryLoadMode.ConnectionOnly, query.LoadMode);
+    }
+
+    private static string BuildLongReadContractMCode()
+    {
+        var padding = string.Join(
+            Environment.NewLine,
+            Enumerable.Repeat("// bounded list preview must not serialize this padding", 250));
+        return $"let{Environment.NewLine}{padding}{Environment.NewLine}    Source = #table({{\"Value\"}}, {{{{1}}}}){Environment.NewLine}in{Environment.NewLine}    Source";
+    }
+
+    private sealed record ReadLoadStateScenario(
+        string QueryName,
+        PowerQueryLoadMode LoadMode,
+        string? TargetSheet,
+        bool IsConnectionOnly,
+        bool IsLoadedToDataModel);
+}

--- a/tests/ExcelMcp.Core.Tests/Unit/AnalysisServiceRegistryRoutingTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/AnalysisServiceRegistryRoutingTests.cs
@@ -32,65 +32,82 @@ public sealed class AnalysisServiceRegistryRoutingTests
         Assert.Equal(action, parsedAction);
         Assert.Equal(expectedAction, ServiceRegistry.Analysis.ToActionString(action));
 
-        var routed = ServiceRegistry.Analysis.RouteAction(
-            action,
-            "session-1",
-            (command, sessionId, args) => JsonSerializer.Serialize(new { command, sessionId, args }),
-            sheetName: "Model",
-            formulaCell: "B1",
-            goal: 40d,
-            changingCell: "A1",
-            scenarioName: "Plan",
-            changingCells: "A1:A2",
-            values: [10d, 20d],
-            comment: "Planning inputs",
-            locked: false,
-            hidden: false,
-            reportType: "pivot-table",
-            resultCells: "B1",
-            tableRange: "D1:F4",
-            rowInputCell: "A1",
-            columnInputCell: "A2");
+        static string Forward(string command, string sessionId, object? args) =>
+            JsonSerializer.Serialize(new { command, sessionId, args });
+
+        var routed = action switch
+        {
+            AnalysisAction.GoalSeek => ServiceRegistry.Analysis.RouteAction(
+                action, "session-1", Forward, sheetName: "Model",
+                formulaCell: "B1", goal: 40d, changingCell: "A1"),
+            AnalysisAction.ListScenarios => ServiceRegistry.Analysis.RouteAction(
+                action, "session-1", Forward, sheetName: "Model"),
+            AnalysisAction.CreateScenario => ServiceRegistry.Analysis.RouteAction(
+                action, "session-1", Forward, sheetName: "Model",
+                scenarioName: "Plan", changingCells: "A1:A2", values: [10d, 20d],
+                comment: "Planning inputs", locked: false, hidden: false),
+            AnalysisAction.UpdateScenario => ServiceRegistry.Analysis.RouteAction(
+                action, "session-1", Forward, sheetName: "Model",
+                scenarioName: "Plan", changingCells: "A1:A2", values: [10d, 20d]),
+            AnalysisAction.ShowScenario or AnalysisAction.DeleteScenario =>
+                ServiceRegistry.Analysis.RouteAction(
+                    action, "session-1", Forward, sheetName: "Model", scenarioName: "Plan"),
+            AnalysisAction.CreateScenarioSummary => ServiceRegistry.Analysis.RouteAction(
+                action, "session-1", Forward, sheetName: "Model",
+                reportType: "pivot-table", resultCells: "B1"),
+            AnalysisAction.CreateDataTable => ServiceRegistry.Analysis.RouteAction(
+                action, "session-1", Forward, sheetName: "Model",
+                tableRange: "D1:F4", rowInputCell: "A1", columnInputCell: "A2"),
+            _ => throw new ArgumentOutOfRangeException(nameof(action))
+        };
 
         using var routedJson = JsonDocument.Parse(routed);
         Assert.Equal($"analysis.{expectedAction}", routedJson.RootElement.GetProperty("command").GetString());
         Assert.Equal("session-1", routedJson.RootElement.GetProperty("sessionId").GetString());
 
-        var cliRoute = ServiceRegistry.Analysis.RouteCliArgs(
-            expectedAction,
-            sheetName: "Model",
-            formulaCell: "B1",
-            goal: 40d,
-            changingCell: "A1",
-            scenarioName: "Plan",
-            changingCells: "A1:A2",
-            values: [10d, 20d],
-            comment: "Planning inputs",
-            locked: false,
-            hidden: false,
-            reportType: "pivot-table",
-            resultCells: "B1",
-            tableRange: "D1:F4",
-            rowInputCell: "A1",
-            columnInputCell: "A2");
+        var cliRoute = action switch
+        {
+            AnalysisAction.GoalSeek => ServiceRegistry.Analysis.RouteCliArgs(
+                expectedAction, sheetName: "Model",
+                formulaCell: "B1", goal: 40d, changingCell: "A1"),
+            AnalysisAction.ListScenarios => ServiceRegistry.Analysis.RouteCliArgs(
+                expectedAction, sheetName: "Model"),
+            AnalysisAction.CreateScenario => ServiceRegistry.Analysis.RouteCliArgs(
+                expectedAction, sheetName: "Model",
+                scenarioName: "Plan", changingCells: "A1:A2", values: [10d, 20d],
+                comment: "Planning inputs", locked: false, hidden: false),
+            AnalysisAction.UpdateScenario => ServiceRegistry.Analysis.RouteCliArgs(
+                expectedAction, sheetName: "Model",
+                scenarioName: "Plan", changingCells: "A1:A2", values: [10d, 20d]),
+            AnalysisAction.ShowScenario or AnalysisAction.DeleteScenario =>
+                ServiceRegistry.Analysis.RouteCliArgs(
+                    expectedAction, sheetName: "Model", scenarioName: "Plan"),
+            AnalysisAction.CreateScenarioSummary => ServiceRegistry.Analysis.RouteCliArgs(
+                expectedAction, sheetName: "Model",
+                reportType: "pivot-table", resultCells: "B1"),
+            AnalysisAction.CreateDataTable => ServiceRegistry.Analysis.RouteCliArgs(
+                expectedAction, sheetName: "Model",
+                tableRange: "D1:F4", rowInputCell: "A1", columnInputCell: "A2"),
+            _ => throw new ArgumentOutOfRangeException(nameof(action))
+        };
 
         Assert.Equal($"analysis.{expectedAction}", cliRoute.Command);
         Assert.NotNull(cliRoute.Args);
     }
 
     [Fact]
-    public void GeneratedGoalSeekRoute_PreservesOmittedGoalForCoreValidation()
+    public void GeneratedGoalSeekRoute_RejectsOmittedRequiredGoal()
     {
-        var routed = ServiceRegistry.Analysis.RouteAction(
-            AnalysisAction.GoalSeek,
-            "session-1",
-            (_, _, args) => JsonSerializer.Serialize(args),
-            sheetName: "Model",
-            formulaCell: "B1",
-            goal: null,
-            changingCell: "A1");
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.Analysis.RouteAction(
+                AnalysisAction.GoalSeek,
+                "session-1",
+                (_, _, args) => JsonSerializer.Serialize(args),
+                sheetName: "Model",
+                formulaCell: "B1",
+                goal: null,
+                changingCell: "A1"));
 
-        using var routedJson = JsonDocument.Parse(routed);
-        Assert.Equal(JsonValueKind.Null, routedJson.RootElement.GetProperty("Goal").ValueKind);
+        Assert.Equal("goal", exception.ParamName);
     }
 }

--- a/tests/ExcelMcp.Core.Tests/Unit/ConditionalFormatAddRuleDeserializationTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/ConditionalFormatAddRuleDeserializationTests.cs
@@ -127,6 +127,22 @@ public sealed class ConditionalFormatAddRuleDeserializationTests
         Assert.Equal("", commands.SheetName);
     }
 
+    [Fact]
+    public void DispatchToCore_ListWorksheetRules_WithOmittedSheetName_IsRejected()
+    {
+        var commands = new CapturingConditionalFormattingCommands();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.ConditionalFormat.DispatchToCore(
+                commands,
+                ConditionalFormatAction.ListWorksheetRules,
+                null!,
+                "{}"));
+
+        Assert.Contains("sheetName", exception.Message, StringComparison.Ordinal);
+        Assert.False(commands.ListWorksheetRulesCalled);
+    }
+
     private sealed class CapturingConditionalFormattingCommands : IConditionalFormattingCommands
     {
         public bool AddRuleCalled { get; private set; }

--- a/tests/ExcelMcp.Core.Tests/Unit/GeneratedActionContractTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/GeneratedActionContractTests.cs
@@ -1,0 +1,660 @@
+using System.Reflection;
+using System.Text.Json;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Sbroenne.ExcelMcp.Core.Commands.Analysis;
+using Sbroenne.ExcelMcp.Core.Commands.Calculation;
+using Sbroenne.ExcelMcp.Core.Commands.Chart;
+using Sbroenne.ExcelMcp.Core.Commands.PivotTable;
+using Sbroenne.ExcelMcp.Core.Commands.XmlMap;
+using Sbroenne.ExcelMcp.Core.Models;
+using Sbroenne.ExcelMcp.Core.Utilities;
+using Sbroenne.ExcelMcp.Generated;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
+
+[Trait("Layer", "Core")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "GeneratedContracts")]
+[Trait("Speed", "Fast")]
+[Trait("RequiresExcel", "false")]
+public sealed class GeneratedActionContractTests
+{
+    [Theory]
+    [InlineData("worksheet", PowerQueryLoadMode.LoadToTable)]
+    [InlineData("TABLE", PowerQueryLoadMode.LoadToTable)]
+    [InlineData("data-model", PowerQueryLoadMode.LoadToDataModel)]
+    [InlineData("both", PowerQueryLoadMode.LoadToBoth)]
+    [InlineData("connection-only", PowerQueryLoadMode.ConnectionOnly)]
+    [InlineData("load-to-table", PowerQueryLoadMode.LoadToTable)]
+    public void PowerQueryDispatch_ParsesDocumentedLoadDestinationAliases(
+        string suppliedValue,
+        PowerQueryLoadMode expected)
+    {
+        var (commands, proxy) = CreateProxy<IPowerQueryCommands>();
+
+        ServiceRegistry.PowerQuery.DispatchToCore(
+            commands,
+            PowerQueryAction.LoadTo,
+            null!,
+            JsonSerializer.Serialize(new
+            {
+                queryName = "Probe",
+                loadDestination = suppliedValue
+            }));
+
+        Assert.Equal(1, proxy.CallCount);
+        Assert.Equal(expected, Assert.IsType<PowerQueryLoadMode>(proxy.LastArguments![2]));
+    }
+
+    [Theory]
+    [InlineData("not-a-destination")]
+    [InlineData("work_sheet")]
+    [InlineData("work-sheet")]
+    [InlineData("0")]
+    [InlineData("999")]
+    [InlineData("-1")]
+    public void PowerQueryDispatch_RejectsUnknownLoadDestinationBeforeCoreDispatch(string suppliedValue)
+    {
+        var (commands, proxy) = CreateProxy<IPowerQueryCommands>();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.PowerQuery.DispatchToCore(
+                commands,
+                PowerQueryAction.LoadTo,
+                null!,
+                JsonSerializer.Serialize(new { queryName = "Probe", loadDestination = suppliedValue })));
+
+        Assert.Contains("loadDestination", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, proxy.CallCount);
+    }
+
+    [Fact]
+    public void LegacyPowerQueryLoadModeParser_RejectsUnknownValue()
+    {
+        Assert.Equal(PowerQueryLoadMode.LoadToTable, ParameterTransforms.ParseLoadMode("worksheet"));
+        Assert.Throws<ArgumentException>(() => ParameterTransforms.ParseLoadMode("not-a-destination"));
+    }
+
+    [Theory]
+    [InlineData("set-mode", """{"mode":"not-a-mode"}""")]
+    [InlineData("calculate", """{"scope":"not-a-scope"}""")]
+    public void CalculationDispatch_RejectsUnknownEnumsBeforeCoreDispatch(string action, string argsJson)
+    {
+        var (commands, proxy) = CreateProxy<ICalculationModeCommands>();
+        Assert.True(ServiceRegistry.Calculation.TryParseAction(action, out var parsedAction));
+
+        Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.Calculation.DispatchToCore(commands, parsedAction, null!, argsJson));
+
+        Assert.Equal(0, proxy.CallCount);
+    }
+
+    [Fact]
+    public void AnalysisDispatch_RejectsUnknownScenarioSummaryTypeBeforeCoreDispatch()
+    {
+        var (commands, proxy) = CreateProxy<IAnalysisCommands>();
+
+        Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.Analysis.DispatchToCore(
+                commands,
+                AnalysisAction.CreateScenarioSummary,
+                null!,
+                """{"sheetName":"Model","reportType":"not-a-report"}"""));
+
+        Assert.Equal(0, proxy.CallCount);
+    }
+
+    [Fact]
+    public void ChartDispatch_RejectsUnknownChartTypeBeforeCoreDispatch()
+    {
+        var (commands, proxy) = CreateProxy<IChartCommands>();
+
+        Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.Chart.DispatchToCore(
+                commands,
+                ChartAction.CreateFromRange,
+                null!,
+                """{"sheetName":"Model","sourceRangeAddress":"A1:B2","chartType":"not-a-chart"}"""));
+
+        Assert.Equal(0, proxy.CallCount);
+    }
+
+    [Fact]
+    public void PivotTableDispatch_RejectsUnknownNullableEnumBeforeCoreDispatch()
+    {
+        var (commands, proxy) = CreateProxy<IPivotTableCommands>();
+
+        Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.PivotTable.DispatchToCore(
+                commands,
+                PivotTableAction.SetCacheOptions,
+                null!,
+                """{"pivotTableName":"PivotTable1","missingItemsLimit":"not-a-limit"}"""));
+
+        Assert.Equal(0, proxy.CallCount);
+    }
+
+    [Theory]
+    [InlineData("calculate", "mode", "manual")]
+    [InlineData("get-mode", "mode", "manual")]
+    public void CalculationCliRoute_RejectsParametersFromOtherActions(
+        string action,
+        string parameterName,
+        string parameterValue)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.Calculation.RouteCliArgs(
+                action,
+                mode: parameterValue,
+                scope: action == "calculate" ? "workbook" : null));
+
+        Assert.Contains(parameterName, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(action, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PowerQueryCliRoute_RejectsParametersFromOtherActions()
+    {
+        var deleteException = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.PowerQuery.RouteCliArgs(
+                "delete",
+                queryName: "Probe",
+                mCode: "let Source = 1 in Source"));
+        Assert.Contains("mCode", deleteException.Message, StringComparison.Ordinal);
+
+        var loadToException = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.PowerQuery.RouteCliArgs(
+                "load-to",
+                queryName: "Probe",
+                loadDestination: "worksheet",
+                timeout: 30));
+        Assert.Contains("timeout", loadToException.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PowerQueryCliRoute_DoesNotTreatOmittedActionDefaultsAsSupplied()
+    {
+        var route = ServiceRegistry.PowerQuery.RouteCliArgs("delete", queryName: "Probe");
+
+        Assert.Equal("powerquery.delete", route.Command);
+    }
+
+    [Theory]
+    [InlineData("worksheet")]
+    [InlineData("WORKSHEET")]
+    [InlineData("data-model")]
+    [InlineData("DATA-MODEL")]
+    public void PowerQueryCliRoute_AcceptsExactAliasesIgnoringCase(string suppliedValue)
+    {
+        var route = ServiceRegistry.PowerQuery.RouteCliArgs(
+            "load-to",
+            queryName: "Probe",
+            loadDestination: suppliedValue);
+
+        Assert.Equal("powerquery.load-to", route.Command);
+    }
+
+    [Fact]
+    public void RawActionValidation_RejectsActionInapplicableExplicitNull()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.ValidateCommandArguments(
+                "calculation.calculate",
+                """{"scope":"workbook","mode":null}"""));
+
+        Assert.Contains("mode", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("calculate", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("""{"sheetName":null,"rangeAddress":"A1"}""")]
+    [InlineData("""{"sheetName":42,"rangeAddress":"A1"}""")]
+    [InlineData("""{"sheetName":true,"rangeAddress":"A1"}""")]
+    public void AllowEmptyRequiredString_RejectsNonStringJsonBeforeCoreDispatch(
+        string argsJson)
+    {
+        var (commands, proxy) = CreateProxy<IConditionalFormattingCommands>();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.ConditionalFormat.DispatchToCore(
+                commands,
+                ConditionalFormatAction.ClearRules,
+                null!,
+                argsJson));
+
+        Assert.Contains("sheetName", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("JSON string", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, proxy.CallCount);
+    }
+
+    [Fact]
+    public void AllowEmptyRequiredString_AcceptsEmptyJsonString()
+    {
+        var (commands, proxy) = CreateProxy<IConditionalFormattingCommands>();
+
+        ServiceRegistry.ConditionalFormat.DispatchToCore(
+            commands,
+            ConditionalFormatAction.ClearRules,
+            null!,
+            """{"sheetName":"","rangeAddress":"A1"}""");
+
+        Assert.Equal(1, proxy.CallCount);
+        Assert.Equal(string.Empty, proxy.LastArguments![1]);
+    }
+
+    [Theory]
+    [InlineData(
+        "powerquery.refresh",
+        """{"queryName":"Probe","Timeout":60}""",
+        "Timeout")]
+    [InlineData(
+        "powerquery.evaluate",
+        """{"MCodeFile":"query.m"}""",
+        "MCodeFile")]
+    [InlineData(
+        "vba.import",
+        """{"moduleName":"Module1","VbaCodeFile":"module.bas"}""",
+        "VbaCodeFile")]
+    [InlineData(
+        "datamodel.create-measure",
+        """{"tableName":"Sales","measureName":"Total","DaxFormulaFile":"measure.dax"}""",
+        "DaxFormulaFile")]
+    [InlineData(
+        "datamodel.evaluate",
+        """{"DaxQueryFile":"query.dax"}""",
+        "DaxQueryFile")]
+    [InlineData(
+        "datamodel.execute-dmv",
+        """{"DmvQueryFile":"query.dmv"}""",
+        "DmvQueryFile")]
+    [InlineData(
+        "xmlmap.add",
+        """{"SchemaFile":"schema.xsd"}""",
+        "SchemaFile")]
+    [InlineData(
+        "xmlmap.import-xml",
+        """{"XmlDataFile":"data.xml"}""",
+        "XmlDataFile")]
+    public void RawActionValidation_RejectsNonCanonicalPropertyCasing(
+        string command,
+        string argsJson,
+        string suppliedProperty)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.ValidateCommandArguments(command, argsJson));
+
+        Assert.Contains(suppliedProperty, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("""{"queryName":"Probe","Timeout":null}""", "Timeout")]
+    [InlineData("""{"queryName":"Probe","unexpected":null}""", "unexpected")]
+    public void RawActionValidation_RejectsInvalidNullPropertyNames(
+        string argsJson,
+        string suppliedProperty)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.ValidateCommandArguments("powerquery.refresh", argsJson));
+
+        Assert.Contains(suppliedProperty, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileOrValueDispatch_ResolvesEveryGeneratedFileAlias()
+    {
+        var path = Path.GetTempFileName();
+        const string content = "canonical file content";
+        File.WriteAllText(path, content);
+
+        try
+        {
+            AssertResolvedFileArgument<IPowerQueryCommands, PowerQueryAction>(
+                ServiceRegistry.PowerQuery.DispatchToCore,
+                PowerQueryAction.Evaluate,
+                JsonSerializer.Serialize(new { mCodeFile = path }),
+                expectedArgumentIndex: 1,
+                content);
+            AssertResolvedFileArgument<IVbaCommands, VbaAction>(
+                ServiceRegistry.Vba.DispatchToCore,
+                VbaAction.Import,
+                JsonSerializer.Serialize(new { moduleName = "Module1", vbaCodeFile = path }),
+                expectedArgumentIndex: 2,
+                content);
+            AssertResolvedFileArgument<IDataModelCommands, DataModelAction>(
+                ServiceRegistry.DataModel.DispatchToCore,
+                DataModelAction.CreateMeasure,
+                JsonSerializer.Serialize(new
+                {
+                    tableName = "Sales",
+                    measureName = "Total",
+                    daxFormulaFile = path
+                }),
+                expectedArgumentIndex: 3,
+                content);
+            AssertResolvedFileArgument<IDataModelCommands, DataModelAction>(
+                ServiceRegistry.DataModel.DispatchToCore,
+                DataModelAction.Evaluate,
+                JsonSerializer.Serialize(new { daxQueryFile = path }),
+                expectedArgumentIndex: 1,
+                content);
+            AssertResolvedFileArgument<IDataModelCommands, DataModelAction>(
+                ServiceRegistry.DataModel.DispatchToCore,
+                DataModelAction.ExecuteDmv,
+                JsonSerializer.Serialize(new { dmvQueryFile = path }),
+                expectedArgumentIndex: 1,
+                content);
+            AssertResolvedFileArgument<IXmlMapCommands, XmlMapAction>(
+                ServiceRegistry.XmlMap.DispatchToCore,
+                XmlMapAction.Add,
+                JsonSerializer.Serialize(new { schemaFile = path }),
+                expectedArgumentIndex: 1,
+                content);
+            AssertResolvedFileArgument<IXmlMapCommands, XmlMapAction>(
+                ServiceRegistry.XmlMap.DispatchToCore,
+                XmlMapAction.ImportXml,
+                JsonSerializer.Serialize(new { xmlDataFile = path }),
+                expectedArgumentIndex: 1,
+                content);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void FileOrValueDispatch_RejectsConflictingInlineAndFileInputs()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var (commands, proxy) = CreateProxy<IPowerQueryCommands>();
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                ServiceRegistry.PowerQuery.DispatchToCore(
+                    commands,
+                    PowerQueryAction.Evaluate,
+                    null!,
+                    JsonSerializer.Serialize(new
+                    {
+                        mCode = "let Source = 1 in Source",
+                        mCodeFile = path
+                    })));
+
+            Assert.Contains("mCode", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("mCodeFile", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(0, proxy.CallCount);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void FileOrValueDispatch_RejectsMissingRequiredInput()
+    {
+        var (commands, proxy) = CreateProxy<IPowerQueryCommands>();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.PowerQuery.DispatchToCore(
+                commands,
+                PowerQueryAction.Evaluate,
+                null!,
+                "{}"));
+
+        Assert.Contains("mCode", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, proxy.CallCount);
+    }
+
+    [Fact]
+    public void FileOrValueDispatch_AllowsNeitherForOptionalInput()
+    {
+        var (commands, proxy) = CreateProxy<IDataModelCommands>();
+
+        ServiceRegistry.DataModel.DispatchToCore(
+            commands,
+            DataModelAction.UpdateMeasure,
+            null!,
+            """{"measureName":"Total","description":"Updated"}""");
+
+        Assert.Equal(1, proxy.CallCount);
+        Assert.Null(proxy.LastArguments![2]);
+    }
+
+    [Fact]
+    public void FileOrValueDispatch_RejectsMissingAndUnreadableFiles()
+    {
+        var missingPath = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}.m");
+        var (missingCommands, missingProxy) = CreateProxy<IPowerQueryCommands>();
+        Assert.Throws<FileNotFoundException>(() =>
+            ServiceRegistry.PowerQuery.DispatchToCore(
+                missingCommands,
+                PowerQueryAction.Evaluate,
+                null!,
+                JsonSerializer.Serialize(new { mCodeFile = missingPath })));
+        Assert.Equal(0, missingProxy.CallCount);
+
+        var unreadablePath = Path.GetTempFileName();
+        try
+        {
+            using var lockStream = new FileStream(
+                unreadablePath,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None);
+            var (unreadableCommands, unreadableProxy) = CreateProxy<IPowerQueryCommands>();
+            Assert.Throws<IOException>(() =>
+                ServiceRegistry.PowerQuery.DispatchToCore(
+                    unreadableCommands,
+                    PowerQueryAction.Evaluate,
+                    null!,
+                    JsonSerializer.Serialize(new { mCodeFile = unreadablePath })));
+            Assert.Equal(0, unreadableProxy.CallCount);
+        }
+        finally
+        {
+            File.Delete(unreadablePath);
+        }
+    }
+
+    [Fact]
+    public void RawDispatch_ConvertsIntegerTimeoutSecondsExactlyOnce()
+    {
+        var (powerQueryCommands, powerQueryProxy) = CreateProxy<IPowerQueryCommands>();
+        ServiceRegistry.PowerQuery.DispatchToCore(
+            powerQueryCommands,
+            PowerQueryAction.Refresh,
+            null!,
+            """{"queryName":"Probe","timeout":0}""");
+        Assert.Equal(TimeSpan.Zero, Assert.IsType<TimeSpan>(powerQueryProxy.LastArguments![2]));
+
+        var (connectionCommands, connectionProxy) = CreateProxy<IConnectionCommands>();
+        ServiceRegistry.Connection.DispatchToCore(
+            connectionCommands,
+            ConnectionAction.Refresh,
+            null!,
+            """{"connectionName":"Probe","timeout":1}""");
+        Assert.Equal(TimeSpan.FromSeconds(1), Assert.IsType<TimeSpan>(connectionProxy.LastArguments![2]));
+
+        var (dataModelCommands, dataModelProxy) = CreateProxy<IDataModelCommands>();
+        ServiceRegistry.DataModel.DispatchToCore(
+            dataModelCommands,
+            DataModelAction.Refresh,
+            null!,
+            """{"timeout":2147483}""");
+        Assert.Equal(TimeSpan.FromSeconds(2147483), Assert.IsType<TimeSpan>(dataModelProxy.LastArguments![2]));
+
+        var (pivotCommands, pivotProxy) = CreateProxy<IPivotTableCommands>();
+        ServiceRegistry.PivotTable.DispatchToCore(
+            pivotCommands,
+            PivotTableAction.Refresh,
+            null!,
+            """{"pivotTableName":"Probe","timeout":60}""");
+        Assert.Equal(TimeSpan.FromSeconds(60), Assert.IsType<TimeSpan>(pivotProxy.LastArguments![2]));
+
+        var (vbaCommands, vbaProxy) = CreateProxy<IVbaCommands>();
+        ServiceRegistry.Vba.DispatchToCore(
+            vbaCommands,
+            VbaAction.Run,
+            null!,
+            """{"procedureName":"Probe","timeout":2147483}""");
+        Assert.Equal(TimeSpan.FromSeconds(2147483), Assert.IsType<TimeSpan>(vbaProxy.LastArguments![2]));
+    }
+
+    [Theory]
+    [InlineData("""{"queryName":"Probe","timeout":-1}""")]
+    [InlineData("""{"queryName":"Probe","timeout":2147484}""")]
+    [InlineData("""{"queryName":"Probe","timeout":"600"}""")]
+    public void RawDispatch_RejectsInvalidTimeoutSecondsBeforeCoreDispatch(string argsJson)
+    {
+        var (commands, proxy) = CreateProxy<IPowerQueryCommands>();
+
+        Assert.ThrowsAny<Exception>(() =>
+            ServiceRegistry.PowerQuery.DispatchToCore(
+                commands,
+                PowerQueryAction.Refresh,
+                null!,
+                argsJson));
+
+        Assert.Equal(0, proxy.CallCount);
+    }
+
+    [Fact]
+    public void RawDispatch_PreservesMissingAndZeroTimeoutSemantics()
+    {
+        var (powerQueryCommands, powerQueryProxy) = CreateProxy<IPowerQueryCommands>();
+        ServiceRegistry.PowerQuery.DispatchToCore(
+            powerQueryCommands,
+            PowerQueryAction.Refresh,
+            null!,
+            """{"queryName":"Probe"}""");
+        Assert.Equal(TimeSpan.Zero, Assert.IsType<TimeSpan>(powerQueryProxy.LastArguments![2]));
+
+        var (connectionCommands, connectionProxy) = CreateProxy<IConnectionCommands>();
+        ServiceRegistry.Connection.DispatchToCore(
+            connectionCommands,
+            ConnectionAction.Refresh,
+            null!,
+            """{"connectionName":"Probe"}""");
+        Assert.Null(connectionProxy.LastArguments![2]);
+    }
+
+    [Fact]
+    public void RawDispatch_RejectsZeroForNonPowerQueryTimeouts()
+    {
+        var (connectionCommands, connectionProxy) = CreateProxy<IConnectionCommands>();
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ServiceRegistry.Connection.DispatchToCore(
+                connectionCommands,
+                ConnectionAction.Refresh,
+                null!,
+                """{"connectionName":"Probe","timeout":0}"""));
+        Assert.Equal(0, connectionProxy.CallCount);
+
+        var (dataModelCommands, dataModelProxy) = CreateProxy<IDataModelCommands>();
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ServiceRegistry.DataModel.DispatchToCore(
+                dataModelCommands,
+                DataModelAction.Refresh,
+                null!,
+                """{"timeout":0}"""));
+        Assert.Equal(0, dataModelProxy.CallCount);
+    }
+
+    [Fact]
+    public void GeneratedRoutes_RejectOutOfRangeTimeoutsBeforeForwarding()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ServiceRegistry.PowerQuery.RouteCliArgs(
+                "refresh",
+                queryName: "Probe",
+                timeout: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ServiceRegistry.Connection.RouteCliArgs(
+                "refresh",
+                connectionName: "Probe",
+                timeout: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ServiceRegistry.Vba.RouteCliArgs(
+                "run",
+                procedureName: "Probe",
+                timeout: ParameterTransforms.MaximumTimeoutSeconds + 1));
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(3600)]
+    public void SessionTimeoutValidation_AcceptsDocumentedBoundaries(int timeoutSeconds)
+    {
+        Assert.Equal(
+            TimeSpan.FromSeconds(timeoutSeconds),
+            ParameterTransforms.ParseTimeoutSeconds(
+                timeoutSeconds,
+                "timeoutSeconds",
+                minimumSeconds: 10,
+                maximumSeconds: 3600));
+    }
+
+    [Fact]
+    public void GeneratedPublicTimeoutContract_UsesNullableIntegerSeconds()
+    {
+        var routeParameter = typeof(ServiceRegistry.PowerQuery)
+            .GetMethod(nameof(ServiceRegistry.PowerQuery.RouteCliArgs))!
+            .GetParameters()
+            .Single(parameter => parameter.Name == "timeout");
+        var actionParameter = typeof(ServiceRegistry.PowerQuery)
+            .GetMethod(nameof(ServiceRegistry.PowerQuery.RouteAction))!
+            .GetParameters()
+            .Single(parameter => parameter.Name == "timeout");
+
+        Assert.Equal(typeof(int?), routeParameter.ParameterType);
+        Assert.Equal(typeof(int?), actionParameter.ParameterType);
+    }
+
+    private static void AssertResolvedFileArgument<TInterface, TAction>(
+        Func<TInterface, TAction, IExcelBatch, string?, string?> dispatch,
+        TAction action,
+        string argsJson,
+        int expectedArgumentIndex,
+        string expectedContent)
+        where TInterface : class
+        where TAction : struct, Enum
+    {
+        var (commands, proxy) = CreateProxy<TInterface>();
+
+        dispatch(commands, action, null!, argsJson);
+
+        Assert.Equal(1, proxy.CallCount);
+        Assert.Equal(expectedContent, proxy.LastArguments![expectedArgumentIndex]);
+    }
+
+    private static (TInterface Commands, RecordingDispatchProxy Proxy) CreateProxy<TInterface>()
+        where TInterface : class
+    {
+        var commands = DispatchProxy.Create<TInterface, RecordingDispatchProxy>();
+        return (commands, (RecordingDispatchProxy)(object)commands);
+    }
+
+    public class RecordingDispatchProxy : DispatchProxy
+    {
+        public int CallCount { get; private set; }
+
+        public object?[]? LastArguments { get; private set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            CallCount++;
+            LastArguments = args;
+
+            if (targetMethod == null || targetMethod.ReturnType == typeof(void))
+            {
+                return null;
+            }
+
+            return Activator.CreateInstance(targetMethod.ReturnType);
+        }
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Unit/PowerQueryIdentityParsingTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/PowerQueryIdentityParsingTests.cs
@@ -1,0 +1,49 @@
+using Sbroenne.ExcelMcp.Core.PowerQuery;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
+
+public class PowerQueryIdentityParsingTests
+{
+    [Theory]
+    [InlineData("OLEDB;Provider=Microsoft.Mashup.OleDb.1;Location=A", "a")]
+    [InlineData("OLEDB;provider=microsoft.mashup.oledb.1;location=\"A;B\"", "a;b")]
+    [InlineData("OLEDB;Provider=Microsoft.Mashup.OleDb.1;Location='A''B'", "a'b")]
+    [InlineData("OLEDB;Provider=Microsoft.Mashup.OleDb.1;Location=Bob's Query;Extended Properties=\"\"", "bob's query")]
+    [InlineData("OLEDB;Provider=Microsoft.Mashup.OleDb.1;Location=A\0", "a")]
+    public void MatchesMashupLocation_ExactCaseInsensitiveLocation_ReturnsTrue(
+        string connectionString,
+        string queryName)
+    {
+        Assert.True(PowerQueryHelpers.MatchesMashupLocation(connectionString, queryName));
+    }
+
+    [Theory]
+    [InlineData("OLEDB;Provider=Microsoft.Mashup.OleDb.1;Location=AA", "A")]
+    [InlineData("OLEDB;Provider=Other.Provider;Location=A", "A")]
+    [InlineData("OLEDB;Provider=Microsoft.Mashup.OleDb.1;Other=A", "A")]
+    public void MatchesMashupLocation_DifferentIdentity_ReturnsFalse(
+        string connectionString,
+        string queryName)
+    {
+        Assert.False(PowerQueryHelpers.MatchesMashupLocation(connectionString, queryName));
+    }
+
+    [Fact]
+    public void TryReplaceMashupLocation_ExactQuotedLocation_PreservesOtherProperties()
+    {
+        const string connectionString =
+            "OLEDB;Provider=Microsoft.Mashup.OleDb.1;Location=\"A;Old\";Extended Properties=\"Keep;This\"";
+
+        var replaced = PowerQueryHelpers.TryReplaceMashupLocation(
+            connectionString,
+            "a;old",
+            "A;New",
+            out var updatedConnectionString);
+
+        Assert.True(replaced);
+        Assert.Equal(
+            "OLEDB;Provider=Microsoft.Mashup.OleDb.1;Location=\"A;New\";Extended Properties=\"Keep;This\"",
+            updatedConnectionString);
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Unit/PowerQueryInfoCompatibilityTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/PowerQueryInfoCompatibilityTests.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sbroenne.ExcelMcp.Core.Models;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
+
+[Trait("Layer", "Core")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "PowerQuery")]
+[Trait("RequiresExcel", "false")]
+[Trait("Speed", "Fast")]
+public sealed class PowerQueryInfoCompatibilityTests
+{
+    [Fact]
+    public void Formula_SourceContractRemainsReadWrite()
+    {
+#pragma warning disable CS0618
+        var query = new PowerQueryInfo
+        {
+            Formula = "let Source = 1 in Source"
+        };
+
+        Assert.Equal("let Source = 1 in Source", query.Formula);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void Formula_RemainsPublicReadWriteAndObsoleteForBinaryCompatibility()
+    {
+        var property = typeof(PowerQueryInfo).GetProperty(
+            "Formula",
+            BindingFlags.Instance | BindingFlags.Public);
+
+        Assert.NotNull(property);
+        Assert.Equal(typeof(string), property.PropertyType);
+        Assert.True(property.CanRead);
+        Assert.True(property.CanWrite);
+        Assert.NotNull(property.GetMethod);
+        Assert.NotNull(property.SetMethod);
+        Assert.NotNull(property.GetCustomAttribute<ObsoleteAttribute>());
+        Assert.NotNull(property.GetCustomAttribute<JsonIgnoreAttribute>());
+
+        var query = new PowerQueryInfo();
+        property.SetValue(query, "let Source = 1 in Source");
+        Assert.Equal("let Source = 1 in Source", property.GetValue(query));
+    }
+
+    [Fact]
+    public void Formula_IsOmittedFromListJsonEvenWhenPopulated()
+    {
+        var property = typeof(PowerQueryInfo).GetProperty("Formula");
+        Assert.NotNull(property);
+        var query = new PowerQueryInfo
+        {
+            Name = "Compatibility",
+            FormulaPreview = "let Source = 1 in Source",
+            CharacterCount = 24
+        };
+        property.SetValue(query, "let Source = 1 in Source");
+
+        var json = JsonSerializer.Serialize(
+            new PowerQueryListResult
+            {
+                Success = true,
+                Queries = [query]
+            },
+            JsonSerializerOptions.Web);
+
+        using var document = JsonDocument.Parse(json);
+        var serializedQuery = Assert.Single(
+            document.RootElement.GetProperty("queries").EnumerateArray());
+        Assert.False(serializedQuery.TryGetProperty("formula", out _));
+        Assert.Equal(
+            "let Source = 1 in Source",
+            serializedQuery.GetProperty("formulaPreview").GetString());
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/ExcelMcp.McpServer.Tests.csproj
+++ b/tests/ExcelMcp.McpServer.Tests/ExcelMcp.McpServer.Tests.csproj
@@ -38,6 +38,10 @@
     <ProjectReference Include="..\..\src\ExcelMcp.CLI\ExcelMcp.CLI.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\OleDataSpaceTestFile.cs" Link="Helpers\OleDataSpaceTestFile.cs" />
+  </ItemGroup>
+
   <!-- Golden files for API contract tests -->
   <ItemGroup>
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/ExcelMcp.McpServer.Tests/Integration/McpToolSurfaceTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/McpToolSurfaceTests.cs
@@ -32,7 +32,7 @@ public class McpToolSurfaceTests(ITestOutputHelper output)
     private const int ExpectedToolCount = 31;
 
     /// <summary>Sum of the <c>action</c> enum values across all registered tools.</summary>
-    private const int ExpectedOperationCount = 326;
+    private const int ExpectedOperationCount = 325;
 
     [Fact]
     public void ToolSurface_MatchesDocumentedGroundTruth()

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolTests.cs
@@ -19,11 +19,6 @@ namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
 [Trait("Feature", "File")]
 public class ExcelFileToolTests(ITestOutputHelper output)
 {
-    private static readonly byte[] Ole2Signature =
-    [
-        0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1
-    ];
-
     [Fact]
     public void Create_MissingDirectory_ReturnsJsonError()
     {
@@ -193,15 +188,19 @@ public class ExcelFileToolTests(ITestOutputHelper output)
         Assert.False(json.GetProperty("exists").GetBoolean());
     }
 
-    [Fact]
-    public void Test_IrmSignatureFile_ReturnsIrmMetadata()
+    [Theory]
+    [InlineData("\tDRMDataSpace")]
+    [InlineData("DRMEncryptedDataSpace")]
+    public void Test_IrmDataSpaceFile_ReturnsIrmMetadata(string dataSpaceName)
     {
         // Arrange
         var tempPath = Path.Join(Path.GetTempPath(), $"ExcelFileTool_Irm_{Guid.NewGuid():N}.xlsx");
 
         try
         {
-            File.WriteAllBytes(tempPath, Ole2Signature);
+            Sbroenne.ExcelMcp.Tests.Helpers.OleDataSpaceTestFile.Write(
+                tempPath,
+                dataSpaceName);
 
             // Act
             var result = ExcelFileTool.ExcelFile(
@@ -216,11 +215,14 @@ public class ExcelFileToolTests(ITestOutputHelper output)
 
             // Assert
             var json = JsonDocument.Parse(result).RootElement;
-            Assert.True(json.GetProperty("success").GetBoolean());
+            Assert.False(json.GetProperty("success").GetBoolean());
             Assert.True(json.GetProperty("exists").GetBoolean());
-            Assert.True(json.GetProperty("isValid").GetBoolean());
+            Assert.False(json.GetProperty("isValid").GetBoolean());
+            Assert.False(json.GetProperty("canOpen").GetBoolean());
             Assert.True(json.GetProperty("isIrmProtected").GetBoolean());
-            Assert.False(json.TryGetProperty("isError", out _));
+            Assert.True(json.GetProperty("willOpenReadOnly").GetBoolean());
+            Assert.True(json.GetProperty("requiresVisibleSession").GetBoolean());
+            Assert.True(json.GetProperty("isError").GetBoolean());
         }
         finally
         {
@@ -231,6 +233,3 @@ public class ExcelFileToolTests(ITestOutputHelper output)
         }
     }
 }
-
-
-

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/FileLifecycleContractProtocolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/FileLifecycleContractProtocolTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.Core.Models.Actions;
+using Sbroenne.ExcelMcp.McpServer.Tools;
+using Xunit;
+using Xunit.Abstractions;
+using ExcelServiceBridge = Sbroenne.ExcelMcp.McpServer.ServiceBridge.ServiceBridge;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "File")]
+[Trait("RequiresExcel", "false")]
+public sealed class FileLifecycleContractProtocolTests : McpIntegrationTestBase
+{
+    public FileLifecycleContractProtocolTests(ITestOutputHelper output)
+        : base(output, "FileLifecycleContractProtocolClient")
+    {
+    }
+
+    [Fact]
+    public async Task ListTools_FileSchema_ExposesOnlyCanonicalLifecycleActions()
+    {
+        var tools = await Client!.ListToolsAsync(cancellationToken: TestCancellationToken);
+        var fileTool = Assert.Single(tools, tool => tool.Name == "file");
+        var actions = fileTool.JsonSchema
+            .GetProperty("properties")
+            .GetProperty("action")
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(value => value.GetString()!)
+            .ToArray();
+
+        Assert.Equal(["list", "open", "close", "create", "test"], actions);
+        Assert.DoesNotContain("close-workbook", actions);
+    }
+
+    [Fact]
+    public async Task FileCloseWorkbook_IsRejectedInsteadOfReportingNoOpSuccess()
+    {
+        var result = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "close-workbook",
+            ["path"] = @"C:\tmp\book.xlsx"
+        });
+
+        Output.WriteLine(result);
+        Assert.DoesNotContain("\"success\":true", result, StringComparison.OrdinalIgnoreCase);
+        Assert.False(string.IsNullOrWhiteSpace(result));
+    }
+
+    [Fact]
+    public async Task FileTest_UsesTheSharedServiceResultShape()
+    {
+        var path = Path.Join(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.xlsx");
+        var serviceResponse = await ExcelServiceBridge.TestFileAsync(path);
+        var toolResult = ExcelFileTool.ExcelFile(
+            FileAction.Test,
+            path,
+            session_id: null,
+            save: false,
+            show: false,
+            timeout_seconds: 120);
+
+        Assert.True(serviceResponse.Success);
+        Assert.NotNull(serviceResponse.Result);
+        Assert.Equal(serviceResponse.Result, toolResult);
+        using var json = JsonDocument.Parse(toolResult);
+        Assert.False(json.RootElement.GetProperty("canOpen").GetBoolean());
+        Assert.False(json.RootElement.GetProperty("willOpenReadOnly").GetBoolean());
+        Assert.False(json.RootElement.GetProperty("requiresVisibleSession").GetBoolean());
+    }
+
+    [Fact]
+    public async Task FileTest_RelativePath_UsesSharedValidationError()
+    {
+        const string path = @"relative\book.xlsx";
+        var serviceResponse = await ExcelServiceBridge.TestFileAsync(path);
+        var toolResult = ExcelFileTool.ExcelFile(
+            FileAction.Test,
+            path,
+            session_id: null,
+            save: false,
+            show: false,
+            timeout_seconds: 120);
+
+        Assert.False(serviceResponse.Success);
+        Assert.Contains("absolute Windows path", serviceResponse.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        using var json = JsonDocument.Parse(toolResult);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(serviceResponse.ErrorMessage, json.RootElement.GetProperty("errorMessage").GetString());
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/FileLifecycleContractProtocolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/FileLifecycleContractProtocolTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using Sbroenne.ExcelMcp.Core.Models.Actions;
 using Sbroenne.ExcelMcp.McpServer.Tools;
 using Xunit;
@@ -40,15 +41,16 @@ public sealed class FileLifecycleContractProtocolTests : McpIntegrationTestBase
     [Fact]
     public async Task FileCloseWorkbook_IsRejectedInsteadOfReportingNoOpSuccess()
     {
-        var result = await CallToolAsync("file", new Dictionary<string, object?>
+        var result = await Client!.CallToolAsync("file", new Dictionary<string, object?>
         {
             ["action"] = "close-workbook",
             ["path"] = @"C:\tmp\book.xlsx"
-        });
+        }, cancellationToken: TestCancellationToken);
 
-        Output.WriteLine(result);
-        Assert.DoesNotContain("\"success\":true", result, StringComparison.OrdinalIgnoreCase);
-        Assert.False(string.IsNullOrWhiteSpace(result));
+        Assert.True(result.IsError);
+        var response = Assert.Single(result.Content.OfType<TextContentBlock>()).Text;
+        Output.WriteLine(response);
+        Assert.False(string.IsNullOrWhiteSpace(response));
     }
 
     [Fact]

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeneratedActionContractProtocolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeneratedActionContractProtocolTests.cs
@@ -1,0 +1,451 @@
+using Xunit;
+using Xunit.Abstractions;
+using ExcelServiceBridge = Sbroenne.ExcelMcp.McpServer.ServiceBridge.ServiceBridge;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "GeneratedContracts")]
+[Trait("RequiresExcel", "false")]
+public sealed class GeneratedActionContractProtocolTests : McpIntegrationTestBase
+{
+    public GeneratedActionContractProtocolTests(ITestOutputHelper output)
+        : base(output, "GeneratedActionContractProtocolClient")
+    {
+    }
+
+    [Theory]
+    [InlineData("calculation_mode", "calculate", "mode", "mode", "manual")]
+    [InlineData("powerquery", "delete", "m_code", "mCode", "let Source = 1 in Source")]
+    [InlineData("powerquery", "delete", "m_code_file", "mCodeFile", "missing-query.pq")]
+    public async Task ToolCall_RejectsParameterFromAnotherActionWithStructuredJson(
+        string toolName,
+        string action,
+        string invalidParameter,
+        string expectedErrorParameter,
+        string invalidValue)
+    {
+        var arguments = new Dictionary<string, object?>
+        {
+            ["action"] = action,
+            ["session_id"] = "missing-session",
+            [invalidParameter] = invalidValue
+        };
+        if (action == "calculate")
+        {
+            arguments["scope"] = "workbook";
+        }
+        else
+        {
+            arguments["query_name"] = "Probe";
+        }
+
+        var result = await CallToolAsync(toolName, arguments);
+
+        using var document = ParseJsonResult(result, $"{toolName}.{action}");
+        AssertFailureEnvelope(
+            document.RootElement,
+            $"{toolName}.{action}",
+            nameof(ArgumentException),
+            expectedErrorCategory: "InvalidInput");
+        Assert.Contains(expectedErrorParameter, document.RootElement.GetProperty("errorMessage").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("session", document.RootElement.GetProperty("errorMessage").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ToolCall_RejectsExplicitNullParameterFromAnotherAction()
+    {
+        var result = await CallToolAsync(
+            "calculation_mode",
+            new Dictionary<string, object?>
+            {
+                ["action"] = "calculate",
+                ["session_id"] = "missing-session",
+                ["scope"] = "workbook",
+                ["mode"] = null
+            });
+
+        using var document = ParseJsonResult(result, "calculation.calculate");
+        AssertFailureEnvelope(
+            document.RootElement,
+            "calculation.calculate",
+            nameof(ArgumentException),
+            expectedErrorCategory: "InvalidInput");
+        Assert.Contains(
+            "mode",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "session",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ToolCall_AllowEmptyRequiredStringRejectsExplicitNullBeforeDispatch()
+    {
+        var result = await CallToolAsync(
+            "conditionalformat",
+            new Dictionary<string, object?>
+            {
+                ["action"] = "clear-rules",
+                ["session_id"] = "missing-session",
+                ["sheet_name"] = null,
+                ["range_address"] = "A1"
+            });
+
+        using var document = ParseJsonResult(result, "conditionalformat.clear-rules");
+        AssertFailureEnvelope(
+            document.RootElement,
+            "conditionalformat.clear-rules",
+            nameof(ArgumentException),
+            expectedErrorCategory: "InvalidInput");
+        Assert.Contains(
+            "sheetName",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "session",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(42)]
+    [InlineData(true)]
+    public async Task ToolCall_AllowEmptyRequiredStringRejectsNonStringBeforeDispatch(
+        object invalidValue)
+    {
+        var result = await CallToolAsync(
+            "conditionalformat",
+            new Dictionary<string, object?>
+            {
+                ["action"] = "clear-rules",
+                ["session_id"] = "missing-session",
+                ["sheet_name"] = invalidValue,
+                ["range_address"] = "A1"
+            });
+
+        Assert.Contains("error", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("conditionalformat", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("session", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ToolCall_AllowEmptyRequiredStringAcceptsEmptyStringBeforeDispatch()
+    {
+        var result = await CallToolAsync(
+            "conditionalformat",
+            new Dictionary<string, object?>
+            {
+                ["action"] = "clear-rules",
+                ["session_id"] = "missing-session",
+                ["sheet_name"] = string.Empty,
+                ["range_address"] = "A1"
+            });
+
+        using var document = ParseJsonResult(result, "conditionalformat.clear-rules");
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains(
+            "session",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "sheetName",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("powerquery", "load-to", "load_destination", "loadDestination", "not-a-destination")]
+    [InlineData("powerquery", "load-to", "load_destination", "loadDestination", "work_sheet")]
+    [InlineData("powerquery", "load-to", "load_destination", "loadDestination", "work-sheet")]
+    [InlineData("powerquery", "load-to", "load_destination", "loadDestination", "0")]
+    [InlineData("chart", "create-from-range", "chart_type", "chartType", "not-a-chart")]
+    public async Task ToolCall_RejectsUnknownEnumWithStructuredJson(
+        string toolName,
+        string action,
+        string enumParameter,
+        string expectedErrorParameter,
+        string invalidValue)
+    {
+        var arguments = new Dictionary<string, object?>
+        {
+            ["action"] = action,
+            ["session_id"] = "missing-session",
+            [enumParameter] = invalidValue
+        };
+        if (toolName == "powerquery")
+        {
+            arguments["query_name"] = "Probe";
+        }
+        else
+        {
+            arguments["sheet_name"] = "Model";
+            arguments["source_range_address"] = "A1:B2";
+        }
+
+        var result = await CallToolAsync(toolName, arguments);
+
+        using var document = ParseJsonResult(result, $"{toolName}.{action}");
+        AssertFailureEnvelope(
+            document.RootElement,
+            $"{toolName}.{action}",
+            nameof(ArgumentException),
+            expectedErrorCategory: "InvalidInput");
+        Assert.Contains(expectedErrorParameter, document.RootElement.GetProperty("errorMessage").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(invalidValue, document.RootElement.GetProperty("errorMessage").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("session", document.RootElement.GetProperty("errorMessage").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("worksheet")]
+    [InlineData("WORKSHEET")]
+    public async Task ToolCall_AcceptsExactAliasIgnoringCase(string loadDestination)
+    {
+        var result = await CallToolAsync(
+            "powerquery",
+            new Dictionary<string, object?>
+            {
+                ["action"] = "load-to",
+                ["session_id"] = "missing-session",
+                ["query_name"] = "Probe",
+                ["load_destination"] = loadDestination
+            });
+
+        using var document = ParseJsonResult(result, "powerquery.load-to");
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains(
+            "session",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "Invalid value",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PowerQueryLoadTo_RejectsTimeoutSecondsAsActionInapplicable()
+    {
+        var result = await CallToolAsync(
+            "powerquery",
+            new Dictionary<string, object?>
+            {
+                ["action"] = "load-to",
+                ["session_id"] = "missing-session",
+                ["query_name"] = "Probe",
+                ["load_destination"] = "worksheet",
+                ["timeout_seconds"] = 60
+            });
+
+        using var document = ParseJsonResult(result, "powerquery.load-to");
+        AssertFailureEnvelope(
+            document.RootElement,
+            "powerquery.load-to",
+            nameof(ArgumentException),
+            expectedErrorCategory: "InvalidInput");
+        Assert.Contains(
+            "timeout",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "session",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task FileCreate_ForwardsMacroEnabledThroughSessionProtocol()
+    {
+        var path = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}.xlsx");
+        await File.WriteAllTextAsync(path, string.Empty);
+        try
+        {
+            var result = await CallToolAsync(
+                "file",
+                new Dictionary<string, object?>
+                {
+                    ["action"] = "create",
+                    ["path"] = path
+                });
+
+            using var document = ParseJsonResult(result, "file.create");
+            Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+            var error = document.RootElement.GetProperty("errorMessage").GetString();
+            Assert.Contains("already exists", error, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("macroEnabled", error, StringComparison.Ordinal);
+            Assert.DoesNotContain("Unknown parameter", error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task ToolCall_RejectsConflictingInlineAndFileInputs()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var result = await CallToolAsync(
+                "powerquery",
+                new Dictionary<string, object?>
+                {
+                    ["action"] = "evaluate",
+                    ["session_id"] = "missing-session",
+                    ["m_code"] = "let Source = 1 in Source",
+                    ["m_code_file"] = path
+                });
+
+            using var document = ParseJsonResult(result, "powerquery.evaluate");
+            AssertFailureEnvelope(
+                document.RootElement,
+                "powerquery.evaluate",
+                nameof(ArgumentException),
+                expectedErrorCategory: "InvalidInput");
+            var error = document.RootElement.GetProperty("errorMessage").GetString();
+            Assert.Contains("mCode", error, StringComparison.Ordinal);
+            Assert.Contains("mCodeFile", error, StringComparison.Ordinal);
+            Assert.DoesNotContain("session", error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("connection", "refresh", "connection_name")]
+    [InlineData("datamodel", "refresh", null)]
+    [InlineData("pivottable", "refresh", "pivot_table_name")]
+    [InlineData("powerquery", "refresh", "query_name")]
+    [InlineData("vba", "run", "procedure_name")]
+    public async Task ToolCall_AcceptsIntegerTimeoutSecondsAcrossGeneratedCategories(
+        string toolName,
+        string action,
+        string? requiredName)
+    {
+        var arguments = new Dictionary<string, object?>
+        {
+            ["action"] = action,
+            ["session_id"] = "missing-session",
+            ["timeout_seconds"] = 60
+        };
+        if (requiredName != null)
+        {
+            arguments[requiredName] = "Probe";
+        }
+
+        var result = await CallToolAsync(toolName, arguments);
+
+        using var document = ParseJsonResult(result, $"{toolName}.{action}");
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains(
+            "session",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "timeout",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("powerquery", "refresh", "query_name", -1)]
+    [InlineData("connection", "refresh", "connection_name", 0)]
+    [InlineData("datamodel", "refresh", null, 2147484)]
+    [InlineData("pivottable", "refresh", "pivot_table_name", 0)]
+    [InlineData("vba", "run", "procedure_name", 0)]
+    public async Task ToolCall_RejectsOutOfRangeTimeoutBeforeSessionLookup(
+        string toolName,
+        string action,
+        string? requiredName,
+        int timeoutSeconds)
+    {
+        var arguments = new Dictionary<string, object?>
+        {
+            ["action"] = action,
+            ["session_id"] = "missing-session",
+            ["timeout_seconds"] = timeoutSeconds
+        };
+        if (requiredName != null)
+        {
+            arguments[requiredName] = "Probe";
+        }
+
+        var result = await CallToolAsync(toolName, arguments);
+
+        using var document = ParseJsonResult(result, $"{toolName}.{action}");
+        AssertFailureEnvelope(
+            document.RootElement,
+            $"{toolName}.{action}",
+            nameof(ArgumentOutOfRangeException),
+            expectedErrorCategory: "InvalidInput");
+        Assert.Contains(
+            "timeout",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "session",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ListTools_ExposesCanonicalTimeoutAndFileAliasSchemas()
+    {
+        var tools = await Client!.ListToolsAsync(cancellationToken: TestCancellationToken);
+
+        foreach (var toolName in new[] { "connection", "datamodel", "pivottable", "powerquery", "vba" })
+        {
+            var tool = Assert.Single(tools, candidate => candidate.Name == toolName);
+            var timeout = tool.JsonSchema.GetProperty("properties").GetProperty("timeout_seconds");
+            Assert.Equal("integer", timeout.GetProperty("type").GetString());
+            Assert.Contains("seconds", timeout.GetProperty("description").GetString(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        var expectedFileAliases = new Dictionary<string, string[]>
+        {
+            ["powerquery"] = ["m_code_file"],
+            ["vba"] = ["vba_code_file"],
+            ["datamodel"] = ["dax_formula_file", "dax_query_file", "dmv_query_file"],
+            ["xmlmap"] = ["schema_file", "xml_data_file"]
+        };
+        foreach (var (toolName, aliases) in expectedFileAliases)
+        {
+            var tool = Assert.Single(tools, candidate => candidate.Name == toolName);
+            var properties = tool.JsonSchema.GetProperty("properties");
+            foreach (var alias in aliases)
+            {
+                var property = properties.GetProperty(alias);
+                Assert.Equal("string", property.GetProperty("type").GetString());
+                Assert.Contains("readable", property.GetProperty("description").GetString(), StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        var vbaTool = Assert.Single(tools, candidate => candidate.Name == "vba");
+        var parametersDescription = vbaTool.JsonSchema
+            .GetProperty("properties")
+            .GetProperty("parameters")
+            .GetProperty("description")
+            .GetString();
+        Assert.DoesNotContain("required for", parametersDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateSessionBridge_DoesNotDefaultMacroEnabledToFalse()
+    {
+        var method = typeof(ExcelServiceBridge).GetMethod(nameof(ExcelServiceBridge.CreateSessionAsync));
+        Assert.NotNull(method);
+        var macroEnabled = Assert.Single(
+            method.GetParameters(),
+            parameter => parameter.Name == "macroEnabled");
+
+        Assert.Null(macroEnabled.DefaultValue);
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerPowerQueryRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerPowerQueryRegressionTests.cs
@@ -96,6 +96,64 @@ public class McpServerPowerQueryRegressionTests : IAsyncLifetime, IAsyncDisposab
     }
 
     [Fact]
+    public async Task PowerQuery_ListIsCompactAndViewReturnsFullM_ViaMcpProtocol()
+    {
+        const string queryName = "McpCompactRead";
+        var workbookPath = Path.Join(_tempDir, $"CompactRead_{Guid.NewGuid():N}.xlsx");
+        var sessionId = await CreateSessionAsync(workbookPath);
+        var padding = string.Join(
+            Environment.NewLine,
+            Enumerable.Repeat("// MCP list must not serialize this padding", 250));
+        var mCode = $"let{Environment.NewLine}{padding}{Environment.NewLine}    Source = #table({{\"Value\"}}, {{{{1}}}}){Environment.NewLine}in{Environment.NewLine}    Source";
+
+        try
+        {
+            var createResult = await CallToolAsync("powerquery", new Dictionary<string, object?>
+            {
+                ["action"] = "create",
+                ["session_id"] = sessionId,
+                ["query_name"] = queryName,
+                ["m_code"] = mCode,
+                ["load_destination"] = "connection-only"
+            }, ToolTimeout);
+            AssertSuccess(createResult, "powerquery.create compact read");
+
+            var listResult = await CallToolAsync("powerquery", new Dictionary<string, object?>
+            {
+                ["action"] = "list",
+                ["session_id"] = sessionId
+            }, ToolTimeout);
+
+            Assert.True(listResult.Length < 1_000);
+            using (var listJson = JsonDocument.Parse(listResult))
+            {
+                var query = Assert.Single(
+                    listJson.RootElement.GetProperty("queries").EnumerateArray(),
+                    item => item.GetProperty("name").GetString() == queryName);
+                Assert.False(query.TryGetProperty("formula", out _));
+                Assert.InRange(query.GetProperty("formulaPreview").GetString()!.Length, 1, 80);
+                Assert.Equal(mCode.Length, query.GetProperty("characterCount").GetInt32());
+                Assert.Equal("connection-only", query.GetProperty("loadMode").GetString());
+            }
+
+            var viewResult = await CallToolAsync("powerquery", new Dictionary<string, object?>
+            {
+                ["action"] = "view",
+                ["session_id"] = sessionId,
+                ["query_name"] = queryName
+            }, ToolTimeout);
+
+            using var viewJson = JsonDocument.Parse(viewResult);
+            Assert.Equal(mCode, viewJson.RootElement.GetProperty("mCode").GetString());
+            Assert.Equal("connection-only", viewJson.RootElement.GetProperty("loadMode").GetString());
+        }
+        finally
+        {
+            await TryCloseSessionAsync(sessionId);
+        }
+    }
+
+    [Fact]
     public async Task PowerQuery_LoadToDataModel_CompletesViaMcpProtocol()
     {
         var workbookPath = Path.Join(_tempDir, $"LoadToDataModel_{Guid.NewGuid():N}.xlsx");

--- a/tests/Shared/OleDataSpaceTestFile.cs
+++ b/tests/Shared/OleDataSpaceTestFile.cs
@@ -1,0 +1,399 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Sbroenne.ExcelMcp.Tests.Helpers;
+
+public static class OleDataSpaceTestFile
+{
+    private const int SectorSize = 512;
+    private const int StreamSize = 4096;
+    private const uint EndOfChain = 0xFFFFFFFE;
+    private const uint FreeSector = 0xFFFFFFFF;
+    private const uint FatSector = 0xFFFFFFFD;
+
+    public static string Write(
+        string path,
+        string dataSpaceName,
+        string? definitionName = null)
+    {
+        File.WriteAllBytes(
+            path,
+            Build(dataSpaceName, definitionName ?? dataSpaceName));
+        return path;
+    }
+
+    public static string WriteDeepDirectory(string path, int entryCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(entryCount);
+        var directorySectorCount = (entryCount + 1 + 3) / 4;
+        var fatSectorCount = 1;
+        while (fatSectorCount * (SectorSize / sizeof(uint))
+               < directorySectorCount + fatSectorCount)
+        {
+            fatSectorCount++;
+        }
+
+        if (fatSectorCount > 109)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(entryCount),
+                "The deterministic fixture supports only header DIFAT entries.");
+        }
+
+        var bytes = new byte[
+            SectorSize * (1 + directorySectorCount + fatSectorCount)];
+        var header = bytes.AsSpan(0, SectorSize);
+        new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 }
+            .CopyTo(header);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[24..], 0x003E);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[26..], 3);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[28..], 0xFFFE);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[30..], 9);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[32..], 6);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[44..], checked((uint)fatSectorCount));
+        BinaryPrimitives.WriteUInt32LittleEndian(header[48..], 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[56..], 4096);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[60..], EndOfChain);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[68..], EndOfChain);
+        for (var offset = 76; offset < SectorSize; offset += sizeof(uint))
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(header[offset..], FreeSector);
+        }
+        for (var index = 0; index < fatSectorCount; index++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                header[(76 + index * sizeof(uint))..],
+                checked((uint)(directorySectorCount + index)));
+        }
+
+        var directory = bytes.AsSpan(
+            SectorSize,
+            directorySectorCount * SectorSize);
+        WriteDirectoryEntry(directory, 0, "Root Entry", 5, child: 1);
+        for (var index = 1; index <= entryCount; index++)
+        {
+            WriteDirectoryEntry(
+                directory,
+                index,
+                $"Entry{index:D6}",
+                1,
+                leftSibling: index == entryCount ? -1 : index + 1);
+        }
+
+        var fatEntries = new uint[fatSectorCount * (SectorSize / sizeof(uint))];
+        Array.Fill(fatEntries, FreeSector);
+        for (var index = 0; index < directorySectorCount; index++)
+        {
+            fatEntries[index] = index == directorySectorCount - 1
+                ? EndOfChain
+                : checked((uint)(index + 1));
+        }
+        for (var index = 0; index < fatSectorCount; index++)
+        {
+            fatEntries[directorySectorCount + index] = FatSector;
+        }
+        for (var index = 0; index < fatSectorCount; index++)
+        {
+            var fatBytes = bytes.AsSpan(
+                SectorSize * (1 + directorySectorCount + index),
+                SectorSize);
+            for (var entry = 0; entry < SectorSize / sizeof(uint); entry++)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    fatBytes[(entry * sizeof(uint))..],
+                    fatEntries[index * (SectorSize / sizeof(uint)) + entry]);
+            }
+        }
+
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    public static string WriteDeepNestedStorages(string path, int entryCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(entryCount);
+        var directorySectorCount = (entryCount + 1 + 3) / 4;
+        var fatSectorCount = 1;
+        while (fatSectorCount * (SectorSize / sizeof(uint))
+               < directorySectorCount + fatSectorCount)
+        {
+            fatSectorCount++;
+        }
+
+        if (fatSectorCount > 109)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(entryCount),
+                "The deterministic fixture supports only header DIFAT entries.");
+        }
+
+        var bytes = new byte[
+            SectorSize * (1 + directorySectorCount + fatSectorCount)];
+        var header = bytes.AsSpan(0, SectorSize);
+        new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 }
+            .CopyTo(header);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[24..], 0x003E);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[26..], 3);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[28..], 0xFFFE);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[30..], 9);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[32..], 6);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[44..], checked((uint)fatSectorCount));
+        BinaryPrimitives.WriteUInt32LittleEndian(header[48..], 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[56..], 4096);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[60..], EndOfChain);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[68..], EndOfChain);
+        for (var offset = 76; offset < SectorSize; offset += sizeof(uint))
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(header[offset..], FreeSector);
+        }
+        for (var index = 0; index < fatSectorCount; index++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                header[(76 + index * sizeof(uint))..],
+                checked((uint)(directorySectorCount + index)));
+        }
+
+        var directory = bytes.AsSpan(
+            SectorSize,
+            directorySectorCount * SectorSize);
+        WriteDirectoryEntry(directory, 0, "Root Entry", 5, child: 1);
+        for (var index = 1; index <= entryCount; index++)
+        {
+            WriteDirectoryEntry(
+                directory,
+                index,
+                $"NestedStorage{index:D18}",
+                1,
+                child: index == entryCount ? -1 : index + 1);
+        }
+
+        var fatEntries = new uint[fatSectorCount * (SectorSize / sizeof(uint))];
+        Array.Fill(fatEntries, FreeSector);
+        for (var index = 0; index < directorySectorCount; index++)
+        {
+            fatEntries[index] = index == directorySectorCount - 1
+                ? EndOfChain
+                : checked((uint)(index + 1));
+        }
+        for (var index = 0; index < fatSectorCount; index++)
+        {
+            fatEntries[directorySectorCount + index] = FatSector;
+        }
+        for (var index = 0; index < fatSectorCount; index++)
+        {
+            var fatBytes = bytes.AsSpan(
+                SectorSize * (1 + directorySectorCount + index),
+                SectorSize);
+            for (var entry = 0; entry < SectorSize / sizeof(uint); entry++)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    fatBytes[(entry * sizeof(uint))..],
+                    fatEntries[index * (SectorSize / sizeof(uint)) + entry]);
+            }
+        }
+
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    public static string WriteOversizedVersion4RootMiniStream(string path)
+    {
+        const int version4SectorSize = 4096;
+        var bytes = new byte[version4SectorSize * 4];
+        var header = bytes.AsSpan(0, 512);
+        new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 }
+            .CopyTo(header);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[24..], 0x003E);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[26..], 4);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[28..], 0xFFFE);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[30..], 12);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[32..], 6);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[40..], 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[44..], 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[48..], 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[56..], 4096);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[60..], 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[64..], 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[68..], EndOfChain);
+        for (var offset = 76; offset < 512; offset += sizeof(uint))
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(header[offset..], FreeSector);
+        }
+        BinaryPrimitives.WriteUInt32LittleEndian(header[76..], 2);
+
+        var directory = bytes.AsSpan(version4SectorSize, version4SectorSize);
+        WriteDirectoryEntry(
+            directory,
+            0,
+            "Root Entry",
+            5,
+            child: 1,
+            streamSize: 9_000_000_000_000);
+        WriteDirectoryEntry(directory, 1, "\u0006DataSpaces", 1, child: 2);
+        WriteDirectoryEntry(
+            directory,
+            2,
+            "DataSpaceMap",
+            2,
+            startSector: 0,
+            streamSize: 64);
+
+        var fat = bytes.AsSpan(version4SectorSize * 3, version4SectorSize);
+        for (var offset = 0; offset < fat.Length; offset += sizeof(uint))
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(fat[offset..], FreeSector);
+        }
+        BinaryPrimitives.WriteUInt32LittleEndian(fat, EndOfChain);
+        BinaryPrimitives.WriteUInt32LittleEndian(fat[sizeof(uint)..], EndOfChain);
+        BinaryPrimitives.WriteUInt32LittleEndian(fat[(2 * sizeof(uint))..], FatSector);
+
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static byte[] Build(string dataSpaceName, string definitionName)
+    {
+        const int directorySectorCount = 2;
+        const int mapStartSector = directorySectorCount;
+        const int definitionStartSector = mapStartSector + StreamSize / SectorSize;
+        const int fatSectorIndex = definitionStartSector + StreamSize / SectorSize;
+        var bytes = new byte[SectorSize * (fatSectorIndex + 2)];
+        var header = bytes.AsSpan(0, SectorSize);
+
+        new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 }
+            .CopyTo(header);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[24..], 0x003E);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[26..], 3);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[28..], 0xFFFE);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[30..], 9);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[32..], 6);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[44..], 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[48..], 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[56..], 4096);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[60..], EndOfChain);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[68..], EndOfChain);
+        for (var offset = 76; offset < SectorSize; offset += sizeof(uint))
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(header[offset..], FreeSector);
+        }
+        BinaryPrimitives.WriteUInt32LittleEndian(header[76..], (uint)fatSectorIndex);
+
+        var directory = bytes.AsSpan(SectorSize, directorySectorCount * SectorSize);
+        WriteDirectoryEntry(directory, 0, "Root Entry", 5, child: 1);
+        WriteDirectoryEntry(directory, 1, "\u0006DataSpaces", 1, child: 2);
+        WriteDirectoryEntry(directory, 2, "DataSpaceInfo", 1, rightSibling: 3, child: 4);
+        WriteDirectoryEntry(
+            directory,
+            3,
+            "DataSpaceMap",
+            2,
+            startSector: mapStartSector,
+            streamSize: StreamSize);
+        WriteDirectoryEntry(
+            directory,
+            4,
+            definitionName,
+            2,
+            startSector: definitionStartSector,
+            streamSize: StreamSize);
+
+        BuildDataSpaceMap(dataSpaceName).CopyTo(Sector(bytes, mapStartSector));
+        BuildDataSpaceDefinition().CopyTo(Sector(bytes, definitionStartSector));
+
+        var fat = Sector(bytes, fatSectorIndex);
+        for (var offset = 0; offset < fat.Length; offset += sizeof(uint))
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(fat[offset..], FreeSector);
+        }
+        WriteChain(fat, 0, directorySectorCount);
+        WriteChain(fat, mapStartSector, StreamSize / SectorSize);
+        WriteChain(fat, definitionStartSector, StreamSize / SectorSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            fat[(fatSectorIndex * sizeof(uint))..],
+            FatSector);
+
+        return bytes;
+    }
+
+    private static byte[] BuildDataSpaceMap(string dataSpaceName)
+    {
+        using var entryStream = new MemoryStream();
+        using (var entry = new BinaryWriter(entryStream, Encoding.Unicode, leaveOpen: true))
+        {
+            entry.Write(1u);
+            entry.Write(0u);
+            WriteUnicodeString(entry, "EncryptedPackage");
+            WriteUnicodeString(entry, dataSpaceName);
+        }
+
+        using var mapStream = new MemoryStream();
+        using (var map = new BinaryWriter(mapStream, Encoding.Unicode, leaveOpen: true))
+        {
+            map.Write(8u);
+            map.Write(1u);
+            map.Write(checked((uint)(entryStream.Length + sizeof(uint))));
+            map.Write(entryStream.ToArray());
+        }
+
+        return mapStream.ToArray();
+    }
+
+    private static byte[] BuildDataSpaceDefinition()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.Unicode, leaveOpen: true);
+        writer.Write(8u);
+        writer.Write(1u);
+        WriteUnicodeString(writer, "DRMTransform");
+        return stream.ToArray();
+    }
+
+    private static void WriteUnicodeString(BinaryWriter writer, string value)
+    {
+        var encoded = Encoding.Unicode.GetBytes(value);
+        writer.Write(checked((uint)encoded.Length));
+        writer.Write(encoded);
+        var padding = (4 - encoded.Length % 4) % 4;
+        writer.Write(new byte[padding]);
+    }
+
+    private static void WriteDirectoryEntry(
+        Span<byte> directory,
+        int index,
+        string name,
+        byte type,
+        int leftSibling = -1,
+        int rightSibling = -1,
+        int child = -1,
+        int startSector = -2,
+        long streamSize = 0)
+    {
+        var entry = directory.Slice(index * 128, 128);
+        var encodedName = Encoding.Unicode.GetBytes(name + "\0");
+        encodedName.CopyTo(entry);
+        BinaryPrimitives.WriteUInt16LittleEndian(entry[64..], checked((ushort)encodedName.Length));
+        entry[66] = type;
+        entry[67] = 1;
+        BinaryPrimitives.WriteInt32LittleEndian(entry[68..], leftSibling);
+        BinaryPrimitives.WriteInt32LittleEndian(entry[72..], rightSibling);
+        BinaryPrimitives.WriteInt32LittleEndian(entry[76..], child);
+        BinaryPrimitives.WriteInt32LittleEndian(entry[116..], startSector);
+        BinaryPrimitives.WriteInt64LittleEndian(entry[120..], streamSize);
+    }
+
+    private static void WriteChain(Span<byte> fat, int startSector, int sectorCount)
+    {
+        for (var index = 0; index < sectorCount; index++)
+        {
+            var next = index == sectorCount - 1
+                ? EndOfChain
+                : checked((uint)(startSector + index + 1));
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                fat[((startSector + index) * sizeof(uint))..],
+                next);
+        }
+    }
+
+    private static Span<byte> Sector(byte[] bytes, int sectorIndex) =>
+        bytes.AsSpan(SectorSize * (sectorIndex + 1), SectorSize);
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -19,7 +19,7 @@ Other tools (openpyxl-based MCP servers and Agent Skills, including Anthropic's 
 
 ## Key features
 
-The Excel MCP Server (excel-mcp) provides **31 specialized tools with 326 operations** for comprehensive Excel automation:
+The Excel MCP Server (excel-mcp) provides **31 specialized tools with 325 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query & M code** - Create, edit and optimize M code. Import from files, databases and APIs. Refresh queries and manage load destinations.
 - 🧮 **Power Pivot & DAX** - Build Data Models, create DAX measures and manage table relationships. Full Power Pivot automation.
@@ -31,7 +31,7 @@ The Excel MCP Server (excel-mcp) provides **31 specialized tools with 326 operat
 - 🐍 **Python in Excel** - Write and run `=PY()` formulas that execute in Excel's cloud Python engine — process worksheet data with pandas, NumPy and more, from your AI assistant.
 - 🧪 **LLM-tested quality** - Tool behavior validated with real LLM workflows using [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering), so AI assistants reliably understand and use every operation.
 
-📚 **[See all 31 tools and 326 operations →](https://excelmcpserver.dev/features/)**
+📚 **[See all 31 tools and 325 operations →](https://excelmcpserver.dev/features/)**
 
 ### Agent Skills (Bundled)
 


### PR DESCRIPTION
## Summary

Unifies the CLI and MCP Server around one strict, truthful automation contract.

- scopes daemon/Excel teardown to PID/start-time-validated identities owned by the selected CLI pipe
- reports daemon startup, stopped, running, and unresponsive states truthfully with absolute deadlines
- rejects unknown enums, numeric enum values, mis-cased/unknown JSON properties, and action-inapplicable parameters before dispatch
- standardizes public timeouts as integer seconds and normalizes all file-or-value inputs consistently
- uses exact Power Query/connection identity instead of substring matching
- returns compact Power Query list metadata while preserving full M in `view`
- aligns file/session lifecycle to `list`, `open`, `create`, `close`, and `test`

## Breaking changes

- removes standalone CLI `session save`; use atomic `session close --save`
- removes MCP `file close-workbook`, which previously returned success without doing work
- rejects previously ignored or implicitly defaulted invalid inputs
- removes full `Formula` from serialized Power Query list results; use `view` for full M
- connection actions require exact connection identity rather than ambiguous display-name aliases

## Safety and compatibility

- stale-build cleanup attempts bounded graceful shutdown and preserves unsaved work before pipe-scoped force cleanup
- failed Excel termination retains ownership and surfaces a close failure
- legacy and modern IRM/AIP containers are detected without deep-opening protected workbooks
- public `PowerQueryInfo.Formula` remains available for Core compatibility but is excluded from list serialization
- malformed/corrupt tracking records fail cleanup instead of reporting success

## Validation

The mandatory pre-commit hook passed in full:

- Release solution build: 0 warnings, 0 errors
- CLI workflow E2E: 12/12
- stale-build graceful-save acceptance: passed
- MCP all-tools E2E: 1/1
- COM leak, Core coverage/naming, MCP/Core parity, success-flag, documentation-count, plugin README, and dynamic-cast gates: passed
- CLI and MCP NuGet/standalone release deliverables: passed
- VS Code extension, MCPB bundle, and agent skills packages: passed

Seven patch changesets document the user-facing behavior.

Fixes #781
Fixes #782
Fixes #783
Fixes #784
Fixes #785
Fixes #786
Fixes #787
Fixes #788
Fixes #789
Fixes #796
Fixes #797
Fixes #798
Fixes #799
Fixes #800
Fixes #801