### PR TITLE
docs: promote Windows MCP Server

### DIFF
--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -58,6 +58,10 @@ hide:
     Check out [PowerPoint MCP Server](https://powerpointmcpserver.dev/) — the
     sister project, built the same way.
 
+!!! tip "Also automating Windows apps and browsers?"
+    Check out [Windows MCP Server](https://windowsmcpserver.dev/) — automate
+    Windows apps and browsers from your AI assistant.
+
 ## Key features
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
## Summary
- add a homepage tip for Windows MCP Server
- keep the existing PowerPoint MCP Server promotion unchanged

## Validation
- strict MkDocs build
- site audit
- deploy path check