### PR TITLE
Fix IRM skips and MCP Registry release metadata

### DIFF
--- a/.changeset/reliable-mcp-registry-metadata.md
+++ b/.changeset/reliable-mcp-registry-metadata.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Reliable MCP Registry releases** (#808): Releases now stamp and verify both MCP Registry version fields, and report publishing failures instead of hiding them.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,14 +208,9 @@ jobs:
 
     - name: Update Project Versions
       run: |
-        $version = $env:VERSION
-
-        # Update MCP Registry server.json (top-level version and package version)
-        $serverJsonPath = "src/ExcelMcp.McpServer/.mcp/server.json"
-        $serverContent = Get-Content $serverJsonPath -Raw
-        $serverContent = $serverContent -replace '("version":\s*)"[\d\.]+"(\s*,\s*\n\s*"packages")' , "`$1`"$version`"`$2"
-        $serverContent = $serverContent -replace '("identifier":\s*"Sbroenne\.ExcelMcp\.McpServer",\s*\n\s*"version":\s*)"[\d\.]+"', "`$1`"$version`""
-        Set-Content $serverJsonPath $serverContent
+        .\scripts\Update-McpRegistryMetadata.ps1 `
+          -ServerJsonPath "src\ExcelMcp.McpServer\.mcp\server.json" `
+          -Version $env:VERSION
       shell: pwsh
 
     - name: Restore
@@ -464,12 +459,9 @@ jobs:
 
     - name: Update server.json Version
       run: |
-        $version = $env:VERSION
-        $serverJsonPath = "src/ExcelMcp.McpServer/.mcp/server.json"
-        $serverContent = Get-Content $serverJsonPath -Raw
-        $serverContent = $serverContent -replace '("version":\s*)"[\d\.]+"(\s*,\s*\n\s*"packages")' , "`$1`"$version`"`$2"
-        $serverContent = $serverContent -replace '("identifier":\s*"Sbroenne\.ExcelMcp\.McpServer",\s*\n\s*"version":\s*)"[\d\.]+"', "`$1`"$version`""
-        Set-Content $serverJsonPath $serverContent
+        .\scripts\Update-McpRegistryMetadata.ps1 `
+          -ServerJsonPath "src\ExcelMcp.McpServer\.mcp\server.json" `
+          -Version $env:VERSION
       shell: pwsh
 
     - name: Wait for NuGet Propagation
@@ -517,7 +509,6 @@ jobs:
         Set-Location src/ExcelMcp.McpServer/.mcp
         ../../../mcp-publisher.exe publish --verbose
       shell: pwsh
-      continue-on-error: true
 
   # =============================================================================
   # Job 7: Create Git Tag

--- a/docs/MCP_REGISTRY_PUBLISHING.md
+++ b/docs/MCP_REGISTRY_PUBLISHING.md
@@ -54,18 +54,20 @@ The publishing process is automated as `publish-mcp-registry` job in `.github/wo
 
 ### 1. Version Update
 The workflow:
-- Updates `server.json` with the new version number (top-level `version` and `packages[].version`)
+- Parses `server.json`, updates both the top-level `version` and the MCP Server
+  package version, then validates that both values match the release version.
 
 ### 2. Wait for NuGet Propagation
 - The MCP Registry uses NuGet as the deployment mechanism
 - The job waits for the NuGet package README to propagate (validates `mcp-name:` tag)
 - Polls up to 3 times with 10-minute intervals
 
-### 3. MCP Registry Publishing (Non-Blocking)
+### 3. MCP Registry Publishing
 - Downloads the MCP Publisher CLI tool
 - Authenticates using GitHub OIDC (no secrets required)
 - Publishes `server.json` to the MCP Registry
-- Uses `continue-on-error: true` to ensure release completes even if MCP Registry publishing fails
+- Fails the registry job if publication fails so the release workflow cannot report
+  the registry update as successful when it was not published
 
 ## Authentication
 
@@ -95,7 +97,7 @@ After release, verify publication:
 **Solution**: 
 - Verify `id-token: write` permission is set in the workflow job
 - Ensure repository is configured for GitHub OIDC
-- MCP Registry publishing failures don't block the release (`continue-on-error: true`)
+- Resolve the failure and rerun the workflow after confirming the registry state
 
 ### Version Not Updated
 
@@ -103,4 +105,5 @@ After release, verify publication:
 
 **Solution**: 
 - Check the `publish-mcp-registry` job logs
-- Re-run the workflow or manually update `server.json` and run mcp-publisher
+- Confirm both `server.json` version fields were stamped with the release version
+  before rerunning the workflow or publishing manually

--- a/scripts/Update-McpRegistryMetadata.ps1
+++ b/scripts/Update-McpRegistryMetadata.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ServerJsonPath,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+$mcpServerPackageId = 'Sbroenne.ExcelMcp.McpServer'
+
+if (-not (Test-Path -LiteralPath $ServerJsonPath -PathType Leaf)) {
+    throw "MCP Registry metadata file was not found: $ServerJsonPath"
+}
+
+$server = Get-Content -LiteralPath $ServerJsonPath -Raw | ConvertFrom-Json
+if ($null -eq $server.PSObject.Properties['version']) {
+    throw "MCP Registry metadata must contain a top-level 'version' property."
+}
+
+if ($null -eq $server.PSObject.Properties['packages']) {
+    throw "MCP Registry metadata must contain a 'packages' array."
+}
+
+$mcpPackages = @(
+    $server.packages | Where-Object {
+        $_.identifier -eq $mcpServerPackageId
+    }
+)
+
+if ($mcpPackages.Count -ne 1) {
+    throw "MCP Registry metadata must contain exactly one package with identifier '$mcpServerPackageId'."
+}
+
+$mcpPackage = $mcpPackages[0]
+if ($null -eq $mcpPackage.PSObject.Properties['version']) {
+    throw "MCP Registry package '$mcpServerPackageId' must contain a 'version' property."
+}
+
+$server.version = $Version
+$mcpPackage.version = $Version
+$server | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $ServerJsonPath -NoNewline
+
+$updatedServer = Get-Content -LiteralPath $ServerJsonPath -Raw | ConvertFrom-Json
+$updatedMcpPackages = @(
+    $updatedServer.packages | Where-Object {
+        $_.identifier -eq $mcpServerPackageId
+    }
+)
+
+if ($updatedServer.version -ne $Version -or
+    $updatedMcpPackages.Count -ne 1 -or
+    $updatedMcpPackages[0].version -ne $Version) {
+    throw "MCP Registry metadata validation failed after stamping version '$Version'."
+}
+
+Write-Output "Updated MCP Registry metadata to version $Version."

--- a/tests/ExcelMcp.CLI.Tests/ExcelMcp.CLI.Tests.csproj
+++ b/tests/ExcelMcp.CLI.Tests/ExcelMcp.CLI.Tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\ExcelMcp.Core.Tests\Helpers\CoreTestHelper.cs" Link="Helpers\CoreTestHelper.cs" />
     <Compile Include="..\ExcelMcp.Core.Tests\Helpers\TempDirectoryFixture.cs" Link="Helpers\TempDirectoryFixture.cs" />
     <Compile Include="..\Shared\OleDataSpaceTestFile.cs" Link="Helpers\OleDataSpaceTestFile.cs" />
+    <Compile Include="..\Shared\ConfiguredIrmFactAttribute.cs" Link="Helpers\ConfiguredIrmFactAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ExcelMcp.CLI.Tests/Integration/IrmProtectedWorkbookRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/IrmProtectedWorkbookRegressionTests.cs
@@ -80,15 +80,12 @@ public sealed class IrmProtectedWorkbookRegressionTests : IDisposable
             "CLI session open must fail fast for protected workbooks when --show is omitted.");
     }
 
-    [Fact]
+    [ConfiguredIrmFact]
     [Trait("RunType", "OnDemand")]
     public async Task SessionOpen_RealIrmWorkbook_WithShow_CompletesWithinTimeoutBudget_WhenConfigured()
     {
-        var irmTestFile = GetConfiguredIrmTestFilePath();
-        if (irmTestFile == null)
-        {
-            return;
-        }
+        var irmTestFile = GetConfiguredIrmTestFilePath()
+            ?? throw new InvalidOperationException("Configured IRM test fixture was unavailable after test discovery.");
 
         Assert.True(FileAccessValidator.IsIrmProtected(irmTestFile),
             "TEST_IRM_FILE must point to a real IRM/AIP-protected workbook for this regression.");

--- a/tests/ExcelMcp.CLI.Tests/Integration/SessionVisibilityRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/SessionVisibilityRegressionTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Sbroenne.ExcelMcp.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -151,15 +152,12 @@ public sealed class SessionVisibilityRegressionTests : IDisposable
         }
     }
 
-    [Fact]
+    [ConfiguredIrmFact]
     [Trait("RunType", "OnDemand")]
     public async Task SessionOpen_RealIrmWorkbookWithShow_ReturnsWithinTimeoutBudget_WhenConfigured()
     {
-        var irmTestFile = GetConfiguredIrmTestFilePath();
-        if (irmTestFile == null)
-        {
-            return;
-        }
+        var irmTestFile = GetConfiguredIrmTestFilePath()
+            ?? throw new InvalidOperationException("Configured IRM test fixture was unavailable after test discovery.");
 
         string? sessionId = null;
         try

--- a/tests/ExcelMcp.ComInterop.Tests/ExcelMcp.ComInterop.Tests.csproj
+++ b/tests/ExcelMcp.ComInterop.Tests/ExcelMcp.ComInterop.Tests.csproj
@@ -39,6 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\ConfiguredIrmFactAttribute.cs" Link="Helpers\ConfiguredIrmFactAttribute.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\Shared\OleDataSpaceTestFile.cs" Link="Helpers\OleDataSpaceTestFile.cs" />
   </ItemGroup>
 

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTests.cs
@@ -522,16 +522,13 @@ public class ExcelBatchTests : IAsyncLifetime
         }
     }
 
-    [Fact]
+    [ConfiguredIrmFact]
     [Trait("RunType", "OnDemand")]
     public async Task BeginBatch_RealIrmWorkbook_CompletesStartupWithinBudget_WhenConfigured()
     {
         // Real IRM startup depends on interactive auth/enterprise policy and cannot run in CI.
-        var irmTestFile = GetConfiguredIrmTestFilePath();
-        if (irmTestFile == null)
-        {
-            return;
-        }
+        var irmTestFile = GetConfiguredIrmTestFilePath()
+            ?? throw new InvalidOperationException("Configured IRM test fixture was unavailable after test discovery.");
 
         var startingExcelPids = Process.GetProcessesByName("EXCEL")
             .Select(process => process.Id)
@@ -701,8 +698,6 @@ public class ExcelBatchTests : IAsyncLifetime
     //
     // Keeping this comment as documentation that the scenario is handled in production code.
 }
-
-
 
 
 

--- a/tests/ExcelMcp.Core.Tests/ExcelMcp.Core.Tests.csproj
+++ b/tests/ExcelMcp.Core.Tests/ExcelMcp.Core.Tests.csproj
@@ -35,6 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\ConfiguredIrmFactAttribute.cs" Link="Helpers\ConfiguredIrmFactAttribute.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\Shared\OleDataSpaceTestFile.cs" Link="Helpers\OleDataSpaceTestFile.cs" />
   </ItemGroup>
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.IrmDetection.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/File/FileCommandsTests.IrmDetection.cs
@@ -107,16 +107,13 @@ public partial class FileCommandsTests
         Assert.False(info.IsIrmProtected, "Legacy .xls (OLE2) must not be flagged as IRM-protected");
     }
 
-    [Fact]
+    [ConfiguredIrmFact]
     [Trait("RunType", "OnDemand")]
     public void Test_RealIrmProtectedFile_DetectsProtection_WhenConfigured()
     {
         // Real protected workbooks require local credentials and cannot run safely in CI.
-        var irmTestFile = GetConfiguredIrmTestFilePath();
-        if (irmTestFile == null)
-        {
-            return;
-        }
+        var irmTestFile = GetConfiguredIrmTestFilePath()
+            ?? throw new InvalidOperationException("Configured IRM test fixture was unavailable after test discovery.");
 
         // Act
         var info = _fileCommands.Test(irmTestFile);

--- a/tests/ExcelMcp.McpServer.Tests/ExcelMcp.McpServer.Tests.csproj
+++ b/tests/ExcelMcp.McpServer.Tests/ExcelMcp.McpServer.Tests.csproj
@@ -39,6 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\ConfiguredIrmFactAttribute.cs" Link="Helpers\ConfiguredIrmFactAttribute.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\Shared\OleDataSpaceTestFile.cs" Link="Helpers\OleDataSpaceTestFile.cs" />
   </ItemGroup>
 

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolProtocolRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolProtocolRegressionTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -90,16 +91,13 @@ public sealed class ExcelFileToolProtocolRegressionTests : McpIntegrationTestBas
         await Task.Delay(TimeSpan.FromSeconds(2));
     }
 
-    [Fact]
+    [ConfiguredIrmFact]
     [Trait("RunType", "OnDemand")]
     public async Task FileOpen_RealIrmWorkbook_ReturnsWithinTimeoutBudget_WhenConfigured()
     {
         // Real IRM/AIP workbooks require local auth state and are intentionally opt-in only.
-        var irmTestFile = GetConfiguredIrmTestFilePath();
-        if (irmTestFile == null)
-        {
-            return;
-        }
+        var irmTestFile = GetConfiguredIrmTestFilePath()
+            ?? throw new InvalidOperationException("Configured IRM test fixture was unavailable after test discovery.");
 
         var testResult = await CallToolAsync("file", new Dictionary<string, object?>
         {

--- a/tests/ExcelMcp.SkillGeneration.Tests/ReleaseMetadataScriptTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/ReleaseMetadataScriptTests.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.SkillGeneration.Tests;
+
+/// <summary>
+/// Integration tests for the release metadata updater used by the MCP Registry workflow.
+/// </summary>
+public sealed class ReleaseMetadataScriptTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string UpdateMetadataScript = Path.Combine(
+        RepoRoot,
+        "scripts",
+        "Update-McpRegistryMetadata.ps1");
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "ReleaseMetadata")]
+    public async Task UpdateMetadata_StampsSeparatedTopLevelAndPackageVersions()
+    {
+        var sandbox = CreateSandbox();
+        try
+        {
+            var metadataPath = Path.Combine(sandbox, "server.json");
+            File.Copy(
+                Path.Combine(RepoRoot, "src", "ExcelMcp.McpServer", ".mcp", "server.json"),
+                metadataPath);
+
+            var result = await RunUpdaterAsync(metadataPath, "9.8.7");
+
+            Assert.True(result.ExitCode == 0, result.CombinedOutput);
+            using var document = JsonDocument.Parse(File.ReadAllText(metadataPath));
+            var root = document.RootElement;
+            Assert.Equal("9.8.7", root.GetProperty("version").GetString());
+
+            var packages = root.GetProperty("packages").EnumerateArray().ToArray();
+            var mcpPackage = Assert.Single(packages, package =>
+                package.GetProperty("identifier").GetString() == "Sbroenne.ExcelMcp.McpServer");
+            Assert.Equal("9.8.7", mcpPackage.GetProperty("version").GetString());
+        }
+        finally
+        {
+            Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "ReleaseMetadata")]
+    public async Task UpdateMetadata_RejectsMissingMcpServerPackage()
+    {
+        var sandbox = CreateSandbox();
+        try
+        {
+            var metadataPath = Path.Combine(sandbox, "server.json");
+            await File.WriteAllTextAsync(metadataPath, """{"version":"1.0.0","packages":[]}""");
+
+            var result = await RunUpdaterAsync(metadataPath, "9.8.7");
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Contains("exactly one", result.CombinedOutput, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    private static string CreateSandbox()
+    {
+        var sandbox = Path.Combine(Path.GetTempPath(), $"ExcelMcpReleaseMetadata-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(sandbox);
+        return sandbox;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Sbroenne.ExcelMcp.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output directory.");
+    }
+
+    private static async Task<ScriptResult> RunUpdaterAsync(string metadataPath, string version)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-ExecutionPolicy");
+        startInfo.ArgumentList.Add("Bypass");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(UpdateMetadataScript);
+        startInfo.ArgumentList.Add("-ServerJsonPath");
+        startInfo.ArgumentList.Add(metadataPath);
+        startInfo.ArgumentList.Add("-Version");
+        startInfo.ArgumentList.Add(version);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(timeout.Token);
+
+        return new ScriptResult(process.ExitCode, await stdout, await stderr);
+    }
+
+    private sealed record ScriptResult(int ExitCode, string Stdout, string Stderr)
+    {
+        public string CombinedOutput => $"{Stdout}{Environment.NewLine}{Stderr}";
+    }
+}

--- a/tests/Shared/ConfiguredIrmFactAttribute.cs
+++ b/tests/Shared/ConfiguredIrmFactAttribute.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Tests.Helpers;
+
+/// <summary>
+/// Skips an opt-in IRM integration test unless TEST_IRM_FILE names an existing workbook.
+/// </summary>
+public sealed class ConfiguredIrmFactAttribute : FactAttribute
+{
+    private const string MissingFixtureMessage =
+        "Set TEST_IRM_FILE to an existing IRM/AIP-protected workbook to run this opt-in regression.";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfiguredIrmFactAttribute"/> class.
+    /// </summary>
+    public ConfiguredIrmFactAttribute()
+    {
+        var irmTestFile = Environment.GetEnvironmentVariable("TEST_IRM_FILE");
+        if (string.IsNullOrWhiteSpace(irmTestFile) || !File.Exists(irmTestFile))
+        {
+            Skip = MissingFixtureMessage;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make opt-in IRM integration tests report **Skipped** when `TEST_IRM_FILE` is unavailable
- stamp and validate both MCP Registry metadata version fields through a shared JSON updater
- surface MCP Registry publishing failures instead of ignoring them

Fixes #806 and #808.

## Validation
- targeted IRM regression tests across CLI, MCP Server, Core, and ComInterop
- MCP Registry metadata updater regression tests
- mandatory pre-commit suite