### PR TITLE
Fix durable Agent Plugin guidance generation

### DIFF
--- a/.changeset/durable-agent-plugin-guidance.md
+++ b/.changeset/durable-agent-plugin-guidance.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Reliable Agent Plugin setup**: Plugin bootstrap caches now use the host-provided data directory, CLI output remains usable in PowerShell pipelines, and generated skill guidance uses current package names and MCP parameters.

--- a/.github/plugins/_shared/download.ps1.template
+++ b/.github/plugins/_shared/download.ps1.template
@@ -14,7 +14,11 @@ $RepoOwner = "sbroenne"
 $RepoName = "mcp-server-excel"
 $ReleaseApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases/latest"
 $ReleasePageUrl = "https://github.com/$RepoOwner/$RepoName/releases/latest"
-$CacheRoot = Join-Path $env:USERPROFILE ".copilot\plugin-runtime\mcp-server-excel\$PluginName"
+$CacheRoot = if (-not [string]::IsNullOrWhiteSpace($env:PLUGIN_DATA)) {
+    Join-Path $env:PLUGIN_DATA "runtime"
+} else {
+    Join-Path $env:USERPROFILE ".copilot\plugin-runtime\mcp-server-excel\$PluginName"
+}
 $DownloadsDir = Join-Path $CacheRoot "downloads"
 $ReleasesDir = Join-Path $CacheRoot "releases"
 $StatePath = Join-Path $CacheRoot "bootstrap-state.json"

--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -36,12 +36,15 @@ This writes `excelcli.cmd` / `excelcli.ps1` to `~/.copilot/bin` and adds that di
 
 ### Step 3: First Use Bootstraps `excelcli`
 
-The plugin now ships **wrapper/download logic** instead of a bundled executable. On first real invocation it:
+The plugin ships **wrapper/download logic** instead of a bundled executable. On first real invocation it:
 
-1. Checks the runtime cache under `~/.copilot\plugin-runtime\mcp-server-excel\excel-cli`
+1. Uses the host-managed persistent plugin data directory (`PLUGIN_DATA\runtime`) for its cache
 2. Queries the newest GitHub Release from `sbroenne/mcp-server-excel`
 3. Downloads the self-contained Windows CLI asset if needed
 4. Reuses that runtime for the rest of the chat session without repeated freshness checks
+
+The optional global shim runs outside an Agent Plugins host and uses
+`~\.copilot\plugin-runtime\mcp-server-excel\excel-cli` as its standalone cache.
 
 You do **not** need a separate standalone install just to use the plugin.
 

--- a/.github/plugins/excel-cli/bin/download.ps1
+++ b/.github/plugins/excel-cli/bin/download.ps1
@@ -14,7 +14,11 @@ $RepoOwner = "sbroenne"
 $RepoName = "mcp-server-excel"
 $ReleaseApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases/latest"
 $ReleasePageUrl = "https://github.com/$RepoOwner/$RepoName/releases/latest"
-$CacheRoot = Join-Path $env:USERPROFILE ".copilot\plugin-runtime\mcp-server-excel\$PluginName"
+$CacheRoot = if (-not [string]::IsNullOrWhiteSpace($env:PLUGIN_DATA)) {
+    Join-Path $env:PLUGIN_DATA "runtime"
+} else {
+    Join-Path $env:USERPROFILE ".copilot\plugin-runtime\mcp-server-excel\$PluginName"
+}
 $DownloadsDir = Join-Path $CacheRoot "downloads"
 $ReleasesDir = Join-Path $CacheRoot "releases"
 $StatePath = Join-Path $CacheRoot "bootstrap-state.json"

--- a/.github/plugins/excel-cli/bin/start-cli.ps1
+++ b/.github/plugins/excel-cli/bin/start-cli.ps1
@@ -65,9 +65,24 @@ if ($null -eq $PassthroughArgs) {
 $startInfo = New-Object System.Diagnostics.ProcessStartInfo
 $startInfo.FileName = $binaryPath
 $startInfo.Arguments = (($PassthroughArgs | ForEach-Object { ConvertTo-NativeArgument -Value $_ }) -join ' ')
-# Inherit this process's stdin/stdout/stderr so interactive and piped usage keep working.
 $startInfo.UseShellExecute = $false
+$startInfo.RedirectStandardOutput = $true
+$startInfo.RedirectStandardError = $true
 
 $process = [System.Diagnostics.Process]::Start($startInfo)
+$stdoutTask = $process.StandardOutput.ReadToEndAsync()
+$stderrTask = $process.StandardError.ReadToEndAsync()
 $process.WaitForExit()
+
+$stdout = $stdoutTask.GetAwaiter().GetResult()
+$stderr = $stderrTask.GetAwaiter().GetResult()
+
+if (-not [string]::IsNullOrEmpty($stderr)) {
+    [Console]::Error.Write($stderr)
+}
+
+if (-not [string]::IsNullOrEmpty($stdout)) {
+    Write-Output -NoEnumerate $stdout
+}
+
 exit $process.ExitCode

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -40,7 +40,11 @@ The plugin does **not** rely on a bundled `mcp-excel.exe`. Its Agent Plugins 1.0
 
 - checks GitHub Releases for the newest `ExcelMcp-MCP-Server-*-windows.zip`
 - downloads and caches the latest self-contained Windows server on first invocation
+- stores the cache under the host-managed `PLUGIN_DATA\runtime` directory
 - re-checks freshness at most once per Copilot chat session
+
+The optional global registration runs outside an Agent Plugins host and uses
+`~\.copilot\plugin-runtime\mcp-server-excel\excel-mcp` as its standalone cache.
 
 If you want the server registered globally in `~/.copilot/mcp-config.json`, run:
 

--- a/.github/plugins/excel-mcp/bin/download.ps1
+++ b/.github/plugins/excel-mcp/bin/download.ps1
@@ -14,7 +14,11 @@ $RepoOwner = "sbroenne"
 $RepoName = "mcp-server-excel"
 $ReleaseApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases/latest"
 $ReleasePageUrl = "https://github.com/$RepoOwner/$RepoName/releases/latest"
-$CacheRoot = Join-Path $env:USERPROFILE ".copilot\plugin-runtime\mcp-server-excel\$PluginName"
+$CacheRoot = if (-not [string]::IsNullOrWhiteSpace($env:PLUGIN_DATA)) {
+    Join-Path $env:PLUGIN_DATA "runtime"
+} else {
+    Join-Path $env:USERPROFILE ".copilot\plugin-runtime\mcp-server-excel\$PluginName"
+}
 $DownloadsDir = Join-Path $CacheRoot "downloads"
 $ReleasesDir = Join-Path $CacheRoot "releases"
 $StatePath = Join-Path $CacheRoot "bootstrap-state.json"

--- a/.github/plugins/marketplace-repo/README.md
+++ b/.github/plugins/marketplace-repo/README.md
@@ -36,7 +36,7 @@ copilot plugin install excel-mcp@mcp-server-excel-plugins
 copilot plugin install excel-cli@mcp-server-excel-plugins
 ```
 
-Both plugins publish wrapper/bootstrap assets plus skills. On first use they fetch the newest self-contained Windows runtime from the main `sbroenne/mcp-server-excel` GitHub Releases feed, then reuse it for the rest of the chat session.
+Both plugins publish wrapper/bootstrap assets plus skills. On first use they fetch the newest self-contained Windows runtime from the main `sbroenne/mcp-server-excel` GitHub Releases feed. The bootstrap compares the release tag and executable version once per Copilot session, stores runtime state in the host-provided `PLUGIN_DATA` directory, and reuses the verified runtime for the rest of the session. Standalone shim use checks for updates at least every 24 hours.
 
 ## Notes
 

--- a/skills/excel-cli/README.md
+++ b/skills/excel-cli/README.md
@@ -63,20 +63,26 @@ npx skills add sbroenne/mcp-server-excel --skill excel-cli
 excel-cli/
 ├── SKILL.md           # Main skill definition with CLI command guidance
 ├── README.md          # This file
-└── references/        # Exact CLI command/action/flag reference
-    └── cli-commands.md
+├── VERSION             # Published plugin version
+└── references/        # CLI command reference and workflow guidance
+    └── *.md
 ```
 
 ## CLI Tool Installation
 
-The **GitHub Copilot `excel-cli` plugin** installs the skill package only.
+The **GitHub Copilot `excel-cli` plugin** installs the skill plus a runtime
+bootstrap wrapper. The wrapper downloads and caches the latest self-contained
+Windows CLI runtime on first use.
 
 ### Via GitHub Copilot Plugin
 
-If you install `excel-cli` through the GitHub Copilot plugin marketplace, install `excelcli` separately and keep using the plugin for workflow guidance:
+Plugin-driven flows can use the bundled wrapper directly. To make `excelcli`
+available on PATH for shell commands, run the optional global shim installer
+from the installed plugin folder:
 
 ```powershell
-dotnet tool install --global Sbroenne.ExcelMcp.CLI
+pwsh -ExecutionPolicy Bypass -File `
+  "$env:USERPROFILE\.copilot\installed-plugins\mcp-server-excel-plugins\excel-cli\com.github.copilot\bin\install-global.ps1"
 ```
 
 ### Via Skill Package
@@ -85,13 +91,9 @@ Plain skill-only installs still need `excelcli` available separately on PATH (fo
 
 ### Manual Download (Standalone)
 
-For other environments, download the standalone CLI:
-```powershell
-# Download from releases
-$url = "https://github.com/sbroenne/mcp-server-excel/releases/latest/download/ExcelMcp-CLI-latest-windows.zip"
-Invoke-WebRequest -Uri $url -OutFile ExcelMcp-CLI.zip
-Expand-Archive -Path ExcelMcp-CLI.zip -DestinationPath $env:ProgramFiles\ExcelMcp
-```
+For other environments, download `ExcelMcp-CLI-{version}-windows.zip` from the
+[latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest),
+extract it to a permanent directory, and add that directory to PATH.
 
 ### Via NuGet Package Manager (Secondary)
 

--- a/skills/excel-cli/SKILL.md
+++ b/skills/excel-cli/SKILL.md
@@ -24,9 +24,10 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
   install the runtime independently via the standalone release zip or
   `dotnet tool install --global Sbroenne.ExcelMcp.CLI`.
   If `excelcli` is not found, report that and stop — do not guess at a path.
-- The runtime itself is downloaded and cached on first use under
-  `~\.copilot\plugin-runtime\mcp-server-excel\excel-cli`, so only the first invocation needs
-  network access
+- Plugin-driven flows download and cache the runtime on first use through
+  `PLUGIN_DATA`; the optional global shim falls back to
+  `~\.copilot\plugin-runtime\mcp-server-excel\excel-cli`. Only the first invocation needs
+  network access.
 
 ## Workflow Checklist
 

--- a/skills/excel-cli/references/analysis.md
+++ b/skills/excel-cli/references/analysis.md
@@ -9,34 +9,34 @@ Use `analysis` for Excel's native Goal Seek, scenarios, scenario summaries, and 
 The formula cell must contain a formula, and the changing cell must be one of its inputs.
 
 ```text
-analysis(action="goal-seek", sheetName="Model", formulaCell="B10", goal=10000, changingCell="B3")
+analysis(action="goal-seek", sheet_name="Model", formula_cell="B10", goal=10000, changing_cell="B3")
 ```
 
 Goal Seek changes the workbook immediately. Read both cells afterward when the exact final values matter.
 
 ## Scenarios
 
-Scenario values must contain exactly one value per cell in `changingCells`, in range order.
+Scenario values must contain exactly one value per cell in `changing_cells`, in range order.
 
 ```text
-analysis(action="create-scenario", sheetName="Model", scenarioName="Growth",
-         changingCells="B3:B5", values=[0.08, 1200, 0.35])
-analysis(action="show-scenario", sheetName="Model", scenarioName="Growth")
-analysis(action="list-scenarios", sheetName="Model")
+analysis(action="create-scenario", sheet_name="Model", scenario_name="Growth",
+         changing_cells="B3:B5", values=[0.08, 1200, 0.35])
+analysis(action="show-scenario", sheet_name="Model", scenario_name="Growth")
+analysis(action="list-scenarios", sheet_name="Model")
 ```
 
-Use `create-scenario-summary` after defining two or more scenarios. Set `reportType` to `summary` for a normal report sheet or `pivot-table` for a Scenario PivotTable. `resultCells` should identify formulas that depend on the changing cells.
+Use `create-scenario-summary` after defining two or more scenarios. Set `report_type` to `summary` for a normal report sheet or `pivot-table` for a Scenario PivotTable. `result_cells` should identify formulas that depend on the changing cells.
 
 ## Data Tables
 
 Prepare the worksheet layout first, including the formula in the table's corner and the input values along its first row or column.
 
-- One-variable row table: provide `rowInputCell`.
-- One-variable column table: provide `columnInputCell`.
+- One-variable row table: provide `row_input_cell`.
+- One-variable column table: provide `column_input_cell`.
 - Two-variable table: provide both.
 
 ```text
-analysis(action="create-data-table", sheetName="Model", tableRange="A1:B11", columnInputCell="D1")
+analysis(action="create-data-table", sheet_name="Model", table_range="A1:B11", column_input_cell="D1")
 ```
 
 Data tables can be calculation-intensive. Use `calculation_mode` when controlling recalculation around larger workbook edits.

--- a/skills/excel-cli/references/anti-patterns.md
+++ b/skills/excel-cli/references/anti-patterns.md
@@ -13,9 +13,9 @@ Applying the same formatting to the same range more than once in a workflow:
 ```
 WRONG: Applying bold repeatedly
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true)
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true)
 // ... other operations ...
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4')
 // Bold was already applied - the second call re-applies it unnecessarily
 ```
 
@@ -24,10 +24,10 @@ Also wrong: calling `format-range` separately for each property instead of combi
 ```
 WRONG: Separate calls for each property
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true)
-range_format(action: 'format-range', rangeAddress: 'A1:D1', fillColor: '#4472C4')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', horizontalAlignment: 'center')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true)
+range_format(action: 'format-range', range_address: 'A1:D1', fill_color: '#4472C4')
+range_format(action: 'format-range', range_address: 'A1:D1', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A1:D1', horizontal_alignment: 'center')
 ```
 
 ### The Solution
@@ -37,8 +37,8 @@ Apply all formatting properties for a range in **one** `format-range` call:
 ```
 CORRECT: One call per range
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1',
-    bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF', horizontalAlignment: 'center')
+range_format(action: 'format-range', range_address: 'A1:D1',
+    bold: true, fill_color: '#4472C4', font_color: '#FFFFFF', horizontal_alignment: 'center')
 ```
 
 Apply each formatting operation **once**. If a subsequent step explicitly changes a property (e.g., "now make the title red"), apply it again — otherwise don't.
@@ -48,17 +48,17 @@ If the same formatting applies to multiple disjoint ranges, do not repeat `forma
 ```
 WRONG: Repeating the same shared formatting payload
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A12:D12', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A24:D24', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A12:D12', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A24:D24', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
 ```
 
 ```
 CORRECT: One shared multi-range formatting call
 
 range_format(action: 'format-ranges',
-    rangeAddresses: ['A1:D1', 'A12:D12', 'A24:D24'],
-    bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
+    range_addresses: ['A1:D1', 'A12:D12', 'A24:D24'],
+    bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
 ```
 
 ### When Multiple Calls ARE Appropriate
@@ -76,8 +76,8 @@ Applying `range_format` to cells that belong to an object with its own style sys
 ```
 WRONG: Formatting a table header row with range_format
 
-table(action: 'create', tableName: 'Sales', rangeAddress: 'A1:D10')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4')
+table(action: 'create', table_name: 'Sales', range_address: 'A1:D10')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4')
 // The table style already controls header appearance — this creates an inconsistent override
 ```
 
@@ -85,7 +85,7 @@ range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColo
 WRONG: Formatting PivotTable cells
 
 pivottable(action: 'create-from-table', ...)
-range_format(action: 'format-range', rangeAddress: 'B3:B20', fillColor: '#E2EFDA')
+range_format(action: 'format-range', range_address: 'B3:B20', fill_color: '#E2EFDA')
 // Formatting is wiped on the next pivottable(refresh)
 ```
 
@@ -96,15 +96,15 @@ Use the style system that belongs to each object type:
 ```
 CORRECT: Table visual styling — one call at creation or via set-style
 
-table(action: 'create', tableName: 'Sales', rangeAddress: 'A1:D10',
-    tableStyle: 'TableStyleMedium2')
+table(action: 'create', table_name: 'Sales', range_address: 'A1:D10',
+    table_style: 'TableStyleMedium2')
 ```
 
 | Object | Correct style approach | Do NOT use |
 |--------|----------------------|------------|
-| Excel Tables | `table(action:'set-style')` or `tableStyle` on create | `range_format` on header/data rows |
+| Excel Tables | `table(action:'set-style')` or `table_style` on create | `range_format` on header/data rows |
 | PivotTables | Not supported — leave default | `range_format` (wiped on refresh) |
-| Charts | `chart_config(action:'set-style', styleNumber: 1-48)` | `range_format` |
+| Charts | `chart_config(action:'set-style', style_id: 1-48)` | `range_format` |
 | Plain cells/ranges | `range_format` | — |
 
 ## Delete-and-Rebuild Anti-Pattern
@@ -116,9 +116,9 @@ Deleting entire structures to make small changes:
 ```
 WRONG: User wants to update cell B5
 
-table(action: 'delete', tableName: 'SalesData')
+table(action: 'delete', table_name: 'SalesData')
 range(action: 'set-values', values: [[entire dataset with B5 fixed]])
-table(action: 'create', tableName: 'SalesData', ...)
+table(action: 'create', table_name: 'SalesData', ...)
 ```
 
 This destroys:
@@ -136,7 +136,7 @@ Use targeted modifications:
 ```
 CORRECT: Update only the changed cell
 
-range(action: 'set-values', rangeAddress: 'B5', values: [[newValue]])
+range(action: 'set-values', range_address: 'B5', values: [[newValue]])
 ```
 
 ### When Rebuild IS Appropriate
@@ -165,14 +165,14 @@ This burns tokens, costs money, and never completes the task.
 
 ### The Solution
 
-If you already have a sessionId, use it. Do not rediscover:
+If you already have a session ID, use it. Do not rediscover:
 
 ```
-CORRECT: Use the sessionId you already have
+CORRECT: Use the session ID you already have
 
 Error: "session expired"
-→ file(action: 'open', path: original_path)  ← Re-open once, get new sessionId
-→ Continue with the new sessionId immediately
+→ file(action: 'open', path: original_path)  ← Re-open once, get a new session ID
+→ Continue with the new session ID immediately
 ```
 
 ### The Rule
@@ -231,9 +231,9 @@ Reading entire range, modifying in memory, writing entire range back:
 ```
 WRONG: Update one cell by rewriting thousands
 
-data = range(action: 'get-values', rangeAddress: 'A1:Z1000')
+data = range(action: 'get-values', range_address: 'A1:Z1000')
 data[4][1] = "new value"  // Modify row 5, column B
-range(action: 'set-values', rangeAddress: 'A1', values: data)
+range(action: 'set-values', range_address: 'A1', values: data)
 ```
 
 This:
@@ -249,7 +249,7 @@ Write only the changed cells:
 ```
 CORRECT: Direct cell update
 
-range(action: 'set-values', rangeAddress: 'B5', values: [["new value"]])
+range(action: 'set-values', range_address: 'B5', values: [["new value"]])
 ```
 
 ## Session Leak Anti-Pattern
@@ -261,9 +261,9 @@ Opening files without closing them:
 ```
 WRONG: Session accumulation
 
-file(action: 'open', filePath: 'file1.xlsx')  // Session 1
-file(action: 'open', filePath: 'file2.xlsx')  // Session 2
-file(action: 'open', filePath: 'file3.xlsx')  // Session 3
+file(action: 'open', path: 'file1.xlsx')  // Session 1
+file(action: 'open', path: 'file2.xlsx')  // Session 2
+file(action: 'open', path: 'file3.xlsx')  // Session 3
 // ... never closed
 ```
 
@@ -282,11 +282,11 @@ CORRECT: Proper lifecycle
 
 session1 = file(action: 'open', path: 'file1.xlsx')
 // ... work with file1 ...
-file(action: 'close', sessionId: session1, save: true)
+file(action: 'close', session_id: session1, save: true)
 
 session2 = file(action: 'open', path: 'file2.xlsx')
 // ... work with file2 ...
-file(action: 'close', sessionId: session2, save: true)
+file(action: 'close', session_id: session2, save: true)
 ```
 
 ## Ignoring Error Context Anti-Pattern
@@ -312,9 +312,9 @@ CORRECT: Error-driven correction
 
 datamodel(action: 'create-measure', ...) 
 → Error: Table 'Sales' not in Data Model
-→ Suggested: table(action: 'add-to-data-model', tableName: 'Sales')
+→ Suggested: table(action: 'add-to-data-model', table_name: 'Sales')
 
-table(action: 'add-to-data-model', tableName: 'Sales')  // Fix prerequisite
+table(action: 'add-to-data-model', table_name: 'Sales')  // Fix prerequisite
 datamodel(action: 'create-measure', ...)  // Now succeeds
 ```
 
@@ -327,8 +327,8 @@ Using locale-specific format codes:
 ```
 WRONG: German/European format
 
-range(action: 'set-number-format', formatCode: '#.##0,00')  // German
-range(action: 'set-number-format', formatCode: '# ##0,00')  // French
+range(action: 'set-number-format', format_code: '#.##0,00')  // German
+range(action: 'set-number-format', format_code: '# ##0,00')  // French
 ```
 
 ### The Solution
@@ -338,7 +338,7 @@ Always use US format codes (Excel translates automatically):
 ```
 CORRECT: US format codes (universal)
 
-range(action: 'set-number-format', formatCode: '#,##0.00')
+range(action: 'set-number-format', format_code: '#,##0.00')
 ```
 
 Excel displays the result in the user's locale setting, but the API requires US format input.
@@ -352,7 +352,7 @@ Wrong load destination for the workflow:
 ```
 WRONG: Loading to worksheet when DAX is needed
 
-powerquery(action: 'create', loadDestination: 'worksheet', ...)
+powerquery(action: 'create', load_destination: 'worksheet', ...)
 datamodel(action: 'create-measure', ...)  // FAILS: table not in Data Model
 ```
 
@@ -363,7 +363,7 @@ Match load destination to workflow:
 ```
 CORRECT: Load to Data Model for DAX workflows
 
-powerquery(action: 'create', loadDestination: 'data-model', ...)
+powerquery(action: 'create', load_destination: 'data-model', ...)
 powerquery(action: 'refresh', ...)
 datamodel(action: 'create-measure', ...)  // Works
 ```
@@ -384,7 +384,7 @@ Creating or updating Power Query queries without testing M code first:
 ```
 WRONG: Creating permanent query with untested M code
 
-powerquery(action: 'create', mCode: '...', ...)
+powerquery(action: 'create', m_code: '...', ...)
 // M code has syntax error → COM exception with cryptic message
 // Now workbook is polluted with broken query
 ```
@@ -403,12 +403,12 @@ Always evaluate M code BEFORE creating permanent queries:
 CORRECT: Test-first development workflow
 
 // Step 1: Test M code without persisting
-powerquery(action: 'evaluate', mCode: '...')
+powerquery(action: 'evaluate', m_code: '...')
 // → Returns actual data preview with columns and rows
 // → Better error messages if M code has issues
 
 // Step 2: Create permanent query with validated code
-powerquery(action: 'create', mCode: '...', ...)
+powerquery(action: 'create', m_code: '...', ...)
 
 // Step 3: Load data to destination
 powerquery(action: 'refresh', ...)
@@ -434,7 +434,7 @@ If create/update fails with COM error, use evaluate to get detailed Power Query 
 
 ```
 powerquery(action: 'create', ...)  // → COM exception
-powerquery(action: 'evaluate', mCode: '...')  // → Detailed M error
+powerquery(action: 'evaluate', m_code: '...')  // → Detailed M error
 // Fix M code based on error
 powerquery(action: 'create', ...)  // → Success
 ```

--- a/skills/excel-cli/references/behavioral-rules.md
+++ b/skills/excel-cli/references/behavioral-rules.md
@@ -93,7 +93,7 @@ When creating or modifying Excel files:
 
 **Use `format-range` for visual layout (header rows, custom colours) — ALL properties in ONE call:**
 - `set-style('Heading 1')` does NOT apply a fill colour; if you want a coloured header row use `format-range`
-- Pass bold, fillColor, fontColor, and alignment together in a single call — do not call `format-range` multiple times for the same range
+- Pass `bold`, `fill_color`, `font_color`, and alignment together in a single call — do not call `format-range` multiple times for the same range
 - If the same formatting payload repeats across multiple non-contiguous ranges, prefer one `format-ranges` call over repeated `format-range` calls
 
 **Apply each formatting operation once** — do not reapply the same properties to the same range unless a later step explicitly changes them.
@@ -136,7 +136,7 @@ Always convert tabular data to Excel Tables (ListObjects):
 
 ```
 1. range set-values (write data including headers)
-2. table create tableName="SalesData" rangeAddress="A1:D100"
+2. table create table_name="SalesData" range_address="A1:D100"
 ```
 
 **Why Tables over plain ranges:**
@@ -183,9 +183,9 @@ authentication occurs; open them with a visible session.
 Always close sessions when done:
 
 ```
-1. file(action: 'open', path: '...')  → sessionId
-2. All operations use sessionId
-3. file(action: 'close', sessionId: '...', save: true)  → saves and closes
+1. file(action: 'open', path: '...')  → session ID
+2. All operations use the returned session ID
+3. file(action: 'close', session_id: '...', save: true)  → saves and closes
 ```
 
 **Why**: Unclosed sessions leave Excel processes running, consuming memory and locking files.
@@ -301,9 +301,9 @@ belong to the selected action are rejected instead of being defaulted or ignored
   session operation timeout.
 - For required generated inline/file pairs, supply exactly one form. Optional
   pairs may omit both, but inline and file forms are always mutually exclusive.
-  Batch aliases are
-  `mCodeFile`, `vbaCodeFile`, `daxFormulaFile`, `daxQueryFile`, `dmvQueryFile`,
-  `schemaFile`, and `xmlDataFile`; MCP uses snake_case and CLI uses kebab-case.
+  MCP file inputs are
+  `m_code_file`, `vba_code_file`, `dax_formula_file`, `dax_query_file`, `dmv_query_file`,
+  `schema_file`, and `xml_data_file`; CLI uses the matching kebab-case flags.
   The file must exist and be readable.
 
 ### Refresh After Create
@@ -312,7 +312,7 @@ belong to the selected action are rejected instead of being defaulted or ignored
 
 ```
 Step 1: powerquery(action: 'create', ...) → Query created
-Step 2: powerquery(action: 'refresh', queryName: '...') → Data loaded
+Step 2: powerquery(action: 'refresh', query_name: '...') → Data loaded
 ```
 
 Without refresh, the query exists but contains no data.
@@ -327,7 +327,7 @@ Excel MCP errors include actionable context:
 {
   "success": false,
   "errorMessage": "Table 'Sales' not found in Data Model",
-  "suggestedNextActions": ["table(action: 'add-to-data-model', tableName: 'Sales')"]
+  "suggestedNextActions": ["table(action: 'add-to-data-model', table_name: 'Sales')"]
 }
 ```
 

--- a/skills/excel-cli/references/chart.md
+++ b/skills/excel-cli/references/chart.md
@@ -11,19 +11,19 @@
 
 ### From Range
 ```
-chart(create-from-range, chartType, sourceRange, sheetName)
+chart(create-from-range, chart_type, source_range, sheet_name)
 ```
 Best for: Simple data in worksheet ranges
 
 ### From PivotTable (PivotChart)
 ```
-chart(create-from-pivottable, pivotTableName)
+chart(create-from-pivottable, pivot_table_name)
 ```
 Best for: Data Model data - creates a single PivotChart object (don't create separate PivotTable + Chart)
 
 ### From Table
 ```
-chart(create-from-table, tableName, chartType)
+chart(create-from-table, table_name, chart_type)
 ```
 Best for: Excel Tables with structured references
 
@@ -36,22 +36,22 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 ## Configuration Actions (chart_config)
 
 ### Series Management
-- `add-series`: Add data series with valuesRange and optional categoryRange
+- `add-series`: Add data series with `values_range` and optional `category_range`
 - `remove-series`: Remove series by index (1-based)
 - `set-source-range`: Replace entire chart data source
 - `set-series-chart-type`: Assign a chart type to one regular-chart series for combo charts
 
 ### Plot Behavior
 - `get-plot-options`: Read row/column orientation, blank-cell display, and hidden-cell plotting
-- `set-plot-options`: Configure `plotBy`, `displayBlanksAs`, and `plotVisibleOnly`
+- `set-plot-options`: Configure `plot_by`, `display_blanks_as`, and `plot_visible_only`
 
 ### Titles and Labels
 - `set-title`: Set chart title (empty string hides)
 - `set-axis-title`: Set axis labels (Category, Value, CategorySecondary, ValueSecondary)
-- `set-data-labels`: Configure data labels (position, showValue, showCategory, showPercentage, showSeriesName, showLegendKey)
+- `set-data-labels`: Configure data labels (`label_position`, `show_value`, `show_category_name`, `show_percentage`, and `show_series_name`)
 
 ### Axis Formatting
-- `get-axis-scale`: Get min, max, majorUnit, minorUnit, and auto flags
+- `get-axis-scale`: Get minimum, maximum, major unit, minor unit, and auto flags
 - `set-axis-scale`: Configure scale properties
 - `get-axis-number-format`: Get current tick label format
 - `set-axis-number-format`: Format axis numbers (e.g., `"$#,##0,,\"M\""` for millions)
@@ -92,8 +92,8 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 - **period**: Required for MovingAverage (2+, default 2)
 - **forward/backward**: Forecast periods ahead/behind data
 - **intercept**: Force trend through specific Y value
-- **displayEquation**: Show formula on chart
-- **displayRSquared**: Show R² goodness-of-fit value
+- **display_equation**: Show formula on chart
+- **display_r_squared**: Show R² goodness-of-fit value
 
 ## Common Workflows
 
@@ -102,13 +102,13 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 1. chart(create-from-range) → chartName
 2. chart_config(set-title, title="Monthly Sales")
 3. chart_config(set-axis-title, axis="Value", title="Revenue ($)")
-4. chart_config(set-axis-number-format, axis="Value", numberFormat="$#,##0")
-5. chart_config(set-data-labels, position="OutsideEnd", showValue=true)
+4. chart_config(set-axis-number-format, axis="Value", number_format="$#,##0")
+5. chart_config(set-data-labels, label_position="OutsideEnd", show_value=true)
 ```
 
 ### Add Analysis
 ```
-1. chart_config(add-trendline, trendlineType="Linear", displayEquation=true, displayRSquared=true)
+1. chart_config(add-trendline, trendline_type="Linear", display_equation=true, display_r_squared=true)
 2. chart_config(set-trendline, forward=3) # Forecast 3 periods ahead
 ```
 
@@ -124,22 +124,22 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 
 Charts support three positioning modes, listed in order of preference:
 
-### 1. targetRange (PREFERRED - One Step)
+### 1. target_range (PREFERRED - One Step)
 ```
-chart(create-from-range, sourceRange='A1:B10', chartType='Line', targetRange='F2:K15')
+chart(create-from-range, source_range='A1:B10', chart_type='Line', target_range='F2:K15')
 ```
 Creates chart AND positions it to the cell range in one call. No point math needed.
 
 ### 2. Auto-Positioning (No Position Specified)
-When you omit both `targetRange` and `left`/`top`, the chart is automatically placed below all existing content (data ranges + other charts) with 10pt padding. This prevents overlap automatically.
+When you omit both `target_range` and `left`/`top`, the chart is automatically placed below all existing content (data ranges + other charts) with 10pt padding. This prevents overlap automatically.
 ```
-chart(create-from-range, sourceRange='A1:B10', chartType='Line')
+chart(create-from-range, source_range='A1:B10', chart_type='Line')
 # → Chart auto-positioned below the used range and any existing charts
 ```
 
 ### 3. Manual Coordinates
 ```
-chart(create-from-range, sourceRange='A1:B10', left=360, top=20)
+chart(create-from-range, source_range='A1:B10', left=360, top=20)
 # left/top in points (72 points = 1 inch)
 ```
 
@@ -156,9 +156,9 @@ Result example with collision warning:
 ```
 
 **If you see an overlap warning:**
-1. Use `chart(fit-to-range, chartName, rangeAddress='F2:K15')` to reposition
-2. Or use `chart(move, chartName, left=..., top=...)` to adjust
-3. Always follow up with `screenshot(capture, rangeAddress='A1:M25')` to include and verify the chart
+1. Use `chart(fit-to-range, chart_name='Chart 1', range_address='F2:K15')` to reposition
+2. Or use `chart(move, chart_name='Chart 1', left=..., top=...)` to adjust
+3. Always follow up with `screenshot(capture, range_address='A1:M25')` to include and verify the chart
 
 ### Position Estimates
 - Rows: ~15 points per row (varies with row height)
@@ -166,10 +166,10 @@ Result example with collision warning:
 - Default chart: 400×300 points
 
 ### Positioning Workflow
-1. **Preferred**: Use `targetRange='F2:K15'` in create call — avoids all overlap issues
+1. **Preferred**: Use `target_range='F2:K15'` in create call — avoids all overlap issues
 2. **Alternative**: Omit position — auto-positioning places chart below content
 3. **Manual**: `get-used-range` → calculate coordinates → specify left/top
-4. **Always verify**: Use `screenshot(capture, rangeAddress='A1:M25')` to visually confirm layout
+4. **Always verify**: Use `screenshot(capture, range_address='A1:M25')` to visually confirm layout
 
 ## Multi-Chart Layout (CRITICAL)
 
@@ -179,15 +179,15 @@ When creating dashboards with multiple charts, **every chart needs explicit posi
 ```
 Data at A1:D10. Place 4 charts in a 2×2 grid below data:
 
-chart(create-from-range, ..., targetRange='A12:F25')   # Top-left
-chart(create-from-range, ..., targetRange='G12:L25')   # Top-right
-chart(create-from-range, ..., targetRange='A27:F40')   # Bottom-left
-chart(create-from-range, ..., targetRange='G27:L40')   # Bottom-right
-screenshot(capture, rangeAddress='A1:M40') → Verify no overlaps
+chart(create-from-range, ..., target_range='A12:F25')   # Top-left
+chart(create-from-range, ..., target_range='G12:L25')   # Top-right
+chart(create-from-range, ..., target_range='A27:F40')   # Bottom-left
+chart(create-from-range, ..., target_range='G27:L40')   # Bottom-right
+screenshot(capture, range_address='A1:M40') → Verify no overlaps
 ```
 
 ### Rules
-- **Use targetRange for every chart** in multi-chart layouts — auto-positioning stacks vertically
+- **Use target_range for every chart** in multi-chart layouts — auto-positioning stacks vertically
 - Leave at least 1-2 rows/columns gap between charts
 - If any chart result includes an overlap warning, fix it before creating the next chart
-- Take a final `screenshot(capture, rangeAddress='A1:M40')` to verify the complete layout
+- Take a final `screenshot(capture, range_address='A1:M40')` to verify the complete layout

--- a/skills/excel-cli/references/conditionalformat.md
+++ b/skills/excel-cli/references/conditionalformat.md
@@ -6,14 +6,14 @@
 
 | Type | Description | Parameters |
 |------|-------------|------------|
-| `cell-value` | Format based on cell value comparison | operatorType + formula1 (+ formula2 for between) |
+| `cell-value` | Format based on cell value comparison | operator_type + formula1 (+ formula2 for between) |
 | `expression` | Format based on formula result | formula only |
 | `color-scale` | 2- or 3-color gradient across the range | colorScaleMin/Mid/Max Type/Value/Color |
-| `data-bar` | In-cell bars proportional to value | dataBarColor, dataBarNegativeColor, dataBarDirection, dataBarShowValue, dataBarMin/Max Type/Value |
-| `icon-set` | Icons (arrows, traffic lights, etc.) per value band | iconSetId, iconSetReverse, iconSetShowIconOnly, iconThreshold1..4 Type/Value |
-| `top10` | Highlight top/bottom N (or percent) | rank, top10Percent, topBottom + formatting |
-| `above-average` | Highlight values above/below average | aboveBelow + formatting |
-| `time-period` | Highlight dates in a period | datePeriod + formatting |
+| `data-bar` | In-cell bars proportional to value | data_bar_color, data_bar_negative_color, data_bar_direction, data_bar_show_value, data_bar_min/max type/value |
+| `icon-set` | Icons (arrows, traffic lights, etc.) per value band | icon_set_id, icon_set_reverse, icon_set_show_icon_only, icon_threshold1..4 type/value |
+| `top10` | Highlight top/bottom N (or percent) | rank, top10_percent, top_bottom + formatting |
+| `above-average` | Highlight values above/below average | above_below + formatting |
+| `time-period` | Highlight dates in a period | date_period + formatting |
 | `unique-values` | Highlight unique (or duplicate) values | formatting |
 | `blanks-condition` | Highlight blank cells | formatting |
 
@@ -32,30 +32,30 @@
 
 **Format Options**:
 
-- `interiorColor`: Background fill color as `#RRGGBB` hex
-- `fontColor`: Text color as `#RRGGBB` hex
-- `fontBold`: `true` or `false`
-- `fontItalic`: `true` or `false`
-- `borderStyle`: Excel border style name
-- `borderColor`: Border color as `#RRGGBB` hex
+- `interior_color`: Background fill color as `#RRGGBB` hex
+- `font_color`: Text color as `#RRGGBB` hex
+- `font_bold`: `true` or `false`
+- `font_italic`: `true` or `false`
+- `border_style`: Excel border style name
+- `border_color`: Border color as `#RRGGBB` hex
 
-**Visual rule parameters** (used by the corresponding `ruleType`):
+**Visual rule parameters** (used by the corresponding `rule_type`):
 
-- **color-scale**: `colorScaleMinType`/`colorScaleMidType`/`colorScaleMaxType`
+- **color-scale**: `color_scale_min_type`/`color_scale_mid_type`/`color_scale_max_type`
   (`minimum`, `maximum`, `number`, `percent`, `percentile`, `formula`), matching
   `...Value` (when the type needs one) and `...Color` (`#RRGGBB`). Supplying any `mid*`
   parameter creates a 3-color scale, otherwise a 2-color scale.
-- **data-bar**: `dataBarColor` (`#RRGGBB`), `dataBarNegativeColor`, `dataBarDirection`
-  (`context`, `leftToRight`, `rightToLeft`), `dataBarShowValue` (`true`/`false`),
-  `dataBarMinType`/`dataBarMaxType` (+ matching values).
-- **icon-set**: `iconSetId` (e.g. `3Arrows`, `3TrafficLights1`, `4Ratings`, `5Quarters`),
-  `iconSetReverse` (`true`/`false`), `iconSetShowIconOnly` (`true`/`false`),
-  `iconThreshold1Type..iconThreshold4Type` (+ matching `...Value`) for the editable bands.
+- **data-bar**: `data_bar_color` (`#RRGGBB`), `data_bar_negative_color`, `data_bar_direction`
+  (`context`, `leftToRight`, `rightToLeft`), `data_bar_show_value` (`true`/`false`),
+  `data_bar_min_type`/`data_bar_max_type` (+ matching values).
+- **icon-set**: `icon_set_id` (e.g. `3Arrows`, `3TrafficLights1`, `4Ratings`, `5Quarters`),
+  `icon_set_reverse` (`true`/`false`), `icon_set_show_icon_only` (`true`/`false`),
+  `icon_threshold1_type..icon_threshold4_type` (+ matching `..._value`) for the editable bands.
 - **top10**: `rank` (count or percent), `top10Percent` (`true`/`false`),
-  `topBottom` (`top`/`bottom`), plus standard formatting options.
-- **above-average**: `aboveBelow` (`aboveAverage`, `belowAverage`, `aboveStdDev`,
+  `top_bottom` (`top`/`bottom`), plus standard formatting options.
+- **above-average**: `above_below` (`aboveAverage`, `belowAverage`, `aboveStdDev`,
   `belowStdDev`, `equalAboveAverage`, `equalBelowAverage`), plus formatting options.
-- **time-period**: `datePeriod` (`today`, `yesterday`, `tomorrow`, `last7Days`,
+- **time-period**: `date_period` (`today`, `yesterday`, `tomorrow`, `last7Days`,
   `thisWeek`, `lastWeek`, `nextWeek`, `thisMonth`, `lastMonth`, `nextMonth`), plus formatting.
 
 **Actions**:
@@ -71,7 +71,7 @@
 
 - Rules are returned in priority order.
 - Colors are returned as `#RRGGBB` hex strings, matching the `add-rule` input format.
-- Formatting fields (interiorColor, fontColor, fontBold/Italic, borderStyle/Color) are only
+- Formatting fields (`interior_color`, `font_color`, `font_bold`/`font_italic`, `border_style`/`border_color`) are only
   present when the rule actually sets them.
 - Visual rule types return their type-specific configuration so they can be fully inspected
   and round-tripped:
@@ -98,11 +98,11 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A10",
-  "ruleType": "cell-value",
-  "operatorType": "greater",
+  "range_address": "A1:A10",
+  "rule_type": "cell-value",
+  "operator_type": "greater",
   "formula1": "100",
-  "interiorColor": "#FFFF00"
+  "interior_color": "#FFFF00"
 }
 ```
 
@@ -110,12 +110,12 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A10",
-  "ruleType": "cell-value",
-  "operatorType": "between",
+  "range_address": "A1:A10",
+  "rule_type": "cell-value",
+  "operator_type": "between",
   "formula1": "50",
   "formula2": "100",
-  "interiorColor": "#90EE90"
+  "interior_color": "#90EE90"
 }
 ```
 
@@ -123,10 +123,10 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:D10",
-  "ruleType": "expression",
+  "range_address": "A1:D10",
+  "rule_type": "expression",
   "formula1": "=$A1=\"Active\"",
-  "interiorColor": "#90EE90"
+  "interior_color": "#90EE90"
 }
 ```
 
@@ -134,15 +134,15 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A100",
-  "ruleType": "color-scale",
-  "colorScaleMinType": "minimum",
-  "colorScaleMinColor": "#F8696B",
-  "colorScaleMidType": "percentile",
-  "colorScaleMidValue": "50",
-  "colorScaleMidColor": "#FFEB84",
-  "colorScaleMaxType": "maximum",
-  "colorScaleMaxColor": "#63BE7B"
+  "range_address": "A1:A100",
+  "rule_type": "color-scale",
+  "color_scale_min_type": "minimum",
+  "color_scale_min_color": "#F8696B",
+  "color_scale_mid_type": "percentile",
+  "color_scale_mid_value": "50",
+  "color_scale_mid_color": "#FFEB84",
+  "color_scale_max_type": "maximum",
+  "color_scale_max_color": "#63BE7B"
 }
 ```
 
@@ -150,11 +150,11 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "B1:B100",
-  "ruleType": "data-bar",
-  "dataBarColor": "#638EC6",
-  "dataBarDirection": "leftToRight",
-  "dataBarShowValue": true
+  "range_address": "B1:B100",
+  "rule_type": "data-bar",
+  "data_bar_color": "#638EC6",
+  "data_bar_direction": "leftToRight",
+  "data_bar_show_value": true
 }
 ```
 
@@ -162,13 +162,13 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "C1:C100",
-  "ruleType": "icon-set",
-  "iconSetId": "3TrafficLights1",
-  "iconThreshold1Type": "percent",
-  "iconThreshold1Value": "33",
-  "iconThreshold2Type": "percent",
-  "iconThreshold2Value": "67"
+  "range_address": "C1:C100",
+  "rule_type": "icon-set",
+  "icon_set_id": "3TrafficLights1",
+  "icon_threshold1_type": "percent",
+  "icon_threshold1_value": "33",
+  "icon_threshold2_type": "percent",
+  "icon_threshold2_value": "67"
 }
 ```
 
@@ -195,7 +195,7 @@ excelcli conditionalformat list-worksheet-rules --session <id> --sheet "Data"
 
 **Common Mistakes**:
 
-- Using `cell-value` type without `operatorType` → Error
+- Using `cell-value` type without `operator_type` → Error
 - Using `between` without both formula1 AND formula2 → Error
 - Forgetting `$` in expression formulas → Rule applies incorrectly across rows/columns
 - Colors without `#` prefix → May not apply correctly

--- a/skills/excel-cli/references/dashboard.md
+++ b/skills/excel-cli/references/dashboard.md
@@ -20,8 +20,8 @@ Every report or dashboard should follow this sequence:
 **Always use Excel Tables for tabular data:**
 
 ```
-range(set-values, rangeAddress='A1', values=[[headers + data]])
-table(create, tableName='SalesData', rangeAddress='A1:D20')
+range(set-values, range_address='A1', values=[[headers + data]])
+table(create, table_name='SalesData', range_address='A1:D20')
 ```
 
 **Why Tables matter:**
@@ -56,46 +56,46 @@ behaviour, not a formatting bug. Never promise a literal rendering when reportin
 **Number formats make cells WIDER, so auto-fit immediately after formatting:**
 
 ```
-range_format(action: 'auto-fit-columns', sheetName: 'Sales', rangeAddress: 'A:F')
+range_format(action: 'auto-fit-columns', sheet_name: 'Sales', range_address: 'A:F')
 ```
 
 A date formatted as `yyyy-mm-dd` or a currency value formatted as `$#,##0.00` does not fit the
 default column width, so Excel renders the cell as `#####`. A screenshot taken before auto-fit will
 show those columns as unreadable hash marks. Auto-fit before Step 5, not after.
 
-Use `range_format auto-fit-rows` as well when any cell has `wrapText` enabled.
+Use `range_format auto-fit-rows` as well when any cell has `wrap_text` enabled.
 
 ## Step 4: Position Charts with No Overlaps
 
 **Charts have automatic collision detection and three positioning modes:**
 
-### Single Chart (Auto-Position or targetRange)
+### Single Chart (Auto-Position or target_range)
 ```
-# Option A: targetRange (explicit cell placement)
-chart(create-from-range, sourceRange='A1:D20', targetRange='F2:K15')
+# Option A: target_range (explicit cell placement)
+chart(create-from-range, source_range='A1:D20', target_range='F2:K15')
 
 # Option B: Omit position — auto-places below content
-chart(create-from-range, sourceRange='A1:D20', chartType='Line')
+chart(create-from-range, source_range='A1:D20', chart_type='Line')
 # → Automatically positioned below the used range
 ```
 
-### Multiple Charts (Dashboard) — Always Use targetRange
+### Multiple Charts (Dashboard) — Always Use target_range
 ```
 Place in a grid pattern below data:
 
-Chart 1: targetRange='A22:F35'    (top-left)
-Chart 2: targetRange='G22:L35'    (top-right)
-Chart 3: targetRange='A37:F50'    (bottom-left)
-Chart 4: targetRange='G37:L50'    (bottom-right)
+Chart 1: target_range='A22:F35'    (top-left)
+Chart 2: target_range='G22:L35'    (top-right)
+Chart 3: target_range='A37:F50'    (bottom-left)
+Chart 4: target_range='G37:L50'    (bottom-right)
 ```
 
 ### Collision Detection
 All chart operations automatically warn about overlaps. If a result includes an `OVERLAP WARNING` message:
 1. Use `chart(fit-to-range)` to reposition
-2. Take `screenshot(capture, rangeAddress='A1:M50')` to verify
+2. Take `screenshot(capture, range_address='A1:M50')` to verify
 
 **Rules:**
-- **Use targetRange for multi-chart layouts** — auto-positioning stacks vertically
+- **Use target_range for multi-chart layouts** — auto-positioning stacks vertically
 - Leave 1-2 rows/columns gap between charts
 - Place charts BELOW the data area, not beside it (more room)
 - Keep chart sizes consistent (same row/column span)
@@ -106,7 +106,7 @@ All chart operations automatically warn about overlaps. If a result includes an 
 **Always take a screenshot after creating charts or complex layouts:**
 
 ```
-screenshot(capture, rangeAddress='A1:M50')
+screenshot(capture, range_address='A1:M50')
 → Confirm: no overlaps, professional spacing, readable labels
 → Confirm: no column renders as ##### (if it does, go back to Step 3 and auto-fit)
 → If issues found: chart(fit-to-range) to reposition, then screenshot again

--- a/skills/excel-cli/references/datamodel.md
+++ b/skills/excel-cli/references/datamodel.md
@@ -27,13 +27,13 @@ You MUST explicitly refresh the Data Model to sync changes.
 
 ```
 # WRONG: Data still shows old values
-table(append, tableName="Sales", csvData="...")  # Worksheet updated
-datamodel(evaluate, daxQuery="...")               # Returns OLD values!
+table(append, table_name="Sales", rows=[["..."]])  # Worksheet updated
+datamodel(evaluate, dax_query="...")               # Returns OLD values!
 
 # CORRECT: Refresh Data Model after worksheet changes
-table(append, tableName="Sales", csvData="...")  # Worksheet updated
+table(append, table_name="Sales", rows=[["..."]])  # Worksheet updated
 datamodel(refresh)                                 # Sync to Data Model
-datamodel(evaluate, daxQuery="...")               # Returns NEW values!
+datamodel(evaluate, dax_query="...")               # Returns NEW values!
 ```
 
 **When refresh is automatic:**
@@ -63,19 +63,19 @@ datamodel(evaluate, daxQuery="...")               # Returns NEW values!
 | Source | Method |
 |--------|--------|
 | Worksheet Excel Table | table with add-to-data-model action |
-| External file (CSV, etc.) | powerquery with loadDestination='data-model' |
-| Database/web source | powerquery with loadDestination='data-model' |
+| External file (CSV, etc.) | powerquery with load_destination='data-model' |
+| Database/web source | powerquery with load_destination='data-model' |
 
 **DAX Formatting**:
 
-DAX formulas are preserved exactly by default on WRITE operations (create-measure, update-measure), subject to Excel locale separator translation. Set `formatDax=true` only with explicit user consent; it sends DAX to daxformatter.com. Remote formatting adds ~100-500ms network latency per write operation. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
+DAX formulas are preserved exactly by default on WRITE operations (create-measure, update-measure), subject to Excel locale separator translation. Set `format_dax=true` only with explicit user consent; it sends DAX to daxformatter.com. Remote formatting adds ~100-500ms network latency per write operation. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
 
 **Action disambiguation**:
 
 - list-tables: List all tables currently in the Data Model
 - list-measures: List all DAX measures (returns raw DAX from Excel)
-- create-measure: Create a new DAX measure (DAX preserved by default; `formatDax=true` opts into remote formatting)
-- update-measure: Modify existing measure's formula/format/description (DAX preserved by default; `formatDax=true` opts into remote formatting)
+- create-measure: Create a new DAX measure (DAX preserved by default; `format_dax=true` opts into remote formatting)
+- update-measure: Modify existing measure's formula/format/description (DAX preserved by default; `format_dax=true` opts into remote formatting)
 - delete-measure: Remove a measure
 - delete-table: Remove table AND ALL its measures (DESTRUCTIVE!)
 - read-info: Get Data Model metadata (culture, compatibility level)
@@ -172,10 +172,10 @@ Reference: [Microsoft DMV Documentation](https://learn.microsoft.com/en-us/analy
 
 **DAX measure creation**:
 
-- tableName: Which table the measure belongs to (for organization)
-- measureName: Display name for the measure
-- daxFormula: DAX expression (e.g., "SUM(Sales[Revenue])")
-- formatString: Optional number format (#,##0.00, 0%, $#,##0, etc.)
+- table_name: Which table the measure belongs to (for organization)
+- measure_name: Display name for the measure
+- dax_formula: DAX expression (e.g., "SUM(Sales[Revenue])")
+- format_type: Optional number format (#,##0.00, 0%, $#,##0, etc.)
 
 **Common DAX patterns**:
 
@@ -225,7 +225,7 @@ A PivotChart is a single object connected to the Data Model. Creating a PivotTab
 - Creating measures before adding source table to Data Model → Error
 - Using worksheet table names instead of Data Model table names
 - Forgetting that delete-table removes ALL measures on that table
-- Not specifying tableName when creating measures (required for organization)
+- Not specifying `table_name` when creating measures (required for organization)
 
 **Server-specific quirks**:
 

--- a/skills/excel-cli/references/drawing.md
+++ b/skills/excel-cli/references/drawing.md
@@ -30,8 +30,8 @@ Colors use `#RRGGBB`. Position and size values use points. Placement values are:
 
 Supported controls are Button, CheckBox, DropDown, GroupBox, Label, ListBox, OptionButton, ScrollBar, and Spinner.
 
-- `linkedCell`: CheckBox, DropDown, ListBox, OptionButton, ScrollBar, and Spinner
-- `inputRange`: DropDown and ListBox only
+- `linked_cell`: CheckBox, DropDown, ListBox, OptionButton, ScrollBar, and Spinner
+- `input_range`: DropDown and ListBox only
 - Button, GroupBox, and Label return explicit nulls for both binding properties
 
 ActiveX/OLE controls and macro assignment are intentionally unavailable. Do not try to create them through VBA as a workaround.
@@ -41,8 +41,8 @@ ActiveX/OLE controls and macro assignment are intentionally unavailable. Do not 
 Use `add-sparkline`, `get-sparkline`, `list-sparklines`, `update-sparkline`, and `delete-sparkline`.
 
 - Types: Line, Column, WinLoss
-- `sourceRange`: data to visualize
-- `locationRange`: cells that host the sparklines
+- `source_range`: data to visualize
+- `location_range`: cells that host the sparklines
 - Line sparklines can show markers
 
 ```powershell

--- a/skills/excel-cli/references/excel_agent_mode.md
+++ b/skills/excel-cli/references/excel_agent_mode.md
@@ -51,7 +51,7 @@ AI navigates through a completed workbook, explaining findings while the user wa
 ```
 1. file(open, path='analysis.xlsx')
 2. window(show)
-3. window(set-state, windowState='maximized')      → Full screen for best visibility
+3. window(set-state, window_state='maximized')      → Full screen for best visibility
 4. window(set-status-bar, text='Reviewing Sales sheet...')
 5. "On the Sales sheet, you can see quarterly revenue trending up 15%..."
 6. worksheet(activate, name='Analysis')            → Switch to next sheet
@@ -79,13 +79,13 @@ AI performs operations one at a time, showing results between each step for trou
 4. window(set-status-bar, text='Inspecting Power Query...')
 5. powerquery(list)
 6. "Found 3 queries. Let me check each one..."
-7. powerquery(view, queryName='Sales')
+7. powerquery(view, query_name='Sales')
 8. window(set-status-bar, text='Refreshing Sales query...')
-9. powerquery(refresh, queryName='Sales')
+9. powerquery(refresh, query_name='Sales')
 10. screenshot(capture-sheet)                      → Show result
 11. "Sales query refreshed successfully. 150 rows loaded. Moving to next..."
 12. window(set-status-bar, text='Refreshing Products query...')
-13. powerquery(refresh, queryName='Products')
+13. powerquery(refresh, query_name='Products')
 14. "Products query failed: [error]. Let me fix the M code..."
 15. window(clear-status-bar)
 ```

--- a/skills/excel-cli/references/gotchas.md
+++ b/skills/excel-cli/references/gotchas.md
@@ -117,9 +117,9 @@ Power Query connections that reference external files or URLs have a "refresh on
 Range addresses in M1 notation (e.g., `A1:D10`) work fine, but range names with spaces, hyphens, or special characters must be enclosed in single quotes or backticks:
 
 ```
-rangeAddress: 'Sales Data'      ← Correct (with spaces)
-rangeAddress: Sales Data        ← WRONG (fails)
-rangeAddress: `Sales Data`      ← Also correct (backticks)
+range_address: 'Sales Data'      ← Correct (with spaces)
+range_address: Sales Data        ← WRONG (fails)
+range_address: `Sales Data`      ← Also correct (backticks)
 ```
 
 Same rule applies for sheet names: `'Sheet Name'!A1:D10`.

--- a/skills/excel-cli/references/pivottable.md
+++ b/skills/excel-cli/references/pivottable.md
@@ -4,7 +4,7 @@
 
 ## CRITICAL: Required Parameters
 
-**`pivotTableName` is REQUIRED for almost all PivotTable operations** across `pivottable`, `pivottable_calc`, and `pivottable_field` tools. The only exception is `list` (which lists all PivotTables). Always specify the PivotTable name.
+**`pivot_table_name` is REQUIRED for almost all PivotTable operations** across `pivottable`, `pivottable_calc`, and `pivottable_field` tools. The only exception is `list` (which lists all PivotTables). Always specify the PivotTable name.
 
 ## Calculated Fields vs DAX Measures
 
@@ -20,15 +20,15 @@ PivotTable calculated fields work well for simple single-table formulas. Use DAX
 ### Calculated Field Workflow
 
 ```
-pivottable_calc(CreateCalculatedField, fieldName="Revenue", formula="=Quantity*UnitPrice")
-pivottable_field(AddValueField, fieldName="Revenue", aggregationFunction="Sum")
+pivottable_calc(action="create-calculated-field", pivot_table_name="SalesPivot", field_name="Revenue", formula="=Quantity*UnitPrice")
+pivottable_field(action="add-value-field", pivot_table_name="SalesPivot", field_name="Revenue", aggregation_function="Sum")
 ```
 
 ### DAX Measure Workflow (for complex scenarios)
 
 ```
-table(add-to-data-model, tableName="Sales")
-datamodel(create-measure, measureName="Revenue", daxFormula="SUMX(Sales, Sales[Quantity]*Sales[UnitPrice])")
+table(action="add-to-data-model", table_name="Sales")
+datamodel(action="create-measure", table_name="Sales", measure_name="Revenue", dax_formula="SUMX(Sales, Sales[Quantity]*Sales[UnitPrice])")
 pivottable(create-from-datamodel, ...)  # Measure automatically available
 ```
 
@@ -45,7 +45,7 @@ pivottable(create-from-datamodel, ...)  # Measure automatically available
 |--------|---------------|------------------------|
 | Worksheet Table | `create-from-table` | NO - worksheet PivotTable |
 | Data Model | `create-from-datamodel` | YES - full DAX support |
-| External | `create` with sourceRange | NO |
+| External | `create-from-range` with `source_range` | NO |
 
 **Rule**: If you need calculated revenue/aggregations, use Data Model as source.
 
@@ -69,8 +69,8 @@ powerquery(refresh, ...)     # Refreshes Power Query AND Data Model
 ## PivotCache Options
 
 - `pivottable(get-cache-options)`: Read refresh, retained-item, optimization, and saved-source settings.
-- `pivottable(set-cache-options)`: Set `enableRefresh`, `refreshOnFileOpen`, `missingItemsLimit`, `optimizeCache`, or `saveSourceData`.
-- `missingItemsLimit` values: `Default`, `None`, `Max`, `Max2`.
+- `pivottable(set-cache-options)`: Set `enable_refresh`, `refresh_on_file_open`, `missing_items_limit`, `optimize_cache`, or `save_source_data`.
+- `missing_items_limit` values: `Default`, `None`, `Max`, `Max2`.
 - Deleted-item retention applies only to regular PivotTables. OLAP/Data Model caches manage members in the model.
 
 ## Field Configuration
@@ -78,20 +78,20 @@ powerquery(refresh, ...)     # Refreshes Power Query AND Data Model
 ### Row/Column/Value Fields
 
 When creating PivotTables, configure fields in order:
-1. Add Row fields: `pivottable_field(AddRowField, fieldName="Region")`
-2. Add Column fields: `pivottable_field(AddColumnField, fieldName="Year")`  
-3. Add Value fields: `pivottable_field(AddValueField, fieldName="Amount", aggregationFunction="Sum")`
-4. Add filters: `pivottable_field(AddFilterField, fieldName="Status")`
-5. **Refresh to update display**: `pivottable(refresh, pivotTableName="...")`
+1. Add Row fields: `pivottable_field(action="add-row-field", pivot_table_name="SalesPivot", field_name="Region")`
+2. Add Column fields: `pivottable_field(action="add-column-field", pivot_table_name="SalesPivot", field_name="Year")`
+3. Add Value fields: `pivottable_field(action="add-value-field", pivot_table_name="SalesPivot", field_name="Amount", aggregation_function="Sum")`
+4. Add filters: `pivottable_field(action="add-filter-field", pivot_table_name="SalesPivot", field_name="Status")`
+5. **Refresh to update display**: `pivottable(action="refresh", pivot_table_name="SalesPivot")`
 
 **IMPORTANT**: Field operations are structural only - they modify the PivotTable layout but don't trigger visual refresh. Call `pivottable(refresh)` after configuring all fields to update the display. This is especially important for OLAP/Data Model PivotTables.
 
 ### Manual Grouping
 
 ```
-pivottable_field(group-items, fieldName="Region", itemNames=["North", "South"], groupName="Core Regions")
-# Use groupedFieldName from the result:
-pivottable_field(ungroup-field, groupedFieldName="Region2")
+pivottable_field(action="group-items", pivot_table_name="SalesPivot", field_name="Region", item_names=["North", "South"], group_name="Core Regions")
+# Use grouped_field_name from the result:
+pivottable_field(action="ungroup-field", pivot_table_name="SalesPivot", grouped_field_name="Region2")
 ```
 
 Manual grouping requires a regular PivotTable and a field already placed in the Row or Column area. OLAP/Data Model PivotTables must add grouping columns in the model.
@@ -99,7 +99,7 @@ Manual grouping requires a regular PivotTable and a field already placed in the 
 ### Drill Through
 
 ```
-pivottable(drill-through, pivotTableName="SalesPivot", cellAddress="G4")
+pivottable(action="drill-through", pivot_table_name="SalesPivot", cell_address="G4")
 ```
 
 The target must be a value cell in a regular PivotTable data body. Excel creates a new worksheet containing the underlying source rows. OLAP/Data Model drill-through is provider-dependent and intentionally not exposed as a deterministic operation.
@@ -121,13 +121,13 @@ The target must be a value cell in a regular PivotTable data body. Excel creates
 
 ```
 # Option 1: Add revenue column to source table FIRST
-range(set-formula, sheetName="Sales", rangeAddress="I2", formula="=[@Quantity]*[@UnitPrice]")
-pivottable(create-from-table, sourceTableName="SalesTable", ...)
-pivottable_field(AddValueField, fieldName="Revenue", aggregationFunction="Sum")  # Works!
+range(action="set-formulas", sheet_name="Sales", range_address="I2", formulas=[["=[@Quantity]*[@UnitPrice]"]])
+pivottable(action="create-from-table", table_name="SalesTable", ...)
+pivottable_field(action="add-value-field", field_name="Revenue", aggregation_function="Sum", ...)  # Works!
 
 # Option 2: Use Data Model (RECOMMENDED)
-table(add-to-data-model, tableName="SalesTable")
-datamodel(create-measure, measureName="Revenue", daxFormula="SUMX(SalesTable, SalesTable[Quantity]*SalesTable[UnitPrice])")
+table(action="add-to-data-model", table_name="SalesTable")
+datamodel(action="create-measure", table_name="SalesTable", measure_name="Revenue", dax_formula="SUMX(SalesTable, SalesTable[Quantity]*SalesTable[UnitPrice])")
 pivottable(create-from-datamodel, ...)  # Measure automatically available
 ```
 
@@ -135,16 +135,16 @@ pivottable(create-from-datamodel, ...)  # Measure automatically available
 
 Always use Data Model for multi-table analysis:
 ```
-table(add-to-data-model, tableName="Sales")
-table(add-to-data-model, tableName="Products")
-datamodel_relationship(create-relationship, fromTable="Sales", fromColumn="ProductID", toTable="Products", toColumn="ProductID")
-datamodel(create-measure, tableName="Sales", measureName="Revenue", daxFormula="SUMX(Sales, RELATED(Products[Price])*Sales[Quantity])")
+table(action="add-to-data-model", table_name="Sales")
+table(action="add-to-data-model", table_name="Products")
+datamodel_relationship(action="create-relationship", from_table="Sales", from_column="ProductID", to_table="Products", to_column="ProductID")
+datamodel(action="create-measure", table_name="Sales", measure_name="Revenue", dax_formula="SUMX(Sales, RELATED(Products[Price])*Sales[Quantity])")
 pivottable(create-from-datamodel)
 ```
 
 ## Layout Styles
 
-The `layoutStyle` parameter controls PivotTable appearance:
+The `row_layout` parameter controls PivotTable appearance:
 
 | Value | Style | Description |
 |-------|-------|-------------|

--- a/skills/excel-cli/references/powerquery.md
+++ b/skills/excel-cli/references/powerquery.md
@@ -32,7 +32,7 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 **M-Code Formatting and reads**:
 
 - Create and Update preserve M code exactly by default and do not call remote services
-- Set `formatMCode=true` only with explicit user consent; it sends M code to powerqueryformatter.com
+- Set `format_m_code=true` only with explicit user consent; it sends M code to powerqueryformatter.com
 - Remote formatting adds ~100-500ms network latency per call
 - Graceful fallback: saves original M code if the formatting service is unavailable
 - `list` returns compact metadata, exact load mode, character count, and at most
@@ -52,7 +52,7 @@ Destination values are case-insensitive. Unknown values fail before the query is
 changed; they never fall back to connection-only or another enum default.
 
 To create DAX measures on Power Query data:
-1. Use powerquery create/load-to with `loadDestination='data-model'`
+1. Use powerquery create/load-to with `load_destination='data-model'`
 2. Then use datamodel to create DAX measures
 
 Alternative path (for existing worksheet tables):
@@ -62,9 +62,9 @@ Alternative path (for existing worksheet tables):
 **Action disambiguation**:
 
 - **evaluate**: **CRITICAL - USE THIS FIRST** - Execute M code directly, return results WITHOUT creating a permanent query (test before create/update!)
-- create: Import NEW query using inline `mCode` (FAILS if query already exists - use update instead)
+- create: Import NEW query using inline `m_code` (FAILS if query already exists - use update instead)
 - update: Update EXISTING query M code + refresh data (use this if query exists)
-- rename: Change query name (requires both `queryName` and `newName` parameters)
+- rename: Change query name (requires both `old_name` and `new_name` parameters)
 - load-to: Loads to worksheet or data model or both (not just config change) - CHECKS for sheet conflicts
 - unload: Removes data from ALL destinations (worksheet AND Data Model) - keeps query definition
 - delete: Completely removes query AND all associated data (worksheet, Data Model connections)
@@ -99,15 +99,15 @@ Alternative path (for existing worksheet tables):
 
 **Inline M code**:
 
-- Provide raw M code directly via `mCode`
+- Provide raw M code directly via `m_code`
 - Keep `.pq` files only for GIT workflows
 
 **Create/LoadTo with existing sheets**:
 
-- Use `targetCellAddress` to place the table on an existing worksheet without deleting other content
+- Use `target_cell_address` to place the table on an existing worksheet without deleting other content
 - Applies to BOTH create and load-to
-- If the worksheet already has data and you omit `targetCellAddress`, the tool returns guidance telling you to provide one
-- Existing tables are refreshed in-place; specifying a different `targetCellAddress` requires unload + reload
+- If the worksheet already has data and you omit `target_cell_address`, the tool returns guidance telling you to provide one
+- Existing tables are refreshed in-place; specifying a different `target_cell_address` requires unload + reload
 - Worksheets that exist but are empty behave like new sheets (default destination = A1)
 
 **Common mistakes**:
@@ -117,15 +117,15 @@ Alternative path (for existing worksheet tables):
 - Using update on new query → ERROR "Query 'X' not found" (should use create)
 - Calling LoadTo without checking if sheet exists (will error if sheet exists)
 - Assuming unload only removes worksheet data → Also removes Data Model connections
-- Calling rename without trimming newName → Server trims automatically, " Query " becomes "Query"
+- Calling rename without trimming `new_name` → Server trims automatically, " Query " becomes "Query"
 - Renaming to conflicting name → Check list first if unsure about existing names
-- Passing an option from another action (for example `mCode` on delete or `timeout` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
+- Passing an option from another action (for example `m_code` on delete or `timeout_seconds` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
 
 **Server-specific quirks**:
 
 - Validation = execution: M code only validated when data loads/refreshes
 - connection-only queries: NOT validated until first execution
-- refresh with loadDestination: Applies load config + refreshes (2-in-1)
+- load-to with `load_destination`: Applies load config and refreshes (2-in-1)
 - Single cell returns [[value]] not scalar
 - Public timeout inputs are integer seconds. Refresh/refresh-all accepts 0-2147483 and defaults to the 30-minute data-operation timeout when `timeout_seconds`/`--timeout` is 0 or omitted. For quick queries use a smaller value (e.g., 60-120 seconds).
 - load-to has no caller timeout parameter and uses the fixed 30-minute data-operation timeout; passing `timeout` to load-to is rejected instead of ignored.
@@ -170,7 +170,7 @@ Reference other queries by name directly: `Source = OtherQueryName`
 ### Source Control Pattern
 
 1. Store M code in `.pq` files
-2. `powerquery create` or `update` with inline `mCode`
+2. `powerquery create` or `update` with inline `m_code`
 3. `refresh` to validate
 4. File name MUST match query name
 

--- a/skills/excel-cli/references/querytable.md
+++ b/skills/excel-cli/references/querytable.md
@@ -17,18 +17,18 @@ Use `querytable` for worksheet QueryTables backed by the desktop Excel COM objec
 
 ```text
 querytable(action: 'create-text',
-    queryTableName: 'OrdersCsv',
-    sourcePath: 'C:\Data\orders.csv',
-    sheetName: 'Orders',
-    destinationAddress: 'A1',
+    query_table_name: 'OrdersCsv',
+    source_path: 'C:\Data\orders.csv',
+    sheet_name: 'Orders',
+    destination_address: 'A1',
     delimiter: ',',
-    textQualifier: 'double-quote',
+    text_qualifier: 'double-quote',
     encoding: 65001,
-    hasHeaders: true)
+    has_headers: true)
 ```
 
 - `delimiter` is exactly one character.
-- `textQualifier` is `double-quote`, `single-quote`, or `none`.
+- `text_qualifier` is `double-quote`, `single-quote`, or `none`.
 - `encoding` is a Windows code page; use `65001` for UTF-8.
 - Creation refreshes synchronously so imported data is ready when the call returns.
 
@@ -36,17 +36,17 @@ querytable(action: 'create-text',
 
 ```text
 querytable(action: 'create-web',
-    queryTableName: 'RatesHtml',
+    query_table_name: 'RatesHtml',
     url: 'https://example.com/rates.html',
-    sheetName: 'Rates',
-    destinationAddress: 'A1',
-    selectionType: 'specified-tables',
-    webTables: '1',
+    sheet_name: 'Rates',
+    destination_address: 'A1',
+    selection_type: 'specified-tables',
+    web_tables: '1',
     formatting: 'none')
 ```
 
-- `selectionType` is `entire-page`, `all-tables`, or `specified-tables`.
-- `webTables` is required with `specified-tables`.
+- `selection_type` is `entire-page`, `all-tables`, or `specified-tables`.
+- `web_tables` is required with `specified-tables`.
 - `formatting` is `none`, `rich-text`, or `all`.
 - This is Excel's legacy HTML web-query engine, not a general HTTP or browser automation API.
 

--- a/skills/excel-cli/references/range.md
+++ b/skills/excel-cli/references/range.md
@@ -23,9 +23,9 @@ If you need the same styling on multiple non-contiguous ranges, use `format-rang
 ## Quick Pattern: Write, Format, Auto-Fit
 
 ```
-range(action: 'set-values', rangeAddress: 'A1:D4', values: [[...], [...]])
-range(action: 'set-number-format', rangeAddress: 'C2:D4', formatCode: '$#,##0.00')
-range_format(action: 'auto-fit-columns', rangeAddress: 'A:D')
+range(action: 'set-values', range_address: 'A1:D4', values: [[...], [...]])
+range(action: 'set-number-format', range_address: 'C2:D4', format_code: '$#,##0.00')
+range_format(action: 'auto-fit-columns', range_address: 'A:D')
 ```
 
 ## Quick Pattern: Repeated Section Headers
@@ -34,11 +34,11 @@ Use `format-ranges` when the same header or section style repeats across disjoin
 
 ```
 range_format(action: 'format-ranges',
-    rangeAddresses: ['A1:G1', 'A12:G12', 'A24:G24'],
+    range_addresses: ['A1:G1', 'A12:G12', 'A24:G24'],
     bold: true,
-    fillColor: '#243F60',
-    fontColor: '#FFFFFF',
-    horizontalAlignment: 'center')
+    fill_color: '#243F60',
+    font_color: '#FFFFFF',
+    horizontal_alignment: 'center')
 ```
 
 All target ranges are validated before formatting begins. If any target range is invalid, nothing is formatted.
@@ -49,11 +49,11 @@ All target ranges are validated before formatting begins. If any target range is
 Pass ALL properties in **one call**:
 
 ```
-range_format(action: 'format-range', rangeAddress: 'A1:D1',
+range_format(action: 'format-range', range_address: 'A1:D1',
     bold: true,
-    fillColor: '#4472C4',
-    fontColor: '#FFFFFF',
-    horizontalAlignment: 'center')
+    fill_color: '#4472C4',
+    font_color: '#FFFFFF',
+    horizontal_alignment: 'center')
 ```
 
 ## Quick Pattern: Semantic Status Cells
@@ -61,8 +61,8 @@ range_format(action: 'format-range', rangeAddress: 'A1:D1',
 Use `set-style` when the meaning (Good/Bad/Neutral) matters and theme-awareness is useful:
 
 ```
-range_format(action: 'set-style', rangeAddress: 'B2:B10', styleName: 'Good')
-range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
+range_format(action: 'set-style', range_address: 'B2:B10', style_name: 'Good')
+range_format(action: 'set-style', range_address: 'C2:C10', style_name: 'Bad')
 ```
 
 ## format-range Properties
@@ -72,15 +72,15 @@ range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
 | `bold` | bool | `true` |
 | `italic` | bool | `true` |
 | `underline` | bool | `true` |
-| `fontSize` | number | `14` |
-| `fontName` | string | `"Calibri"` |
-| `fontColor` | hex color | `"#FFFFFF"` |
-| `fillColor` | hex color | `"#4472C4"` |
-| `horizontalAlignment` | string | `"center"`, `"left"`, `"right"` |
-| `verticalAlignment` | string | `"middle"`, `"top"`, `"bottom"` |
-| `wrapText` | bool | `true` |
-| `borderStyle` | string | `"thin"`, `"medium"`, `"thick"` |
-| `borderColor` | hex color | `"#000000"` |
+| `font_size` | number | `14` |
+| `font_name` | string | `"Calibri"` |
+| `font_color` | hex color | `"#FFFFFF"` |
+| `fill_color` | hex color | `"#4472C4"` |
+| `horizontal_alignment` | string | `"center"`, `"left"`, `"right"` |
+| `vertical_alignment` | string | `"middle"`, `"top"`, `"bottom"` |
+| `wrap_text` | bool | `true` |
+| `border_style` | string | `"thin"`, `"medium"`, `"thick"` |
+| `border_color` | hex color | `"#000000"` |
 | `orientation` | int | `-90` to `90` (degrees) |
 
 ## set-style Presets
@@ -88,7 +88,7 @@ range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
 Built-in style names: `Normal`, `Heading 1`, `Heading 2`, `Heading 3`, `Heading 4`, `Title`, `Good`, `Bad`, `Neutral`, `Currency`, `Percent`, `Comma`
 
 ```
-range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
+range_format(action: 'set-style', range_address: 'A1:D1', style_name: 'Heading 1')
 ```
 
 ## Format Codes
@@ -124,7 +124,7 @@ than raw ones and will render as `#####` at the default column width.
 
 **SetNumberFormat**: Apply one format to entire range.
 
-- `formatCode`: Format code from table above
+- `format_code`: Format code from table above
 
 **SetNumberFormats**: Apply different formats per cell.
 
@@ -136,10 +136,10 @@ than raw ones and will render as `#####` at the default column width.
 Use modern threaded comments only when the installed desktop Excel build exposes them:
 
 ```text
-range_link(action: 'add-threaded-comment', sheetName: 'Review', cellAddress: 'B2', text: 'Check this value')
-range_link(action: 'add-threaded-comment-reply', sheetName: 'Review', cellAddress: 'B2', text: 'Confirmed')
-range_link(action: 'list-threaded-comments', sheetName: 'Review', cellAddress: 'B2')
-range_link(action: 'delete-threaded-comment', sheetName: 'Review', cellAddress: 'B2')
+range_link(action: 'add-threaded-comment', sheet_name: 'Review', cell_address: 'B2', text: 'Check this value')
+range_link(action: 'add-threaded-comment-reply', sheet_name: 'Review', cell_address: 'B2', text: 'Confirmed')
+range_link(action: 'list-threaded-comments', sheet_name: 'Review', cell_address: 'B2')
+range_link(action: 'delete-threaded-comment', sheet_name: 'Review', cell_address: 'B2')
 ```
 
 These actions expose local Excel PIA comment text, author, date, and replies. Microsoft 365 service features such as @mentions, assignments, reactions, presence, sharing, and coauthoring state are not available through local Excel COM.

--- a/skills/excel-cli/references/screenshot.md
+++ b/skills/excel-cli/references/screenshot.md
@@ -8,7 +8,7 @@
 
 ```
 1. chart(create-from-range, ...)  → Chart created
-2. screenshot(capture, rangeAddress='A1:M20')  ← REQUIRED — never skip this step
+2. screenshot(capture, range_address='A1:M20')  ← REQUIRED — never skip this step
 3. file(close, save=true)
 ```
 
@@ -25,8 +25,8 @@ This rule applies even if:
 
 | Action | Purpose | Parameters |
 |--------|---------|------------|
-| `capture` | Capture a specific range | `rangeAddress` (default: A1:Z30), `sheetName`, `quality` |
-| `capture-sheet` | Capture the worksheet's used cell range | `sheetName`, `quality` |
+| `capture` | Capture a specific range | `range_address` (default: A1:Z30), `sheet_name`, `quality` |
+| `capture-sheet` | Capture the worksheet's used cell range | `sheet_name`, `quality` |
 
 `capture-sheet` is cell-driven: it captures Excel's used range. On a chart-only worksheet, or when a chart extends beyond the used cells, use `capture` with an explicit range that covers the chart (for example, `A1:M25`).
 
@@ -53,8 +53,8 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 
 ### After Chart Creation or Positioning
 ```
-1. chart(create-from-range, ..., targetRange='F2:K15')
-2. screenshot(capture, rangeAddress='A1:O25')  → Verify chart doesn't overlap data
+1. chart(create-from-range, ..., target_range='F2:K15')
+2. screenshot(capture, range_address='A1:O25')  → Verify chart doesn't overlap data
 ```
 
 ### After Complex Formatting
@@ -68,7 +68,7 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 ```
 1. pivottable(add-row-field, ...)
 2. pivottable(add-value-field, ...)
-3. screenshot(capture, rangeAddress='A1:M25')  → Include charts and verify layout
+3. screenshot(capture, range_address='A1:M25')  → Include charts and verify layout
 ```
 
 ## Best Practices
@@ -86,8 +86,8 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 ### Chart Overlap Verification
 ```
 1. range(get-used-range) → "A1:D20"
-2. chart(create-from-range, sourceRange='A1:D20', targetRange='F2:K15')
-3. screenshot(capture, rangeAddress='A1:K20')
+2. chart(create-from-range, source_range='A1:D20', target_range='F2:K15')
+3. screenshot(capture, range_address='A1:K20')
    → Visually confirm chart is positioned next to data, not on top of it
 ```
 
@@ -96,13 +96,13 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 When creating dashboards with multiple charts:
 
 1. get-used-range → Know where data ends
-2. Create Chart 1 with targetRange below/beside data
-3. Create Chart 2 with targetRange that does NOT overlap Chart 1
-4. Create Chart 3, Chart 4, etc. — each in a non-overlapping targetRange
-5. screenshot(capture, rangeAddress='A1:M40') → Verify NO charts overlap each other or data
+2. Create Chart 1 with `target_range` below/beside data
+3. Create Chart 2 with `target_range` that does NOT overlap Chart 1
+4. Create Chart 3, Chart 4, etc. — each in a non-overlapping `target_range`
+5. screenshot(capture, range_address='A1:M40') → Verify NO charts overlap each other or data
 
 Key rules for multi-chart layouts:
-- Use targetRange for every chart — never rely on default positioning
+- Use `target_range` for every chart — never rely on default positioning
 - Leave at least 1-2 rows/columns between charts
 - Place charts in a grid pattern (e.g., 2x2) below the data area
 - If overlap detected, use chart(fit-to-range) to reposition
@@ -111,7 +111,7 @@ Key rules for multi-chart layouts:
 ### Dashboard Layout Check
 ```
 1. Create multiple charts and tables
-2. screenshot(capture, rangeAddress='A1:M40')
+2. screenshot(capture, range_address='A1:M40')
    → Verify overall dashboard layout, spacing, and alignment
 3. If issues found: reposition with chart(fit-to-range), then screenshot again
 ```

--- a/skills/excel-cli/references/slicer.md
+++ b/skills/excel-cli/references/slicer.md
@@ -12,26 +12,26 @@ Two distinct slicer types exist:
 
 | Action | Description | Required Parameters |
 |--------|-------------|---------------------|
-| `create-slicer` | Create PivotTable slicer | pivotTableName, fieldName |
+| `create-slicer` | Create PivotTable slicer | pivot_table_name, field_name |
 | `list-slicers` | List all PivotTable slicers | (none) |
-| `set-slicer-selection` | Set PivotTable slicer filter | slicerName, selectedItems |
-| `delete-slicer` | Delete PivotTable slicer | slicerName |
-| `create-table-slicer` | Create Table slicer | tableName, columnName |
+| `set-slicer-selection` | Set PivotTable slicer filter | slicer_name, selected_items |
+| `delete-slicer` | Delete PivotTable slicer | slicer_name |
+| `create-table-slicer` | Create Table slicer | table_name, column_name |
 | `list-table-slicers` | List all Table slicers | (none) |
-| `set-table-slicer-selection` | Set Table slicer filter | slicerName, selectedItems |
-| `delete-table-slicer` | Delete Table slicer | slicerName |
+| `set-table-slicer-selection` | Set Table slicer filter | slicer_name, selected_items |
+| `delete-table-slicer` | Delete Table slicer | slicer_name |
 
-**CRITICAL: Required Parameters** - The "Required Parameters" column above is strict. Missing any required parameter will cause an error. Pay special attention to `pivotTableName` for PivotTable slicers and `slicerName` for selection/deletion operations.
+**CRITICAL: Required Parameters** - The "Required Parameters" column above is strict. Missing any required parameter will cause an error. Pay special attention to `pivot_table_name` for PivotTable slicers and `slicer_name` for selection/deletion operations.
 
 **Naming Convention**:
 
-- If `slicerName` not provided, auto-generates `{FieldName}Slicer` or `{ColumnName}Slicer`
+- If `slicer_name` is not provided, Excel auto-generates a name from the field or column
 - Slicer names must be unique within workbook
 - Use `list-slicers` or `list-table-slicers` to check existing names
 
 **Selection Behavior**:
 
-- `selectedItems` is a list of strings: `["Value1", "Value2"]`
+- `selected_items` is a JSON array of strings: `["Value1", "Value2"]`
 - Empty list `[]` clears all filters (shows all items)
 - Values must match exactly (case-sensitive)
 - Invalid values are silently ignored
@@ -53,7 +53,7 @@ The `--selected-items` parameter requires a JSON array. Use proper shell escapin
 
 **Positioning**:
 
-- `destinationSheet` specifies which worksheet hosts the slicer
+- `destination_sheet` specifies which worksheet hosts the slicer
 - `position` is a cell address for top-left corner (e.g., `'E1'`, `'G5'`)
 - The slicer's top-left corner aligns to the specified cell
 - Default position if not specified: Excel chooses

--- a/skills/excel-cli/references/table.md
+++ b/skills/excel-cli/references/table.md
@@ -13,17 +13,17 @@ To analyze worksheet data with DAX measures:
 
 **Action disambiguation**:
 
-- create: Create NEW table from a range (requires sheetName, tableName, rangeAddress). Pass `tableStyle` here to style at creation time.
+- create: Create NEW table from a range (requires `sheet_name`, `table_name`, and `range_address`). Pass `table_style` here to style at creation time.
 - read: Get table metadata (range, columns, style, row counts)
-- get-data: Get actual table DATA as 2D array (use visibleOnly=true for filtered data)
+- get-data: Get actual table DATA as 2D array (use `visible_only=true` for filtered data)
 - rename: Rename an existing table
 - delete: Remove table (keeps data, removes table formatting)
 - resize: Change table range (expand/contract)
 - set-style: Change table visual style (TableStyleLight1-21, TableStyleMedium1-28, TableStyleDark1-11). Default is TableStyleMedium2.
-- toggle-totals: Show or hide the totals row (showTotals: true/false)
+- toggle-totals: Show or hide the totals row (`show_totals`: true/false)
 - set-column-total: Set the aggregate function on a totals-row column (Sum, Count, Average, Min, Max, None)
 - add-to-data-model: Add an existing worksheet table to Power Pivot for DAX analysis
-- append: Add rows to existing table (requires rows or rowsFile parameter)
+- append: Add rows to existing table (requires `rows` or `rows_file`)
 - **create-from-dax**: Create table populated by a DAX EVALUATE query from Data Model
 - **update-dax**: Update an existing DAX-backed table's query
 - **get-dax**: Get the DAX query behind a DAX-backed table
@@ -34,8 +34,8 @@ Excel Tables manage their own header/row/totals formatting through table styles.
 
 | Goal | Correct approach |
 |------|-----------------|
-| Style a table | `table(action: 'set-style', tableStyle: 'TableStyleMedium2')` |
-| Style at creation | `table(action: 'create', tableStyle: 'TableStyleMedium2', ...)` |
+| Style a table | `table(action: 'set-style', table_style: 'TableStyleMedium2')` |
+| Style at creation | `table(action: 'create', table_style: 'TableStyleMedium2', ...)` |
 | Custom branding on table | Use a Medium/Dark table style that matches your palette — avoid overriding individual cells |
 
 Common table style choices:
@@ -75,7 +75,7 @@ Example DAX queries for create-from-dax:
 |------|------|
 | Create/manage worksheet tables | table |
 | Add worksheet table to Power Pivot | table (add-to-data-model) |
-| Import external data to Data Model | powerquery (loadDestination='data-model') |
+| Import external data to Data Model | powerquery (load_destination='data-model') |
 | Create DAX measures | datamodel |
 | Create PivotTables from Data Model | pivottable |
 
@@ -84,11 +84,11 @@ Example DAX queries for create-from-dax:
 - Trying to create DAX measures without first adding table to Data Model
 - Using datamodel to add tables (it only manages existing Data Model tables)
 - Confusing get-data (returns cell values) with read (returns metadata)
-- Forgetting hasHeaders parameter when creating tables from headerless data
+- Forgetting `has_headers` when creating tables from headerless data
 
 **Server-specific quirks**:
 
-- Style parameter is overloaded: table style name OR total function (context-dependent)
-- csvData parameter: dedicated parameter for append action (CSV format: comma-separated, newline-separated rows)
-- visibleOnly parameter only applies to get-data action
+- `table_style` applies to table creation and set-style; totals use `total_function`
+- `rows` accepts a 2D array and `rows_file` accepts JSON or CSV input for append
+- `visible_only` applies only to get-data
 - Table names must be unique within workbook (Excel requirement)

--- a/skills/excel-cli/references/workflows.md
+++ b/skills/excel-cli/references/workflows.md
@@ -31,7 +31,7 @@ Excel's Power Pivot has key limitations compared to Power BI/SSAS:
 
 ### Data Model Prerequisites
 ```
-1. Load table (powerquery refresh loadDestination="data-model")
+1. Load table (powerquery load-to load_destination="data-model")
 2. THEN create relationships (datamodel_relationship with create-relationship action)
 3. THEN create measures (datamodel create-measure)
 ```
@@ -60,5 +60,5 @@ After Power Query: powerquery list, powerquery view
 After refresh:     datamodel list-tables
 After measure:     datamodel list-measures, datamodel evaluate
 After relationship: datamodel_relationship list-relationships
-After chart/layout: screenshot(capture, rangeAddress='A1:M50') (visual verification)
+After chart/layout: screenshot(capture, range_address='A1:M50') (visual verification)
 ```

--- a/skills/excel-mcp/README.md
+++ b/skills/excel-mcp/README.md
@@ -51,25 +51,9 @@ npx skills add sbroenne/mcp-server-excel --skill excel-mcp
 excel-mcp/
 ├── SKILL.md           # Main skill definition with MCP tool guidance
 ├── README.md          # This file
+├── VERSION             # Published plugin version
 └── references/        # Detailed domain-specific guidance
-    ├── anti-patterns.md
-    ├── behavioral-rules.md
-    ├── chart.md
-    ├── conditionalformat.md
-    ├── dashboard.md
-    ├── datamodel.md
-    ├── dmv-reference.md
-    ├── excel_agent_mode.md
-    ├── gotchas.md
-    ├── m-code-syntax.md
-    ├── pivottable.md
-    ├── powerquery.md
-    ├── range.md
-    ├── screenshot.md
-    ├── slicer.md
-    ├── table.md
-    ├── window.md
-    └── worksheet.md
+    └── *.md
 ```
 
 Distributable packages add a `VERSION` file during the build. The canonical skill
@@ -81,6 +65,6 @@ The skill works with the Excel MCP Server. See [Installation Guide](https://exce
 
 ## Related
 
-- [Excel CLI Skill](../excel-cli/SKILL.md) - For coding agents preferring CLI tools
+- [Excel CLI Plugin](https://github.com/sbroenne/mcp-server-excel-plugins/tree/main/plugins/excel-cli) - For coding agents preferring CLI tools
 - [Documentation](https://excelmcpserver.dev/)
 - [GitHub Repository](https://github.com/sbroenne/mcp-server-excel)

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -95,7 +95,7 @@ Always convert tabular data to Excel Tables:
 
 ```
 1. range set-values (write data including headers)
-2. table create tableName="SalesData" rangeAddress="A1:D100"
+2. table create table_name="SalesData" range_address="A1:D100"
 ```
 
 **Why:** Structured references, auto-expand, required for Data Model/DAX.
@@ -103,9 +103,9 @@ Always convert tabular data to Excel Tables:
 ### Rule 5: Session Lifecycle
 
 ```
-1. file(action: 'open', path: '...')  → sessionId
-2. All operations use sessionId
-3. file(action: 'close', save: true)  → saves and closes
+1. file(action: 'open', path: '...')  → session ID
+2. All operations use the returned session ID
+3. file(action: 'close', session_id: '...', save: true)  → saves and closes
 ```
 
 **Unclosed sessions leave Excel processes running, locking files.**
@@ -116,7 +116,7 @@ DAX operations require tables in the Data Model:
 
 ```
 Step 1: Create table → Table exists
-Step 2: table(action: 'add-to-datamodel') → Table in Data Model
+Step 2: table(action: 'add-to-data-model') → Table in Data Model
 Step 3: datamodel(action: 'create-measure') → NOW this works
 ```
 
@@ -125,7 +125,7 @@ Step 3: datamodel(action: 'create-measure') → NOW this works
 **BEST PRACTICE: Test-First Workflow**
 
 ```
-1. powerquery(action: 'evaluate', mCode: '...') → Test WITHOUT persisting
+1. powerquery(action: 'evaluate', m_code: '...') → Test WITHOUT persisting
 2. powerquery(action: 'create', ...) → Store validated query
 3. powerquery(action: 'refresh', ...) → Load data
 ```
@@ -153,7 +153,7 @@ Error responses include actionable hints:
 {
   "success": false,
   "errorMessage": "Table 'Sales' not found in Data Model",
-  "suggestedNextActions": ["table(action: 'add-to-data-model', tableName: 'Sales')"]
+  "suggestedNextActions": ["table(action: 'add-to-data-model', table_name: 'Sales')"]
 }
 ```
 

--- a/skills/excel-mcp/references/analysis.md
+++ b/skills/excel-mcp/references/analysis.md
@@ -7,34 +7,34 @@ Use `analysis` for Excel's native Goal Seek, scenarios, scenario summaries, and 
 The formula cell must contain a formula, and the changing cell must be one of its inputs.
 
 ```text
-analysis(action="goal-seek", sheetName="Model", formulaCell="B10", goal=10000, changingCell="B3")
+analysis(action="goal-seek", sheet_name="Model", formula_cell="B10", goal=10000, changing_cell="B3")
 ```
 
 Goal Seek changes the workbook immediately. Read both cells afterward when the exact final values matter.
 
 ## Scenarios
 
-Scenario values must contain exactly one value per cell in `changingCells`, in range order.
+Scenario values must contain exactly one value per cell in `changing_cells`, in range order.
 
 ```text
-analysis(action="create-scenario", sheetName="Model", scenarioName="Growth",
-         changingCells="B3:B5", values=[0.08, 1200, 0.35])
-analysis(action="show-scenario", sheetName="Model", scenarioName="Growth")
-analysis(action="list-scenarios", sheetName="Model")
+analysis(action="create-scenario", sheet_name="Model", scenario_name="Growth",
+         changing_cells="B3:B5", values=[0.08, 1200, 0.35])
+analysis(action="show-scenario", sheet_name="Model", scenario_name="Growth")
+analysis(action="list-scenarios", sheet_name="Model")
 ```
 
-Use `create-scenario-summary` after defining two or more scenarios. Set `reportType` to `summary` for a normal report sheet or `pivot-table` for a Scenario PivotTable. `resultCells` should identify formulas that depend on the changing cells.
+Use `create-scenario-summary` after defining two or more scenarios. Set `report_type` to `summary` for a normal report sheet or `pivot-table` for a Scenario PivotTable. `result_cells` should identify formulas that depend on the changing cells.
 
 ## Data Tables
 
 Prepare the worksheet layout first, including the formula in the table's corner and the input values along its first row or column.
 
-- One-variable row table: provide `rowInputCell`.
-- One-variable column table: provide `columnInputCell`.
+- One-variable row table: provide `row_input_cell`.
+- One-variable column table: provide `column_input_cell`.
 - Two-variable table: provide both.
 
 ```text
-analysis(action="create-data-table", sheetName="Model", tableRange="A1:B11", columnInputCell="D1")
+analysis(action="create-data-table", sheet_name="Model", table_range="A1:B11", column_input_cell="D1")
 ```
 
 Data tables can be calculation-intensive. Use `calculation_mode` when controlling recalculation around larger workbook edits.

--- a/skills/excel-mcp/references/anti-patterns.md
+++ b/skills/excel-mcp/references/anti-patterns.md
@@ -11,9 +11,9 @@ Applying the same formatting to the same range more than once in a workflow:
 ```
 WRONG: Applying bold repeatedly
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true)
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true)
 // ... other operations ...
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4')
 // Bold was already applied - the second call re-applies it unnecessarily
 ```
 
@@ -22,10 +22,10 @@ Also wrong: calling `format-range` separately for each property instead of combi
 ```
 WRONG: Separate calls for each property
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true)
-range_format(action: 'format-range', rangeAddress: 'A1:D1', fillColor: '#4472C4')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', horizontalAlignment: 'center')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true)
+range_format(action: 'format-range', range_address: 'A1:D1', fill_color: '#4472C4')
+range_format(action: 'format-range', range_address: 'A1:D1', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A1:D1', horizontal_alignment: 'center')
 ```
 
 ### The Solution
@@ -35,8 +35,8 @@ Apply all formatting properties for a range in **one** `format-range` call:
 ```
 CORRECT: One call per range
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1',
-    bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF', horizontalAlignment: 'center')
+range_format(action: 'format-range', range_address: 'A1:D1',
+    bold: true, fill_color: '#4472C4', font_color: '#FFFFFF', horizontal_alignment: 'center')
 ```
 
 Apply each formatting operation **once**. If a subsequent step explicitly changes a property (e.g., "now make the title red"), apply it again — otherwise don't.
@@ -46,17 +46,17 @@ If the same formatting applies to multiple disjoint ranges, do not repeat `forma
 ```
 WRONG: Repeating the same shared formatting payload
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A12:D12', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A24:D24', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A12:D12', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A24:D24', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
 ```
 
 ```
 CORRECT: One shared multi-range formatting call
 
 range_format(action: 'format-ranges',
-    rangeAddresses: ['A1:D1', 'A12:D12', 'A24:D24'],
-    bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
+    range_addresses: ['A1:D1', 'A12:D12', 'A24:D24'],
+    bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
 ```
 
 ### When Multiple Calls ARE Appropriate
@@ -74,8 +74,8 @@ Applying `range_format` to cells that belong to an object with its own style sys
 ```
 WRONG: Formatting a table header row with range_format
 
-table(action: 'create', tableName: 'Sales', rangeAddress: 'A1:D10')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4')
+table(action: 'create', table_name: 'Sales', range_address: 'A1:D10')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4')
 // The table style already controls header appearance — this creates an inconsistent override
 ```
 
@@ -83,7 +83,7 @@ range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColo
 WRONG: Formatting PivotTable cells
 
 pivottable(action: 'create-from-table', ...)
-range_format(action: 'format-range', rangeAddress: 'B3:B20', fillColor: '#E2EFDA')
+range_format(action: 'format-range', range_address: 'B3:B20', fill_color: '#E2EFDA')
 // Formatting is wiped on the next pivottable(refresh)
 ```
 
@@ -94,15 +94,15 @@ Use the style system that belongs to each object type:
 ```
 CORRECT: Table visual styling — one call at creation or via set-style
 
-table(action: 'create', tableName: 'Sales', rangeAddress: 'A1:D10',
-    tableStyle: 'TableStyleMedium2')
+table(action: 'create', table_name: 'Sales', range_address: 'A1:D10',
+    table_style: 'TableStyleMedium2')
 ```
 
 | Object | Correct style approach | Do NOT use |
 |--------|----------------------|------------|
-| Excel Tables | `table(action:'set-style')` or `tableStyle` on create | `range_format` on header/data rows |
+| Excel Tables | `table(action:'set-style')` or `table_style` on create | `range_format` on header/data rows |
 | PivotTables | Not supported — leave default | `range_format` (wiped on refresh) |
-| Charts | `chart_config(action:'set-style', styleNumber: 1-48)` | `range_format` |
+| Charts | `chart_config(action:'set-style', style_id: 1-48)` | `range_format` |
 | Plain cells/ranges | `range_format` | — |
 
 ## Delete-and-Rebuild Anti-Pattern
@@ -114,9 +114,9 @@ Deleting entire structures to make small changes:
 ```
 WRONG: User wants to update cell B5
 
-table(action: 'delete', tableName: 'SalesData')
+table(action: 'delete', table_name: 'SalesData')
 range(action: 'set-values', values: [[entire dataset with B5 fixed]])
-table(action: 'create', tableName: 'SalesData', ...)
+table(action: 'create', table_name: 'SalesData', ...)
 ```
 
 This destroys:
@@ -134,7 +134,7 @@ Use targeted modifications:
 ```
 CORRECT: Update only the changed cell
 
-range(action: 'set-values', rangeAddress: 'B5', values: [[newValue]])
+range(action: 'set-values', range_address: 'B5', values: [[newValue]])
 ```
 
 ### When Rebuild IS Appropriate
@@ -163,14 +163,14 @@ This burns tokens, costs money, and never completes the task.
 
 ### The Solution
 
-If you already have a sessionId, use it. Do not rediscover:
+If you already have a session ID, use it. Do not rediscover:
 
 ```
-CORRECT: Use the sessionId you already have
+CORRECT: Use the session ID you already have
 
 Error: "session expired"
-→ file(action: 'open', path: original_path)  ← Re-open once, get new sessionId
-→ Continue with the new sessionId immediately
+→ file(action: 'open', path: original_path)  ← Re-open once, get a new session ID
+→ Continue with the new session ID immediately
 ```
 
 ### The Rule
@@ -229,9 +229,9 @@ Reading entire range, modifying in memory, writing entire range back:
 ```
 WRONG: Update one cell by rewriting thousands
 
-data = range(action: 'get-values', rangeAddress: 'A1:Z1000')
+data = range(action: 'get-values', range_address: 'A1:Z1000')
 data[4][1] = "new value"  // Modify row 5, column B
-range(action: 'set-values', rangeAddress: 'A1', values: data)
+range(action: 'set-values', range_address: 'A1', values: data)
 ```
 
 This:
@@ -247,7 +247,7 @@ Write only the changed cells:
 ```
 CORRECT: Direct cell update
 
-range(action: 'set-values', rangeAddress: 'B5', values: [["new value"]])
+range(action: 'set-values', range_address: 'B5', values: [["new value"]])
 ```
 
 ## Session Leak Anti-Pattern
@@ -259,9 +259,9 @@ Opening files without closing them:
 ```
 WRONG: Session accumulation
 
-file(action: 'open', filePath: 'file1.xlsx')  // Session 1
-file(action: 'open', filePath: 'file2.xlsx')  // Session 2
-file(action: 'open', filePath: 'file3.xlsx')  // Session 3
+file(action: 'open', path: 'file1.xlsx')  // Session 1
+file(action: 'open', path: 'file2.xlsx')  // Session 2
+file(action: 'open', path: 'file3.xlsx')  // Session 3
 // ... never closed
 ```
 
@@ -280,11 +280,11 @@ CORRECT: Proper lifecycle
 
 session1 = file(action: 'open', path: 'file1.xlsx')
 // ... work with file1 ...
-file(action: 'close', sessionId: session1, save: true)
+file(action: 'close', session_id: session1, save: true)
 
 session2 = file(action: 'open', path: 'file2.xlsx')
 // ... work with file2 ...
-file(action: 'close', sessionId: session2, save: true)
+file(action: 'close', session_id: session2, save: true)
 ```
 
 ## Ignoring Error Context Anti-Pattern
@@ -310,9 +310,9 @@ CORRECT: Error-driven correction
 
 datamodel(action: 'create-measure', ...) 
 → Error: Table 'Sales' not in Data Model
-→ Suggested: table(action: 'add-to-data-model', tableName: 'Sales')
+→ Suggested: table(action: 'add-to-data-model', table_name: 'Sales')
 
-table(action: 'add-to-data-model', tableName: 'Sales')  // Fix prerequisite
+table(action: 'add-to-data-model', table_name: 'Sales')  // Fix prerequisite
 datamodel(action: 'create-measure', ...)  // Now succeeds
 ```
 
@@ -325,8 +325,8 @@ Using locale-specific format codes:
 ```
 WRONG: German/European format
 
-range(action: 'set-number-format', formatCode: '#.##0,00')  // German
-range(action: 'set-number-format', formatCode: '# ##0,00')  // French
+range(action: 'set-number-format', format_code: '#.##0,00')  // German
+range(action: 'set-number-format', format_code: '# ##0,00')  // French
 ```
 
 ### The Solution
@@ -336,7 +336,7 @@ Always use US format codes (Excel translates automatically):
 ```
 CORRECT: US format codes (universal)
 
-range(action: 'set-number-format', formatCode: '#,##0.00')
+range(action: 'set-number-format', format_code: '#,##0.00')
 ```
 
 Excel displays the result in the user's locale setting, but the API requires US format input.
@@ -350,7 +350,7 @@ Wrong load destination for the workflow:
 ```
 WRONG: Loading to worksheet when DAX is needed
 
-powerquery(action: 'create', loadDestination: 'worksheet', ...)
+powerquery(action: 'create', load_destination: 'worksheet', ...)
 datamodel(action: 'create-measure', ...)  // FAILS: table not in Data Model
 ```
 
@@ -361,7 +361,7 @@ Match load destination to workflow:
 ```
 CORRECT: Load to Data Model for DAX workflows
 
-powerquery(action: 'create', loadDestination: 'data-model', ...)
+powerquery(action: 'create', load_destination: 'data-model', ...)
 powerquery(action: 'refresh', ...)
 datamodel(action: 'create-measure', ...)  // Works
 ```
@@ -382,7 +382,7 @@ Creating or updating Power Query queries without testing M code first:
 ```
 WRONG: Creating permanent query with untested M code
 
-powerquery(action: 'create', mCode: '...', ...)
+powerquery(action: 'create', m_code: '...', ...)
 // M code has syntax error → COM exception with cryptic message
 // Now workbook is polluted with broken query
 ```
@@ -401,12 +401,12 @@ Always evaluate M code BEFORE creating permanent queries:
 CORRECT: Test-first development workflow
 
 // Step 1: Test M code without persisting
-powerquery(action: 'evaluate', mCode: '...')
+powerquery(action: 'evaluate', m_code: '...')
 // → Returns actual data preview with columns and rows
 // → Better error messages if M code has issues
 
 // Step 2: Create permanent query with validated code
-powerquery(action: 'create', mCode: '...', ...)
+powerquery(action: 'create', m_code: '...', ...)
 
 // Step 3: Load data to destination
 powerquery(action: 'refresh', ...)
@@ -432,7 +432,7 @@ If create/update fails with COM error, use evaluate to get detailed Power Query 
 
 ```
 powerquery(action: 'create', ...)  // → COM exception
-powerquery(action: 'evaluate', mCode: '...')  // → Detailed M error
+powerquery(action: 'evaluate', m_code: '...')  // → Detailed M error
 // Fix M code based on error
 powerquery(action: 'create', ...)  // → Success
 ```

--- a/skills/excel-mcp/references/behavioral-rules.md
+++ b/skills/excel-mcp/references/behavioral-rules.md
@@ -91,7 +91,7 @@ When creating or modifying Excel files:
 
 **Use `format-range` for visual layout (header rows, custom colours) — ALL properties in ONE call:**
 - `set-style('Heading 1')` does NOT apply a fill colour; if you want a coloured header row use `format-range`
-- Pass bold, fillColor, fontColor, and alignment together in a single call — do not call `format-range` multiple times for the same range
+- Pass `bold`, `fill_color`, `font_color`, and alignment together in a single call — do not call `format-range` multiple times for the same range
 - If the same formatting payload repeats across multiple non-contiguous ranges, prefer one `format-ranges` call over repeated `format-range` calls
 
 **Apply each formatting operation once** — do not reapply the same properties to the same range unless a later step explicitly changes them.
@@ -134,7 +134,7 @@ Always convert tabular data to Excel Tables (ListObjects):
 
 ```
 1. range set-values (write data including headers)
-2. table create tableName="SalesData" rangeAddress="A1:D100"
+2. table create table_name="SalesData" range_address="A1:D100"
 ```
 
 **Why Tables over plain ranges:**
@@ -181,9 +181,9 @@ authentication occurs; open them with a visible session.
 Always close sessions when done:
 
 ```
-1. file(action: 'open', path: '...')  → sessionId
-2. All operations use sessionId
-3. file(action: 'close', sessionId: '...', save: true)  → saves and closes
+1. file(action: 'open', path: '...')  → session ID
+2. All operations use the returned session ID
+3. file(action: 'close', session_id: '...', save: true)  → saves and closes
 ```
 
 **Why**: Unclosed sessions leave Excel processes running, consuming memory and locking files.
@@ -299,9 +299,9 @@ belong to the selected action are rejected instead of being defaulted or ignored
   session operation timeout.
 - For required generated inline/file pairs, supply exactly one form. Optional
   pairs may omit both, but inline and file forms are always mutually exclusive.
-  Batch aliases are
-  `mCodeFile`, `vbaCodeFile`, `daxFormulaFile`, `daxQueryFile`, `dmvQueryFile`,
-  `schemaFile`, and `xmlDataFile`; MCP uses snake_case and CLI uses kebab-case.
+  MCP file inputs are
+  `m_code_file`, `vba_code_file`, `dax_formula_file`, `dax_query_file`, `dmv_query_file`,
+  `schema_file`, and `xml_data_file`; CLI uses the matching kebab-case flags.
   The file must exist and be readable.
 
 ### Refresh After Create
@@ -310,7 +310,7 @@ belong to the selected action are rejected instead of being defaulted or ignored
 
 ```
 Step 1: powerquery(action: 'create', ...) → Query created
-Step 2: powerquery(action: 'refresh', queryName: '...') → Data loaded
+Step 2: powerquery(action: 'refresh', query_name: '...') → Data loaded
 ```
 
 Without refresh, the query exists but contains no data.
@@ -325,7 +325,7 @@ Excel MCP errors include actionable context:
 {
   "success": false,
   "errorMessage": "Table 'Sales' not found in Data Model",
-  "suggestedNextActions": ["table(action: 'add-to-data-model', tableName: 'Sales')"]
+  "suggestedNextActions": ["table(action: 'add-to-data-model', table_name: 'Sales')"]
 }
 ```
 

--- a/skills/excel-mcp/references/chart.md
+++ b/skills/excel-mcp/references/chart.md
@@ -9,19 +9,19 @@
 
 ### From Range
 ```
-chart(create-from-range, chartType, sourceRange, sheetName)
+chart(create-from-range, chart_type, source_range, sheet_name)
 ```
 Best for: Simple data in worksheet ranges
 
 ### From PivotTable (PivotChart)
 ```
-chart(create-from-pivottable, pivotTableName)
+chart(create-from-pivottable, pivot_table_name)
 ```
 Best for: Data Model data - creates a single PivotChart object (don't create separate PivotTable + Chart)
 
 ### From Table
 ```
-chart(create-from-table, tableName, chartType)
+chart(create-from-table, table_name, chart_type)
 ```
 Best for: Excel Tables with structured references
 
@@ -34,22 +34,22 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 ## Configuration Actions (chart_config)
 
 ### Series Management
-- `add-series`: Add data series with valuesRange and optional categoryRange
+- `add-series`: Add data series with `values_range` and optional `category_range`
 - `remove-series`: Remove series by index (1-based)
 - `set-source-range`: Replace entire chart data source
 - `set-series-chart-type`: Assign a chart type to one regular-chart series for combo charts
 
 ### Plot Behavior
 - `get-plot-options`: Read row/column orientation, blank-cell display, and hidden-cell plotting
-- `set-plot-options`: Configure `plotBy`, `displayBlanksAs`, and `plotVisibleOnly`
+- `set-plot-options`: Configure `plot_by`, `display_blanks_as`, and `plot_visible_only`
 
 ### Titles and Labels
 - `set-title`: Set chart title (empty string hides)
 - `set-axis-title`: Set axis labels (Category, Value, CategorySecondary, ValueSecondary)
-- `set-data-labels`: Configure data labels (position, showValue, showCategory, showPercentage, showSeriesName, showLegendKey)
+- `set-data-labels`: Configure data labels (`label_position`, `show_value`, `show_category_name`, `show_percentage`, and `show_series_name`)
 
 ### Axis Formatting
-- `get-axis-scale`: Get min, max, majorUnit, minorUnit, and auto flags
+- `get-axis-scale`: Get minimum, maximum, major unit, minor unit, and auto flags
 - `set-axis-scale`: Configure scale properties
 - `get-axis-number-format`: Get current tick label format
 - `set-axis-number-format`: Format axis numbers (e.g., `"$#,##0,,\"M\""` for millions)
@@ -90,8 +90,8 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 - **period**: Required for MovingAverage (2+, default 2)
 - **forward/backward**: Forecast periods ahead/behind data
 - **intercept**: Force trend through specific Y value
-- **displayEquation**: Show formula on chart
-- **displayRSquared**: Show R² goodness-of-fit value
+- **display_equation**: Show formula on chart
+- **display_r_squared**: Show R² goodness-of-fit value
 
 ## Common Workflows
 
@@ -100,13 +100,13 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 1. chart(create-from-range) → chartName
 2. chart_config(set-title, title="Monthly Sales")
 3. chart_config(set-axis-title, axis="Value", title="Revenue ($)")
-4. chart_config(set-axis-number-format, axis="Value", numberFormat="$#,##0")
-5. chart_config(set-data-labels, position="OutsideEnd", showValue=true)
+4. chart_config(set-axis-number-format, axis="Value", number_format="$#,##0")
+5. chart_config(set-data-labels, label_position="OutsideEnd", show_value=true)
 ```
 
 ### Add Analysis
 ```
-1. chart_config(add-trendline, trendlineType="Linear", displayEquation=true, displayRSquared=true)
+1. chart_config(add-trendline, trendline_type="Linear", display_equation=true, display_r_squared=true)
 2. chart_config(set-trendline, forward=3) # Forecast 3 periods ahead
 ```
 
@@ -122,22 +122,22 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 
 Charts support three positioning modes, listed in order of preference:
 
-### 1. targetRange (PREFERRED - One Step)
+### 1. target_range (PREFERRED - One Step)
 ```
-chart(create-from-range, sourceRange='A1:B10', chartType='Line', targetRange='F2:K15')
+chart(create-from-range, source_range='A1:B10', chart_type='Line', target_range='F2:K15')
 ```
 Creates chart AND positions it to the cell range in one call. No point math needed.
 
 ### 2. Auto-Positioning (No Position Specified)
-When you omit both `targetRange` and `left`/`top`, the chart is automatically placed below all existing content (data ranges + other charts) with 10pt padding. This prevents overlap automatically.
+When you omit both `target_range` and `left`/`top`, the chart is automatically placed below all existing content (data ranges + other charts) with 10pt padding. This prevents overlap automatically.
 ```
-chart(create-from-range, sourceRange='A1:B10', chartType='Line')
+chart(create-from-range, source_range='A1:B10', chart_type='Line')
 # → Chart auto-positioned below the used range and any existing charts
 ```
 
 ### 3. Manual Coordinates
 ```
-chart(create-from-range, sourceRange='A1:B10', left=360, top=20)
+chart(create-from-range, source_range='A1:B10', left=360, top=20)
 # left/top in points (72 points = 1 inch)
 ```
 
@@ -154,9 +154,9 @@ Result example with collision warning:
 ```
 
 **If you see an overlap warning:**
-1. Use `chart(fit-to-range, chartName, rangeAddress='F2:K15')` to reposition
-2. Or use `chart(move, chartName, left=..., top=...)` to adjust
-3. Always follow up with `screenshot(capture, rangeAddress='A1:M25')` to include and verify the chart
+1. Use `chart(fit-to-range, chart_name='Chart 1', range_address='F2:K15')` to reposition
+2. Or use `chart(move, chart_name='Chart 1', left=..., top=...)` to adjust
+3. Always follow up with `screenshot(capture, range_address='A1:M25')` to include and verify the chart
 
 ### Position Estimates
 - Rows: ~15 points per row (varies with row height)
@@ -164,10 +164,10 @@ Result example with collision warning:
 - Default chart: 400×300 points
 
 ### Positioning Workflow
-1. **Preferred**: Use `targetRange='F2:K15'` in create call — avoids all overlap issues
+1. **Preferred**: Use `target_range='F2:K15'` in create call — avoids all overlap issues
 2. **Alternative**: Omit position — auto-positioning places chart below content
 3. **Manual**: `get-used-range` → calculate coordinates → specify left/top
-4. **Always verify**: Use `screenshot(capture, rangeAddress='A1:M25')` to visually confirm layout
+4. **Always verify**: Use `screenshot(capture, range_address='A1:M25')` to visually confirm layout
 
 ## Multi-Chart Layout (CRITICAL)
 
@@ -177,15 +177,15 @@ When creating dashboards with multiple charts, **every chart needs explicit posi
 ```
 Data at A1:D10. Place 4 charts in a 2×2 grid below data:
 
-chart(create-from-range, ..., targetRange='A12:F25')   # Top-left
-chart(create-from-range, ..., targetRange='G12:L25')   # Top-right
-chart(create-from-range, ..., targetRange='A27:F40')   # Bottom-left
-chart(create-from-range, ..., targetRange='G27:L40')   # Bottom-right
-screenshot(capture, rangeAddress='A1:M40') → Verify no overlaps
+chart(create-from-range, ..., target_range='A12:F25')   # Top-left
+chart(create-from-range, ..., target_range='G12:L25')   # Top-right
+chart(create-from-range, ..., target_range='A27:F40')   # Bottom-left
+chart(create-from-range, ..., target_range='G27:L40')   # Bottom-right
+screenshot(capture, range_address='A1:M40') → Verify no overlaps
 ```
 
 ### Rules
-- **Use targetRange for every chart** in multi-chart layouts — auto-positioning stacks vertically
+- **Use target_range for every chart** in multi-chart layouts — auto-positioning stacks vertically
 - Leave at least 1-2 rows/columns gap between charts
 - If any chart result includes an overlap warning, fix it before creating the next chart
-- Take a final `screenshot(capture, rangeAddress='A1:M40')` to verify the complete layout
+- Take a final `screenshot(capture, range_address='A1:M40')` to verify the complete layout

--- a/skills/excel-mcp/references/claude-desktop.md
+++ b/skills/excel-mcp/references/claude-desktop.md
@@ -1,106 +1,87 @@
 # Claude Desktop Configuration
 
-Excel MCP Server works with Claude Desktop on Windows, but requires specific configuration for the Windows container environment.
+Excel MCP Server works with Claude Desktop on Windows through the MCPB bundle
+or a manual stdio configuration.
 
-## Configuration Location
+## Requirements
 
-Claude Desktop config file:
-```
-%APPDATA%\Claude\claude_desktop_config.json
-```
+- Windows 10 or later
+- Microsoft Excel 2016 or later (desktop version)
 
-## Basic Configuration
+The published Windows packages are self-contained; no .NET runtime is required.
+
+## Recommended: MCPB Bundle
+
+1. Download `excel-mcp-{version}.mcpb` from the
+   [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest).
+2. Double-click the bundle or drag it into Claude Desktop.
+3. Restart Claude Desktop.
+
+The bundle contains the MCP server and configures Claude Desktop automatically.
+
+## Manual Configuration
+
+1. Download `ExcelMcp-MCP-Server-{version}-windows.zip` from the
+   [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest).
+2. Extract it to a permanent directory such as `C:\Tools\ExcelMcp`.
+3. Add the server to `%APPDATA%\Claude\claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
     "excel-mcp": {
-      "command": "excel-mcp-server.exe",
+      "command": "C:\\Tools\\ExcelMcp\\mcp-excel.exe",
       "args": []
     }
   }
 }
 ```
 
-Or using the .NET tool:
-```json
-{
-  "mcpServers": {
-    "excel-mcp": {
-      "command": "dotnet",
-      "args": ["excel-mcp-server"]
-    }
-  }
-}
-```
-
-## Windows Container Considerations
-
-Claude Desktop runs in a Windows container with specific constraints:
-
-### File System Access
-
-The container has limited file system access. Excel files should be in accessible locations:
-
-- **User Documents**: `C:\Users\<username>\Documents\`
-- **User Desktop**: `C:\Users\<username>\Desktop\`
-- **Temp directory**: `%TEMP%` or `C:\Users\<username>\AppData\Local\Temp\`
-
-**Recommendation**: Work with files in your Documents folder.
-
-### Excel Instance
-
-- Excel MCP Server manages its own Excel instance via COM automation
-- The Excel window may be visible or hidden depending on operation
-- Long-running operations show Excel's progress indicators
-
-### Session Persistence
-
-Sessions are tied to the Claude Desktop session:
-- Closing Claude Desktop terminates active Excel sessions
-- Unsaved changes may be lost
-- Use explicit `file(action: 'close', save: true)` to persist work
+Restart Claude Desktop after saving the configuration.
 
 ## Recommended Workflow
 
-```
-1. Create or open file in accessible location:
-   file(action: 'create', filePath: 'C:\\Users\\Me\\Documents\\report.xlsx')
+```text
+1. Create or open a workbook:
+   file(action: 'create', path: 'C:\Users\Me\Documents\report.xlsx')
 
-2. Perform operations with returned sessionId
+2. Use the returned session ID for workbook operations.
 
-3. Explicitly save and close when done:
-   file(action: 'close', sessionId: '...', save: true)
+3. Save and close:
+   file(action: 'close', session_id: '...', save: true)
 ```
+
+Use full Windows paths and close sessions explicitly so Excel processes do not
+remain open and lock workbooks.
 
 ## Troubleshooting
 
-### "Excel not found" Error
-- Ensure Microsoft Excel is installed on the Windows system
-- Excel 2016, 2019, 2021, or Microsoft 365 required
+### Excel not found
 
-### "Access denied" Error
-- Check file path is in accessible directory
-- Ensure file is not open in another Excel instance
-- Try using Documents folder instead of other locations
+- Confirm that desktop Excel 2016 or later is installed.
+- Confirm that Excel starts normally for the current Windows user.
 
-### "COM timeout" Error
-- Excel may be showing a dialog - check for visible Excel window
-- Operation may be long-running - wait for completion
-- Restart Claude Desktop if Excel becomes unresponsive
+### Access denied or file locked
 
-### VBA Operations Fail
-VBA requires explicit trust setting in Excel:
-1. Open Excel Options → Trust Center → Trust Center Settings
-2. Enable "Trust access to the VBA project object model"
-3. Restart Excel MCP Server
+- Confirm that the path is writable.
+- Close any other Excel instance that already has the workbook open.
+- Try a workbook in the user's Documents directory.
 
-## MCPB Bundle Alternative
+### COM timeout
 
-For simplified installation, use the MCPB bundle which auto-configures Claude Desktop:
+- Check whether Excel is displaying a modal dialog.
+- Allow long-running refresh or calculation operations to finish.
+- Restart Claude Desktop if the Excel process is unresponsive.
 
-1. Download `excel-mcp-bundle.mcpb` from releases
-2. Double-click to install
-3. Restart Claude Desktop
+### VBA operations fail
 
-See the main repository for MCPB installation instructions.
+VBA project editing requires explicit trust:
+
+1. Open Excel Options.
+2. Select **Trust Center** and then **Trust Center Settings**.
+3. Enable **Trust access to the VBA project object model**.
+4. Restart Excel MCP Server.
+
+See the current
+[MCP Server installation guide](https://excelmcpserver.dev/installation-mcp-server/)
+for other supported clients and setup methods.

--- a/skills/excel-mcp/references/conditionalformat.md
+++ b/skills/excel-mcp/references/conditionalformat.md
@@ -4,14 +4,14 @@
 
 | Type | Description | Parameters |
 |------|-------------|------------|
-| `cell-value` | Format based on cell value comparison | operatorType + formula1 (+ formula2 for between) |
+| `cell-value` | Format based on cell value comparison | operator_type + formula1 (+ formula2 for between) |
 | `expression` | Format based on formula result | formula only |
 | `color-scale` | 2- or 3-color gradient across the range | colorScaleMin/Mid/Max Type/Value/Color |
-| `data-bar` | In-cell bars proportional to value | dataBarColor, dataBarNegativeColor, dataBarDirection, dataBarShowValue, dataBarMin/Max Type/Value |
-| `icon-set` | Icons (arrows, traffic lights, etc.) per value band | iconSetId, iconSetReverse, iconSetShowIconOnly, iconThreshold1..4 Type/Value |
-| `top10` | Highlight top/bottom N (or percent) | rank, top10Percent, topBottom + formatting |
-| `above-average` | Highlight values above/below average | aboveBelow + formatting |
-| `time-period` | Highlight dates in a period | datePeriod + formatting |
+| `data-bar` | In-cell bars proportional to value | data_bar_color, data_bar_negative_color, data_bar_direction, data_bar_show_value, data_bar_min/max type/value |
+| `icon-set` | Icons (arrows, traffic lights, etc.) per value band | icon_set_id, icon_set_reverse, icon_set_show_icon_only, icon_threshold1..4 type/value |
+| `top10` | Highlight top/bottom N (or percent) | rank, top10_percent, top_bottom + formatting |
+| `above-average` | Highlight values above/below average | above_below + formatting |
+| `time-period` | Highlight dates in a period | date_period + formatting |
 | `unique-values` | Highlight unique (or duplicate) values | formatting |
 | `blanks-condition` | Highlight blank cells | formatting |
 
@@ -30,30 +30,30 @@
 
 **Format Options**:
 
-- `interiorColor`: Background fill color as `#RRGGBB` hex
-- `fontColor`: Text color as `#RRGGBB` hex
-- `fontBold`: `true` or `false`
-- `fontItalic`: `true` or `false`
-- `borderStyle`: Excel border style name
-- `borderColor`: Border color as `#RRGGBB` hex
+- `interior_color`: Background fill color as `#RRGGBB` hex
+- `font_color`: Text color as `#RRGGBB` hex
+- `font_bold`: `true` or `false`
+- `font_italic`: `true` or `false`
+- `border_style`: Excel border style name
+- `border_color`: Border color as `#RRGGBB` hex
 
-**Visual rule parameters** (used by the corresponding `ruleType`):
+**Visual rule parameters** (used by the corresponding `rule_type`):
 
-- **color-scale**: `colorScaleMinType`/`colorScaleMidType`/`colorScaleMaxType`
+- **color-scale**: `color_scale_min_type`/`color_scale_mid_type`/`color_scale_max_type`
   (`minimum`, `maximum`, `number`, `percent`, `percentile`, `formula`), matching
   `...Value` (when the type needs one) and `...Color` (`#RRGGBB`). Supplying any `mid*`
   parameter creates a 3-color scale, otherwise a 2-color scale.
-- **data-bar**: `dataBarColor` (`#RRGGBB`), `dataBarNegativeColor`, `dataBarDirection`
-  (`context`, `leftToRight`, `rightToLeft`), `dataBarShowValue` (`true`/`false`),
-  `dataBarMinType`/`dataBarMaxType` (+ matching values).
-- **icon-set**: `iconSetId` (e.g. `3Arrows`, `3TrafficLights1`, `4Ratings`, `5Quarters`),
-  `iconSetReverse` (`true`/`false`), `iconSetShowIconOnly` (`true`/`false`),
-  `iconThreshold1Type..iconThreshold4Type` (+ matching `...Value`) for the editable bands.
+- **data-bar**: `data_bar_color` (`#RRGGBB`), `data_bar_negative_color`, `data_bar_direction`
+  (`context`, `leftToRight`, `rightToLeft`), `data_bar_show_value` (`true`/`false`),
+  `data_bar_min_type`/`data_bar_max_type` (+ matching values).
+- **icon-set**: `icon_set_id` (e.g. `3Arrows`, `3TrafficLights1`, `4Ratings`, `5Quarters`),
+  `icon_set_reverse` (`true`/`false`), `icon_set_show_icon_only` (`true`/`false`),
+  `icon_threshold1_type..icon_threshold4_type` (+ matching `..._value`) for the editable bands.
 - **top10**: `rank` (count or percent), `top10Percent` (`true`/`false`),
-  `topBottom` (`top`/`bottom`), plus standard formatting options.
-- **above-average**: `aboveBelow` (`aboveAverage`, `belowAverage`, `aboveStdDev`,
+  `top_bottom` (`top`/`bottom`), plus standard formatting options.
+- **above-average**: `above_below` (`aboveAverage`, `belowAverage`, `aboveStdDev`,
   `belowStdDev`, `equalAboveAverage`, `equalBelowAverage`), plus formatting options.
-- **time-period**: `datePeriod` (`today`, `yesterday`, `tomorrow`, `last7Days`,
+- **time-period**: `date_period` (`today`, `yesterday`, `tomorrow`, `last7Days`,
   `thisWeek`, `lastWeek`, `nextWeek`, `thisMonth`, `lastMonth`, `nextMonth`), plus formatting.
 
 **Actions**:
@@ -69,7 +69,7 @@
 
 - Rules are returned in priority order.
 - Colors are returned as `#RRGGBB` hex strings, matching the `add-rule` input format.
-- Formatting fields (interiorColor, fontColor, fontBold/Italic, borderStyle/Color) are only
+- Formatting fields (`interior_color`, `font_color`, `font_bold`/`font_italic`, `border_style`/`border_color`) are only
   present when the rule actually sets them.
 - Visual rule types return their type-specific configuration so they can be fully inspected
   and round-tripped:
@@ -96,11 +96,11 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A10",
-  "ruleType": "cell-value",
-  "operatorType": "greater",
+  "range_address": "A1:A10",
+  "rule_type": "cell-value",
+  "operator_type": "greater",
   "formula1": "100",
-  "interiorColor": "#FFFF00"
+  "interior_color": "#FFFF00"
 }
 ```
 
@@ -108,12 +108,12 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A10",
-  "ruleType": "cell-value",
-  "operatorType": "between",
+  "range_address": "A1:A10",
+  "rule_type": "cell-value",
+  "operator_type": "between",
   "formula1": "50",
   "formula2": "100",
-  "interiorColor": "#90EE90"
+  "interior_color": "#90EE90"
 }
 ```
 
@@ -121,10 +121,10 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:D10",
-  "ruleType": "expression",
+  "range_address": "A1:D10",
+  "rule_type": "expression",
   "formula1": "=$A1=\"Active\"",
-  "interiorColor": "#90EE90"
+  "interior_color": "#90EE90"
 }
 ```
 
@@ -132,15 +132,15 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A100",
-  "ruleType": "color-scale",
-  "colorScaleMinType": "minimum",
-  "colorScaleMinColor": "#F8696B",
-  "colorScaleMidType": "percentile",
-  "colorScaleMidValue": "50",
-  "colorScaleMidColor": "#FFEB84",
-  "colorScaleMaxType": "maximum",
-  "colorScaleMaxColor": "#63BE7B"
+  "range_address": "A1:A100",
+  "rule_type": "color-scale",
+  "color_scale_min_type": "minimum",
+  "color_scale_min_color": "#F8696B",
+  "color_scale_mid_type": "percentile",
+  "color_scale_mid_value": "50",
+  "color_scale_mid_color": "#FFEB84",
+  "color_scale_max_type": "maximum",
+  "color_scale_max_color": "#63BE7B"
 }
 ```
 
@@ -148,11 +148,11 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "B1:B100",
-  "ruleType": "data-bar",
-  "dataBarColor": "#638EC6",
-  "dataBarDirection": "leftToRight",
-  "dataBarShowValue": true
+  "range_address": "B1:B100",
+  "rule_type": "data-bar",
+  "data_bar_color": "#638EC6",
+  "data_bar_direction": "leftToRight",
+  "data_bar_show_value": true
 }
 ```
 
@@ -160,13 +160,13 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "C1:C100",
-  "ruleType": "icon-set",
-  "iconSetId": "3TrafficLights1",
-  "iconThreshold1Type": "percent",
-  "iconThreshold1Value": "33",
-  "iconThreshold2Type": "percent",
-  "iconThreshold2Value": "67"
+  "range_address": "C1:C100",
+  "rule_type": "icon-set",
+  "icon_set_id": "3TrafficLights1",
+  "icon_threshold1_type": "percent",
+  "icon_threshold1_value": "33",
+  "icon_threshold2_type": "percent",
+  "icon_threshold2_value": "67"
 }
 ```
 
@@ -193,7 +193,7 @@ excelcli conditionalformat list-worksheet-rules --session <id> --sheet "Data"
 
 **Common Mistakes**:
 
-- Using `cell-value` type without `operatorType` → Error
+- Using `cell-value` type without `operator_type` → Error
 - Using `between` without both formula1 AND formula2 → Error
 - Forgetting `$` in expression formulas → Rule applies incorrectly across rows/columns
 - Colors without `#` prefix → May not apply correctly

--- a/skills/excel-mcp/references/dashboard.md
+++ b/skills/excel-mcp/references/dashboard.md
@@ -18,8 +18,8 @@ Every report or dashboard should follow this sequence:
 **Always use Excel Tables for tabular data:**
 
 ```
-range(set-values, rangeAddress='A1', values=[[headers + data]])
-table(create, tableName='SalesData', rangeAddress='A1:D20')
+range(set-values, range_address='A1', values=[[headers + data]])
+table(create, table_name='SalesData', range_address='A1:D20')
 ```
 
 **Why Tables matter:**
@@ -54,46 +54,46 @@ behaviour, not a formatting bug. Never promise a literal rendering when reportin
 **Number formats make cells WIDER, so auto-fit immediately after formatting:**
 
 ```
-range_format(action: 'auto-fit-columns', sheetName: 'Sales', rangeAddress: 'A:F')
+range_format(action: 'auto-fit-columns', sheet_name: 'Sales', range_address: 'A:F')
 ```
 
 A date formatted as `yyyy-mm-dd` or a currency value formatted as `$#,##0.00` does not fit the
 default column width, so Excel renders the cell as `#####`. A screenshot taken before auto-fit will
 show those columns as unreadable hash marks. Auto-fit before Step 5, not after.
 
-Use `range_format auto-fit-rows` as well when any cell has `wrapText` enabled.
+Use `range_format auto-fit-rows` as well when any cell has `wrap_text` enabled.
 
 ## Step 4: Position Charts with No Overlaps
 
 **Charts have automatic collision detection and three positioning modes:**
 
-### Single Chart (Auto-Position or targetRange)
+### Single Chart (Auto-Position or target_range)
 ```
-# Option A: targetRange (explicit cell placement)
-chart(create-from-range, sourceRange='A1:D20', targetRange='F2:K15')
+# Option A: target_range (explicit cell placement)
+chart(create-from-range, source_range='A1:D20', target_range='F2:K15')
 
 # Option B: Omit position — auto-places below content
-chart(create-from-range, sourceRange='A1:D20', chartType='Line')
+chart(create-from-range, source_range='A1:D20', chart_type='Line')
 # → Automatically positioned below the used range
 ```
 
-### Multiple Charts (Dashboard) — Always Use targetRange
+### Multiple Charts (Dashboard) — Always Use target_range
 ```
 Place in a grid pattern below data:
 
-Chart 1: targetRange='A22:F35'    (top-left)
-Chart 2: targetRange='G22:L35'    (top-right)
-Chart 3: targetRange='A37:F50'    (bottom-left)
-Chart 4: targetRange='G37:L50'    (bottom-right)
+Chart 1: target_range='A22:F35'    (top-left)
+Chart 2: target_range='G22:L35'    (top-right)
+Chart 3: target_range='A37:F50'    (bottom-left)
+Chart 4: target_range='G37:L50'    (bottom-right)
 ```
 
 ### Collision Detection
 All chart operations automatically warn about overlaps. If a result includes an `OVERLAP WARNING` message:
 1. Use `chart(fit-to-range)` to reposition
-2. Take `screenshot(capture, rangeAddress='A1:M50')` to verify
+2. Take `screenshot(capture, range_address='A1:M50')` to verify
 
 **Rules:**
-- **Use targetRange for multi-chart layouts** — auto-positioning stacks vertically
+- **Use target_range for multi-chart layouts** — auto-positioning stacks vertically
 - Leave 1-2 rows/columns gap between charts
 - Place charts BELOW the data area, not beside it (more room)
 - Keep chart sizes consistent (same row/column span)
@@ -104,7 +104,7 @@ All chart operations automatically warn about overlaps. If a result includes an 
 **Always take a screenshot after creating charts or complex layouts:**
 
 ```
-screenshot(capture, rangeAddress='A1:M50')
+screenshot(capture, range_address='A1:M50')
 → Confirm: no overlaps, professional spacing, readable labels
 → Confirm: no column renders as ##### (if it does, go back to Step 3 and auto-fit)
 → If issues found: chart(fit-to-range) to reposition, then screenshot again

--- a/skills/excel-mcp/references/datamodel.md
+++ b/skills/excel-mcp/references/datamodel.md
@@ -25,13 +25,13 @@ You MUST explicitly refresh the Data Model to sync changes.
 
 ```
 # WRONG: Data still shows old values
-table(append, tableName="Sales", csvData="...")  # Worksheet updated
-datamodel(evaluate, daxQuery="...")               # Returns OLD values!
+table(append, table_name="Sales", rows=[["..."]])  # Worksheet updated
+datamodel(evaluate, dax_query="...")               # Returns OLD values!
 
 # CORRECT: Refresh Data Model after worksheet changes
-table(append, tableName="Sales", csvData="...")  # Worksheet updated
+table(append, table_name="Sales", rows=[["..."]])  # Worksheet updated
 datamodel(refresh)                                 # Sync to Data Model
-datamodel(evaluate, daxQuery="...")               # Returns NEW values!
+datamodel(evaluate, dax_query="...")               # Returns NEW values!
 ```
 
 **When refresh is automatic:**
@@ -61,19 +61,19 @@ datamodel(evaluate, daxQuery="...")               # Returns NEW values!
 | Source | Method |
 |--------|--------|
 | Worksheet Excel Table | table with add-to-data-model action |
-| External file (CSV, etc.) | powerquery with loadDestination='data-model' |
-| Database/web source | powerquery with loadDestination='data-model' |
+| External file (CSV, etc.) | powerquery with load_destination='data-model' |
+| Database/web source | powerquery with load_destination='data-model' |
 
 **DAX Formatting**:
 
-DAX formulas are preserved exactly by default on WRITE operations (create-measure, update-measure), subject to Excel locale separator translation. Set `formatDax=true` only with explicit user consent; it sends DAX to daxformatter.com. Remote formatting adds ~100-500ms network latency per write operation. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
+DAX formulas are preserved exactly by default on WRITE operations (create-measure, update-measure), subject to Excel locale separator translation. Set `format_dax=true` only with explicit user consent; it sends DAX to daxformatter.com. Remote formatting adds ~100-500ms network latency per write operation. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
 
 **Action disambiguation**:
 
 - list-tables: List all tables currently in the Data Model
 - list-measures: List all DAX measures (returns raw DAX from Excel)
-- create-measure: Create a new DAX measure (DAX preserved by default; `formatDax=true` opts into remote formatting)
-- update-measure: Modify existing measure's formula/format/description (DAX preserved by default; `formatDax=true` opts into remote formatting)
+- create-measure: Create a new DAX measure (DAX preserved by default; `format_dax=true` opts into remote formatting)
+- update-measure: Modify existing measure's formula/format/description (DAX preserved by default; `format_dax=true` opts into remote formatting)
 - delete-measure: Remove a measure
 - delete-table: Remove table AND ALL its measures (DESTRUCTIVE!)
 - read-info: Get Data Model metadata (culture, compatibility level)
@@ -170,10 +170,10 @@ Reference: [Microsoft DMV Documentation](https://learn.microsoft.com/en-us/analy
 
 **DAX measure creation**:
 
-- tableName: Which table the measure belongs to (for organization)
-- measureName: Display name for the measure
-- daxFormula: DAX expression (e.g., "SUM(Sales[Revenue])")
-- formatString: Optional number format (#,##0.00, 0%, $#,##0, etc.)
+- table_name: Which table the measure belongs to (for organization)
+- measure_name: Display name for the measure
+- dax_formula: DAX expression (e.g., "SUM(Sales[Revenue])")
+- format_type: Optional number format (#,##0.00, 0%, $#,##0, etc.)
 
 **Common DAX patterns**:
 
@@ -223,7 +223,7 @@ A PivotChart is a single object connected to the Data Model. Creating a PivotTab
 - Creating measures before adding source table to Data Model → Error
 - Using worksheet table names instead of Data Model table names
 - Forgetting that delete-table removes ALL measures on that table
-- Not specifying tableName when creating measures (required for organization)
+- Not specifying `table_name` when creating measures (required for organization)
 
 **Server-specific quirks**:
 

--- a/skills/excel-mcp/references/drawing.md
+++ b/skills/excel-mcp/references/drawing.md
@@ -28,8 +28,8 @@ Colors use `#RRGGBB`. Position and size values use points. Placement values are:
 
 Supported controls are Button, CheckBox, DropDown, GroupBox, Label, ListBox, OptionButton, ScrollBar, and Spinner.
 
-- `linkedCell`: CheckBox, DropDown, ListBox, OptionButton, ScrollBar, and Spinner
-- `inputRange`: DropDown and ListBox only
+- `linked_cell`: CheckBox, DropDown, ListBox, OptionButton, ScrollBar, and Spinner
+- `input_range`: DropDown and ListBox only
 - Button, GroupBox, and Label return explicit nulls for both binding properties
 
 ActiveX/OLE controls and macro assignment are intentionally unavailable. Do not try to create them through VBA as a workaround.
@@ -39,8 +39,8 @@ ActiveX/OLE controls and macro assignment are intentionally unavailable. Do not 
 Use `add-sparkline`, `get-sparkline`, `list-sparklines`, `update-sparkline`, and `delete-sparkline`.
 
 - Types: Line, Column, WinLoss
-- `sourceRange`: data to visualize
-- `locationRange`: cells that host the sparklines
+- `source_range`: data to visualize
+- `location_range`: cells that host the sparklines
 - Line sparklines can show markers
 
 ```powershell

--- a/skills/excel-mcp/references/excel_agent_mode.md
+++ b/skills/excel-mcp/references/excel_agent_mode.md
@@ -49,7 +49,7 @@ AI navigates through a completed workbook, explaining findings while the user wa
 ```
 1. file(open, path='analysis.xlsx')
 2. window(show)
-3. window(set-state, windowState='maximized')      → Full screen for best visibility
+3. window(set-state, window_state='maximized')      → Full screen for best visibility
 4. window(set-status-bar, text='Reviewing Sales sheet...')
 5. "On the Sales sheet, you can see quarterly revenue trending up 15%..."
 6. worksheet(activate, name='Analysis')            → Switch to next sheet
@@ -77,13 +77,13 @@ AI performs operations one at a time, showing results between each step for trou
 4. window(set-status-bar, text='Inspecting Power Query...')
 5. powerquery(list)
 6. "Found 3 queries. Let me check each one..."
-7. powerquery(view, queryName='Sales')
+7. powerquery(view, query_name='Sales')
 8. window(set-status-bar, text='Refreshing Sales query...')
-9. powerquery(refresh, queryName='Sales')
+9. powerquery(refresh, query_name='Sales')
 10. screenshot(capture-sheet)                      → Show result
 11. "Sales query refreshed successfully. 150 rows loaded. Moving to next..."
 12. window(set-status-bar, text='Refreshing Products query...')
-13. powerquery(refresh, queryName='Products')
+13. powerquery(refresh, query_name='Products')
 14. "Products query failed: [error]. Let me fix the M code..."
 15. window(clear-status-bar)
 ```

--- a/skills/excel-mcp/references/gotchas.md
+++ b/skills/excel-mcp/references/gotchas.md
@@ -115,9 +115,9 @@ Power Query connections that reference external files or URLs have a "refresh on
 Range addresses in M1 notation (e.g., `A1:D10`) work fine, but range names with spaces, hyphens, or special characters must be enclosed in single quotes or backticks:
 
 ```
-rangeAddress: 'Sales Data'      ← Correct (with spaces)
-rangeAddress: Sales Data        ← WRONG (fails)
-rangeAddress: `Sales Data`      ← Also correct (backticks)
+range_address: 'Sales Data'      ← Correct (with spaces)
+range_address: Sales Data        ← WRONG (fails)
+range_address: `Sales Data`      ← Also correct (backticks)
 ```
 
 Same rule applies for sheet names: `'Sheet Name'!A1:D10`.

--- a/skills/excel-mcp/references/pivottable.md
+++ b/skills/excel-mcp/references/pivottable.md
@@ -2,7 +2,7 @@
 
 ## CRITICAL: Required Parameters
 
-**`pivotTableName` is REQUIRED for almost all PivotTable operations** across `pivottable`, `pivottable_calc`, and `pivottable_field` tools. The only exception is `list` (which lists all PivotTables). Always specify the PivotTable name.
+**`pivot_table_name` is REQUIRED for almost all PivotTable operations** across `pivottable`, `pivottable_calc`, and `pivottable_field` tools. The only exception is `list` (which lists all PivotTables). Always specify the PivotTable name.
 
 ## Calculated Fields vs DAX Measures
 
@@ -18,15 +18,15 @@ PivotTable calculated fields work well for simple single-table formulas. Use DAX
 ### Calculated Field Workflow
 
 ```
-pivottable_calc(CreateCalculatedField, fieldName="Revenue", formula="=Quantity*UnitPrice")
-pivottable_field(AddValueField, fieldName="Revenue", aggregationFunction="Sum")
+pivottable_calc(action="create-calculated-field", pivot_table_name="SalesPivot", field_name="Revenue", formula="=Quantity*UnitPrice")
+pivottable_field(action="add-value-field", pivot_table_name="SalesPivot", field_name="Revenue", aggregation_function="Sum")
 ```
 
 ### DAX Measure Workflow (for complex scenarios)
 
 ```
-table(add-to-data-model, tableName="Sales")
-datamodel(create-measure, measureName="Revenue", daxFormula="SUMX(Sales, Sales[Quantity]*Sales[UnitPrice])")
+table(action="add-to-data-model", table_name="Sales")
+datamodel(action="create-measure", table_name="Sales", measure_name="Revenue", dax_formula="SUMX(Sales, Sales[Quantity]*Sales[UnitPrice])")
 pivottable(create-from-datamodel, ...)  # Measure automatically available
 ```
 
@@ -43,7 +43,7 @@ pivottable(create-from-datamodel, ...)  # Measure automatically available
 |--------|---------------|------------------------|
 | Worksheet Table | `create-from-table` | NO - worksheet PivotTable |
 | Data Model | `create-from-datamodel` | YES - full DAX support |
-| External | `create` with sourceRange | NO |
+| External | `create-from-range` with `source_range` | NO |
 
 **Rule**: If you need calculated revenue/aggregations, use Data Model as source.
 
@@ -67,8 +67,8 @@ powerquery(refresh, ...)     # Refreshes Power Query AND Data Model
 ## PivotCache Options
 
 - `pivottable(get-cache-options)`: Read refresh, retained-item, optimization, and saved-source settings.
-- `pivottable(set-cache-options)`: Set `enableRefresh`, `refreshOnFileOpen`, `missingItemsLimit`, `optimizeCache`, or `saveSourceData`.
-- `missingItemsLimit` values: `Default`, `None`, `Max`, `Max2`.
+- `pivottable(set-cache-options)`: Set `enable_refresh`, `refresh_on_file_open`, `missing_items_limit`, `optimize_cache`, or `save_source_data`.
+- `missing_items_limit` values: `Default`, `None`, `Max`, `Max2`.
 - Deleted-item retention applies only to regular PivotTables. OLAP/Data Model caches manage members in the model.
 
 ## Field Configuration
@@ -76,20 +76,20 @@ powerquery(refresh, ...)     # Refreshes Power Query AND Data Model
 ### Row/Column/Value Fields
 
 When creating PivotTables, configure fields in order:
-1. Add Row fields: `pivottable_field(AddRowField, fieldName="Region")`
-2. Add Column fields: `pivottable_field(AddColumnField, fieldName="Year")`  
-3. Add Value fields: `pivottable_field(AddValueField, fieldName="Amount", aggregationFunction="Sum")`
-4. Add filters: `pivottable_field(AddFilterField, fieldName="Status")`
-5. **Refresh to update display**: `pivottable(refresh, pivotTableName="...")`
+1. Add Row fields: `pivottable_field(action="add-row-field", pivot_table_name="SalesPivot", field_name="Region")`
+2. Add Column fields: `pivottable_field(action="add-column-field", pivot_table_name="SalesPivot", field_name="Year")`
+3. Add Value fields: `pivottable_field(action="add-value-field", pivot_table_name="SalesPivot", field_name="Amount", aggregation_function="Sum")`
+4. Add filters: `pivottable_field(action="add-filter-field", pivot_table_name="SalesPivot", field_name="Status")`
+5. **Refresh to update display**: `pivottable(action="refresh", pivot_table_name="SalesPivot")`
 
 **IMPORTANT**: Field operations are structural only - they modify the PivotTable layout but don't trigger visual refresh. Call `pivottable(refresh)` after configuring all fields to update the display. This is especially important for OLAP/Data Model PivotTables.
 
 ### Manual Grouping
 
 ```
-pivottable_field(group-items, fieldName="Region", itemNames=["North", "South"], groupName="Core Regions")
-# Use groupedFieldName from the result:
-pivottable_field(ungroup-field, groupedFieldName="Region2")
+pivottable_field(action="group-items", pivot_table_name="SalesPivot", field_name="Region", item_names=["North", "South"], group_name="Core Regions")
+# Use grouped_field_name from the result:
+pivottable_field(action="ungroup-field", pivot_table_name="SalesPivot", grouped_field_name="Region2")
 ```
 
 Manual grouping requires a regular PivotTable and a field already placed in the Row or Column area. OLAP/Data Model PivotTables must add grouping columns in the model.
@@ -97,7 +97,7 @@ Manual grouping requires a regular PivotTable and a field already placed in the 
 ### Drill Through
 
 ```
-pivottable(drill-through, pivotTableName="SalesPivot", cellAddress="G4")
+pivottable(action="drill-through", pivot_table_name="SalesPivot", cell_address="G4")
 ```
 
 The target must be a value cell in a regular PivotTable data body. Excel creates a new worksheet containing the underlying source rows. OLAP/Data Model drill-through is provider-dependent and intentionally not exposed as a deterministic operation.
@@ -119,13 +119,13 @@ The target must be a value cell in a regular PivotTable data body. Excel creates
 
 ```
 # Option 1: Add revenue column to source table FIRST
-range(set-formula, sheetName="Sales", rangeAddress="I2", formula="=[@Quantity]*[@UnitPrice]")
-pivottable(create-from-table, sourceTableName="SalesTable", ...)
-pivottable_field(AddValueField, fieldName="Revenue", aggregationFunction="Sum")  # Works!
+range(action="set-formulas", sheet_name="Sales", range_address="I2", formulas=[["=[@Quantity]*[@UnitPrice]"]])
+pivottable(action="create-from-table", table_name="SalesTable", ...)
+pivottable_field(action="add-value-field", field_name="Revenue", aggregation_function="Sum", ...)  # Works!
 
 # Option 2: Use Data Model (RECOMMENDED)
-table(add-to-data-model, tableName="SalesTable")
-datamodel(create-measure, measureName="Revenue", daxFormula="SUMX(SalesTable, SalesTable[Quantity]*SalesTable[UnitPrice])")
+table(action="add-to-data-model", table_name="SalesTable")
+datamodel(action="create-measure", table_name="SalesTable", measure_name="Revenue", dax_formula="SUMX(SalesTable, SalesTable[Quantity]*SalesTable[UnitPrice])")
 pivottable(create-from-datamodel, ...)  # Measure automatically available
 ```
 
@@ -133,16 +133,16 @@ pivottable(create-from-datamodel, ...)  # Measure automatically available
 
 Always use Data Model for multi-table analysis:
 ```
-table(add-to-data-model, tableName="Sales")
-table(add-to-data-model, tableName="Products")
-datamodel_relationship(create-relationship, fromTable="Sales", fromColumn="ProductID", toTable="Products", toColumn="ProductID")
-datamodel(create-measure, tableName="Sales", measureName="Revenue", daxFormula="SUMX(Sales, RELATED(Products[Price])*Sales[Quantity])")
+table(action="add-to-data-model", table_name="Sales")
+table(action="add-to-data-model", table_name="Products")
+datamodel_relationship(action="create-relationship", from_table="Sales", from_column="ProductID", to_table="Products", to_column="ProductID")
+datamodel(action="create-measure", table_name="Sales", measure_name="Revenue", dax_formula="SUMX(Sales, RELATED(Products[Price])*Sales[Quantity])")
 pivottable(create-from-datamodel)
 ```
 
 ## Layout Styles
 
-The `layoutStyle` parameter controls PivotTable appearance:
+The `row_layout` parameter controls PivotTable appearance:
 
 | Value | Style | Description |
 |-------|-------|-------------|

--- a/skills/excel-mcp/references/powerquery.md
+++ b/skills/excel-mcp/references/powerquery.md
@@ -30,7 +30,7 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 **M-Code Formatting and reads**:
 
 - Create and Update preserve M code exactly by default and do not call remote services
-- Set `formatMCode=true` only with explicit user consent; it sends M code to powerqueryformatter.com
+- Set `format_m_code=true` only with explicit user consent; it sends M code to powerqueryformatter.com
 - Remote formatting adds ~100-500ms network latency per call
 - Graceful fallback: saves original M code if the formatting service is unavailable
 - `list` returns compact metadata, exact load mode, character count, and at most
@@ -50,7 +50,7 @@ Destination values are case-insensitive. Unknown values fail before the query is
 changed; they never fall back to connection-only or another enum default.
 
 To create DAX measures on Power Query data:
-1. Use powerquery create/load-to with `loadDestination='data-model'`
+1. Use powerquery create/load-to with `load_destination='data-model'`
 2. Then use datamodel to create DAX measures
 
 Alternative path (for existing worksheet tables):
@@ -60,9 +60,9 @@ Alternative path (for existing worksheet tables):
 **Action disambiguation**:
 
 - **evaluate**: **CRITICAL - USE THIS FIRST** - Execute M code directly, return results WITHOUT creating a permanent query (test before create/update!)
-- create: Import NEW query using inline `mCode` (FAILS if query already exists - use update instead)
+- create: Import NEW query using inline `m_code` (FAILS if query already exists - use update instead)
 - update: Update EXISTING query M code + refresh data (use this if query exists)
-- rename: Change query name (requires both `queryName` and `newName` parameters)
+- rename: Change query name (requires both `old_name` and `new_name` parameters)
 - load-to: Loads to worksheet or data model or both (not just config change) - CHECKS for sheet conflicts
 - unload: Removes data from ALL destinations (worksheet AND Data Model) - keeps query definition
 - delete: Completely removes query AND all associated data (worksheet, Data Model connections)
@@ -97,15 +97,15 @@ Alternative path (for existing worksheet tables):
 
 **Inline M code**:
 
-- Provide raw M code directly via `mCode`
+- Provide raw M code directly via `m_code`
 - Keep `.pq` files only for GIT workflows
 
 **Create/LoadTo with existing sheets**:
 
-- Use `targetCellAddress` to place the table on an existing worksheet without deleting other content
+- Use `target_cell_address` to place the table on an existing worksheet without deleting other content
 - Applies to BOTH create and load-to
-- If the worksheet already has data and you omit `targetCellAddress`, the tool returns guidance telling you to provide one
-- Existing tables are refreshed in-place; specifying a different `targetCellAddress` requires unload + reload
+- If the worksheet already has data and you omit `target_cell_address`, the tool returns guidance telling you to provide one
+- Existing tables are refreshed in-place; specifying a different `target_cell_address` requires unload + reload
 - Worksheets that exist but are empty behave like new sheets (default destination = A1)
 
 **Common mistakes**:
@@ -115,15 +115,15 @@ Alternative path (for existing worksheet tables):
 - Using update on new query → ERROR "Query 'X' not found" (should use create)
 - Calling LoadTo without checking if sheet exists (will error if sheet exists)
 - Assuming unload only removes worksheet data → Also removes Data Model connections
-- Calling rename without trimming newName → Server trims automatically, " Query " becomes "Query"
+- Calling rename without trimming `new_name` → Server trims automatically, " Query " becomes "Query"
 - Renaming to conflicting name → Check list first if unsure about existing names
-- Passing an option from another action (for example `mCode` on delete or `timeout` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
+- Passing an option from another action (for example `m_code` on delete or `timeout_seconds` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
 
 **Server-specific quirks**:
 
 - Validation = execution: M code only validated when data loads/refreshes
 - connection-only queries: NOT validated until first execution
-- refresh with loadDestination: Applies load config + refreshes (2-in-1)
+- load-to with `load_destination`: Applies load config and refreshes (2-in-1)
 - Single cell returns [[value]] not scalar
 - Public timeout inputs are integer seconds. Refresh/refresh-all accepts 0-2147483 and defaults to the 30-minute data-operation timeout when `timeout_seconds`/`--timeout` is 0 or omitted. For quick queries use a smaller value (e.g., 60-120 seconds).
 - load-to has no caller timeout parameter and uses the fixed 30-minute data-operation timeout; passing `timeout` to load-to is rejected instead of ignored.
@@ -168,7 +168,7 @@ Reference other queries by name directly: `Source = OtherQueryName`
 ### Source Control Pattern
 
 1. Store M code in `.pq` files
-2. `powerquery create` or `update` with inline `mCode`
+2. `powerquery create` or `update` with inline `m_code`
 3. `refresh` to validate
 4. File name MUST match query name
 

--- a/skills/excel-mcp/references/querytable.md
+++ b/skills/excel-mcp/references/querytable.md
@@ -15,18 +15,18 @@ Use `querytable` for worksheet QueryTables backed by the desktop Excel COM objec
 
 ```text
 querytable(action: 'create-text',
-    queryTableName: 'OrdersCsv',
-    sourcePath: 'C:\Data\orders.csv',
-    sheetName: 'Orders',
-    destinationAddress: 'A1',
+    query_table_name: 'OrdersCsv',
+    source_path: 'C:\Data\orders.csv',
+    sheet_name: 'Orders',
+    destination_address: 'A1',
     delimiter: ',',
-    textQualifier: 'double-quote',
+    text_qualifier: 'double-quote',
     encoding: 65001,
-    hasHeaders: true)
+    has_headers: true)
 ```
 
 - `delimiter` is exactly one character.
-- `textQualifier` is `double-quote`, `single-quote`, or `none`.
+- `text_qualifier` is `double-quote`, `single-quote`, or `none`.
 - `encoding` is a Windows code page; use `65001` for UTF-8.
 - Creation refreshes synchronously so imported data is ready when the call returns.
 
@@ -34,17 +34,17 @@ querytable(action: 'create-text',
 
 ```text
 querytable(action: 'create-web',
-    queryTableName: 'RatesHtml',
+    query_table_name: 'RatesHtml',
     url: 'https://example.com/rates.html',
-    sheetName: 'Rates',
-    destinationAddress: 'A1',
-    selectionType: 'specified-tables',
-    webTables: '1',
+    sheet_name: 'Rates',
+    destination_address: 'A1',
+    selection_type: 'specified-tables',
+    web_tables: '1',
     formatting: 'none')
 ```
 
-- `selectionType` is `entire-page`, `all-tables`, or `specified-tables`.
-- `webTables` is required with `specified-tables`.
+- `selection_type` is `entire-page`, `all-tables`, or `specified-tables`.
+- `web_tables` is required with `specified-tables`.
 - `formatting` is `none`, `rich-text`, or `all`.
 - This is Excel's legacy HTML web-query engine, not a general HTTP or browser automation API.
 

--- a/skills/excel-mcp/references/range.md
+++ b/skills/excel-mcp/references/range.md
@@ -21,9 +21,9 @@ If you need the same styling on multiple non-contiguous ranges, use `format-rang
 ## Quick Pattern: Write, Format, Auto-Fit
 
 ```
-range(action: 'set-values', rangeAddress: 'A1:D4', values: [[...], [...]])
-range(action: 'set-number-format', rangeAddress: 'C2:D4', formatCode: '$#,##0.00')
-range_format(action: 'auto-fit-columns', rangeAddress: 'A:D')
+range(action: 'set-values', range_address: 'A1:D4', values: [[...], [...]])
+range(action: 'set-number-format', range_address: 'C2:D4', format_code: '$#,##0.00')
+range_format(action: 'auto-fit-columns', range_address: 'A:D')
 ```
 
 ## Quick Pattern: Repeated Section Headers
@@ -32,11 +32,11 @@ Use `format-ranges` when the same header or section style repeats across disjoin
 
 ```
 range_format(action: 'format-ranges',
-    rangeAddresses: ['A1:G1', 'A12:G12', 'A24:G24'],
+    range_addresses: ['A1:G1', 'A12:G12', 'A24:G24'],
     bold: true,
-    fillColor: '#243F60',
-    fontColor: '#FFFFFF',
-    horizontalAlignment: 'center')
+    fill_color: '#243F60',
+    font_color: '#FFFFFF',
+    horizontal_alignment: 'center')
 ```
 
 All target ranges are validated before formatting begins. If any target range is invalid, nothing is formatted.
@@ -47,11 +47,11 @@ All target ranges are validated before formatting begins. If any target range is
 Pass ALL properties in **one call**:
 
 ```
-range_format(action: 'format-range', rangeAddress: 'A1:D1',
+range_format(action: 'format-range', range_address: 'A1:D1',
     bold: true,
-    fillColor: '#4472C4',
-    fontColor: '#FFFFFF',
-    horizontalAlignment: 'center')
+    fill_color: '#4472C4',
+    font_color: '#FFFFFF',
+    horizontal_alignment: 'center')
 ```
 
 ## Quick Pattern: Semantic Status Cells
@@ -59,8 +59,8 @@ range_format(action: 'format-range', rangeAddress: 'A1:D1',
 Use `set-style` when the meaning (Good/Bad/Neutral) matters and theme-awareness is useful:
 
 ```
-range_format(action: 'set-style', rangeAddress: 'B2:B10', styleName: 'Good')
-range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
+range_format(action: 'set-style', range_address: 'B2:B10', style_name: 'Good')
+range_format(action: 'set-style', range_address: 'C2:C10', style_name: 'Bad')
 ```
 
 ## format-range Properties
@@ -70,15 +70,15 @@ range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
 | `bold` | bool | `true` |
 | `italic` | bool | `true` |
 | `underline` | bool | `true` |
-| `fontSize` | number | `14` |
-| `fontName` | string | `"Calibri"` |
-| `fontColor` | hex color | `"#FFFFFF"` |
-| `fillColor` | hex color | `"#4472C4"` |
-| `horizontalAlignment` | string | `"center"`, `"left"`, `"right"` |
-| `verticalAlignment` | string | `"middle"`, `"top"`, `"bottom"` |
-| `wrapText` | bool | `true` |
-| `borderStyle` | string | `"thin"`, `"medium"`, `"thick"` |
-| `borderColor` | hex color | `"#000000"` |
+| `font_size` | number | `14` |
+| `font_name` | string | `"Calibri"` |
+| `font_color` | hex color | `"#FFFFFF"` |
+| `fill_color` | hex color | `"#4472C4"` |
+| `horizontal_alignment` | string | `"center"`, `"left"`, `"right"` |
+| `vertical_alignment` | string | `"middle"`, `"top"`, `"bottom"` |
+| `wrap_text` | bool | `true` |
+| `border_style` | string | `"thin"`, `"medium"`, `"thick"` |
+| `border_color` | hex color | `"#000000"` |
 | `orientation` | int | `-90` to `90` (degrees) |
 
 ## set-style Presets
@@ -86,7 +86,7 @@ range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
 Built-in style names: `Normal`, `Heading 1`, `Heading 2`, `Heading 3`, `Heading 4`, `Title`, `Good`, `Bad`, `Neutral`, `Currency`, `Percent`, `Comma`
 
 ```
-range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
+range_format(action: 'set-style', range_address: 'A1:D1', style_name: 'Heading 1')
 ```
 
 ## Format Codes
@@ -122,7 +122,7 @@ than raw ones and will render as `#####` at the default column width.
 
 **SetNumberFormat**: Apply one format to entire range.
 
-- `formatCode`: Format code from table above
+- `format_code`: Format code from table above
 
 **SetNumberFormats**: Apply different formats per cell.
 
@@ -134,10 +134,10 @@ than raw ones and will render as `#####` at the default column width.
 Use modern threaded comments only when the installed desktop Excel build exposes them:
 
 ```text
-range_link(action: 'add-threaded-comment', sheetName: 'Review', cellAddress: 'B2', text: 'Check this value')
-range_link(action: 'add-threaded-comment-reply', sheetName: 'Review', cellAddress: 'B2', text: 'Confirmed')
-range_link(action: 'list-threaded-comments', sheetName: 'Review', cellAddress: 'B2')
-range_link(action: 'delete-threaded-comment', sheetName: 'Review', cellAddress: 'B2')
+range_link(action: 'add-threaded-comment', sheet_name: 'Review', cell_address: 'B2', text: 'Check this value')
+range_link(action: 'add-threaded-comment-reply', sheet_name: 'Review', cell_address: 'B2', text: 'Confirmed')
+range_link(action: 'list-threaded-comments', sheet_name: 'Review', cell_address: 'B2')
+range_link(action: 'delete-threaded-comment', sheet_name: 'Review', cell_address: 'B2')
 ```
 
 These actions expose local Excel PIA comment text, author, date, and replies. Microsoft 365 service features such as @mentions, assignments, reactions, presence, sharing, and coauthoring state are not available through local Excel COM.

--- a/skills/excel-mcp/references/screenshot.md
+++ b/skills/excel-mcp/references/screenshot.md
@@ -6,7 +6,7 @@
 
 ```
 1. chart(create-from-range, ...)  → Chart created
-2. screenshot(capture, rangeAddress='A1:M20')  ← REQUIRED — never skip this step
+2. screenshot(capture, range_address='A1:M20')  ← REQUIRED — never skip this step
 3. file(close, save=true)
 ```
 
@@ -23,8 +23,8 @@ This rule applies even if:
 
 | Action | Purpose | Parameters |
 |--------|---------|------------|
-| `capture` | Capture a specific range | `rangeAddress` (default: A1:Z30), `sheetName`, `quality` |
-| `capture-sheet` | Capture the worksheet's used cell range | `sheetName`, `quality` |
+| `capture` | Capture a specific range | `range_address` (default: A1:Z30), `sheet_name`, `quality` |
+| `capture-sheet` | Capture the worksheet's used cell range | `sheet_name`, `quality` |
 
 `capture-sheet` is cell-driven: it captures Excel's used range. On a chart-only worksheet, or when a chart extends beyond the used cells, use `capture` with an explicit range that covers the chart (for example, `A1:M25`).
 
@@ -51,8 +51,8 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 
 ### After Chart Creation or Positioning
 ```
-1. chart(create-from-range, ..., targetRange='F2:K15')
-2. screenshot(capture, rangeAddress='A1:O25')  → Verify chart doesn't overlap data
+1. chart(create-from-range, ..., target_range='F2:K15')
+2. screenshot(capture, range_address='A1:O25')  → Verify chart doesn't overlap data
 ```
 
 ### After Complex Formatting
@@ -66,7 +66,7 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 ```
 1. pivottable(add-row-field, ...)
 2. pivottable(add-value-field, ...)
-3. screenshot(capture, rangeAddress='A1:M25')  → Include charts and verify layout
+3. screenshot(capture, range_address='A1:M25')  → Include charts and verify layout
 ```
 
 ## Best Practices
@@ -84,8 +84,8 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 ### Chart Overlap Verification
 ```
 1. range(get-used-range) → "A1:D20"
-2. chart(create-from-range, sourceRange='A1:D20', targetRange='F2:K15')
-3. screenshot(capture, rangeAddress='A1:K20')
+2. chart(create-from-range, source_range='A1:D20', target_range='F2:K15')
+3. screenshot(capture, range_address='A1:K20')
    → Visually confirm chart is positioned next to data, not on top of it
 ```
 
@@ -94,13 +94,13 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 When creating dashboards with multiple charts:
 
 1. get-used-range → Know where data ends
-2. Create Chart 1 with targetRange below/beside data
-3. Create Chart 2 with targetRange that does NOT overlap Chart 1
-4. Create Chart 3, Chart 4, etc. — each in a non-overlapping targetRange
-5. screenshot(capture, rangeAddress='A1:M40') → Verify NO charts overlap each other or data
+2. Create Chart 1 with `target_range` below/beside data
+3. Create Chart 2 with `target_range` that does NOT overlap Chart 1
+4. Create Chart 3, Chart 4, etc. — each in a non-overlapping `target_range`
+5. screenshot(capture, range_address='A1:M40') → Verify NO charts overlap each other or data
 
 Key rules for multi-chart layouts:
-- Use targetRange for every chart — never rely on default positioning
+- Use `target_range` for every chart — never rely on default positioning
 - Leave at least 1-2 rows/columns between charts
 - Place charts in a grid pattern (e.g., 2x2) below the data area
 - If overlap detected, use chart(fit-to-range) to reposition
@@ -109,7 +109,7 @@ Key rules for multi-chart layouts:
 ### Dashboard Layout Check
 ```
 1. Create multiple charts and tables
-2. screenshot(capture, rangeAddress='A1:M40')
+2. screenshot(capture, range_address='A1:M40')
    → Verify overall dashboard layout, spacing, and alignment
 3. If issues found: reposition with chart(fit-to-range), then screenshot again
 ```

--- a/skills/excel-mcp/references/slicer.md
+++ b/skills/excel-mcp/references/slicer.md
@@ -10,26 +10,26 @@ Two distinct slicer types exist:
 
 | Action | Description | Required Parameters |
 |--------|-------------|---------------------|
-| `create-slicer` | Create PivotTable slicer | pivotTableName, fieldName |
+| `create-slicer` | Create PivotTable slicer | pivot_table_name, field_name |
 | `list-slicers` | List all PivotTable slicers | (none) |
-| `set-slicer-selection` | Set PivotTable slicer filter | slicerName, selectedItems |
-| `delete-slicer` | Delete PivotTable slicer | slicerName |
-| `create-table-slicer` | Create Table slicer | tableName, columnName |
+| `set-slicer-selection` | Set PivotTable slicer filter | slicer_name, selected_items |
+| `delete-slicer` | Delete PivotTable slicer | slicer_name |
+| `create-table-slicer` | Create Table slicer | table_name, column_name |
 | `list-table-slicers` | List all Table slicers | (none) |
-| `set-table-slicer-selection` | Set Table slicer filter | slicerName, selectedItems |
-| `delete-table-slicer` | Delete Table slicer | slicerName |
+| `set-table-slicer-selection` | Set Table slicer filter | slicer_name, selected_items |
+| `delete-table-slicer` | Delete Table slicer | slicer_name |
 
-**CRITICAL: Required Parameters** - The "Required Parameters" column above is strict. Missing any required parameter will cause an error. Pay special attention to `pivotTableName` for PivotTable slicers and `slicerName` for selection/deletion operations.
+**CRITICAL: Required Parameters** - The "Required Parameters" column above is strict. Missing any required parameter will cause an error. Pay special attention to `pivot_table_name` for PivotTable slicers and `slicer_name` for selection/deletion operations.
 
 **Naming Convention**:
 
-- If `slicerName` not provided, auto-generates `{FieldName}Slicer` or `{ColumnName}Slicer`
+- If `slicer_name` is not provided, Excel auto-generates a name from the field or column
 - Slicer names must be unique within workbook
 - Use `list-slicers` or `list-table-slicers` to check existing names
 
 **Selection Behavior**:
 
-- `selectedItems` is a list of strings: `["Value1", "Value2"]`
+- `selected_items` is a JSON array of strings: `["Value1", "Value2"]`
 - Empty list `[]` clears all filters (shows all items)
 - Values must match exactly (case-sensitive)
 - Invalid values are silently ignored
@@ -51,7 +51,7 @@ The `--selected-items` parameter requires a JSON array. Use proper shell escapin
 
 **Positioning**:
 
-- `destinationSheet` specifies which worksheet hosts the slicer
+- `destination_sheet` specifies which worksheet hosts the slicer
 - `position` is a cell address for top-left corner (e.g., `'E1'`, `'G5'`)
 - The slicer's top-left corner aligns to the specified cell
 - Default position if not specified: Excel chooses

--- a/skills/excel-mcp/references/table.md
+++ b/skills/excel-mcp/references/table.md
@@ -11,17 +11,17 @@ To analyze worksheet data with DAX measures:
 
 **Action disambiguation**:
 
-- create: Create NEW table from a range (requires sheetName, tableName, rangeAddress). Pass `tableStyle` here to style at creation time.
+- create: Create NEW table from a range (requires `sheet_name`, `table_name`, and `range_address`). Pass `table_style` here to style at creation time.
 - read: Get table metadata (range, columns, style, row counts)
-- get-data: Get actual table DATA as 2D array (use visibleOnly=true for filtered data)
+- get-data: Get actual table DATA as 2D array (use `visible_only=true` for filtered data)
 - rename: Rename an existing table
 - delete: Remove table (keeps data, removes table formatting)
 - resize: Change table range (expand/contract)
 - set-style: Change table visual style (TableStyleLight1-21, TableStyleMedium1-28, TableStyleDark1-11). Default is TableStyleMedium2.
-- toggle-totals: Show or hide the totals row (showTotals: true/false)
+- toggle-totals: Show or hide the totals row (`show_totals`: true/false)
 - set-column-total: Set the aggregate function on a totals-row column (Sum, Count, Average, Min, Max, None)
 - add-to-data-model: Add an existing worksheet table to Power Pivot for DAX analysis
-- append: Add rows to existing table (requires rows or rowsFile parameter)
+- append: Add rows to existing table (requires `rows` or `rows_file`)
 - **create-from-dax**: Create table populated by a DAX EVALUATE query from Data Model
 - **update-dax**: Update an existing DAX-backed table's query
 - **get-dax**: Get the DAX query behind a DAX-backed table
@@ -32,8 +32,8 @@ Excel Tables manage their own header/row/totals formatting through table styles.
 
 | Goal | Correct approach |
 |------|-----------------|
-| Style a table | `table(action: 'set-style', tableStyle: 'TableStyleMedium2')` |
-| Style at creation | `table(action: 'create', tableStyle: 'TableStyleMedium2', ...)` |
+| Style a table | `table(action: 'set-style', table_style: 'TableStyleMedium2')` |
+| Style at creation | `table(action: 'create', table_style: 'TableStyleMedium2', ...)` |
 | Custom branding on table | Use a Medium/Dark table style that matches your palette — avoid overriding individual cells |
 
 Common table style choices:
@@ -73,7 +73,7 @@ Example DAX queries for create-from-dax:
 |------|------|
 | Create/manage worksheet tables | table |
 | Add worksheet table to Power Pivot | table (add-to-data-model) |
-| Import external data to Data Model | powerquery (loadDestination='data-model') |
+| Import external data to Data Model | powerquery (load_destination='data-model') |
 | Create DAX measures | datamodel |
 | Create PivotTables from Data Model | pivottable |
 
@@ -82,11 +82,11 @@ Example DAX queries for create-from-dax:
 - Trying to create DAX measures without first adding table to Data Model
 - Using datamodel to add tables (it only manages existing Data Model tables)
 - Confusing get-data (returns cell values) with read (returns metadata)
-- Forgetting hasHeaders parameter when creating tables from headerless data
+- Forgetting `has_headers` when creating tables from headerless data
 
 **Server-specific quirks**:
 
-- Style parameter is overloaded: table style name OR total function (context-dependent)
-- csvData parameter: dedicated parameter for append action (CSV format: comma-separated, newline-separated rows)
-- visibleOnly parameter only applies to get-data action
+- `table_style` applies to table creation and set-style; totals use `total_function`
+- `rows` accepts a 2D array and `rows_file` accepts JSON or CSV input for append
+- `visible_only` applies only to get-data
 - Table names must be unique within workbook (Excel requirement)

--- a/skills/excel-mcp/references/workflows.md
+++ b/skills/excel-mcp/references/workflows.md
@@ -29,7 +29,7 @@ Excel's Power Pivot has key limitations compared to Power BI/SSAS:
 
 ### Data Model Prerequisites
 ```
-1. Load table (powerquery refresh loadDestination="data-model")
+1. Load table (powerquery load-to load_destination="data-model")
 2. THEN create relationships (datamodel_relationship with create-relationship action)
 3. THEN create measures (datamodel create-measure)
 ```
@@ -58,5 +58,5 @@ After Power Query: powerquery list, powerquery view
 After refresh:     datamodel list-tables
 After measure:     datamodel list-measures, datamodel evaluate
 After relationship: datamodel_relationship list-relationships
-After chart/layout: screenshot(capture, rangeAddress='A1:M50') (visual verification)
+After chart/layout: screenshot(capture, range_address='A1:M50') (visual verification)
 ```

--- a/skills/shared/analysis.md
+++ b/skills/shared/analysis.md
@@ -7,34 +7,34 @@ Use `analysis` for Excel's native Goal Seek, scenarios, scenario summaries, and 
 The formula cell must contain a formula, and the changing cell must be one of its inputs.
 
 ```text
-analysis(action="goal-seek", sheetName="Model", formulaCell="B10", goal=10000, changingCell="B3")
+analysis(action="goal-seek", sheet_name="Model", formula_cell="B10", goal=10000, changing_cell="B3")
 ```
 
 Goal Seek changes the workbook immediately. Read both cells afterward when the exact final values matter.
 
 ## Scenarios
 
-Scenario values must contain exactly one value per cell in `changingCells`, in range order.
+Scenario values must contain exactly one value per cell in `changing_cells`, in range order.
 
 ```text
-analysis(action="create-scenario", sheetName="Model", scenarioName="Growth",
-         changingCells="B3:B5", values=[0.08, 1200, 0.35])
-analysis(action="show-scenario", sheetName="Model", scenarioName="Growth")
-analysis(action="list-scenarios", sheetName="Model")
+analysis(action="create-scenario", sheet_name="Model", scenario_name="Growth",
+         changing_cells="B3:B5", values=[0.08, 1200, 0.35])
+analysis(action="show-scenario", sheet_name="Model", scenario_name="Growth")
+analysis(action="list-scenarios", sheet_name="Model")
 ```
 
-Use `create-scenario-summary` after defining two or more scenarios. Set `reportType` to `summary` for a normal report sheet or `pivot-table` for a Scenario PivotTable. `resultCells` should identify formulas that depend on the changing cells.
+Use `create-scenario-summary` after defining two or more scenarios. Set `report_type` to `summary` for a normal report sheet or `pivot-table` for a Scenario PivotTable. `result_cells` should identify formulas that depend on the changing cells.
 
 ## Data Tables
 
 Prepare the worksheet layout first, including the formula in the table's corner and the input values along its first row or column.
 
-- One-variable row table: provide `rowInputCell`.
-- One-variable column table: provide `columnInputCell`.
+- One-variable row table: provide `row_input_cell`.
+- One-variable column table: provide `column_input_cell`.
 - Two-variable table: provide both.
 
 ```text
-analysis(action="create-data-table", sheetName="Model", tableRange="A1:B11", columnInputCell="D1")
+analysis(action="create-data-table", sheet_name="Model", table_range="A1:B11", column_input_cell="D1")
 ```
 
 Data tables can be calculation-intensive. Use `calculation_mode` when controlling recalculation around larger workbook edits.

--- a/skills/shared/anti-patterns.md
+++ b/skills/shared/anti-patterns.md
@@ -11,9 +11,9 @@ Applying the same formatting to the same range more than once in a workflow:
 ```
 WRONG: Applying bold repeatedly
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true)
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true)
 // ... other operations ...
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4')
 // Bold was already applied - the second call re-applies it unnecessarily
 ```
 
@@ -22,10 +22,10 @@ Also wrong: calling `format-range` separately for each property instead of combi
 ```
 WRONG: Separate calls for each property
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true)
-range_format(action: 'format-range', rangeAddress: 'A1:D1', fillColor: '#4472C4')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', horizontalAlignment: 'center')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true)
+range_format(action: 'format-range', range_address: 'A1:D1', fill_color: '#4472C4')
+range_format(action: 'format-range', range_address: 'A1:D1', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A1:D1', horizontal_alignment: 'center')
 ```
 
 ### The Solution
@@ -35,8 +35,8 @@ Apply all formatting properties for a range in **one** `format-range` call:
 ```
 CORRECT: One call per range
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1',
-    bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF', horizontalAlignment: 'center')
+range_format(action: 'format-range', range_address: 'A1:D1',
+    bold: true, fill_color: '#4472C4', font_color: '#FFFFFF', horizontal_alignment: 'center')
 ```
 
 Apply each formatting operation **once**. If a subsequent step explicitly changes a property (e.g., "now make the title red"), apply it again — otherwise don't.
@@ -46,17 +46,17 @@ If the same formatting applies to multiple disjoint ranges, do not repeat `forma
 ```
 WRONG: Repeating the same shared formatting payload
 
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A12:D12', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
-range_format(action: 'format-range', rangeAddress: 'A24:D24', bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A12:D12', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
+range_format(action: 'format-range', range_address: 'A24:D24', bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
 ```
 
 ```
 CORRECT: One shared multi-range formatting call
 
 range_format(action: 'format-ranges',
-    rangeAddresses: ['A1:D1', 'A12:D12', 'A24:D24'],
-    bold: true, fillColor: '#4472C4', fontColor: '#FFFFFF')
+    range_addresses: ['A1:D1', 'A12:D12', 'A24:D24'],
+    bold: true, fill_color: '#4472C4', font_color: '#FFFFFF')
 ```
 
 ### When Multiple Calls ARE Appropriate
@@ -74,8 +74,8 @@ Applying `range_format` to cells that belong to an object with its own style sys
 ```
 WRONG: Formatting a table header row with range_format
 
-table(action: 'create', tableName: 'Sales', rangeAddress: 'A1:D10')
-range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColor: '#4472C4')
+table(action: 'create', table_name: 'Sales', range_address: 'A1:D10')
+range_format(action: 'format-range', range_address: 'A1:D1', bold: true, fill_color: '#4472C4')
 // The table style already controls header appearance — this creates an inconsistent override
 ```
 
@@ -83,7 +83,7 @@ range_format(action: 'format-range', rangeAddress: 'A1:D1', bold: true, fillColo
 WRONG: Formatting PivotTable cells
 
 pivottable(action: 'create-from-table', ...)
-range_format(action: 'format-range', rangeAddress: 'B3:B20', fillColor: '#E2EFDA')
+range_format(action: 'format-range', range_address: 'B3:B20', fill_color: '#E2EFDA')
 // Formatting is wiped on the next pivottable(refresh)
 ```
 
@@ -94,15 +94,15 @@ Use the style system that belongs to each object type:
 ```
 CORRECT: Table visual styling — one call at creation or via set-style
 
-table(action: 'create', tableName: 'Sales', rangeAddress: 'A1:D10',
-    tableStyle: 'TableStyleMedium2')
+table(action: 'create', table_name: 'Sales', range_address: 'A1:D10',
+    table_style: 'TableStyleMedium2')
 ```
 
 | Object | Correct style approach | Do NOT use |
 |--------|----------------------|------------|
-| Excel Tables | `table(action:'set-style')` or `tableStyle` on create | `range_format` on header/data rows |
+| Excel Tables | `table(action:'set-style')` or `table_style` on create | `range_format` on header/data rows |
 | PivotTables | Not supported — leave default | `range_format` (wiped on refresh) |
-| Charts | `chart_config(action:'set-style', styleNumber: 1-48)` | `range_format` |
+| Charts | `chart_config(action:'set-style', style_id: 1-48)` | `range_format` |
 | Plain cells/ranges | `range_format` | — |
 
 ## Delete-and-Rebuild Anti-Pattern
@@ -114,9 +114,9 @@ Deleting entire structures to make small changes:
 ```
 WRONG: User wants to update cell B5
 
-table(action: 'delete', tableName: 'SalesData')
+table(action: 'delete', table_name: 'SalesData')
 range(action: 'set-values', values: [[entire dataset with B5 fixed]])
-table(action: 'create', tableName: 'SalesData', ...)
+table(action: 'create', table_name: 'SalesData', ...)
 ```
 
 This destroys:
@@ -134,7 +134,7 @@ Use targeted modifications:
 ```
 CORRECT: Update only the changed cell
 
-range(action: 'set-values', rangeAddress: 'B5', values: [[newValue]])
+range(action: 'set-values', range_address: 'B5', values: [[newValue]])
 ```
 
 ### When Rebuild IS Appropriate
@@ -163,14 +163,14 @@ This burns tokens, costs money, and never completes the task.
 
 ### The Solution
 
-If you already have a sessionId, use it. Do not rediscover:
+If you already have a session ID, use it. Do not rediscover:
 
 ```
-CORRECT: Use the sessionId you already have
+CORRECT: Use the session ID you already have
 
 Error: "session expired"
-→ file(action: 'open', path: original_path)  ← Re-open once, get new sessionId
-→ Continue with the new sessionId immediately
+→ file(action: 'open', path: original_path)  ← Re-open once, get a new session ID
+→ Continue with the new session ID immediately
 ```
 
 ### The Rule
@@ -229,9 +229,9 @@ Reading entire range, modifying in memory, writing entire range back:
 ```
 WRONG: Update one cell by rewriting thousands
 
-data = range(action: 'get-values', rangeAddress: 'A1:Z1000')
+data = range(action: 'get-values', range_address: 'A1:Z1000')
 data[4][1] = "new value"  // Modify row 5, column B
-range(action: 'set-values', rangeAddress: 'A1', values: data)
+range(action: 'set-values', range_address: 'A1', values: data)
 ```
 
 This:
@@ -247,7 +247,7 @@ Write only the changed cells:
 ```
 CORRECT: Direct cell update
 
-range(action: 'set-values', rangeAddress: 'B5', values: [["new value"]])
+range(action: 'set-values', range_address: 'B5', values: [["new value"]])
 ```
 
 ## Session Leak Anti-Pattern
@@ -259,9 +259,9 @@ Opening files without closing them:
 ```
 WRONG: Session accumulation
 
-file(action: 'open', filePath: 'file1.xlsx')  // Session 1
-file(action: 'open', filePath: 'file2.xlsx')  // Session 2
-file(action: 'open', filePath: 'file3.xlsx')  // Session 3
+file(action: 'open', path: 'file1.xlsx')  // Session 1
+file(action: 'open', path: 'file2.xlsx')  // Session 2
+file(action: 'open', path: 'file3.xlsx')  // Session 3
 // ... never closed
 ```
 
@@ -280,11 +280,11 @@ CORRECT: Proper lifecycle
 
 session1 = file(action: 'open', path: 'file1.xlsx')
 // ... work with file1 ...
-file(action: 'close', sessionId: session1, save: true)
+file(action: 'close', session_id: session1, save: true)
 
 session2 = file(action: 'open', path: 'file2.xlsx')
 // ... work with file2 ...
-file(action: 'close', sessionId: session2, save: true)
+file(action: 'close', session_id: session2, save: true)
 ```
 
 ## Ignoring Error Context Anti-Pattern
@@ -310,9 +310,9 @@ CORRECT: Error-driven correction
 
 datamodel(action: 'create-measure', ...) 
 → Error: Table 'Sales' not in Data Model
-→ Suggested: table(action: 'add-to-data-model', tableName: 'Sales')
+→ Suggested: table(action: 'add-to-data-model', table_name: 'Sales')
 
-table(action: 'add-to-data-model', tableName: 'Sales')  // Fix prerequisite
+table(action: 'add-to-data-model', table_name: 'Sales')  // Fix prerequisite
 datamodel(action: 'create-measure', ...)  // Now succeeds
 ```
 
@@ -325,8 +325,8 @@ Using locale-specific format codes:
 ```
 WRONG: German/European format
 
-range(action: 'set-number-format', formatCode: '#.##0,00')  // German
-range(action: 'set-number-format', formatCode: '# ##0,00')  // French
+range(action: 'set-number-format', format_code: '#.##0,00')  // German
+range(action: 'set-number-format', format_code: '# ##0,00')  // French
 ```
 
 ### The Solution
@@ -336,7 +336,7 @@ Always use US format codes (Excel translates automatically):
 ```
 CORRECT: US format codes (universal)
 
-range(action: 'set-number-format', formatCode: '#,##0.00')
+range(action: 'set-number-format', format_code: '#,##0.00')
 ```
 
 Excel displays the result in the user's locale setting, but the API requires US format input.
@@ -350,7 +350,7 @@ Wrong load destination for the workflow:
 ```
 WRONG: Loading to worksheet when DAX is needed
 
-powerquery(action: 'create', loadDestination: 'worksheet', ...)
+powerquery(action: 'create', load_destination: 'worksheet', ...)
 datamodel(action: 'create-measure', ...)  // FAILS: table not in Data Model
 ```
 
@@ -361,7 +361,7 @@ Match load destination to workflow:
 ```
 CORRECT: Load to Data Model for DAX workflows
 
-powerquery(action: 'create', loadDestination: 'data-model', ...)
+powerquery(action: 'create', load_destination: 'data-model', ...)
 powerquery(action: 'refresh', ...)
 datamodel(action: 'create-measure', ...)  // Works
 ```
@@ -382,7 +382,7 @@ Creating or updating Power Query queries without testing M code first:
 ```
 WRONG: Creating permanent query with untested M code
 
-powerquery(action: 'create', mCode: '...', ...)
+powerquery(action: 'create', m_code: '...', ...)
 // M code has syntax error → COM exception with cryptic message
 // Now workbook is polluted with broken query
 ```
@@ -401,12 +401,12 @@ Always evaluate M code BEFORE creating permanent queries:
 CORRECT: Test-first development workflow
 
 // Step 1: Test M code without persisting
-powerquery(action: 'evaluate', mCode: '...')
+powerquery(action: 'evaluate', m_code: '...')
 // → Returns actual data preview with columns and rows
 // → Better error messages if M code has issues
 
 // Step 2: Create permanent query with validated code
-powerquery(action: 'create', mCode: '...', ...)
+powerquery(action: 'create', m_code: '...', ...)
 
 // Step 3: Load data to destination
 powerquery(action: 'refresh', ...)
@@ -432,7 +432,7 @@ If create/update fails with COM error, use evaluate to get detailed Power Query 
 
 ```
 powerquery(action: 'create', ...)  // → COM exception
-powerquery(action: 'evaluate', mCode: '...')  // → Detailed M error
+powerquery(action: 'evaluate', m_code: '...')  // → Detailed M error
 // Fix M code based on error
 powerquery(action: 'create', ...)  // → Success
 ```

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -91,7 +91,7 @@ When creating or modifying Excel files:
 
 **Use `format-range` for visual layout (header rows, custom colours) — ALL properties in ONE call:**
 - `set-style('Heading 1')` does NOT apply a fill colour; if you want a coloured header row use `format-range`
-- Pass bold, fillColor, fontColor, and alignment together in a single call — do not call `format-range` multiple times for the same range
+- Pass `bold`, `fill_color`, `font_color`, and alignment together in a single call — do not call `format-range` multiple times for the same range
 - If the same formatting payload repeats across multiple non-contiguous ranges, prefer one `format-ranges` call over repeated `format-range` calls
 
 **Apply each formatting operation once** — do not reapply the same properties to the same range unless a later step explicitly changes them.
@@ -134,7 +134,7 @@ Always convert tabular data to Excel Tables (ListObjects):
 
 ```
 1. range set-values (write data including headers)
-2. table create tableName="SalesData" rangeAddress="A1:D100"
+2. table create table_name="SalesData" range_address="A1:D100"
 ```
 
 **Why Tables over plain ranges:**
@@ -181,9 +181,9 @@ authentication occurs; open them with a visible session.
 Always close sessions when done:
 
 ```
-1. file(action: 'open', path: '...')  → sessionId
-2. All operations use sessionId
-3. file(action: 'close', sessionId: '...', save: true)  → saves and closes
+1. file(action: 'open', path: '...')  → session ID
+2. All operations use the returned session ID
+3. file(action: 'close', session_id: '...', save: true)  → saves and closes
 ```
 
 **Why**: Unclosed sessions leave Excel processes running, consuming memory and locking files.
@@ -299,9 +299,9 @@ belong to the selected action are rejected instead of being defaulted or ignored
   session operation timeout.
 - For required generated inline/file pairs, supply exactly one form. Optional
   pairs may omit both, but inline and file forms are always mutually exclusive.
-  Batch aliases are
-  `mCodeFile`, `vbaCodeFile`, `daxFormulaFile`, `daxQueryFile`, `dmvQueryFile`,
-  `schemaFile`, and `xmlDataFile`; MCP uses snake_case and CLI uses kebab-case.
+  MCP file inputs are
+  `m_code_file`, `vba_code_file`, `dax_formula_file`, `dax_query_file`, `dmv_query_file`,
+  `schema_file`, and `xml_data_file`; CLI uses the matching kebab-case flags.
   The file must exist and be readable.
 
 ### Refresh After Create
@@ -310,7 +310,7 @@ belong to the selected action are rejected instead of being defaulted or ignored
 
 ```
 Step 1: powerquery(action: 'create', ...) → Query created
-Step 2: powerquery(action: 'refresh', queryName: '...') → Data loaded
+Step 2: powerquery(action: 'refresh', query_name: '...') → Data loaded
 ```
 
 Without refresh, the query exists but contains no data.
@@ -325,7 +325,7 @@ Excel MCP errors include actionable context:
 {
   "success": false,
   "errorMessage": "Table 'Sales' not found in Data Model",
-  "suggestedNextActions": ["table(action: 'add-to-data-model', tableName: 'Sales')"]
+  "suggestedNextActions": ["table(action: 'add-to-data-model', table_name: 'Sales')"]
 }
 ```
 

--- a/skills/shared/chart.md
+++ b/skills/shared/chart.md
@@ -9,19 +9,19 @@
 
 ### From Range
 ```
-chart(create-from-range, chartType, sourceRange, sheetName)
+chart(create-from-range, chart_type, source_range, sheet_name)
 ```
 Best for: Simple data in worksheet ranges
 
 ### From PivotTable (PivotChart)
 ```
-chart(create-from-pivottable, pivotTableName)
+chart(create-from-pivottable, pivot_table_name)
 ```
 Best for: Data Model data - creates a single PivotChart object (don't create separate PivotTable + Chart)
 
 ### From Table
 ```
-chart(create-from-table, tableName, chartType)
+chart(create-from-table, table_name, chart_type)
 ```
 Best for: Excel Tables with structured references
 
@@ -34,22 +34,22 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 ## Configuration Actions (chart_config)
 
 ### Series Management
-- `add-series`: Add data series with valuesRange and optional categoryRange
+- `add-series`: Add data series with `values_range` and optional `category_range`
 - `remove-series`: Remove series by index (1-based)
 - `set-source-range`: Replace entire chart data source
 - `set-series-chart-type`: Assign a chart type to one regular-chart series for combo charts
 
 ### Plot Behavior
 - `get-plot-options`: Read row/column orientation, blank-cell display, and hidden-cell plotting
-- `set-plot-options`: Configure `plotBy`, `displayBlanksAs`, and `plotVisibleOnly`
+- `set-plot-options`: Configure `plot_by`, `display_blanks_as`, and `plot_visible_only`
 
 ### Titles and Labels
 - `set-title`: Set chart title (empty string hides)
 - `set-axis-title`: Set axis labels (Category, Value, CategorySecondary, ValueSecondary)
-- `set-data-labels`: Configure data labels (position, showValue, showCategory, showPercentage, showSeriesName, showLegendKey)
+- `set-data-labels`: Configure data labels (`label_position`, `show_value`, `show_category_name`, `show_percentage`, and `show_series_name`)
 
 ### Axis Formatting
-- `get-axis-scale`: Get min, max, majorUnit, minorUnit, and auto flags
+- `get-axis-scale`: Get minimum, maximum, major unit, minor unit, and auto flags
 - `set-axis-scale`: Configure scale properties
 - `get-axis-number-format`: Get current tick label format
 - `set-axis-number-format`: Format axis numbers (e.g., `"$#,##0,,\"M\""` for millions)
@@ -90,8 +90,8 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 - **period**: Required for MovingAverage (2+, default 2)
 - **forward/backward**: Forecast periods ahead/behind data
 - **intercept**: Force trend through specific Y value
-- **displayEquation**: Show formula on chart
-- **displayRSquared**: Show R² goodness-of-fit value
+- **display_equation**: Show formula on chart
+- **display_r_squared**: Show R² goodness-of-fit value
 
 ## Common Workflows
 
@@ -100,13 +100,13 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 1. chart(create-from-range) → chartName
 2. chart_config(set-title, title="Monthly Sales")
 3. chart_config(set-axis-title, axis="Value", title="Revenue ($)")
-4. chart_config(set-axis-number-format, axis="Value", numberFormat="$#,##0")
-5. chart_config(set-data-labels, position="OutsideEnd", showValue=true)
+4. chart_config(set-axis-number-format, axis="Value", number_format="$#,##0")
+5. chart_config(set-data-labels, label_position="OutsideEnd", show_value=true)
 ```
 
 ### Add Analysis
 ```
-1. chart_config(add-trendline, trendlineType="Linear", displayEquation=true, displayRSquared=true)
+1. chart_config(add-trendline, trendline_type="Linear", display_equation=true, display_r_squared=true)
 2. chart_config(set-trendline, forward=3) # Forecast 3 periods ahead
 ```
 
@@ -122,22 +122,22 @@ Specialized: `Waterfall`, `Funnel`, `Treemap`, `Sunburst`, `BoxWhisker`, `Histog
 
 Charts support three positioning modes, listed in order of preference:
 
-### 1. targetRange (PREFERRED - One Step)
+### 1. target_range (PREFERRED - One Step)
 ```
-chart(create-from-range, sourceRange='A1:B10', chartType='Line', targetRange='F2:K15')
+chart(create-from-range, source_range='A1:B10', chart_type='Line', target_range='F2:K15')
 ```
 Creates chart AND positions it to the cell range in one call. No point math needed.
 
 ### 2. Auto-Positioning (No Position Specified)
-When you omit both `targetRange` and `left`/`top`, the chart is automatically placed below all existing content (data ranges + other charts) with 10pt padding. This prevents overlap automatically.
+When you omit both `target_range` and `left`/`top`, the chart is automatically placed below all existing content (data ranges + other charts) with 10pt padding. This prevents overlap automatically.
 ```
-chart(create-from-range, sourceRange='A1:B10', chartType='Line')
+chart(create-from-range, source_range='A1:B10', chart_type='Line')
 # → Chart auto-positioned below the used range and any existing charts
 ```
 
 ### 3. Manual Coordinates
 ```
-chart(create-from-range, sourceRange='A1:B10', left=360, top=20)
+chart(create-from-range, source_range='A1:B10', left=360, top=20)
 # left/top in points (72 points = 1 inch)
 ```
 
@@ -154,9 +154,9 @@ Result example with collision warning:
 ```
 
 **If you see an overlap warning:**
-1. Use `chart(fit-to-range, chartName, rangeAddress='F2:K15')` to reposition
-2. Or use `chart(move, chartName, left=..., top=...)` to adjust
-3. Always follow up with `screenshot(capture, rangeAddress='A1:M25')` to include and verify the chart
+1. Use `chart(fit-to-range, chart_name='Chart 1', range_address='F2:K15')` to reposition
+2. Or use `chart(move, chart_name='Chart 1', left=..., top=...)` to adjust
+3. Always follow up with `screenshot(capture, range_address='A1:M25')` to include and verify the chart
 
 ### Position Estimates
 - Rows: ~15 points per row (varies with row height)
@@ -164,10 +164,10 @@ Result example with collision warning:
 - Default chart: 400×300 points
 
 ### Positioning Workflow
-1. **Preferred**: Use `targetRange='F2:K15'` in create call — avoids all overlap issues
+1. **Preferred**: Use `target_range='F2:K15'` in create call — avoids all overlap issues
 2. **Alternative**: Omit position — auto-positioning places chart below content
 3. **Manual**: `get-used-range` → calculate coordinates → specify left/top
-4. **Always verify**: Use `screenshot(capture, rangeAddress='A1:M25')` to visually confirm layout
+4. **Always verify**: Use `screenshot(capture, range_address='A1:M25')` to visually confirm layout
 
 ## Multi-Chart Layout (CRITICAL)
 
@@ -177,15 +177,15 @@ When creating dashboards with multiple charts, **every chart needs explicit posi
 ```
 Data at A1:D10. Place 4 charts in a 2×2 grid below data:
 
-chart(create-from-range, ..., targetRange='A12:F25')   # Top-left
-chart(create-from-range, ..., targetRange='G12:L25')   # Top-right
-chart(create-from-range, ..., targetRange='A27:F40')   # Bottom-left
-chart(create-from-range, ..., targetRange='G27:L40')   # Bottom-right
-screenshot(capture, rangeAddress='A1:M40') → Verify no overlaps
+chart(create-from-range, ..., target_range='A12:F25')   # Top-left
+chart(create-from-range, ..., target_range='G12:L25')   # Top-right
+chart(create-from-range, ..., target_range='A27:F40')   # Bottom-left
+chart(create-from-range, ..., target_range='G27:L40')   # Bottom-right
+screenshot(capture, range_address='A1:M40') → Verify no overlaps
 ```
 
 ### Rules
-- **Use targetRange for every chart** in multi-chart layouts — auto-positioning stacks vertically
+- **Use target_range for every chart** in multi-chart layouts — auto-positioning stacks vertically
 - Leave at least 1-2 rows/columns gap between charts
 - If any chart result includes an overlap warning, fix it before creating the next chart
-- Take a final `screenshot(capture, rangeAddress='A1:M40')` to verify the complete layout
+- Take a final `screenshot(capture, range_address='A1:M40')` to verify the complete layout

--- a/skills/shared/conditionalformat.md
+++ b/skills/shared/conditionalformat.md
@@ -4,14 +4,14 @@
 
 | Type | Description | Parameters |
 |------|-------------|------------|
-| `cell-value` | Format based on cell value comparison | operatorType + formula1 (+ formula2 for between) |
+| `cell-value` | Format based on cell value comparison | operator_type + formula1 (+ formula2 for between) |
 | `expression` | Format based on formula result | formula only |
 | `color-scale` | 2- or 3-color gradient across the range | colorScaleMin/Mid/Max Type/Value/Color |
-| `data-bar` | In-cell bars proportional to value | dataBarColor, dataBarNegativeColor, dataBarDirection, dataBarShowValue, dataBarMin/Max Type/Value |
-| `icon-set` | Icons (arrows, traffic lights, etc.) per value band | iconSetId, iconSetReverse, iconSetShowIconOnly, iconThreshold1..4 Type/Value |
-| `top10` | Highlight top/bottom N (or percent) | rank, top10Percent, topBottom + formatting |
-| `above-average` | Highlight values above/below average | aboveBelow + formatting |
-| `time-period` | Highlight dates in a period | datePeriod + formatting |
+| `data-bar` | In-cell bars proportional to value | data_bar_color, data_bar_negative_color, data_bar_direction, data_bar_show_value, data_bar_min/max type/value |
+| `icon-set` | Icons (arrows, traffic lights, etc.) per value band | icon_set_id, icon_set_reverse, icon_set_show_icon_only, icon_threshold1..4 type/value |
+| `top10` | Highlight top/bottom N (or percent) | rank, top10_percent, top_bottom + formatting |
+| `above-average` | Highlight values above/below average | above_below + formatting |
+| `time-period` | Highlight dates in a period | date_period + formatting |
 | `unique-values` | Highlight unique (or duplicate) values | formatting |
 | `blanks-condition` | Highlight blank cells | formatting |
 
@@ -30,30 +30,30 @@
 
 **Format Options**:
 
-- `interiorColor`: Background fill color as `#RRGGBB` hex
-- `fontColor`: Text color as `#RRGGBB` hex
-- `fontBold`: `true` or `false`
-- `fontItalic`: `true` or `false`
-- `borderStyle`: Excel border style name
-- `borderColor`: Border color as `#RRGGBB` hex
+- `interior_color`: Background fill color as `#RRGGBB` hex
+- `font_color`: Text color as `#RRGGBB` hex
+- `font_bold`: `true` or `false`
+- `font_italic`: `true` or `false`
+- `border_style`: Excel border style name
+- `border_color`: Border color as `#RRGGBB` hex
 
-**Visual rule parameters** (used by the corresponding `ruleType`):
+**Visual rule parameters** (used by the corresponding `rule_type`):
 
-- **color-scale**: `colorScaleMinType`/`colorScaleMidType`/`colorScaleMaxType`
+- **color-scale**: `color_scale_min_type`/`color_scale_mid_type`/`color_scale_max_type`
   (`minimum`, `maximum`, `number`, `percent`, `percentile`, `formula`), matching
   `...Value` (when the type needs one) and `...Color` (`#RRGGBB`). Supplying any `mid*`
   parameter creates a 3-color scale, otherwise a 2-color scale.
-- **data-bar**: `dataBarColor` (`#RRGGBB`), `dataBarNegativeColor`, `dataBarDirection`
-  (`context`, `leftToRight`, `rightToLeft`), `dataBarShowValue` (`true`/`false`),
-  `dataBarMinType`/`dataBarMaxType` (+ matching values).
-- **icon-set**: `iconSetId` (e.g. `3Arrows`, `3TrafficLights1`, `4Ratings`, `5Quarters`),
-  `iconSetReverse` (`true`/`false`), `iconSetShowIconOnly` (`true`/`false`),
-  `iconThreshold1Type..iconThreshold4Type` (+ matching `...Value`) for the editable bands.
+- **data-bar**: `data_bar_color` (`#RRGGBB`), `data_bar_negative_color`, `data_bar_direction`
+  (`context`, `leftToRight`, `rightToLeft`), `data_bar_show_value` (`true`/`false`),
+  `data_bar_min_type`/`data_bar_max_type` (+ matching values).
+- **icon-set**: `icon_set_id` (e.g. `3Arrows`, `3TrafficLights1`, `4Ratings`, `5Quarters`),
+  `icon_set_reverse` (`true`/`false`), `icon_set_show_icon_only` (`true`/`false`),
+  `icon_threshold1_type..icon_threshold4_type` (+ matching `..._value`) for the editable bands.
 - **top10**: `rank` (count or percent), `top10Percent` (`true`/`false`),
-  `topBottom` (`top`/`bottom`), plus standard formatting options.
-- **above-average**: `aboveBelow` (`aboveAverage`, `belowAverage`, `aboveStdDev`,
+  `top_bottom` (`top`/`bottom`), plus standard formatting options.
+- **above-average**: `above_below` (`aboveAverage`, `belowAverage`, `aboveStdDev`,
   `belowStdDev`, `equalAboveAverage`, `equalBelowAverage`), plus formatting options.
-- **time-period**: `datePeriod` (`today`, `yesterday`, `tomorrow`, `last7Days`,
+- **time-period**: `date_period` (`today`, `yesterday`, `tomorrow`, `last7Days`,
   `thisWeek`, `lastWeek`, `nextWeek`, `thisMonth`, `lastMonth`, `nextMonth`), plus formatting.
 
 **Actions**:
@@ -69,7 +69,7 @@
 
 - Rules are returned in priority order.
 - Colors are returned as `#RRGGBB` hex strings, matching the `add-rule` input format.
-- Formatting fields (interiorColor, fontColor, fontBold/Italic, borderStyle/Color) are only
+- Formatting fields (`interior_color`, `font_color`, `font_bold`/`font_italic`, `border_style`/`border_color`) are only
   present when the rule actually sets them.
 - Visual rule types return their type-specific configuration so they can be fully inspected
   and round-tripped:
@@ -96,11 +96,11 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A10",
-  "ruleType": "cell-value",
-  "operatorType": "greater",
+  "range_address": "A1:A10",
+  "rule_type": "cell-value",
+  "operator_type": "greater",
   "formula1": "100",
-  "interiorColor": "#FFFF00"
+  "interior_color": "#FFFF00"
 }
 ```
 
@@ -108,12 +108,12 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A10",
-  "ruleType": "cell-value",
-  "operatorType": "between",
+  "range_address": "A1:A10",
+  "rule_type": "cell-value",
+  "operator_type": "between",
   "formula1": "50",
   "formula2": "100",
-  "interiorColor": "#90EE90"
+  "interior_color": "#90EE90"
 }
 ```
 
@@ -121,10 +121,10 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:D10",
-  "ruleType": "expression",
+  "range_address": "A1:D10",
+  "rule_type": "expression",
   "formula1": "=$A1=\"Active\"",
-  "interiorColor": "#90EE90"
+  "interior_color": "#90EE90"
 }
 ```
 
@@ -132,15 +132,15 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "A1:A100",
-  "ruleType": "color-scale",
-  "colorScaleMinType": "minimum",
-  "colorScaleMinColor": "#F8696B",
-  "colorScaleMidType": "percentile",
-  "colorScaleMidValue": "50",
-  "colorScaleMidColor": "#FFEB84",
-  "colorScaleMaxType": "maximum",
-  "colorScaleMaxColor": "#63BE7B"
+  "range_address": "A1:A100",
+  "rule_type": "color-scale",
+  "color_scale_min_type": "minimum",
+  "color_scale_min_color": "#F8696B",
+  "color_scale_mid_type": "percentile",
+  "color_scale_mid_value": "50",
+  "color_scale_mid_color": "#FFEB84",
+  "color_scale_max_type": "maximum",
+  "color_scale_max_color": "#63BE7B"
 }
 ```
 
@@ -148,11 +148,11 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "B1:B100",
-  "ruleType": "data-bar",
-  "dataBarColor": "#638EC6",
-  "dataBarDirection": "leftToRight",
-  "dataBarShowValue": true
+  "range_address": "B1:B100",
+  "rule_type": "data-bar",
+  "data_bar_color": "#638EC6",
+  "data_bar_direction": "leftToRight",
+  "data_bar_show_value": true
 }
 ```
 
@@ -160,13 +160,13 @@
 ```json
 {
   "action": "add-rule",
-  "rangeAddress": "C1:C100",
-  "ruleType": "icon-set",
-  "iconSetId": "3TrafficLights1",
-  "iconThreshold1Type": "percent",
-  "iconThreshold1Value": "33",
-  "iconThreshold2Type": "percent",
-  "iconThreshold2Value": "67"
+  "range_address": "C1:C100",
+  "rule_type": "icon-set",
+  "icon_set_id": "3TrafficLights1",
+  "icon_threshold1_type": "percent",
+  "icon_threshold1_value": "33",
+  "icon_threshold2_type": "percent",
+  "icon_threshold2_value": "67"
 }
 ```
 
@@ -193,7 +193,7 @@ excelcli conditionalformat list-worksheet-rules --session <id> --sheet "Data"
 
 **Common Mistakes**:
 
-- Using `cell-value` type without `operatorType` → Error
+- Using `cell-value` type without `operator_type` → Error
 - Using `between` without both formula1 AND formula2 → Error
 - Forgetting `$` in expression formulas → Rule applies incorrectly across rows/columns
 - Colors without `#` prefix → May not apply correctly

--- a/skills/shared/dashboard.md
+++ b/skills/shared/dashboard.md
@@ -18,8 +18,8 @@ Every report or dashboard should follow this sequence:
 **Always use Excel Tables for tabular data:**
 
 ```
-range(set-values, rangeAddress='A1', values=[[headers + data]])
-table(create, tableName='SalesData', rangeAddress='A1:D20')
+range(set-values, range_address='A1', values=[[headers + data]])
+table(create, table_name='SalesData', range_address='A1:D20')
 ```
 
 **Why Tables matter:**
@@ -54,46 +54,46 @@ behaviour, not a formatting bug. Never promise a literal rendering when reportin
 **Number formats make cells WIDER, so auto-fit immediately after formatting:**
 
 ```
-range_format(action: 'auto-fit-columns', sheetName: 'Sales', rangeAddress: 'A:F')
+range_format(action: 'auto-fit-columns', sheet_name: 'Sales', range_address: 'A:F')
 ```
 
 A date formatted as `yyyy-mm-dd` or a currency value formatted as `$#,##0.00` does not fit the
 default column width, so Excel renders the cell as `#####`. A screenshot taken before auto-fit will
 show those columns as unreadable hash marks. Auto-fit before Step 5, not after.
 
-Use `range_format auto-fit-rows` as well when any cell has `wrapText` enabled.
+Use `range_format auto-fit-rows` as well when any cell has `wrap_text` enabled.
 
 ## Step 4: Position Charts with No Overlaps
 
 **Charts have automatic collision detection and three positioning modes:**
 
-### Single Chart (Auto-Position or targetRange)
+### Single Chart (Auto-Position or target_range)
 ```
-# Option A: targetRange (explicit cell placement)
-chart(create-from-range, sourceRange='A1:D20', targetRange='F2:K15')
+# Option A: target_range (explicit cell placement)
+chart(create-from-range, source_range='A1:D20', target_range='F2:K15')
 
 # Option B: Omit position — auto-places below content
-chart(create-from-range, sourceRange='A1:D20', chartType='Line')
+chart(create-from-range, source_range='A1:D20', chart_type='Line')
 # → Automatically positioned below the used range
 ```
 
-### Multiple Charts (Dashboard) — Always Use targetRange
+### Multiple Charts (Dashboard) — Always Use target_range
 ```
 Place in a grid pattern below data:
 
-Chart 1: targetRange='A22:F35'    (top-left)
-Chart 2: targetRange='G22:L35'    (top-right)
-Chart 3: targetRange='A37:F50'    (bottom-left)
-Chart 4: targetRange='G37:L50'    (bottom-right)
+Chart 1: target_range='A22:F35'    (top-left)
+Chart 2: target_range='G22:L35'    (top-right)
+Chart 3: target_range='A37:F50'    (bottom-left)
+Chart 4: target_range='G37:L50'    (bottom-right)
 ```
 
 ### Collision Detection
 All chart operations automatically warn about overlaps. If a result includes an `OVERLAP WARNING` message:
 1. Use `chart(fit-to-range)` to reposition
-2. Take `screenshot(capture, rangeAddress='A1:M50')` to verify
+2. Take `screenshot(capture, range_address='A1:M50')` to verify
 
 **Rules:**
-- **Use targetRange for multi-chart layouts** — auto-positioning stacks vertically
+- **Use target_range for multi-chart layouts** — auto-positioning stacks vertically
 - Leave 1-2 rows/columns gap between charts
 - Place charts BELOW the data area, not beside it (more room)
 - Keep chart sizes consistent (same row/column span)
@@ -104,7 +104,7 @@ All chart operations automatically warn about overlaps. If a result includes an 
 **Always take a screenshot after creating charts or complex layouts:**
 
 ```
-screenshot(capture, rangeAddress='A1:M50')
+screenshot(capture, range_address='A1:M50')
 → Confirm: no overlaps, professional spacing, readable labels
 → Confirm: no column renders as ##### (if it does, go back to Step 3 and auto-fit)
 → If issues found: chart(fit-to-range) to reposition, then screenshot again

--- a/skills/shared/datamodel.md
+++ b/skills/shared/datamodel.md
@@ -25,13 +25,13 @@ You MUST explicitly refresh the Data Model to sync changes.
 
 ```
 # WRONG: Data still shows old values
-table(append, tableName="Sales", csvData="...")  # Worksheet updated
-datamodel(evaluate, daxQuery="...")               # Returns OLD values!
+table(append, table_name="Sales", rows=[["..."]])  # Worksheet updated
+datamodel(evaluate, dax_query="...")               # Returns OLD values!
 
 # CORRECT: Refresh Data Model after worksheet changes
-table(append, tableName="Sales", csvData="...")  # Worksheet updated
+table(append, table_name="Sales", rows=[["..."]])  # Worksheet updated
 datamodel(refresh)                                 # Sync to Data Model
-datamodel(evaluate, daxQuery="...")               # Returns NEW values!
+datamodel(evaluate, dax_query="...")               # Returns NEW values!
 ```
 
 **When refresh is automatic:**
@@ -61,19 +61,19 @@ datamodel(evaluate, daxQuery="...")               # Returns NEW values!
 | Source | Method |
 |--------|--------|
 | Worksheet Excel Table | table with add-to-data-model action |
-| External file (CSV, etc.) | powerquery with loadDestination='data-model' |
-| Database/web source | powerquery with loadDestination='data-model' |
+| External file (CSV, etc.) | powerquery with load_destination='data-model' |
+| Database/web source | powerquery with load_destination='data-model' |
 
 **DAX Formatting**:
 
-DAX formulas are preserved exactly by default on WRITE operations (create-measure, update-measure), subject to Excel locale separator translation. Set `formatDax=true` only with explicit user consent; it sends DAX to daxformatter.com. Remote formatting adds ~100-500ms network latency per write operation. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
+DAX formulas are preserved exactly by default on WRITE operations (create-measure, update-measure), subject to Excel locale separator translation. Set `format_dax=true` only with explicit user consent; it sends DAX to daxformatter.com. Remote formatting adds ~100-500ms network latency per write operation. If formatting fails (network issues, API errors), the original DAX is saved unchanged - operations never fail due to formatting.
 
 **Action disambiguation**:
 
 - list-tables: List all tables currently in the Data Model
 - list-measures: List all DAX measures (returns raw DAX from Excel)
-- create-measure: Create a new DAX measure (DAX preserved by default; `formatDax=true` opts into remote formatting)
-- update-measure: Modify existing measure's formula/format/description (DAX preserved by default; `formatDax=true` opts into remote formatting)
+- create-measure: Create a new DAX measure (DAX preserved by default; `format_dax=true` opts into remote formatting)
+- update-measure: Modify existing measure's formula/format/description (DAX preserved by default; `format_dax=true` opts into remote formatting)
 - delete-measure: Remove a measure
 - delete-table: Remove table AND ALL its measures (DESTRUCTIVE!)
 - read-info: Get Data Model metadata (culture, compatibility level)
@@ -170,10 +170,10 @@ Reference: [Microsoft DMV Documentation](https://learn.microsoft.com/en-us/analy
 
 **DAX measure creation**:
 
-- tableName: Which table the measure belongs to (for organization)
-- measureName: Display name for the measure
-- daxFormula: DAX expression (e.g., "SUM(Sales[Revenue])")
-- formatString: Optional number format (#,##0.00, 0%, $#,##0, etc.)
+- table_name: Which table the measure belongs to (for organization)
+- measure_name: Display name for the measure
+- dax_formula: DAX expression (e.g., "SUM(Sales[Revenue])")
+- format_type: Optional number format (#,##0.00, 0%, $#,##0, etc.)
 
 **Common DAX patterns**:
 
@@ -223,7 +223,7 @@ A PivotChart is a single object connected to the Data Model. Creating a PivotTab
 - Creating measures before adding source table to Data Model → Error
 - Using worksheet table names instead of Data Model table names
 - Forgetting that delete-table removes ALL measures on that table
-- Not specifying tableName when creating measures (required for organization)
+- Not specifying `table_name` when creating measures (required for organization)
 
 **Server-specific quirks**:
 

--- a/skills/shared/drawing.md
+++ b/skills/shared/drawing.md
@@ -28,8 +28,8 @@ Colors use `#RRGGBB`. Position and size values use points. Placement values are:
 
 Supported controls are Button, CheckBox, DropDown, GroupBox, Label, ListBox, OptionButton, ScrollBar, and Spinner.
 
-- `linkedCell`: CheckBox, DropDown, ListBox, OptionButton, ScrollBar, and Spinner
-- `inputRange`: DropDown and ListBox only
+- `linked_cell`: CheckBox, DropDown, ListBox, OptionButton, ScrollBar, and Spinner
+- `input_range`: DropDown and ListBox only
 - Button, GroupBox, and Label return explicit nulls for both binding properties
 
 ActiveX/OLE controls and macro assignment are intentionally unavailable. Do not try to create them through VBA as a workaround.
@@ -39,8 +39,8 @@ ActiveX/OLE controls and macro assignment are intentionally unavailable. Do not 
 Use `add-sparkline`, `get-sparkline`, `list-sparklines`, `update-sparkline`, and `delete-sparkline`.
 
 - Types: Line, Column, WinLoss
-- `sourceRange`: data to visualize
-- `locationRange`: cells that host the sparklines
+- `source_range`: data to visualize
+- `location_range`: cells that host the sparklines
 - Line sparklines can show markers
 
 ```powershell

--- a/skills/shared/excel_agent_mode.md
+++ b/skills/shared/excel_agent_mode.md
@@ -49,7 +49,7 @@ AI navigates through a completed workbook, explaining findings while the user wa
 ```
 1. file(open, path='analysis.xlsx')
 2. window(show)
-3. window(set-state, windowState='maximized')      → Full screen for best visibility
+3. window(set-state, window_state='maximized')      → Full screen for best visibility
 4. window(set-status-bar, text='Reviewing Sales sheet...')
 5. "On the Sales sheet, you can see quarterly revenue trending up 15%..."
 6. worksheet(activate, name='Analysis')            → Switch to next sheet
@@ -77,13 +77,13 @@ AI performs operations one at a time, showing results between each step for trou
 4. window(set-status-bar, text='Inspecting Power Query...')
 5. powerquery(list)
 6. "Found 3 queries. Let me check each one..."
-7. powerquery(view, queryName='Sales')
+7. powerquery(view, query_name='Sales')
 8. window(set-status-bar, text='Refreshing Sales query...')
-9. powerquery(refresh, queryName='Sales')
+9. powerquery(refresh, query_name='Sales')
 10. screenshot(capture-sheet)                      → Show result
 11. "Sales query refreshed successfully. 150 rows loaded. Moving to next..."
 12. window(set-status-bar, text='Refreshing Products query...')
-13. powerquery(refresh, queryName='Products')
+13. powerquery(refresh, query_name='Products')
 14. "Products query failed: [error]. Let me fix the M code..."
 15. window(clear-status-bar)
 ```

--- a/skills/shared/gotchas.md
+++ b/skills/shared/gotchas.md
@@ -115,9 +115,9 @@ Power Query connections that reference external files or URLs have a "refresh on
 Range addresses in M1 notation (e.g., `A1:D10`) work fine, but range names with spaces, hyphens, or special characters must be enclosed in single quotes or backticks:
 
 ```
-rangeAddress: 'Sales Data'      ← Correct (with spaces)
-rangeAddress: Sales Data        ← WRONG (fails)
-rangeAddress: `Sales Data`      ← Also correct (backticks)
+range_address: 'Sales Data'      ← Correct (with spaces)
+range_address: Sales Data        ← WRONG (fails)
+range_address: `Sales Data`      ← Also correct (backticks)
 ```
 
 Same rule applies for sheet names: `'Sheet Name'!A1:D10`.

--- a/skills/shared/pivottable.md
+++ b/skills/shared/pivottable.md
@@ -2,7 +2,7 @@
 
 ## CRITICAL: Required Parameters
 
-**`pivotTableName` is REQUIRED for almost all PivotTable operations** across `pivottable`, `pivottable_calc`, and `pivottable_field` tools. The only exception is `list` (which lists all PivotTables). Always specify the PivotTable name.
+**`pivot_table_name` is REQUIRED for almost all PivotTable operations** across `pivottable`, `pivottable_calc`, and `pivottable_field` tools. The only exception is `list` (which lists all PivotTables). Always specify the PivotTable name.
 
 ## Calculated Fields vs DAX Measures
 
@@ -18,15 +18,15 @@ PivotTable calculated fields work well for simple single-table formulas. Use DAX
 ### Calculated Field Workflow
 
 ```
-pivottable_calc(CreateCalculatedField, fieldName="Revenue", formula="=Quantity*UnitPrice")
-pivottable_field(AddValueField, fieldName="Revenue", aggregationFunction="Sum")
+pivottable_calc(action="create-calculated-field", pivot_table_name="SalesPivot", field_name="Revenue", formula="=Quantity*UnitPrice")
+pivottable_field(action="add-value-field", pivot_table_name="SalesPivot", field_name="Revenue", aggregation_function="Sum")
 ```
 
 ### DAX Measure Workflow (for complex scenarios)
 
 ```
-table(add-to-data-model, tableName="Sales")
-datamodel(create-measure, measureName="Revenue", daxFormula="SUMX(Sales, Sales[Quantity]*Sales[UnitPrice])")
+table(action="add-to-data-model", table_name="Sales")
+datamodel(action="create-measure", table_name="Sales", measure_name="Revenue", dax_formula="SUMX(Sales, Sales[Quantity]*Sales[UnitPrice])")
 pivottable(create-from-datamodel, ...)  # Measure automatically available
 ```
 
@@ -43,7 +43,7 @@ pivottable(create-from-datamodel, ...)  # Measure automatically available
 |--------|---------------|------------------------|
 | Worksheet Table | `create-from-table` | NO - worksheet PivotTable |
 | Data Model | `create-from-datamodel` | YES - full DAX support |
-| External | `create` with sourceRange | NO |
+| External | `create-from-range` with `source_range` | NO |
 
 **Rule**: If you need calculated revenue/aggregations, use Data Model as source.
 
@@ -67,8 +67,8 @@ powerquery(refresh, ...)     # Refreshes Power Query AND Data Model
 ## PivotCache Options
 
 - `pivottable(get-cache-options)`: Read refresh, retained-item, optimization, and saved-source settings.
-- `pivottable(set-cache-options)`: Set `enableRefresh`, `refreshOnFileOpen`, `missingItemsLimit`, `optimizeCache`, or `saveSourceData`.
-- `missingItemsLimit` values: `Default`, `None`, `Max`, `Max2`.
+- `pivottable(set-cache-options)`: Set `enable_refresh`, `refresh_on_file_open`, `missing_items_limit`, `optimize_cache`, or `save_source_data`.
+- `missing_items_limit` values: `Default`, `None`, `Max`, `Max2`.
 - Deleted-item retention applies only to regular PivotTables. OLAP/Data Model caches manage members in the model.
 
 ## Field Configuration
@@ -76,20 +76,20 @@ powerquery(refresh, ...)     # Refreshes Power Query AND Data Model
 ### Row/Column/Value Fields
 
 When creating PivotTables, configure fields in order:
-1. Add Row fields: `pivottable_field(AddRowField, fieldName="Region")`
-2. Add Column fields: `pivottable_field(AddColumnField, fieldName="Year")`  
-3. Add Value fields: `pivottable_field(AddValueField, fieldName="Amount", aggregationFunction="Sum")`
-4. Add filters: `pivottable_field(AddFilterField, fieldName="Status")`
-5. **Refresh to update display**: `pivottable(refresh, pivotTableName="...")`
+1. Add Row fields: `pivottable_field(action="add-row-field", pivot_table_name="SalesPivot", field_name="Region")`
+2. Add Column fields: `pivottable_field(action="add-column-field", pivot_table_name="SalesPivot", field_name="Year")`
+3. Add Value fields: `pivottable_field(action="add-value-field", pivot_table_name="SalesPivot", field_name="Amount", aggregation_function="Sum")`
+4. Add filters: `pivottable_field(action="add-filter-field", pivot_table_name="SalesPivot", field_name="Status")`
+5. **Refresh to update display**: `pivottable(action="refresh", pivot_table_name="SalesPivot")`
 
 **IMPORTANT**: Field operations are structural only - they modify the PivotTable layout but don't trigger visual refresh. Call `pivottable(refresh)` after configuring all fields to update the display. This is especially important for OLAP/Data Model PivotTables.
 
 ### Manual Grouping
 
 ```
-pivottable_field(group-items, fieldName="Region", itemNames=["North", "South"], groupName="Core Regions")
-# Use groupedFieldName from the result:
-pivottable_field(ungroup-field, groupedFieldName="Region2")
+pivottable_field(action="group-items", pivot_table_name="SalesPivot", field_name="Region", item_names=["North", "South"], group_name="Core Regions")
+# Use grouped_field_name from the result:
+pivottable_field(action="ungroup-field", pivot_table_name="SalesPivot", grouped_field_name="Region2")
 ```
 
 Manual grouping requires a regular PivotTable and a field already placed in the Row or Column area. OLAP/Data Model PivotTables must add grouping columns in the model.
@@ -97,7 +97,7 @@ Manual grouping requires a regular PivotTable and a field already placed in the 
 ### Drill Through
 
 ```
-pivottable(drill-through, pivotTableName="SalesPivot", cellAddress="G4")
+pivottable(action="drill-through", pivot_table_name="SalesPivot", cell_address="G4")
 ```
 
 The target must be a value cell in a regular PivotTable data body. Excel creates a new worksheet containing the underlying source rows. OLAP/Data Model drill-through is provider-dependent and intentionally not exposed as a deterministic operation.
@@ -119,13 +119,13 @@ The target must be a value cell in a regular PivotTable data body. Excel creates
 
 ```
 # Option 1: Add revenue column to source table FIRST
-range(set-formula, sheetName="Sales", rangeAddress="I2", formula="=[@Quantity]*[@UnitPrice]")
-pivottable(create-from-table, sourceTableName="SalesTable", ...)
-pivottable_field(AddValueField, fieldName="Revenue", aggregationFunction="Sum")  # Works!
+range(action="set-formulas", sheet_name="Sales", range_address="I2", formulas=[["=[@Quantity]*[@UnitPrice]"]])
+pivottable(action="create-from-table", table_name="SalesTable", ...)
+pivottable_field(action="add-value-field", field_name="Revenue", aggregation_function="Sum", ...)  # Works!
 
 # Option 2: Use Data Model (RECOMMENDED)
-table(add-to-data-model, tableName="SalesTable")
-datamodel(create-measure, measureName="Revenue", daxFormula="SUMX(SalesTable, SalesTable[Quantity]*SalesTable[UnitPrice])")
+table(action="add-to-data-model", table_name="SalesTable")
+datamodel(action="create-measure", table_name="SalesTable", measure_name="Revenue", dax_formula="SUMX(SalesTable, SalesTable[Quantity]*SalesTable[UnitPrice])")
 pivottable(create-from-datamodel, ...)  # Measure automatically available
 ```
 
@@ -133,16 +133,16 @@ pivottable(create-from-datamodel, ...)  # Measure automatically available
 
 Always use Data Model for multi-table analysis:
 ```
-table(add-to-data-model, tableName="Sales")
-table(add-to-data-model, tableName="Products")
-datamodel_relationship(create-relationship, fromTable="Sales", fromColumn="ProductID", toTable="Products", toColumn="ProductID")
-datamodel(create-measure, tableName="Sales", measureName="Revenue", daxFormula="SUMX(Sales, RELATED(Products[Price])*Sales[Quantity])")
+table(action="add-to-data-model", table_name="Sales")
+table(action="add-to-data-model", table_name="Products")
+datamodel_relationship(action="create-relationship", from_table="Sales", from_column="ProductID", to_table="Products", to_column="ProductID")
+datamodel(action="create-measure", table_name="Sales", measure_name="Revenue", dax_formula="SUMX(Sales, RELATED(Products[Price])*Sales[Quantity])")
 pivottable(create-from-datamodel)
 ```
 
 ## Layout Styles
 
-The `layoutStyle` parameter controls PivotTable appearance:
+The `row_layout` parameter controls PivotTable appearance:
 
 | Value | Style | Description |
 |-------|-------|-------------|

--- a/skills/shared/powerquery.md
+++ b/skills/shared/powerquery.md
@@ -30,7 +30,7 @@ Step 3: refresh/load-to → Load data to destination (worksheet/data-model)
 **M-Code Formatting and reads**:
 
 - Create and Update preserve M code exactly by default and do not call remote services
-- Set `formatMCode=true` only with explicit user consent; it sends M code to powerqueryformatter.com
+- Set `format_m_code=true` only with explicit user consent; it sends M code to powerqueryformatter.com
 - Remote formatting adds ~100-500ms network latency per call
 - Graceful fallback: saves original M code if the formatting service is unavailable
 - `list` returns compact metadata, exact load mode, character count, and at most
@@ -50,7 +50,7 @@ Destination values are case-insensitive. Unknown values fail before the query is
 changed; they never fall back to connection-only or another enum default.
 
 To create DAX measures on Power Query data:
-1. Use powerquery create/load-to with `loadDestination='data-model'`
+1. Use powerquery create/load-to with `load_destination='data-model'`
 2. Then use datamodel to create DAX measures
 
 Alternative path (for existing worksheet tables):
@@ -60,9 +60,9 @@ Alternative path (for existing worksheet tables):
 **Action disambiguation**:
 
 - **evaluate**: **CRITICAL - USE THIS FIRST** - Execute M code directly, return results WITHOUT creating a permanent query (test before create/update!)
-- create: Import NEW query using inline `mCode` (FAILS if query already exists - use update instead)
+- create: Import NEW query using inline `m_code` (FAILS if query already exists - use update instead)
 - update: Update EXISTING query M code + refresh data (use this if query exists)
-- rename: Change query name (requires both `queryName` and `newName` parameters)
+- rename: Change query name (requires both `old_name` and `new_name` parameters)
 - load-to: Loads to worksheet or data model or both (not just config change) - CHECKS for sheet conflicts
 - unload: Removes data from ALL destinations (worksheet AND Data Model) - keeps query definition
 - delete: Completely removes query AND all associated data (worksheet, Data Model connections)
@@ -97,15 +97,15 @@ Alternative path (for existing worksheet tables):
 
 **Inline M code**:
 
-- Provide raw M code directly via `mCode`
+- Provide raw M code directly via `m_code`
 - Keep `.pq` files only for GIT workflows
 
 **Create/LoadTo with existing sheets**:
 
-- Use `targetCellAddress` to place the table on an existing worksheet without deleting other content
+- Use `target_cell_address` to place the table on an existing worksheet without deleting other content
 - Applies to BOTH create and load-to
-- If the worksheet already has data and you omit `targetCellAddress`, the tool returns guidance telling you to provide one
-- Existing tables are refreshed in-place; specifying a different `targetCellAddress` requires unload + reload
+- If the worksheet already has data and you omit `target_cell_address`, the tool returns guidance telling you to provide one
+- Existing tables are refreshed in-place; specifying a different `target_cell_address` requires unload + reload
 - Worksheets that exist but are empty behave like new sheets (default destination = A1)
 
 **Common mistakes**:
@@ -115,15 +115,15 @@ Alternative path (for existing worksheet tables):
 - Using update on new query → ERROR "Query 'X' not found" (should use create)
 - Calling LoadTo without checking if sheet exists (will error if sheet exists)
 - Assuming unload only removes worksheet data → Also removes Data Model connections
-- Calling rename without trimming newName → Server trims automatically, " Query " becomes "Query"
+- Calling rename without trimming `new_name` → Server trims automatically, " Query " becomes "Query"
 - Renaming to conflicting name → Check list first if unsure about existing names
-- Passing an option from another action (for example `mCode` on delete or `timeout` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
+- Passing an option from another action (for example `m_code` on delete or `timeout_seconds` on load-to) → ERROR; category-wide schemas expose the union of options, but each action validates its own subset
 
 **Server-specific quirks**:
 
 - Validation = execution: M code only validated when data loads/refreshes
 - connection-only queries: NOT validated until first execution
-- refresh with loadDestination: Applies load config + refreshes (2-in-1)
+- load-to with `load_destination`: Applies load config and refreshes (2-in-1)
 - Single cell returns [[value]] not scalar
 - Public timeout inputs are integer seconds. Refresh/refresh-all accepts 0-2147483 and defaults to the 30-minute data-operation timeout when `timeout_seconds`/`--timeout` is 0 or omitted. For quick queries use a smaller value (e.g., 60-120 seconds).
 - load-to has no caller timeout parameter and uses the fixed 30-minute data-operation timeout; passing `timeout` to load-to is rejected instead of ignored.
@@ -168,7 +168,7 @@ Reference other queries by name directly: `Source = OtherQueryName`
 ### Source Control Pattern
 
 1. Store M code in `.pq` files
-2. `powerquery create` or `update` with inline `mCode`
+2. `powerquery create` or `update` with inline `m_code`
 3. `refresh` to validate
 4. File name MUST match query name
 

--- a/skills/shared/querytable.md
+++ b/skills/shared/querytable.md
@@ -15,18 +15,18 @@ Use `querytable` for worksheet QueryTables backed by the desktop Excel COM objec
 
 ```text
 querytable(action: 'create-text',
-    queryTableName: 'OrdersCsv',
-    sourcePath: 'C:\Data\orders.csv',
-    sheetName: 'Orders',
-    destinationAddress: 'A1',
+    query_table_name: 'OrdersCsv',
+    source_path: 'C:\Data\orders.csv',
+    sheet_name: 'Orders',
+    destination_address: 'A1',
     delimiter: ',',
-    textQualifier: 'double-quote',
+    text_qualifier: 'double-quote',
     encoding: 65001,
-    hasHeaders: true)
+    has_headers: true)
 ```
 
 - `delimiter` is exactly one character.
-- `textQualifier` is `double-quote`, `single-quote`, or `none`.
+- `text_qualifier` is `double-quote`, `single-quote`, or `none`.
 - `encoding` is a Windows code page; use `65001` for UTF-8.
 - Creation refreshes synchronously so imported data is ready when the call returns.
 
@@ -34,17 +34,17 @@ querytable(action: 'create-text',
 
 ```text
 querytable(action: 'create-web',
-    queryTableName: 'RatesHtml',
+    query_table_name: 'RatesHtml',
     url: 'https://example.com/rates.html',
-    sheetName: 'Rates',
-    destinationAddress: 'A1',
-    selectionType: 'specified-tables',
-    webTables: '1',
+    sheet_name: 'Rates',
+    destination_address: 'A1',
+    selection_type: 'specified-tables',
+    web_tables: '1',
     formatting: 'none')
 ```
 
-- `selectionType` is `entire-page`, `all-tables`, or `specified-tables`.
-- `webTables` is required with `specified-tables`.
+- `selection_type` is `entire-page`, `all-tables`, or `specified-tables`.
+- `web_tables` is required with `specified-tables`.
 - `formatting` is `none`, `rich-text`, or `all`.
 - This is Excel's legacy HTML web-query engine, not a general HTTP or browser automation API.
 

--- a/skills/shared/range.md
+++ b/skills/shared/range.md
@@ -21,9 +21,9 @@ If you need the same styling on multiple non-contiguous ranges, use `format-rang
 ## Quick Pattern: Write, Format, Auto-Fit
 
 ```
-range(action: 'set-values', rangeAddress: 'A1:D4', values: [[...], [...]])
-range(action: 'set-number-format', rangeAddress: 'C2:D4', formatCode: '$#,##0.00')
-range_format(action: 'auto-fit-columns', rangeAddress: 'A:D')
+range(action: 'set-values', range_address: 'A1:D4', values: [[...], [...]])
+range(action: 'set-number-format', range_address: 'C2:D4', format_code: '$#,##0.00')
+range_format(action: 'auto-fit-columns', range_address: 'A:D')
 ```
 
 ## Quick Pattern: Repeated Section Headers
@@ -32,11 +32,11 @@ Use `format-ranges` when the same header or section style repeats across disjoin
 
 ```
 range_format(action: 'format-ranges',
-    rangeAddresses: ['A1:G1', 'A12:G12', 'A24:G24'],
+    range_addresses: ['A1:G1', 'A12:G12', 'A24:G24'],
     bold: true,
-    fillColor: '#243F60',
-    fontColor: '#FFFFFF',
-    horizontalAlignment: 'center')
+    fill_color: '#243F60',
+    font_color: '#FFFFFF',
+    horizontal_alignment: 'center')
 ```
 
 All target ranges are validated before formatting begins. If any target range is invalid, nothing is formatted.
@@ -47,11 +47,11 @@ All target ranges are validated before formatting begins. If any target range is
 Pass ALL properties in **one call**:
 
 ```
-range_format(action: 'format-range', rangeAddress: 'A1:D1',
+range_format(action: 'format-range', range_address: 'A1:D1',
     bold: true,
-    fillColor: '#4472C4',
-    fontColor: '#FFFFFF',
-    horizontalAlignment: 'center')
+    fill_color: '#4472C4',
+    font_color: '#FFFFFF',
+    horizontal_alignment: 'center')
 ```
 
 ## Quick Pattern: Semantic Status Cells
@@ -59,8 +59,8 @@ range_format(action: 'format-range', rangeAddress: 'A1:D1',
 Use `set-style` when the meaning (Good/Bad/Neutral) matters and theme-awareness is useful:
 
 ```
-range_format(action: 'set-style', rangeAddress: 'B2:B10', styleName: 'Good')
-range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
+range_format(action: 'set-style', range_address: 'B2:B10', style_name: 'Good')
+range_format(action: 'set-style', range_address: 'C2:C10', style_name: 'Bad')
 ```
 
 ## format-range Properties
@@ -70,15 +70,15 @@ range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
 | `bold` | bool | `true` |
 | `italic` | bool | `true` |
 | `underline` | bool | `true` |
-| `fontSize` | number | `14` |
-| `fontName` | string | `"Calibri"` |
-| `fontColor` | hex color | `"#FFFFFF"` |
-| `fillColor` | hex color | `"#4472C4"` |
-| `horizontalAlignment` | string | `"center"`, `"left"`, `"right"` |
-| `verticalAlignment` | string | `"middle"`, `"top"`, `"bottom"` |
-| `wrapText` | bool | `true` |
-| `borderStyle` | string | `"thin"`, `"medium"`, `"thick"` |
-| `borderColor` | hex color | `"#000000"` |
+| `font_size` | number | `14` |
+| `font_name` | string | `"Calibri"` |
+| `font_color` | hex color | `"#FFFFFF"` |
+| `fill_color` | hex color | `"#4472C4"` |
+| `horizontal_alignment` | string | `"center"`, `"left"`, `"right"` |
+| `vertical_alignment` | string | `"middle"`, `"top"`, `"bottom"` |
+| `wrap_text` | bool | `true` |
+| `border_style` | string | `"thin"`, `"medium"`, `"thick"` |
+| `border_color` | hex color | `"#000000"` |
 | `orientation` | int | `-90` to `90` (degrees) |
 
 ## set-style Presets
@@ -86,7 +86,7 @@ range_format(action: 'set-style', rangeAddress: 'C2:C10', styleName: 'Bad')
 Built-in style names: `Normal`, `Heading 1`, `Heading 2`, `Heading 3`, `Heading 4`, `Title`, `Good`, `Bad`, `Neutral`, `Currency`, `Percent`, `Comma`
 
 ```
-range_format(action: 'set-style', rangeAddress: 'A1:D1', styleName: 'Heading 1')
+range_format(action: 'set-style', range_address: 'A1:D1', style_name: 'Heading 1')
 ```
 
 ## Format Codes
@@ -122,7 +122,7 @@ than raw ones and will render as `#####` at the default column width.
 
 **SetNumberFormat**: Apply one format to entire range.
 
-- `formatCode`: Format code from table above
+- `format_code`: Format code from table above
 
 **SetNumberFormats**: Apply different formats per cell.
 
@@ -134,10 +134,10 @@ than raw ones and will render as `#####` at the default column width.
 Use modern threaded comments only when the installed desktop Excel build exposes them:
 
 ```text
-range_link(action: 'add-threaded-comment', sheetName: 'Review', cellAddress: 'B2', text: 'Check this value')
-range_link(action: 'add-threaded-comment-reply', sheetName: 'Review', cellAddress: 'B2', text: 'Confirmed')
-range_link(action: 'list-threaded-comments', sheetName: 'Review', cellAddress: 'B2')
-range_link(action: 'delete-threaded-comment', sheetName: 'Review', cellAddress: 'B2')
+range_link(action: 'add-threaded-comment', sheet_name: 'Review', cell_address: 'B2', text: 'Check this value')
+range_link(action: 'add-threaded-comment-reply', sheet_name: 'Review', cell_address: 'B2', text: 'Confirmed')
+range_link(action: 'list-threaded-comments', sheet_name: 'Review', cell_address: 'B2')
+range_link(action: 'delete-threaded-comment', sheet_name: 'Review', cell_address: 'B2')
 ```
 
 These actions expose local Excel PIA comment text, author, date, and replies. Microsoft 365 service features such as @mentions, assignments, reactions, presence, sharing, and coauthoring state are not available through local Excel COM.

--- a/skills/shared/screenshot.md
+++ b/skills/shared/screenshot.md
@@ -6,7 +6,7 @@
 
 ```
 1. chart(create-from-range, ...)  → Chart created
-2. screenshot(capture, rangeAddress='A1:M20')  ← REQUIRED — never skip this step
+2. screenshot(capture, range_address='A1:M20')  ← REQUIRED — never skip this step
 3. file(close, save=true)
 ```
 
@@ -23,8 +23,8 @@ This rule applies even if:
 
 | Action | Purpose | Parameters |
 |--------|---------|------------|
-| `capture` | Capture a specific range | `rangeAddress` (default: A1:Z30), `sheetName`, `quality` |
-| `capture-sheet` | Capture the worksheet's used cell range | `sheetName`, `quality` |
+| `capture` | Capture a specific range | `range_address` (default: A1:Z30), `sheet_name`, `quality` |
+| `capture-sheet` | Capture the worksheet's used cell range | `sheet_name`, `quality` |
 
 `capture-sheet` is cell-driven: it captures Excel's used range. On a chart-only worksheet, or when a chart extends beyond the used cells, use `capture` with an explicit range that covers the chart (for example, `A1:M25`).
 
@@ -51,8 +51,8 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 
 ### After Chart Creation or Positioning
 ```
-1. chart(create-from-range, ..., targetRange='F2:K15')
-2. screenshot(capture, rangeAddress='A1:O25')  → Verify chart doesn't overlap data
+1. chart(create-from-range, ..., target_range='F2:K15')
+2. screenshot(capture, range_address='A1:O25')  → Verify chart doesn't overlap data
 ```
 
 ### After Complex Formatting
@@ -66,7 +66,7 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 ```
 1. pivottable(add-row-field, ...)
 2. pivottable(add-value-field, ...)
-3. screenshot(capture, rangeAddress='A1:M25')  → Include charts and verify layout
+3. screenshot(capture, range_address='A1:M25')  → Include charts and verify layout
 ```
 
 ## Best Practices
@@ -84,8 +84,8 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 ### Chart Overlap Verification
 ```
 1. range(get-used-range) → "A1:D20"
-2. chart(create-from-range, sourceRange='A1:D20', targetRange='F2:K15')
-3. screenshot(capture, rangeAddress='A1:K20')
+2. chart(create-from-range, source_range='A1:D20', target_range='F2:K15')
+3. screenshot(capture, range_address='A1:K20')
    → Visually confirm chart is positioned next to data, not on top of it
 ```
 
@@ -94,13 +94,13 @@ Default is `Medium` — use this for most cases. Only use `High` when fine text 
 When creating dashboards with multiple charts:
 
 1. get-used-range → Know where data ends
-2. Create Chart 1 with targetRange below/beside data
-3. Create Chart 2 with targetRange that does NOT overlap Chart 1
-4. Create Chart 3, Chart 4, etc. — each in a non-overlapping targetRange
-5. screenshot(capture, rangeAddress='A1:M40') → Verify NO charts overlap each other or data
+2. Create Chart 1 with `target_range` below/beside data
+3. Create Chart 2 with `target_range` that does NOT overlap Chart 1
+4. Create Chart 3, Chart 4, etc. — each in a non-overlapping `target_range`
+5. screenshot(capture, range_address='A1:M40') → Verify NO charts overlap each other or data
 
 Key rules for multi-chart layouts:
-- Use targetRange for every chart — never rely on default positioning
+- Use `target_range` for every chart — never rely on default positioning
 - Leave at least 1-2 rows/columns between charts
 - Place charts in a grid pattern (e.g., 2x2) below the data area
 - If overlap detected, use chart(fit-to-range) to reposition
@@ -109,7 +109,7 @@ Key rules for multi-chart layouts:
 ### Dashboard Layout Check
 ```
 1. Create multiple charts and tables
-2. screenshot(capture, rangeAddress='A1:M40')
+2. screenshot(capture, range_address='A1:M40')
    → Verify overall dashboard layout, spacing, and alignment
 3. If issues found: reposition with chart(fit-to-range), then screenshot again
 ```

--- a/skills/shared/slicer.md
+++ b/skills/shared/slicer.md
@@ -10,26 +10,26 @@ Two distinct slicer types exist:
 
 | Action | Description | Required Parameters |
 |--------|-------------|---------------------|
-| `create-slicer` | Create PivotTable slicer | pivotTableName, fieldName |
+| `create-slicer` | Create PivotTable slicer | pivot_table_name, field_name |
 | `list-slicers` | List all PivotTable slicers | (none) |
-| `set-slicer-selection` | Set PivotTable slicer filter | slicerName, selectedItems |
-| `delete-slicer` | Delete PivotTable slicer | slicerName |
-| `create-table-slicer` | Create Table slicer | tableName, columnName |
+| `set-slicer-selection` | Set PivotTable slicer filter | slicer_name, selected_items |
+| `delete-slicer` | Delete PivotTable slicer | slicer_name |
+| `create-table-slicer` | Create Table slicer | table_name, column_name |
 | `list-table-slicers` | List all Table slicers | (none) |
-| `set-table-slicer-selection` | Set Table slicer filter | slicerName, selectedItems |
-| `delete-table-slicer` | Delete Table slicer | slicerName |
+| `set-table-slicer-selection` | Set Table slicer filter | slicer_name, selected_items |
+| `delete-table-slicer` | Delete Table slicer | slicer_name |
 
-**CRITICAL: Required Parameters** - The "Required Parameters" column above is strict. Missing any required parameter will cause an error. Pay special attention to `pivotTableName` for PivotTable slicers and `slicerName` for selection/deletion operations.
+**CRITICAL: Required Parameters** - The "Required Parameters" column above is strict. Missing any required parameter will cause an error. Pay special attention to `pivot_table_name` for PivotTable slicers and `slicer_name` for selection/deletion operations.
 
 **Naming Convention**:
 
-- If `slicerName` not provided, auto-generates `{FieldName}Slicer` or `{ColumnName}Slicer`
+- If `slicer_name` is not provided, Excel auto-generates a name from the field or column
 - Slicer names must be unique within workbook
 - Use `list-slicers` or `list-table-slicers` to check existing names
 
 **Selection Behavior**:
 
-- `selectedItems` is a list of strings: `["Value1", "Value2"]`
+- `selected_items` is a JSON array of strings: `["Value1", "Value2"]`
 - Empty list `[]` clears all filters (shows all items)
 - Values must match exactly (case-sensitive)
 - Invalid values are silently ignored
@@ -51,7 +51,7 @@ The `--selected-items` parameter requires a JSON array. Use proper shell escapin
 
 **Positioning**:
 
-- `destinationSheet` specifies which worksheet hosts the slicer
+- `destination_sheet` specifies which worksheet hosts the slicer
 - `position` is a cell address for top-left corner (e.g., `'E1'`, `'G5'`)
 - The slicer's top-left corner aligns to the specified cell
 - Default position if not specified: Excel chooses

--- a/skills/shared/table.md
+++ b/skills/shared/table.md
@@ -11,17 +11,17 @@ To analyze worksheet data with DAX measures:
 
 **Action disambiguation**:
 
-- create: Create NEW table from a range (requires sheetName, tableName, rangeAddress). Pass `tableStyle` here to style at creation time.
+- create: Create NEW table from a range (requires `sheet_name`, `table_name`, and `range_address`). Pass `table_style` here to style at creation time.
 - read: Get table metadata (range, columns, style, row counts)
-- get-data: Get actual table DATA as 2D array (use visibleOnly=true for filtered data)
+- get-data: Get actual table DATA as 2D array (use `visible_only=true` for filtered data)
 - rename: Rename an existing table
 - delete: Remove table (keeps data, removes table formatting)
 - resize: Change table range (expand/contract)
 - set-style: Change table visual style (TableStyleLight1-21, TableStyleMedium1-28, TableStyleDark1-11). Default is TableStyleMedium2.
-- toggle-totals: Show or hide the totals row (showTotals: true/false)
+- toggle-totals: Show or hide the totals row (`show_totals`: true/false)
 - set-column-total: Set the aggregate function on a totals-row column (Sum, Count, Average, Min, Max, None)
 - add-to-data-model: Add an existing worksheet table to Power Pivot for DAX analysis
-- append: Add rows to existing table (requires rows or rowsFile parameter)
+- append: Add rows to existing table (requires `rows` or `rows_file`)
 - **create-from-dax**: Create table populated by a DAX EVALUATE query from Data Model
 - **update-dax**: Update an existing DAX-backed table's query
 - **get-dax**: Get the DAX query behind a DAX-backed table
@@ -32,8 +32,8 @@ Excel Tables manage their own header/row/totals formatting through table styles.
 
 | Goal | Correct approach |
 |------|-----------------|
-| Style a table | `table(action: 'set-style', tableStyle: 'TableStyleMedium2')` |
-| Style at creation | `table(action: 'create', tableStyle: 'TableStyleMedium2', ...)` |
+| Style a table | `table(action: 'set-style', table_style: 'TableStyleMedium2')` |
+| Style at creation | `table(action: 'create', table_style: 'TableStyleMedium2', ...)` |
 | Custom branding on table | Use a Medium/Dark table style that matches your palette — avoid overriding individual cells |
 
 Common table style choices:
@@ -73,7 +73,7 @@ Example DAX queries for create-from-dax:
 |------|------|
 | Create/manage worksheet tables | table |
 | Add worksheet table to Power Pivot | table (add-to-data-model) |
-| Import external data to Data Model | powerquery (loadDestination='data-model') |
+| Import external data to Data Model | powerquery (load_destination='data-model') |
 | Create DAX measures | datamodel |
 | Create PivotTables from Data Model | pivottable |
 
@@ -82,11 +82,11 @@ Example DAX queries for create-from-dax:
 - Trying to create DAX measures without first adding table to Data Model
 - Using datamodel to add tables (it only manages existing Data Model tables)
 - Confusing get-data (returns cell values) with read (returns metadata)
-- Forgetting hasHeaders parameter when creating tables from headerless data
+- Forgetting `has_headers` when creating tables from headerless data
 
 **Server-specific quirks**:
 
-- Style parameter is overloaded: table style name OR total function (context-dependent)
-- csvData parameter: dedicated parameter for append action (CSV format: comma-separated, newline-separated rows)
-- visibleOnly parameter only applies to get-data action
+- `table_style` applies to table creation and set-style; totals use `total_function`
+- `rows` accepts a 2D array and `rows_file` accepts JSON or CSV input for append
+- `visible_only` applies only to get-data
 - Table names must be unique within workbook (Excel requirement)

--- a/skills/shared/workflows.md
+++ b/skills/shared/workflows.md
@@ -29,7 +29,7 @@ Excel's Power Pivot has key limitations compared to Power BI/SSAS:
 
 ### Data Model Prerequisites
 ```
-1. Load table (powerquery refresh loadDestination="data-model")
+1. Load table (powerquery load-to load_destination="data-model")
 2. THEN create relationships (datamodel_relationship with create-relationship action)
 3. THEN create measures (datamodel create-measure)
 ```
@@ -58,5 +58,5 @@ After Power Query: powerquery list, powerquery view
 After refresh:     datamodel list-tables
 After measure:     datamodel list-measures, datamodel evaluate
 After relationship: datamodel_relationship list-relationships
-After chart/layout: screenshot(capture, rangeAddress='A1:M50') (visual verification)
+After chart/layout: screenshot(capture, range_address='A1:M50') (visual verification)
 ```

--- a/skills/templates/SKILL.cli.sbn
+++ b/skills/templates/SKILL.cli.sbn
@@ -24,9 +24,10 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
   install the runtime independently via the standalone release zip or
   `dotnet tool install --global Sbroenne.ExcelMcp.CLI`.
   If `excelcli` is not found, report that and stop — do not guess at a path.
-- The runtime itself is downloaded and cached on first use under
-  `~\.copilot\plugin-runtime\mcp-server-excel\excel-cli`, so only the first invocation needs
-  network access
+- Plugin-driven flows download and cache the runtime on first use through
+  `PLUGIN_DATA`; the optional global shim falls back to
+  `~\.copilot\plugin-runtime\mcp-server-excel\excel-cli`. Only the first invocation needs
+  network access.
 
 ## Workflow Checklist
 

--- a/skills/templates/SKILL.mcp.sbn
+++ b/skills/templates/SKILL.mcp.sbn
@@ -95,7 +95,7 @@ Always convert tabular data to Excel Tables:
 
 ```
 1. range set-values (write data including headers)
-2. table create tableName="SalesData" rangeAddress="A1:D100"
+2. table create table_name="SalesData" range_address="A1:D100"
 ```
 
 **Why:** Structured references, auto-expand, required for Data Model/DAX.
@@ -103,9 +103,9 @@ Always convert tabular data to Excel Tables:
 ### Rule 5: Session Lifecycle
 
 ```
-1. file(action: 'open', path: '...')  → sessionId
-2. All operations use sessionId
-3. file(action: 'close', save: true)  → saves and closes
+1. file(action: 'open', path: '...')  → session ID
+2. All operations use the returned session ID
+3. file(action: 'close', session_id: '...', save: true)  → saves and closes
 ```
 
 **Unclosed sessions leave Excel processes running, locking files.**
@@ -116,7 +116,7 @@ DAX operations require tables in the Data Model:
 
 ```
 Step 1: Create table → Table exists
-Step 2: table(action: 'add-to-datamodel') → Table in Data Model
+Step 2: table(action: 'add-to-data-model') → Table in Data Model
 Step 3: datamodel(action: 'create-measure') → NOW this works
 ```
 
@@ -125,7 +125,7 @@ Step 3: datamodel(action: 'create-measure') → NOW this works
 **BEST PRACTICE: Test-First Workflow**
 
 ```
-1. powerquery(action: 'evaluate', mCode: '...') → Test WITHOUT persisting
+1. powerquery(action: 'evaluate', m_code: '...') → Test WITHOUT persisting
 2. powerquery(action: 'create', ...) → Store validated query
 3. powerquery(action: 'refresh', ...) → Load data
 ```
@@ -153,7 +153,7 @@ Error responses include actionable hints:
 {
   "success": false,
   "errorMessage": "Table 'Sales' not found in Data Model",
-  "suggestedNextActions": ["table(action: 'add-to-data-model', tableName: 'Sales')"]
+  "suggestedNextActions": ["table(action: 'add-to-data-model', table_name: 'Sales')"]
 }
 ```
 

--- a/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
@@ -51,6 +51,82 @@ public sealed class PluginBootstrapBuildTests
     }
 
     [Fact]
+    public void CanonicalPluginGuidance_UsesCurrentAssetsAndSnakeCaseMcpParameters()
+    {
+        var files = Directory
+            .GetFiles(Path.Combine(RepoRoot, "skills", "shared"), "*.md")
+            .Concat(
+            [
+                Path.Combine(RepoRoot, "skills", "templates", "SKILL.mcp.sbn"),
+                Path.Combine(RepoRoot, "skills", "excel-mcp", "references", "claude-desktop.md"),
+                Path.Combine(RepoRoot, "skills", "excel-mcp", "README.md"),
+                Path.Combine(RepoRoot, "skills", "excel-cli", "README.md"),
+                Path.Combine(RepoRoot, ".github", "plugins", "excel-mcp", "README.md"),
+                Path.Combine(RepoRoot, ".github", "plugins", "excel-cli", "README.md"),
+                Path.Combine(RepoRoot, ".github", "plugins", "marketplace-repo", "README.md")
+            ])
+            .ToArray();
+
+        string[] retiredNames =
+        [
+            "ExcelMcp-CLI-latest-windows.zip",
+            "excel-mcp-server.exe",
+            "excel-mcp-bundle.mcpb"
+        ];
+
+        var unquotedCamelCaseArgument = new Regex(
+            """(?<!["A-Za-z0-9_])(?<name>[a-z][A-Za-z0-9]*[A-Z][A-Za-z0-9]*)(?=\s*[:=])""",
+            RegexOptions.CultureInvariant);
+        var quotedCamelCaseArgument = new Regex(
+            "\"(?<name>[a-z][A-Za-z0-9]*[A-Z][A-Za-z0-9]*)\"\\s*:",
+            RegexOptions.CultureInvariant);
+        var allowedUnquotedNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "canOpen",
+            "itemName"
+        };
+        var allowedQuotedNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "chartName",
+            "errorMessage",
+            "mcpServers",
+            "suggestedNextActions"
+        };
+
+        var violations = new List<string>();
+        foreach (var file in files)
+        {
+            var text = File.ReadAllText(file);
+            var relativePath = Path.GetRelativePath(RepoRoot, file);
+
+            violations.AddRange(
+                retiredNames
+                    .Where(text.Contains)
+                    .Select(name => $"{relativePath}: retired name '{name}'"));
+
+            violations.AddRange(
+                unquotedCamelCaseArgument
+                    .Matches(text)
+                    .Select(match => match.Groups["name"].Value)
+                    .Where(name => !allowedUnquotedNames.Contains(name))
+                    .Distinct(StringComparer.Ordinal)
+                    .Select(name => $"{relativePath}: camelCase MCP argument '{name}'"));
+
+            violations.AddRange(
+                quotedCamelCaseArgument
+                    .Matches(text)
+                    .Select(match => match.Groups["name"].Value)
+                    .Where(name => !allowedQuotedNames.Contains(name))
+                    .Distinct(StringComparer.Ordinal)
+                    .Select(name => $"{relativePath}: camelCase MCP argument '{name}'"));
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            $"Canonical plugin guidance contains stale names or MCP arguments:{Environment.NewLine}{string.Join(Environment.NewLine, violations)}");
+    }
+
+    [Fact]
     [Trait("Category", "Integration")]
     [Trait("Feature", "PluginBootstrap")]
     public async Task BuildPlugins_PreservesCurrentBootstrapAssetsAndDropsLegacyBootstrapFiles()
@@ -444,6 +520,60 @@ public sealed class PluginBootstrapBuildTests
             Assert.Equal(1, ReadMockCallCount(userProfile, "rest"));
             Assert.Equal(1, ReadMockCallCount(userProfile, "web"));
             Assert.Equal(1, ReadMockCallCount(userProfile, "expand"));
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
+    [Theory]
+    [InlineData("excel-cli", "excelcli.exe", "ExcelMcp-CLI-{0}-windows.zip")]
+    [InlineData("excel-mcp", "mcp-excel.exe", "ExcelMcp-MCP-Server-{0}-windows.zip")]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task DownloadBootstrap_WithPluginData_UsesHostManagedRuntimeDirectory(
+        string pluginName,
+        string executableName,
+        string assetNameFormat)
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox($"download-plugin-data-{pluginName}");
+        try
+        {
+            var userProfile = Path.Combine(sandbox, "user");
+            var pluginData = Path.Combine(sandbox, "plugin-data");
+            Directory.CreateDirectory(userProfile);
+            Directory.CreateDirectory(pluginData);
+
+            var harnessPath = CreateDownloadHarnessScript(sandbox);
+            var version = "1.2.3";
+            var tag = $"v{version}";
+            var assetName = string.Format(CultureInfo.InvariantCulture, assetNameFormat, version);
+
+            var result = await RunPowerShellFileAsync(
+                harnessPath,
+                [
+                    "-ScriptPath", GetPluginScriptPath(pluginName, "download.ps1"),
+                    "-ExecutableName", executableName,
+                    "-Tag", tag,
+                    "-AssetName", assetName,
+                    "-Mode", "success"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["USERPROFILE"] = userProfile,
+                    ["PLUGIN_DATA"] = pluginData,
+                    ["COPILOT_AGENT_SESSION_ID"] = "session-a",
+                    ["OS"] = "Windows_NT"
+                });
+
+            Assert.Equal(0, result.ExitCode);
+
+            var statePath = Path.Combine(pluginData, "runtime", "bootstrap-state.json");
+            Assert.True(File.Exists(statePath), $"Expected host-managed bootstrap state at {statePath}");
+            Assert.False(File.Exists(GetBootstrapStatePath(userProfile, pluginName)));
         }
         finally
         {
@@ -1490,6 +1620,55 @@ public sealed class PluginBootstrapBuildTests
         }
     }
 
+    [Fact]
+    public void StartCliWrapper_RelaysRedirectedStandardOutputAndError()
+    {
+        var script = File.ReadAllText(GetPluginScriptPath("excel-cli", "start-cli.ps1"));
+
+        Assert.Contains("$startInfo.RedirectStandardOutput = $true", script, StringComparison.Ordinal);
+        Assert.Contains("$startInfo.RedirectStandardError = $true", script, StringComparison.Ordinal);
+        Assert.Contains("$process.StandardOutput.ReadToEndAsync()", script, StringComparison.Ordinal);
+        Assert.Contains("$process.StandardError.ReadToEndAsync()", script, StringComparison.Ordinal);
+        Assert.Contains("[Console]::Error.Write($stderr)", script, StringComparison.Ordinal);
+        Assert.Contains("Write-Output -NoEnumerate $stdout", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public async Task StartCliWrapper_PreservesPipelineOutput()
+    {
+        Assert.True(OperatingSystem.IsWindows(), "Plugin bootstrap packaging tests require Windows.");
+
+        var sandbox = CreateSandbox("start-cli-pipeline-output");
+        try
+        {
+            var binDirectory = Path.Combine(sandbox, "bin");
+            Directory.CreateDirectory(binDirectory);
+
+            var wrapperPath = Path.Combine(binDirectory, "start-cli.ps1");
+            File.Copy(GetPluginScriptPath("excel-cli", "start-cli.ps1"), wrapperPath);
+            File.WriteAllText(
+                Path.Combine(binDirectory, "download.ps1"),
+                """
+                param([switch]$PassThru, [switch]$Quiet)
+                (Get-Command "cmd.exe").Source
+                """);
+
+            var result = await RunPowerShellFileAsync(
+                wrapperPath,
+                ["/d", "/s", "/c", "echo pipeline-output & echo pipeline-error 1>&2"]);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("pipeline-output", result.Stdout, StringComparison.Ordinal);
+            Assert.Contains("pipeline-error", result.Stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(sandbox);
+        }
+    }
+
     [SupportedOSPlatform("windows")]
     private static string[] SplitCommandLine(string commandLine)
     {
@@ -1970,7 +2149,7 @@ public sealed class PluginBootstrapBuildTests
         // The bootstrap reads ambient environment. Scrub the variables it consults so that a
         // developer machine or CI runner which happens to define them cannot silently change
         // what these tests exercise; callers opt back in by passing them explicitly.
-        foreach (var ambientName in new[] { "COPILOT_AGENT_SESSION_ID", "GITHUB_TOKEN", "GH_TOKEN" })
+        foreach (var ambientName in new[] { "COPILOT_AGENT_SESSION_ID", "PLUGIN_DATA", "GITHUB_TOKEN", "GH_TOKEN" })
         {
             startInfo.Environment.Remove(ambientName);
         }


### PR DESCRIPTION
## Summary
- prefer Agent Plugins 1.0 `PLUGIN_DATA\runtime` storage while retaining the standalone cache fallback
- preserve `excelcli` stdout and stderr for PowerShell pipelines
- synchronize canonical templates, shared references, generated skills, and plugin READMEs with current release assets, bootstrap behavior, snake_case MCP parameters, and the 31 tools / 325 operations count
- add regression coverage for documentation drift, host-managed cache selection, and CLI pipeline output

## Validation
- repository pre-commit hook passed, including Release build, bootstrap drift, docs counts, CLI/MCP release packages, VS Code package, MCPB, agent skills, plugin READMEs, COM leak, coverage, success-flag, and dynamic-cast checks
- `ExcelMcp.SkillGeneration.Tests`: 67 tests passed when excluding `BuildAgentSkills_StampsVersionFileIntoEveryPackagedSkill`; 5 focused regression cases passed
- temporary Agent Plugins 1.0 package build passed for both plugins

## Local environment note
The one excluded test assumes the repository and `%TEMP%` share a drive. This worktree is on `D:` while `%TEMP%` is on `C:`, so its relative-path setup becomes an invalid `D:\...\C:\...` path. The hook's actual agent-skills package build passed.