### PR TITLE
Add npm distribution for MCP server

### DIFF
--- a/.changeset/npm-mcp-server.md
+++ b/.changeset/npm-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": minor
+---
+
+**Install the MCP Server with npm**: Run `npx -y @sbroenne/mcp-server-excel` to use the self-contained Windows server without installing .NET or downloading an executable manually.

--- a/.github/instructions/development-workflow.instructions.md
+++ b/.github/instructions/development-workflow.instructions.md
@@ -101,7 +101,7 @@ Quick reference:
 ## Release Process (Maintainers)
 
 **Release:** Use `workflow_dispatch` on the release workflow with version bump (major/minor/patch) or custom version. Releases ALL components with same version:
-- MCP Server → NuGet + ZIP
+- MCP Server → npm + NuGet + ZIP
 - CLI → NuGet + ZIP
 - VS Code Extension → Marketplace + VSIX
 - MCPB → Claude Desktop bundle

--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -15,7 +15,12 @@
 **Claude Desktop (MCPB)**
 - Download `excel-mcp-{{VERSION}}.mcpb` and double-click to install
 
-**Standalone Executables** (Primary — no .NET runtime required)
+**npm MCP Server** (Primary — no .NET runtime required)
+```powershell
+npx -y @sbroenne/mcp-server-excel
+```
+
+**Standalone Executables** (no .NET runtime required)
 - MCP Server: Download `ExcelMcp-MCP-Server-{{VERSION}}-windows.zip`, extract `mcp-excel.exe`
 - CLI: Download `ExcelMcp-CLI-{{VERSION}}-windows.zip`, extract `excelcli.exe`
 - Add the exe(s) to your PATH, then configure your MCP client with command `mcp-excel`
@@ -34,7 +39,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 ### Requirements
 - Windows OS
 - Microsoft Excel 2016+
-- No .NET runtime required for VS Code Extension, MCPB, or standalone executables
+- No .NET runtime required for npm, VS Code Extension, MCPB, or standalone executables
 - .NET 10 Runtime required for NuGet (.NET tool) installation only
 
 ### Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,13 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
       - name: Restore
         run: dotnet restore Sbroenne.ExcelMcp.sln
 
@@ -146,6 +153,12 @@ jobs:
         run: |
           & scripts/check-plugin-readmes.ps1
           if ($LASTEXITCODE -ne 0) { throw "Plugin README validation failed." }
+
+      - name: npm launcher tests
+        shell: pwsh
+        run: |
+          npm ci --prefix npm-packages/mcp-server-excel --ignore-scripts
+          npm test --prefix npm-packages/mcp-server-excel
 
       # --- Excel-free build smoke checks (absorbed from the old Build CLI /
       #     Build MCP Server workflows) ---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release All Components
 
 # Unified release workflow for all ExcelMcp components:
-# - MCP Server (standalone exe ZIP — primary) + NuGet (.NET tool — secondary)
+# - MCP Server (npm + standalone exe ZIP — primary) + NuGet (.NET tool — secondary)
 # - CLI (standalone exe ZIP — primary) + NuGet (.NET tool — secondary)
 # - VS Code Extension (VSIX + Marketplace)
 # - MCPB (Claude Desktop bundle)
@@ -14,6 +14,7 @@ name: Release All Components
 #
 # Required GitHub Secrets:
 # - NUGET_USER: Your NuGet.org username (profile name, NOT email)
+# - NPM_TOKEN: Granular npm publish token used to bootstrap new packages; trusted publishing takes precedence once configured
 # - VSCE_TOKEN: VS Code Marketplace PAT
 # - APPINSIGHTS_CONNECTION_STRING: Application Insights connection string
 #
@@ -199,6 +200,13 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        registry-url: https://registry.npmjs.org
+        package-manager-cache: false
+
     - name: Set Version
       run: |
         $version = "${{ needs.version.outputs.version }}"
@@ -224,7 +232,7 @@ jobs:
     - name: Pack NuGet (secondary distribution)
       run: dotnet pack src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj --configuration Release --no-build --output ./nupkg -p:Version=${{ env.VERSION }}
 
-    - name: Publish MCP Server (standalone exe — primary distribution)
+    - name: Publish MCP Server (standalone exe)
       run: |
         dotnet publish src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj `
           --configuration Release `
@@ -266,6 +274,24 @@ jobs:
         Compress-Archive -Path "mcp-server-release/*" -DestinationPath "ExcelMcp-MCP-Server-$version-windows.zip"
       shell: pwsh
 
+    - name: Test npm Launcher
+      run: |
+        npm ci --prefix npm-packages/mcp-server-excel --ignore-scripts
+        npm test --prefix npm-packages/mcp-server-excel
+      shell: pwsh
+
+    - name: Build and Test npm Packages
+      run: |
+        .\scripts\Build-NpmPackages.ps1 `
+          -Version $env:VERSION `
+          -RuntimeExecutable "mcp-server-publish\mcp-excel.exe" `
+          -OutputDirectory "npm-artifacts"
+
+        .\scripts\Test-NpmPackages.ps1 `
+          -LauncherPackage "npm-artifacts\sbroenne-mcp-server-excel-$env:VERSION.tgz" `
+          -RuntimePackage "npm-artifacts\sbroenne-mcp-server-excel-win32-x64-$env:VERSION.tgz"
+      shell: pwsh
+
     - name: Upload ZIP Artifact
       uses: actions/upload-artifact@v7
       with:
@@ -277,6 +303,12 @@ jobs:
       with:
         name: mcp-server-nupkg
         path: nupkg/*.nupkg
+
+    - name: Upload npm Artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: mcp-server-npm
+        path: npm-artifacts/*.tgz
 
   # =============================================================================
   # Job 3: Build and Publish VS Code Extension
@@ -439,11 +471,11 @@ jobs:
         path: artifacts/skills/excel-skills-*.zip
 
   # =============================================================================
-  # Job 6: Wait for NuGet Propagation + MCP Registry
+  # Job 6: Wait for Package Propagation + MCP Registry
   # =============================================================================
   publish-mcp-registry:
     name: MCP Registry
-    needs: [version, create-tag, build-mcp-server]
+    needs: [version, publish]
     runs-on: windows-latest
     permissions:
       id-token: write
@@ -464,31 +496,52 @@ jobs:
           -Version $env:VERSION
       shell: pwsh
 
-    - name: Wait for NuGet Propagation
+    - name: Wait for NuGet and npm Propagation
       run: |
         $version = $env:VERSION
-        $packageId = "sbroenne.excelmcp.mcpserver"
-        $readmeUrl = "https://api.nuget.org/v3-flatcontainer/$packageId/$version/readme"
+        $nugetPackageId = "sbroenne.excelmcp.mcpserver"
+        $nugetReadmeUrl = "https://api.nuget.org/v3-flatcontainer/$nugetPackageId/$version/readme"
+        $npmPackageUrl = "https://registry.npmjs.org/@sbroenne%2fmcp-server-excel/$version"
 
-        Write-Output "Waiting for NuGet CDN propagation..."
+        Write-Output "Waiting for NuGet and npm propagation..."
         $maxAttempts = 3
         $pollInterval = 600  # 10 minutes
 
-        # First check immediately; subsequent checks wait pollInterval seconds
         for ($i = 1; $i -le $maxAttempts; $i++) {
           Write-Output "Attempt $i of $maxAttempts..."
+          $nugetReady = $false
+          $npmReady = $false
+
           try {
-            $response = Invoke-WebRequest -Uri $readmeUrl -UseBasicParsing -ErrorAction Stop
-            if ($response.StatusCode -eq 200) {
-              $content = [System.Text.Encoding]::UTF8.GetString($response.Content)
-              if ($content -match "mcp-name:\s+io\.github\.sbroenne/mcp-server-excel") {
-                Write-Output "README propagated successfully"
-                break
-              }
-            }
+            $response = Invoke-WebRequest -Uri $nugetReadmeUrl -UseBasicParsing -ErrorAction Stop
+            $content = [System.Text.Encoding]::UTF8.GetString($response.Content)
+            $nugetReady = $response.StatusCode -eq 200 -and
+              $content -match "mcp-name:\s+io\.github\.sbroenne/mcp-server-excel"
           } catch {
-            Write-Output "README not yet available"
+            Write-Output "NuGet README not yet available"
           }
+
+          try {
+            $npmPackage = Invoke-RestMethod -Uri $npmPackageUrl -ErrorAction Stop
+            $npmReady = $npmPackage.mcpName -eq "io.github.sbroenne/mcp-server-excel"
+          } catch {
+            Write-Output "npm package not yet available"
+          }
+
+          if ($nugetReady -and $npmReady) {
+            Write-Output "NuGet and npm metadata propagated successfully"
+            break
+          }
+
+          if ($i -eq $maxAttempts) {
+            if (-not $nugetReady) {
+              throw "NuGet package metadata did not propagate after $maxAttempts attempts."
+            }
+            if (-not $npmReady) {
+              throw "npm package metadata did not propagate after $maxAttempts attempts."
+            }
+          }
+
           if ($i -lt $maxAttempts) {
             Write-Output "Waiting $pollInterval seconds before retry..."
             Start-Sleep -Seconds $pollInterval
@@ -545,7 +598,7 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
-      id-token: write  # Required for NuGet OIDC
+      id-token: write  # Required for NuGet and npm OIDC
 
     steps:
     - uses: actions/checkout@v7
@@ -559,6 +612,8 @@ jobs:
       uses: actions/setup-node@v7
       with:
         node-version: ${{ env.NODE_VERSION }}
+        registry-url: https://registry.npmjs.org
+        package-manager-cache: false
 
     - name: Set Version
       run: |
@@ -577,6 +632,12 @@ jobs:
       with:
         name: cli-nupkg
         path: cli-nupkg
+
+    - name: Download npm Packages
+      uses: actions/download-artifact@v8
+      with:
+        name: mcp-server-npm
+        path: npm-packages
 
     - name: Download VS Code VSIX
       uses: actions/download-artifact@v8
@@ -605,6 +666,38 @@ jobs:
           --skip-duplicate
         Write-Output "Published Sbroenne.ExcelMcp.CLI.$version to NuGet.org"
       shell: pwsh
+
+    - name: Publish to npm
+      run: |
+        npm install --global npm@11
+
+        function Publish-NpmPackage {
+          param(
+            [string]$PackageName,
+            [string]$Tarball
+          )
+
+          npm view "$PackageName@$env:VERSION" version --json 2>$null | Out-Null
+          if ($LASTEXITCODE -eq 0) {
+            Write-Output "$PackageName@$env:VERSION is already published; skipping."
+            return
+          }
+
+          npm publish $Tarball --access public
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to publish $PackageName@$env:VERSION."
+          }
+        }
+
+        Publish-NpmPackage `
+          -PackageName "@sbroenne/mcp-server-excel-win32-x64" `
+          -Tarball "npm-packages/sbroenne-mcp-server-excel-win32-x64-$env:VERSION.tgz"
+        Publish-NpmPackage `
+          -PackageName "@sbroenne/mcp-server-excel" `
+          -Tarball "npm-packages/sbroenne-mcp-server-excel-$env:VERSION.tgz"
+      shell: pwsh
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Publish to VS Code Marketplace
       uses: HaaLeo/publish-vscode-extension@v2

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ bld/
 [Bb]in/
 !.github/plugins/**/bin/
 !.github/plugins/**/bin/**
+!npm-packages/mcp-server-excel/bin/
+!npm-packages/mcp-server-excel/bin/**
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/

--- a/docs/INSTALLATION-MCP-SERVER.md
+++ b/docs/INSTALLATION-MCP-SERVER.md
@@ -14,7 +14,7 @@ Installation instructions for the ExcelMcp **MCP Server** — the entry point fo
 - **Microsoft Analysis Services OLE DB Provider (MSOLAP)** - Required for DAX query execution (`evaluate`, `execute-dmv` actions)
   - Easiest: Install [Power BI Desktop](https://powerbi.microsoft.com/desktop) (includes MSOLAP)
   - Alternative: [Microsoft OLE DB Driver for Analysis Services](https://learn.microsoft.com/analysis-services/client-libraries)
-- **Node.js** - Only required for `npx` commands (`add-mcp` auto-configuration, agent skills). Install with `winget install OpenJS.NodeJS.LTS` or from [nodejs.org](https://nodejs.org/)
+- **Node.js** - Required for the recommended `npx` installation and other `npx` commands. Install with `winget install OpenJS.NodeJS.LTS` or from [nodejs.org](https://nodejs.org/)
 
 ---
 
@@ -26,6 +26,7 @@ Use this order to avoid setup confusion:
    - **VS Code Extension** (GitHub Copilot users) — auto-configures everything
    - **Claude Desktop MCPB** — one-click MCP installation
    - **GitHub Copilot Plugin** (Copilot CLI users) — marketplace installation
+   - **npm package** (other MCP clients) — runs the self-contained server through `npx`
    - **Manual MCP setup** (other MCP clients like Cursor, Windsurf)
 2. **Validate MCP setup** (run the quick test prompt in Step 4 of manual setup, or test in your client after extension/MCPB/plugin install)
 3. **Optional:** also install the [CLI](INSTALLATION-CLI.md) (`excelcli`) for scripting/RPA
@@ -80,7 +81,21 @@ copilot plugin install excel-mcp@mcp-server-excel-plugins
 
 **Best for:** Other MCP clients (Cursor, Windsurf, Cline, Claude Code, Codex), advanced users
 
-### Step 1: Download MCP Server
+### Step 1: Choose npm or the Standalone Executable
+
+#### Option A: npm (Recommended)
+
+Run the self-contained server directly through npm:
+
+```powershell
+npx -y @sbroenne/mcp-server-excel --version
+```
+
+The npm package includes the Windows server, so it does not require .NET or a
+separate download from GitHub Releases. npm caches the package after the first
+run.
+
+#### Option B: Standalone Executable
 
 1. Go to the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest)
 2. Download **`ExcelMcp-MCP-Server-{version}-windows.zip`**
@@ -93,7 +108,9 @@ Expand-Archive "ExcelMcp-MCP-Server-1.x.x-windows.zip" -DestinationPath "C:\Tool
 
 The ZIP contains `mcp-excel.exe` — a fully self-contained executable (no .NET runtime needed).
 
-### Step 2: Add to PATH (Recommended)
+### Step 2: Add the Standalone Executable to PATH
+
+Skip this step when using npm.
 
 To use `mcp-excel` as a command without specifying the full path:
 
@@ -116,25 +133,25 @@ Or manually: **Settings → System → About → Advanced system settings → En
 Use [`add-mcp`](https://github.com/neondatabase/add-mcp) to configure all detected coding agents with a single command:
 
 ```powershell
-npx add-mcp "mcp-excel" --name excel-mcp
+npx add-mcp "npx -y @sbroenne/mcp-server-excel" --name excel-mcp
 ```
 
 This auto-detects and configures **Cursor, VS Code, Claude Code, Claude Desktop, Codex, Zed, Gemini CLI**, and more. Use flags to customize:
 
 ```powershell
 # Configure specific agents only
-npx add-mcp "mcp-excel" --name excel-mcp -a cursor -a claude-code
+npx add-mcp "npx -y @sbroenne/mcp-server-excel" --name excel-mcp -a cursor -a claude-code
 
 # Configure globally (user-wide, all projects)
-npx add-mcp "mcp-excel" --name excel-mcp -g
+npx add-mcp "npx -y @sbroenne/mcp-server-excel" --name excel-mcp -g
 
 # Non-interactive (skip prompts)
-npx add-mcp "mcp-excel" --name excel-mcp --all -y
+npx add-mcp "npx -y @sbroenne/mcp-server-excel" --name excel-mcp --all -y
 ```
 
-> **Requires:** [Node.js](https://nodejs.org/) for `npx`. Install with `winget install OpenJS.NodeJS.LTS` if not already available. No permanent `add-mcp` installation needed — `npx` downloads, runs, and cleans up automatically.
+> **Requires:** [Node.js](https://nodejs.org/) for `npx`. Install with `winget install OpenJS.NodeJS.LTS` if not already available. No permanent `add-mcp` installation is needed.
 
-> **Note:** If `mcp-excel` is not on your PATH, use the full path instead: `npx add-mcp "C:\Tools\ExcelMcp\mcp-excel.exe" --name excel-mcp`
+> **Standalone alternative:** Use `npx add-mcp "C:\Tools\ExcelMcp\mcp-excel.exe" --name excel-mcp` after extracting the ZIP.
 
 #### Option B: Manual Configuration
 
@@ -148,13 +165,14 @@ Create `.vscode/mcp.json` in your workspace:
 {
   "servers": {
     "excel-mcp": {
-      "command": "mcp-excel"
+      "command": "npx",
+      "args": ["-y", "@sbroenne/mcp-server-excel"]
     }
   }
 }
 ```
 
-> If `mcp-excel` is not on PATH, use the full path: `"command": "C:\\Tools\\ExcelMcp\\mcp-excel.exe"`
+> For the standalone executable, replace `command` with `mcp-excel` and omit `args`.
 
 **For GitHub Copilot (Visual Studio):**
 
@@ -164,7 +182,8 @@ Create `.mcp.json` in your solution directory or `%USERPROFILE%\.mcp.json`:
 {
   "servers": {
     "excel-mcp": {
-      "command": "mcp-excel"
+      "command": "npx",
+      "args": ["-y", "@sbroenne/mcp-server-excel"]
     }
   }
 }
@@ -180,8 +199,8 @@ Create `.mcp.json` in your solution directory or `%USERPROFILE%\.mcp.json`:
 {
   "mcpServers": {
     "excel-mcp": {
-      "command": "mcp-excel",
-      "args": [],
+      "command": "npx",
+      "args": ["-y", "@sbroenne/mcp-server-excel"],
       "env": {}
     }
   }
@@ -201,8 +220,8 @@ Create `.mcp.json` in your solution directory or `%USERPROFILE%\.mcp.json`:
 {
   "mcpServers": {
     "excel-mcp": {
-      "command": "mcp-excel",
-      "args": [],
+      "command": "npx",
+      "args": ["-y", "@sbroenne/mcp-server-excel"],
       "env": {}
     }
   }
@@ -221,8 +240,8 @@ Create `.mcp.json` in your solution directory or `%USERPROFILE%\.mcp.json`:
 {
   "mcpServers": {
     "excel-mcp": {
-      "command": "mcp-excel",
-      "args": [],
+      "command": "npx",
+      "args": ["-y", "@sbroenne/mcp-server-excel"],
       "env": {}
     }
   }
@@ -241,8 +260,8 @@ Create `.mcp.json` in your solution directory or `%USERPROFILE%\.mcp.json`:
 {
   "mcpServers": {
     "excel-mcp": {
-      "command": "mcp-excel",
-      "args": [],
+      "command": "npx",
+      "args": ["-y", "@sbroenne/mcp-server-excel"],
       "env": {}
     }
   }
@@ -291,7 +310,7 @@ dotnet tool update --global Sbroenne.ExcelMcp.McpServer
 dotnet tool uninstall --global Sbroenne.ExcelMcp.McpServer
 ```
 
-> **Why NuGet is secondary:** The standalone exe distribution requires no .NET runtime, making it easier to install for most users. NuGet is available as an alternative for users who prefer package managers or already have .NET installed in their workflow.
+> **Why NuGet is secondary:** The recommended npm package and the standalone exe require no .NET runtime. NuGet remains available for users who already have .NET installed in their workflow.
 
 ---
 
@@ -300,12 +319,18 @@ dotnet tool uninstall --global Sbroenne.ExcelMcp.McpServer
 ### Check Current Version
 
 ```powershell
-mcp-excel --version
+npx -y @sbroenne/mcp-server-excel --version
 ```
 
 ### Update to New Version
 
-**Standalone exe (primary):**
+**npm (primary):**
+
+Unpinned `npx` configurations resolve the newest published package. Restart the
+MCP client to start the new version. If the configuration pins a version, update
+the version after the package name.
+
+**Standalone exe:**
 
 1. Go to the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest)
 2. Download the new ZIP: `ExcelMcp-MCP-Server-{version}-windows.zip`
@@ -334,7 +359,8 @@ Before updating, check the [changelog](../CHANGELOG.md) or [GitHub Releases](htt
 
 ### 1. "mcp-excel is not recognized as an internal or external command"
 
-**Solution:** `mcp-excel.exe` is not on your PATH.
+This error applies to the standalone executable. Either use the recommended npm
+configuration or add `mcp-excel.exe` to your PATH.
 
 Either:
 - Add the directory containing `mcp-excel.exe` to your PATH (see Step 2 above)
@@ -351,7 +377,7 @@ Test-Path "C:\Tools\ExcelMcp\mcp-excel.exe"
 
 **Verify it runs:**
 ```powershell
-mcp-excel --version
+npx -y @sbroenne/mcp-server-excel --version
 ```
 
 ### 3. "Workbook is locked" or "Cannot open file"
@@ -372,6 +398,8 @@ ExcelMcp requires exclusive access to workbooks (Excel COM limitation).
 ## Uninstallation
 
 ```powershell
+# npm: no global installation to remove
+
 # Standalone exe: simply delete the extracted files
 Remove-Item "C:\Tools\ExcelMcp\mcp-excel.exe" -Force
 

--- a/docs/MCP_REGISTRY_PUBLISHING.md
+++ b/docs/MCP_REGISTRY_PUBLISHING.md
@@ -37,7 +37,9 @@ Key fields:
 
 ### Package Validation
 
-The MCP Registry validates ownership by checking for `mcp-name:` in the package README.
+The registry offers both NuGet and npm installations. It validates NuGet
+ownership through `mcp-name:` in the package README and npm ownership through
+the `mcpName` property in the launcher package.
 
 Location: `src/ExcelMcp.McpServer/README.md`
 
@@ -48,18 +50,26 @@ The README includes this validation metadata:
 
 This HTML comment is invisible to users but allows the registry to verify the package belongs to this server.
 
+The npm package at `npm-packages/mcp-server-excel/package.json` contains:
+
+```json
+{
+  "mcpName": "io.github.sbroenne/mcp-server-excel"
+}
+```
+
 ## Publishing Workflow
 
 The publishing process is automated as `publish-mcp-registry` job in `.github/workflows/release.yml`:
 
 ### 1. Version Update
 The workflow:
-- Parses `server.json`, updates both the top-level `version` and the MCP Server
-  package version, then validates that both values match the release version.
+- Parses `server.json`, updates the top-level version plus the NuGet and npm
+  package versions, then validates that all values match the release version.
 
-### 2. Wait for NuGet Propagation
-- The MCP Registry uses NuGet as the deployment mechanism
-- The job waits for the NuGet package README to propagate (validates `mcp-name:` tag)
+### 2. Wait for NuGet and npm Propagation
+- The MCP Registry offers both NuGet and npm deployment mechanisms
+- The job waits for the NuGet README and npm `mcpName` metadata to propagate
 - Polls up to 3 times with 10-minute intervals
 
 ### 3. MCP Registry Publishing
@@ -105,5 +115,5 @@ After release, verify publication:
 
 **Solution**: 
 - Check the `publish-mcp-registry` job logs
-- Confirm both `server.json` version fields were stamped with the release version
+- Confirm the top-level, NuGet, and npm `server.json` versions were stamped with the release version
   before rerunning the workflow or publishing manually

--- a/docs/NUGET-GUIDE.md
+++ b/docs/NUGET-GUIDE.md
@@ -2,7 +2,7 @@
 
 Complete guide for publishing and managing all ExcelMcp NuGet packages using OIDC Trusted Publishing.
 
-> **Distribution Channels:** NuGet is the **secondary** distribution channel. The **primary** channel is standalone self-contained executables distributed via GitHub Releases — no .NET runtime required. See [INSTALLATION.md](INSTALLATION.md) for the recommended installation methods.
+> **Distribution Channels:** NuGet is the **secondary** distribution channel. The MCP Server is primarily distributed through npm and as a standalone self-contained executable — neither requires a .NET runtime. See [INSTALLATION-MCP-SERVER.md](INSTALLATION-MCP-SERVER.md) for the recommended installation methods.
 
 ## Table of Contents
 

--- a/docs/PRE-COMMIT-SETUP.md
+++ b/docs/PRE-COMMIT-SETUP.md
@@ -13,7 +13,7 @@ This repository includes automated pre-commit checks to prevent code quality iss
 7. **CLI Workflow Smoke Test** - Validates the end-to-end CLI workflow
 8. **MCP Server Smoke Test** - Validates the all-tools MCP smoke workflow
 9. **CLI Release Deliverables** - Builds the CLI NuGet package and standalone ZIP locally
-10. **MCP Server Release Deliverables** - Builds the MCP Server NuGet package and standalone ZIP locally
+10. **MCP Server Release Deliverables** - Builds and tests the MCP Server npm packages, NuGet package, and standalone ZIP locally
 11. **VS Code Extension Packaging** - Runs the VSIX release packaging path (`npm run package`)
 12. **MCPB Bundle Packaging** - Builds the Claude Desktop `.mcpb` bundle locally
 13. **Agent Skills Deliverables** - Builds the skills ZIP locally
@@ -146,7 +146,7 @@ The Excel-free subset of these checks runs in CI/CD (GitHub-hosted runners have 
 
  The hook now validates every locally buildable release artifact before commit publication:
  - CLI NuGet package + standalone ZIP
- - MCP Server NuGet package + standalone ZIP
+ - MCP Server npm packages + NuGet package + standalone ZIP
  - VS Code VSIX
  - Claude Desktop MCPB bundle
  - Agent skills ZIP

--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -8,7 +8,7 @@ All ExcelMcp components are released together with a single version tag:
 
 | Component | Primary Distribution | Secondary Distribution | Description |
 |-----------|---------------------|----------------------|-------------|
-| **MCP Server** | Standalone exe ZIP | NuGet (.NET tool) | `mcp-excel.exe` — no .NET runtime required |
+| **MCP Server** | npm + standalone exe ZIP | NuGet (.NET tool) | `npx @sbroenne/mcp-server-excel` or `mcp-excel.exe` — no .NET runtime required |
 | **CLI** | Standalone exe ZIP | NuGet (.NET tool) | `excelcli.exe` — no .NET runtime required |
 | **VS Code Extension** | VSIX + Marketplace | — | Self-contained — bundles MCP Server + CLI + skills |
 | **MCPB** | Claude Desktop bundle | — | Self-contained one-click installation |
@@ -27,19 +27,21 @@ When you run the release workflow, all components are released together:
 1. **CLI** → Standalone self-contained exe (`excelcli.exe`) shipped as:
    - ZIP file (primary distribution)
    - NuGet package (secondary distribution)
-2. **MCP Server** → Standalone self-contained exe (`mcp-excel.exe`) + ZIP [primary] + NuGet pack [secondary]
+2. **MCP Server** → npm launcher and Windows runtime packages + standalone self-contained exe ZIP [primary] + NuGet pack [secondary]
 3. **VS Code Extension** → Self-contained VSIX (bundles both exes + skills) → VS Code Marketplace
 4. **MCPB** → Claude Desktop bundle (`.mcpb` file)
 5. **Agent Skills** → ZIP package for AI coding assistants
 6. **GitHub Copilot Plugins** → Republished to the GitHub Copilot plugin marketplace repo via `publish-plugins.yml` with wrapper/bootstrap assets only; the plugins fetch the newest self-contained Windows runtime from the main release on first use (see [Phase 3 Plugin Publishing](../.github/workflows/docs/publish-plugins-setup.md))
 7. **NuGet** → Both packages published to NuGet.org (secondary channel)
-8. **MCP Registry** → Updated after NuGet propagation
+8. **MCP Registry** → Updated after NuGet and npm propagation
 9. **GitHub Release** → Created with all artifacts + auto-PR to update CHANGELOG
 
 ### Release Artifacts
 
 | Artifact | Format | Distribution |
 |----------|--------|--------------|
+| `@sbroenne/mcp-server-excel@{version}` | npm | npm registry (primary launcher package) |
+| `@sbroenne/mcp-server-excel-win32-x64@{version}` | npm | npm registry (self-contained Windows runtime) |
 | `ExcelMcp-MCP-Server-{version}-windows.zip` | ZIP | GitHub Release (primary — contains `mcp-excel.exe`) |
 | `ExcelMcp-CLI-{version}-windows.zip` | ZIP | GitHub Release (primary — contains `excelcli.exe`) |
 | `Sbroenne.ExcelMcp.CLI.{version}.nupkg` | NuGet | NuGet.org (secondary — contains `excelcli.exe`, requires .NET 10 runtime) |
@@ -80,9 +82,9 @@ workflow runs (see [Changelog Generation](#changelog-generation) below).
 
 The workflow will:
 1. Calculate the next version from the latest git tag
-2. Build all components (standalone exes + NuGet packages)
+2. Build all components (npm packages, standalone exes, and NuGet packages)
 3. Create and push the git tag (`v1.5.7`)
-4. Publish to NuGet.org, VS Code Marketplace, MCP Registry
+4. Publish to npm, NuGet.org, VS Code Marketplace, and MCP Registry
 5. Create GitHub Release with all artifacts
 6. Auto-PR to update `CHANGELOG.md`
 
@@ -91,13 +93,13 @@ The workflow will:
 The main release workflow runs automatically (10 jobs), then the plugin publish workflow runs automatically if the release succeeds:
 
 1. **build-cli** (3-5 min) → Builds standalone `excelcli.exe` (win-x64, self-contained), creates ZIP + NuGet pack
-2. **build-mcp-server** (4-6 min) → Builds standalone `mcp-excel.exe` (win-x64, self-contained), creates ZIP + NuGet pack
+2. **build-mcp-server** (4-6 min) → Builds standalone `mcp-excel.exe` (win-x64, self-contained), creates and tests npm packages, ZIP, and NuGet pack
 3. **build-vscode** (5-8 min) → Builds self-contained VSIX (bundles exes), publishes to VS Code Marketplace
 4. **build-mcpb** (3-5 min) → Builds Claude Desktop bundle
 5. **build-agent-skills** (1-2 min) → Builds agent skills ZIP package (for direct skill extraction via `npx skills add`)
 6. **create-tag** → Creates git tag (waits for all builds)
-7. **publish-mcp-registry** (10-30 min) → Waits for NuGet propagation, updates MCP Registry
-8. **publish** → Publishes to NuGet.org and VS Code Marketplace
+7. **publish-mcp-registry** (10-30 min) → Waits for NuGet and npm propagation, updates MCP Registry
+8. **publish** → Publishes to npm, NuGet.org, and VS Code Marketplace
 9. **create-release** → Creates GitHub Release with all artifacts (release notes generated from compiled changesets), then creates auto-PR to commit the updated CHANGELOG.md
 10. **publish-plugins.yml** (follow-on workflow) → Sync-gated republish of `excel-mcp` and `excel-cli` to `sbroenne/mcp-server-excel-plugins` when plugin-facing install artifacts changed
 
@@ -106,6 +108,7 @@ The main release workflow runs automatically (10 jobs), then the plugin publish 
 After workflow completes:
 
 - [ ] GitHub Release created with all artifacts (MCP Server ZIP, CLI ZIP, VSIX, MCPB, skills ZIP)
+- [ ] npm launcher and Windows runtime packages are available at the release version
 - [ ] NuGet packages available on NuGet.org (may take 10-30 min for full propagation)
 - [ ] VS Code Marketplace updated (verify self-contained extension works without .NET)
 - [ ] MCP Registry updated
@@ -239,14 +242,15 @@ Configure these GitHub repository secrets and variables:
 | Type | Name | Purpose |
 |------|------|---------|
 | Secret | `NUGET_USER` | NuGet.org username (for OIDC trusted publishing) |
+| Secret | `NPM_TOKEN` | Granular npm publish token for the first package publish and fallback authentication |
 | Secret | `VSCE_TOKEN` | VS Code Marketplace PAT |
 | Secret | `APPINSIGHTS_CONNECTION_STRING` | Application Insights (optional telemetry) |
 | Secret | `PLUGINS_REPO_TOKEN` | Cross-repo PAT (`public_repo`) or app token (`contents:write`) for publishing plugins to `sbroenne/mcp-server-excel-plugins` |
 
 > **Notes:**
 > - NuGet uses OIDC trusted publishing (no API key needed). The `NUGET_USER` is just the NuGet.org profile name for OIDC token exchange.
+> - npm trusted publishing cannot bootstrap a new package. Use `NPM_TOKEN` for the first release, configure `release.yml` as the trusted publisher for both npm packages, then remove the token; npm automatically prefers OIDC and generates provenance.
 > - The follow-on plugin publish workflow uses a stored cross-repo token (`PLUGINS_REPO_TOKEN`) with write access to the published plugin repo. A PAT needs `public_repo`; an app token needs `contents:write`.
-> - **No npm tokens required** — agent skills are distributed through GitHub Release ZIP and direct skill extraction (`npx skills add`), not npm registry.
 
 ## Troubleshooting
 
@@ -254,6 +258,12 @@ Configure these GitHub repository secrets and variables:
 
 - Verify `NUGET_USER` secret is set to your NuGet.org profile name (not email)
 - Check NuGet.org trusted publishers are configured for OIDC
+
+### npm Publishing Fails
+
+- For the first release, verify `NPM_TOKEN` can publish public packages under the `@sbroenne` scope
+- After the first release, configure both packages to trust the `release.yml` GitHub Actions workflow
+- Confirm the workflow has `id-token: write` and uses npm 11 or later
 
 ### VS Code Marketplace Fails
 
@@ -288,5 +298,5 @@ Configure these GitHub repository secrets and variables:
 4. **Reduced coordination** — no need to remember multiple tag patterns
 5. **Complete changelog** — all changes documented in one place, auto-updated via PR
 6. **Faster releases** — parallel builds for independent components
-7. **Dual distribution** — standalone exe (primary, no .NET needed) + NuGet (secondary, for .NET users)
+7. **Multiple distribution choices** — npm and standalone exe (primary, no .NET needed) + NuGet (secondary, for .NET users)
 8. **Self-contained VS Code** — extension bundles everything, no external dependencies

--- a/npm-packages/mcp-server-excel-win32-x64/README.md
+++ b/npm-packages/mcp-server-excel-win32-x64/README.md
@@ -1,0 +1,6 @@
+# ExcelMcp Windows x64 Runtime
+
+This platform package contains the self-contained Windows x64 executable used by
+`@sbroenne/mcp-server-excel`. Install the launcher package instead of depending
+on this package directly. Windows Arm64 runs the executable through the
+operating system's x64 emulation.

--- a/npm-packages/mcp-server-excel-win32-x64/package.json
+++ b/npm-packages/mcp-server-excel-win32-x64/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@sbroenne/mcp-server-excel-win32-x64",
+  "version": "0.0.0-development",
+  "description": "Windows x64 runtime for the ExcelMcp MCP server.",
+  "license": "MIT",
+  "main": "mcp-excel.exe",
+  "files": [
+    "mcp-excel.exe"
+  ],
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "preferUnplugged": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sbroenne/mcp-server-excel",
+    "directory": "npm-packages/mcp-server-excel-win32-x64"
+  },
+  "homepage": "https://excelmcpserver.dev/",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/npm-packages/mcp-server-excel/README.md
+++ b/npm-packages/mcp-server-excel/README.md
@@ -1,0 +1,17 @@
+# ExcelMcp MCP Server
+
+Run the self-contained ExcelMcp server through npm:
+
+```powershell
+npx -y @sbroenne/mcp-server-excel
+```
+
+The package is Windows-only and requires Microsoft Excel 2016 or later. It does
+not require the .NET SDK or a separately installed .NET runtime.
+
+The Node.js entry point only launches the packaged .NET server. MCP tools and
+Excel automation continue to run in the existing ExcelMcp implementation.
+
+[Documentation](https://excelmcpserver.dev/installation-mcp-server/) |
+[Source](https://github.com/sbroenne/mcp-server-excel) |
+[Issues](https://github.com/sbroenne/mcp-server-excel/issues)

--- a/npm-packages/mcp-server-excel/bin/mcp-excel.js
+++ b/npm-packages/mcp-server-excel/bin/mcp-excel.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { main } from '../lib/launcher.js';
+
+const exitCode = main();
+if (exitCode !== undefined) {
+  process.exitCode = exitCode;
+}

--- a/npm-packages/mcp-server-excel/lib/launcher.js
+++ b/npm-packages/mcp-server-excel/lib/launcher.js
@@ -1,0 +1,60 @@
+import { createRequire } from 'node:module';
+
+import { foregroundChild } from 'foreground-child';
+
+const runtimePackageName = '@sbroenne/mcp-server-excel-win32-x64';
+const require = createRequire(import.meta.url);
+
+export function resolveRuntime({
+  platform = process.platform,
+  arch = process.arch,
+  resolvePackage = packageName => require.resolve(packageName)
+} = {}) {
+  if (platform !== 'win32') {
+    throw new Error('ExcelMcp is Windows only.');
+  }
+
+  if (arch !== 'x64' && arch !== 'arm64') {
+    throw new Error(`ExcelMcp requires Windows x64 or Arm64; this Node.js process is ${arch}.`);
+  }
+
+  try {
+    return resolvePackage(runtimePackageName);
+  } catch (cause) {
+    throw new Error(
+      `Could not find ${runtimePackageName}. Reinstall @sbroenne/mcp-server-excel ` +
+        'with optional dependencies enabled; do not use --omit=optional.',
+      { cause }
+    );
+  }
+}
+
+export function launch({
+  args = process.argv.slice(2),
+  platform = process.platform,
+  arch = process.arch,
+  resolvePackage,
+  foreground = foregroundChild
+} = {}) {
+  const executable = resolveRuntime({ platform, arch, resolvePackage });
+
+  return foreground(executable, args, {
+    shell: false,
+    stdio: 'inherit',
+    windowsHide: true
+  });
+}
+
+export function main({
+  launchProcess = launch,
+  stderr = process.stderr
+} = {}) {
+  try {
+    launchProcess();
+    return undefined;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr.write(`excel-mcp: ${message}\n`);
+    return 1;
+  }
+}

--- a/npm-packages/mcp-server-excel/package-lock.json
+++ b/npm-packages/mcp-server-excel/package-lock.json
@@ -1,0 +1,69 @@
+{
+  "name": "@sbroenne/mcp-server-excel",
+  "version": "0.0.0-development",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sbroenne/mcp-server-excel",
+      "version": "0.0.0-development",
+      "license": "MIT",
+      "dependencies": {
+        "foreground-child": "^4.0.3"
+      },
+      "bin": {
+        "mcp-excel": "bin/mcp-excel.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@sbroenne/mcp-server-excel-win32-x64": "file:../mcp-server-excel-win32-x64"
+      }
+    },
+    "../mcp-server-excel-win32-x64": {
+      "name": "@sbroenne/mcp-server-excel-win32-x64",
+      "version": "0.0.0-development",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sbroenne/mcp-server-excel-win32-x64": {
+      "resolved": "../mcp-server-excel-win32-x64",
+      "link": true
+    },
+    "node_modules/foreground-child": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-4.0.3.tgz",
+      "integrity": "sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    }
+  }
+}

--- a/npm-packages/mcp-server-excel/package.json
+++ b/npm-packages/mcp-server-excel/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@sbroenne/mcp-server-excel",
+  "version": "0.0.0-development",
+  "description": "Excel automation MCP server for Windows, distributed through npm.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "mcp-excel": "bin/mcp-excel.js"
+  },
+  "files": [
+    "bin",
+    "lib"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sbroenne/mcp-server-excel",
+    "directory": "npm-packages/mcp-server-excel"
+  },
+  "homepage": "https://excelmcpserver.dev/",
+  "bugs": {
+    "url": "https://github.com/sbroenne/mcp-server-excel/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "excel",
+    "windows",
+    "automation"
+  ],
+  "mcpName": "io.github.sbroenne/mcp-server-excel",
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "foreground-child": "^4.0.3"
+  },
+  "optionalDependencies": {
+    "@sbroenne/mcp-server-excel-win32-x64": "file:../mcp-server-excel-win32-x64"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/npm-packages/mcp-server-excel/scripts/verify-runtime.mjs
+++ b/npm-packages/mcp-server-excel/scripts/verify-runtime.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+
+const launcherPath = process.argv[2];
+if (!launcherPath) {
+  throw new Error('Usage: node verify-runtime.mjs <launcher-path>');
+}
+
+const child = spawn(process.execPath, [launcherPath], {
+  stdio: ['pipe', 'pipe', 'pipe'],
+  windowsHide: true
+});
+
+let stdout = '';
+let stderr = '';
+let initialized;
+let tools;
+
+const timeout = setTimeout(() => {
+  child.kill();
+  throw new Error(`Timed out waiting for MCP responses.\nstdout: ${stdout}\nstderr: ${stderr}`);
+}, 30_000);
+
+child.stderr.on('data', chunk => {
+  stderr += chunk.toString('utf8');
+});
+
+child.stdout.on('data', chunk => {
+  stdout += chunk.toString('utf8');
+  const lines = stdout.split(/\r?\n/);
+  stdout = lines.pop() ?? '';
+
+  for (const line of lines.filter(value => value.trim())) {
+    const message = JSON.parse(line);
+    if (message.id === 1) {
+      initialized = message;
+      child.stdin.write(
+        `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`
+      );
+      child.stdin.write(
+        `${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })}\n`
+      );
+    } else if (message.id === 2) {
+      tools = message;
+      child.stdin.end();
+    }
+  }
+});
+
+child.stdin.write(
+  `${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: {
+        name: 'excel-mcp-npm-smoke-test',
+        version: '1.0.0'
+      }
+    }
+  })}\n`
+);
+
+const exitCode = await new Promise((resolve, reject) => {
+  child.once('error', reject);
+  child.once('close', resolve);
+});
+clearTimeout(timeout);
+
+assert.equal(exitCode, 0, `Launcher exited with code ${exitCode}.\nstderr: ${stderr}`);
+assert.equal(initialized?.result?.serverInfo?.name, 'excel-mcp');
+assert.ok(Array.isArray(tools?.result?.tools));
+assert.ok(tools.result.tools.length > 0);
+
+console.log(
+  `MCP handshake succeeded with ${tools.result.tools.length} tools ` +
+    `(server ${initialized.result.serverInfo.version}).`
+);

--- a/npm-packages/mcp-server-excel/test/launcher.test.js
+++ b/npm-packages/mcp-server-excel/test/launcher.test.js
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { launch, main, resolveRuntime } from '../lib/launcher.js';
+
+test('resolveRuntime rejects unsupported operating systems', () => {
+  assert.throws(
+    () => resolveRuntime({ platform: 'linux', arch: 'x64' }),
+    /Windows only/
+  );
+});
+
+test('resolveRuntime supports Windows Arm64 through x64 emulation', () => {
+  assert.equal(
+    resolveRuntime({
+      platform: 'win32',
+      arch: 'arm64',
+      resolvePackage: () => 'C:\\runtime\\mcp-excel.exe'
+    }),
+    'C:\\runtime\\mcp-excel.exe'
+  );
+});
+
+test('resolveRuntime rejects unsupported Windows architectures', () => {
+  assert.throws(
+    () => resolveRuntime({ platform: 'win32', arch: 'ia32' }),
+    /x64 or Arm64/
+  );
+});
+
+test('resolveRuntime explains how to restore an omitted binary package', () => {
+  assert.throws(
+    () =>
+      resolveRuntime({
+        platform: 'win32',
+        arch: 'x64',
+        resolvePackage: () => {
+          throw new Error('package not found');
+        }
+      }),
+    /optional dependencies enabled/
+  );
+});
+
+test('launch forwards arguments and foreground process options', () => {
+  const expectedChild = {};
+  let invocation;
+
+  const actualChild = launch({
+    platform: 'win32',
+    arch: 'x64',
+    args: ['--version'],
+    resolvePackage: () => 'C:\\runtime\\mcp-excel.exe',
+    foreground: (...parameters) => {
+      invocation = parameters;
+      return expectedChild;
+    }
+  });
+
+  assert.equal(actualChild, expectedChild);
+  assert.deepEqual(invocation, [
+    'C:\\runtime\\mcp-excel.exe',
+    ['--version'],
+    {
+      shell: false,
+      stdio: 'inherit',
+      windowsHide: true
+    }
+  ]);
+});
+
+test('main reports launcher failures only on stderr', () => {
+  let stderr = '';
+
+  const exitCode = main({
+    launchProcess: () => {
+      throw new Error('runtime unavailable');
+    },
+    stderr: {
+      write: value => {
+        stderr += value;
+      }
+    }
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(stderr, 'excel-mcp: runtime unavailable\n');
+});
+
+test('main leaves process lifetime to foreground-child after launch', () => {
+  const child = {};
+
+  const exitCode = main({
+    launchProcess: () => child,
+    stderr: {
+      write: () => assert.fail('stderr should not be written')
+    }
+  });
+
+  assert.equal(exitCode, undefined);
+});

--- a/scripts/Build-NpmPackages.ps1
+++ b/scripts/Build-NpmPackages.ps1
@@ -1,0 +1,160 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Version,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RuntimeExecutable,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$OutputDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$launcherSource = Join-Path $repoRoot 'npm-packages\mcp-server-excel'
+$runtimeSource = Join-Path $repoRoot 'npm-packages\mcp-server-excel-win32-x64'
+$licensePath = Join-Path $repoRoot 'LICENSE'
+$resolvedRuntime = (Resolve-Path -LiteralPath $RuntimeExecutable).Path
+$resolvedOutput = [IO.Path]::GetFullPath($OutputDirectory)
+$stagingRoot = Join-Path ([IO.Path]::GetTempPath()) "ExcelMcpNpm-$([Guid]::NewGuid().ToString('N'))"
+$launcherStage = Join-Path $stagingRoot 'mcp-server-excel'
+$runtimeStage = Join-Path $stagingRoot 'mcp-server-excel-win32-x64'
+
+function Copy-PackageSource {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Source,
+
+        [Parameter(Mandatory)]
+        [string]$Destination,
+
+        [Parameter(Mandatory)]
+        [string[]]$Entries
+    )
+
+    New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+    foreach ($entry in $Entries) {
+        Copy-Item -LiteralPath (Join-Path $Source $entry) -Destination $Destination -Recurse
+    }
+    Copy-Item -LiteralPath $licensePath -Destination $Destination
+}
+
+function Write-PackageManifest {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [scriptblock]$Update
+    )
+
+    $manifest = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    & $Update $manifest
+    $json = ($manifest | ConvertTo-Json -Depth 20) -replace "`r?`n", "`n"
+    Set-Content -LiteralPath $Path -Value $json -NoNewline
+}
+
+function New-NpmTarball {
+    param(
+        [Parameter(Mandatory)]
+        [string]$PackageDirectory,
+
+        [Parameter(Mandatory)]
+        [string[]]$RequiredFiles
+    )
+
+    $manifest = Get-Content -LiteralPath (Join-Path $PackageDirectory 'package.json') -Raw | ConvertFrom-Json
+    $archiveName = "$(($manifest.name.TrimStart('@')) -replace '/', '-')-$($manifest.version).tgz"
+    $archivePath = Join-Path $resolvedOutput $archiveName
+    $inspectionDirectory = Join-Path $stagingRoot "inspect-$([Guid]::NewGuid().ToString('N'))"
+
+    if (Test-Path -LiteralPath $archivePath) {
+        Remove-Item -LiteralPath $archivePath -Force
+    }
+
+    & npm.cmd pack $PackageDirectory --pack-destination $resolvedOutput --silent | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "npm pack failed for '$PackageDirectory' with exit code $LASTEXITCODE."
+    }
+
+    if (-not (Test-Path -LiteralPath $archivePath -PathType Leaf)) {
+        throw "npm pack did not create the expected archive '$archivePath'."
+    }
+
+    New-Item -ItemType Directory -Path $inspectionDirectory -Force | Out-Null
+    try {
+        & tar -xf $archivePath -C $inspectionDirectory
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect packed npm package '$archiveName'."
+        }
+
+        foreach ($requiredFile in $RequiredFiles) {
+            $packedPath = Join-Path (Join-Path $inspectionDirectory 'package') $requiredFile
+            if (-not (Test-Path -LiteralPath $packedPath -PathType Leaf)) {
+                throw "Packed npm package '$archiveName' is missing required file '$requiredFile'."
+            }
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $inspectionDirectory -Recurse -Force
+    }
+
+    return $archivePath
+}
+
+if (-not (Test-Path -LiteralPath $launcherSource -PathType Container) -or
+    -not (Test-Path -LiteralPath $runtimeSource -PathType Container)) {
+    throw 'npm package source directories are missing.'
+}
+
+if ([IO.Path]::GetExtension($resolvedRuntime) -ne '.exe') {
+    throw "Runtime executable must be an .exe file: $resolvedRuntime"
+}
+
+New-Item -ItemType Directory -Path $resolvedOutput -Force | Out-Null
+New-Item -ItemType Directory -Path $stagingRoot -Force | Out-Null
+
+try {
+    Copy-PackageSource `
+        -Source $launcherSource `
+        -Destination $launcherStage `
+        -Entries @('package.json', 'README.md', 'bin', 'lib')
+    Copy-PackageSource `
+        -Source $runtimeSource `
+        -Destination $runtimeStage `
+        -Entries @('package.json', 'README.md')
+    Copy-Item -LiteralPath $resolvedRuntime -Destination (Join-Path $runtimeStage 'mcp-excel.exe')
+
+    Write-PackageManifest -Path (Join-Path $runtimeStage 'package.json') -Update {
+        param($manifest)
+        $manifest.version = $Version
+    }
+    Write-PackageManifest -Path (Join-Path $launcherStage 'package.json') -Update {
+        param($manifest)
+        $manifest.version = $Version
+        $manifest.optionalDependencies.'@sbroenne/mcp-server-excel-win32-x64' = $Version
+    }
+
+    $runtimeTarball = New-NpmTarball `
+        -PackageDirectory $runtimeStage `
+        -RequiredFiles @('mcp-excel.exe', 'package.json')
+    $launcherTarball = New-NpmTarball `
+        -PackageDirectory $launcherStage `
+        -RequiredFiles @('bin/mcp-excel.js', 'lib/launcher.js', 'package.json')
+
+    [pscustomobject]@{
+        LauncherPackage = $launcherTarball
+        RuntimePackage = $runtimeTarball
+    } | ConvertTo-Json -Compress
+}
+finally {
+    if (Test-Path -LiteralPath $stagingRoot) {
+        Remove-Item -LiteralPath $stagingRoot -Recurse -Force
+    }
+}

--- a/scripts/Test-NpmPackages.ps1
+++ b/scripts/Test-NpmPackages.ps1
@@ -1,0 +1,68 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$LauncherPackage,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RuntimePackage
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$smokeScript = Join-Path $repoRoot 'npm-packages\mcp-server-excel\scripts\verify-runtime.mjs'
+$resolvedLauncher = (Resolve-Path -LiteralPath $LauncherPackage).Path
+$resolvedRuntime = (Resolve-Path -LiteralPath $RuntimePackage).Path
+$sandbox = Join-Path ([IO.Path]::GetTempPath()) "ExcelMcpNpmTest-$([Guid]::NewGuid().ToString('N'))"
+
+function Remove-Sandbox {
+    for ($attempt = 1; $attempt -le 20; $attempt++) {
+        try {
+            Remove-Item -LiteralPath $sandbox -Recurse -Force
+            return
+        }
+        catch {
+            if ($attempt -eq 20) {
+                throw
+            }
+
+            Start-Sleep -Milliseconds 250
+        }
+    }
+}
+
+New-Item -ItemType Directory -Path $sandbox -Force | Out-Null
+
+try {
+    & npm.cmd install `
+        --prefix $sandbox `
+        --ignore-scripts `
+        --no-audit `
+        --no-fund `
+        $resolvedRuntime `
+        $resolvedLauncher
+    if ($LASTEXITCODE -ne 0) {
+        throw "npm package installation failed with exit code $LASTEXITCODE."
+    }
+
+    $launcherScript = Join-Path $sandbox 'node_modules\@sbroenne\mcp-server-excel\bin\mcp-excel.js'
+    $versionOutput = & node.exe $launcherScript --version 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        throw "npm launcher --version failed with exit code $LASTEXITCODE. $versionOutput"
+    }
+    Write-Output ($versionOutput.Trim())
+
+    $smokeOutput = & node.exe $smokeScript $launcherScript 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        throw "npm launcher MCP handshake failed with exit code $LASTEXITCODE. $smokeOutput"
+    }
+    Write-Output ($smokeOutput.Trim())
+}
+finally {
+    if (Test-Path -LiteralPath $sandbox) {
+        Remove-Sandbox
+    }
+}

--- a/scripts/Update-McpRegistryMetadata.ps1
+++ b/scripts/Update-McpRegistryMetadata.ps1
@@ -10,7 +10,10 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$mcpServerPackageId = 'Sbroenne.ExcelMcp.McpServer'
+$mcpServerPackageIds = @(
+    'Sbroenne.ExcelMcp.McpServer',
+    '@sbroenne/mcp-server-excel'
+)
 
 if (-not (Test-Path -LiteralPath $ServerJsonPath -PathType Leaf)) {
     throw "MCP Registry metadata file was not found: $ServerJsonPath"
@@ -25,36 +28,43 @@ if ($null -eq $server.PSObject.Properties['packages']) {
     throw "MCP Registry metadata must contain a 'packages' array."
 }
 
-$mcpPackages = @(
-    $server.packages | Where-Object {
-        $_.identifier -eq $mcpServerPackageId
-    }
-)
-
-if ($mcpPackages.Count -ne 1) {
-    throw "MCP Registry metadata must contain exactly one package with identifier '$mcpServerPackageId'."
-}
-
-$mcpPackage = $mcpPackages[0]
-if ($null -eq $mcpPackage.PSObject.Properties['version']) {
-    throw "MCP Registry package '$mcpServerPackageId' must contain a 'version' property."
-}
-
 $server.version = $Version
-$mcpPackage.version = $Version
+foreach ($packageId in $mcpServerPackageIds) {
+    $matchingPackages = @(
+        $server.packages | Where-Object {
+            $_.identifier -eq $packageId
+        }
+    )
+
+    if ($matchingPackages.Count -ne 1) {
+        throw "MCP Registry metadata must contain exactly one package with identifier '$packageId'."
+    }
+
+    $package = $matchingPackages[0]
+    if ($null -eq $package.PSObject.Properties['version']) {
+        throw "MCP Registry package '$packageId' must contain a 'version' property."
+    }
+
+    $package.version = $Version
+}
+
 $server | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $ServerJsonPath -NoNewline
 
 $updatedServer = Get-Content -LiteralPath $ServerJsonPath -Raw | ConvertFrom-Json
-$updatedMcpPackages = @(
-    $updatedServer.packages | Where-Object {
-        $_.identifier -eq $mcpServerPackageId
-    }
-)
-
-if ($updatedServer.version -ne $Version -or
-    $updatedMcpPackages.Count -ne 1 -or
-    $updatedMcpPackages[0].version -ne $Version) {
+if ($updatedServer.version -ne $Version) {
     throw "MCP Registry metadata validation failed after stamping version '$Version'."
+}
+
+foreach ($packageId in $mcpServerPackageIds) {
+    $updatedPackages = @(
+        $updatedServer.packages | Where-Object {
+            $_.identifier -eq $packageId
+        }
+    )
+
+    if ($updatedPackages.Count -ne 1 -or $updatedPackages[0].version -ne $Version) {
+        throw "MCP Registry metadata validation failed for package '$packageId' after stamping version '$Version'."
+    }
 }
 
 Write-Output "Updated MCP Registry metadata to version $Version."

--- a/scripts/pre-commit.ps1
+++ b/scripts/pre-commit.ps1
@@ -380,14 +380,16 @@ Invoke-ValidationStep `
 Invoke-ValidationStep `
     -Heading "Building MCP Server release deliverables..." `
     -FailureSummary "MCP Server release deliverable validation failed!" `
-    -SuccessSummary "MCP Server release deliverables passed - NuGet package and standalone ZIP were built locally" `
+    -SuccessSummary "MCP Server release deliverables passed - npm, NuGet, and standalone ZIP packages were built locally" `
     -Action {
         $mcpNupkgDir = Join-Path $preCommitArtifactsDir "mcp-server-nupkg"
+        $mcpNpmDir = Join-Path $preCommitArtifactsDir "mcp-server-npm"
         $mcpPublishDir = Join-Path $preCommitArtifactsDir "mcp-server-publish"
         $mcpReleaseDir = Join-Path $preCommitArtifactsDir "mcp-server-release"
         $mcpZipPath = Join-Path $preCommitArtifactsDir "ExcelMcp-MCP-Server-$version-windows.zip"
 
         Reset-Directory -Path $mcpNupkgDir
+        Reset-Directory -Path $mcpNpmDir
         Reset-Directory -Path $mcpPublishDir
         Reset-Directory -Path $mcpReleaseDir
 
@@ -410,6 +412,16 @@ Invoke-ValidationStep `
 
             Rename-Item $publishedExe "mcp-excel.exe"
 
+            npm ci --prefix npm-packages\mcp-server-excel --ignore-scripts
+            npm test --prefix npm-packages\mcp-server-excel
+            .\scripts\Build-NpmPackages.ps1 `
+                -Version $version `
+                -RuntimeExecutable $renamedExe `
+                -OutputDirectory $mcpNpmDir
+            .\scripts\Test-NpmPackages.ps1 `
+                -LauncherPackage (Join-Path $mcpNpmDir "sbroenne-mcp-server-excel-$version.tgz") `
+                -RuntimePackage (Join-Path $mcpNpmDir "sbroenne-mcp-server-excel-win32-x64-$version.tgz")
+
             Copy-Item (Join-Path $mcpPublishDir "mcp-excel.exe") $mcpReleaseDir
             Copy-Item "README.md" $mcpReleaseDir
             Copy-Item "LICENSE" $mcpReleaseDir
@@ -422,6 +434,10 @@ Invoke-ValidationStep `
 
             if (-not (Get-ChildItem $mcpNupkgDir -Filter "*.nupkg" -ErrorAction Stop)) {
                 throw "MCP Server NuGet package was not created."
+            }
+
+            if ((Get-ChildItem $mcpNpmDir -Filter "*.tgz" -ErrorAction Stop).Count -ne 2) {
+                throw "MCP Server npm packages were not created."
             }
 
             if (-not (Test-Path $mcpZipPath)) {

--- a/src/ExcelMcp.McpServer/.mcp/server.json
+++ b/src/ExcelMcp.McpServer/.mcp/server.json
@@ -15,6 +15,16 @@
       },
       "packageArguments": [],
       "environmentVariables": []
+    },
+    {
+      "registryType": "npm",
+      "identifier": "@sbroenne/mcp-server-excel",
+      "version": "1.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [],
+      "environmentVariables": []
     }
   ],
   "repository": {

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -5,6 +5,7 @@ mcp-name: io.github.sbroenne/mcp-server-excel
 
 [![GitHub Release](https://img.shields.io/github/v/release/sbroenne/mcp-server-excel)](https://github.com/sbroenne/mcp-server-excel/releases/latest)
 [![GitHub Downloads](https://img.shields.io/github/downloads/sbroenne/mcp-server-excel/total?label=Downloads)](https://github.com/sbroenne/mcp-server-excel/releases)
+[![npm](https://img.shields.io/npm/v/%40sbroenne%2Fmcp-server-excel)](https://www.npmjs.com/package/@sbroenne/mcp-server-excel)
 [![NuGet](https://img.shields.io/nuget/v/Sbroenne.ExcelMcp.McpServer.svg)](https://www.nuget.org/packages/Sbroenne.ExcelMcp.McpServer)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-blue.svg)](https://github.com/sbroenne/mcp-server-excel)
 
@@ -27,20 +28,25 @@ Unlike file-parser libraries that rewrite `.xlsx` files directly, ExcelMcp drive
 **Quick Setup Options:**
 
 1. **VS Code Extension** - [One-click install](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp) for GitHub Copilot
-2. **Standalone exe** - Works with Claude Desktop, Cursor, Cline, Windsurf, and other MCP clients
+2. **npm** - Run through `npx` with no .NET installation or manual executable setup
 3. **MCP Registry** - Find us at [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/servers/io.github.sbroenne/mcp-server-excel)
 
 **Manual Installation (All MCP Clients):**
 
-**Primary — Standalone exe (no .NET runtime required):**
+**Primary — npm (no .NET runtime required):**
 
 ```powershell
-# Download from latest release:
-# https://github.com/sbroenne/mcp-server-excel/releases/latest
-# ExcelMcp-MCP-Server-{version}-windows.zip → extract mcp-excel.exe
+npx -y @sbroenne/mcp-server-excel
+```
 
-# Add to PATH, then configure your MCP client:
-# { "command": "mcp-excel" }
+Configure MCP clients with `command: "npx"` and
+`args: ["-y", "@sbroenne/mcp-server-excel"]`.
+
+**Standalone executable:**
+
+```powershell
+# Download ExcelMcp-MCP-Server-{version}-windows.zip from GitHub Releases,
+# extract mcp-excel.exe, and configure the client with { "command": "mcp-excel" }.
 ```
 
 **Secondary — .NET Global Tool (requires .NET 10 runtime):**

--- a/tests/ExcelMcp.SkillGeneration.Tests/ReleaseMetadataScriptTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/ReleaseMetadataScriptTests.cs
@@ -36,9 +36,13 @@ public sealed class ReleaseMetadataScriptTests
             Assert.Equal("9.8.7", root.GetProperty("version").GetString());
 
             var packages = root.GetProperty("packages").EnumerateArray().ToArray();
-            var mcpPackage = Assert.Single(packages, package =>
+            var nugetPackage = Assert.Single(packages, package =>
                 package.GetProperty("identifier").GetString() == "Sbroenne.ExcelMcp.McpServer");
-            Assert.Equal("9.8.7", mcpPackage.GetProperty("version").GetString());
+            Assert.Equal("9.8.7", nugetPackage.GetProperty("version").GetString());
+
+            var npmPackage = Assert.Single(packages, package =>
+                package.GetProperty("identifier").GetString() == "@sbroenne/mcp-server-excel");
+            Assert.Equal("9.8.7", npmPackage.GetProperty("version").GetString());
         }
         finally
         {
@@ -61,6 +65,43 @@ public sealed class ReleaseMetadataScriptTests
 
             Assert.NotEqual(0, result.ExitCode);
             Assert.Contains("exactly one", result.CombinedOutput, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "ReleaseMetadata")]
+    public async Task UpdateMetadata_RejectsMissingNpmPackage()
+    {
+        var sandbox = CreateSandbox();
+        try
+        {
+            var metadataPath = Path.Combine(sandbox, "server.json");
+            await File.WriteAllTextAsync(
+                metadataPath,
+                """
+                {
+                  "version": "1.0.0",
+                  "packages": [
+                    {
+                      "identifier": "Sbroenne.ExcelMcp.McpServer",
+                      "version": "1.0.0"
+                    }
+                  ]
+                }
+                """);
+
+            var result = await RunUpdaterAsync(metadataPath, "9.8.7");
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Contains(
+                "@sbroenne/mcp-server-excel",
+                result.CombinedOutput,
+                StringComparison.Ordinal);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- add `@sbroenne/mcp-server-excel`, a small Node launcher that starts the existing self-contained .NET MCP server through `foreground-child`
- add `@sbroenne/mcp-server-excel-win32-x64`, an npm platform package containing the release executable, with Windows Arm64 supported through x64 emulation
- build, smoke-test, publish, and register both packages in the release workflow while preserving the existing standalone, MCPB, VSIX, plugin, and NuGet distributions
- make `npx -y @sbroenne/mcp-server-excel` the recommended manual MCP setup and document first-publication/trusted-publishing requirements

## Validation

- 7 Node launcher tests
- clean tarball install, `--version`, MCP initialize, and `tools/list` against the current self-contained executable
- package sizes: 2.2 KB launcher and 67.2 MB compressed runtime
- release metadata tests, full Release solution build, repository audit scripts, strict MkDocs build and site audit
- full pre-commit suite, including Excel-dependent CLI and MCP end-to-end tests and all release packaging gates

## Release setup

The first npm publication requires the `NPM_TOKEN` bootstrap secret because trusted publishers can only be configured after the scoped packages exist. After that release, configure both npm packages to trust `.github/workflows/release.yml`; npm OIDC then takes precedence and publishes provenance automatically.