### PR TITLE
Fix MCP screenshot routing and telemetry success tracking

### DIFF
--- a/.changeset/bright-screenshots-report.md
+++ b/.changeset/bright-screenshots-report.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+Fix worksheet screenshots failing when using `capture-sheet`, and report failed MCP tool operations accurately in privacy-safe usage telemetry.

--- a/src/ExcelMcp.McpServer/Tools/ExcelScreenshotTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelScreenshotTool.cs
@@ -50,13 +50,13 @@ public static class ExcelScreenshotTool
         var jsonResponse = ExcelToolsBase.ExecuteToolAction(
             "screenshot",
             ServiceRegistry.Screenshot.ToActionString(action),
-            () => ServiceRegistry.Screenshot.RouteAction(
+            () => RouteScreenshotAction(
                 action,
                 session_id,
-                ExcelToolsBase.ForwardToServiceFunc,
-                sheetName: sheet_name,
-                rangeAddress: range_address,
-                quality: quality
+                sheet_name,
+                range_address,
+                quality,
+                ExcelToolsBase.ForwardToServiceFunc
             ));
 
         // Parse the JSON response to extract image data
@@ -98,5 +98,22 @@ public static class ExcelScreenshotTool
                 Content = [new TextContentBlock { Text = jsonResponse }]
             };
         }
+    }
+
+    internal static string RouteScreenshotAction(
+        ScreenshotAction action,
+        string sessionId,
+        string? sheetName,
+        string rangeAddress,
+        ScreenshotQuality quality,
+        Func<string, string, object?, string> forwardToService)
+    {
+        return ServiceRegistry.Screenshot.RouteAction(
+            action,
+            sessionId,
+            forwardToService,
+            sheetName: sheetName,
+            rangeAddress: action == ScreenshotAction.CaptureRange ? rangeAddress : null,
+            quality: quality);
     }
 }

--- a/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
@@ -265,7 +265,8 @@ public static class ExcelToolsBase
         try
         {
             using var document = JsonDocument.Parse(response);
-            return !document.RootElement.TryGetProperty("success", out var success)
+            return document.RootElement.ValueKind != JsonValueKind.Object
+                || !document.RootElement.TryGetProperty("success", out var success)
                 || success.ValueKind != JsonValueKind.False;
         }
         catch (JsonException)
@@ -397,5 +398,4 @@ public static class ExcelToolsBase
         }, JsonOptions);
     }
 }
-
 

--- a/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
@@ -271,7 +271,7 @@ public static class ExcelToolsBase
         }
         catch (JsonException)
         {
-            return true;
+            return false;
         }
     }
 
@@ -398,4 +398,3 @@ public static class ExcelToolsBase
         }, JsonOptions);
     }
 }
-

--- a/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
@@ -200,6 +200,21 @@ public static class ExcelToolsBase
         string actionName,
         string? path,
         Func<string> operation,
+        Func<Exception, string?>? customHandler = null) =>
+        ExecuteToolAction(
+            toolName,
+            actionName,
+            path,
+            operation,
+            ExcelMcpTelemetry.TrackToolInvocation,
+            customHandler);
+
+    internal static string ExecuteToolAction(
+        string toolName,
+        string actionName,
+        string? path,
+        Func<string> operation,
+        Action<string, string, long, bool, string?> trackInvocation,
         Func<Exception, string?>? customHandler = null)
     {
         var stopwatch = Stopwatch.StartNew();
@@ -208,7 +223,7 @@ public static class ExcelToolsBase
         try
         {
             var result = operation();
-            success = true;
+            success = IsSuccessfulToolResponse(result);
             return result;
         }
         catch (Exception ex)
@@ -241,7 +256,21 @@ public static class ExcelToolsBase
         finally
         {
             stopwatch.Stop();
-            ExcelMcpTelemetry.TrackToolInvocation(toolName, actionName, stopwatch.ElapsedMilliseconds, success, path);
+            trackInvocation(toolName, actionName, stopwatch.ElapsedMilliseconds, success, path);
+        }
+    }
+
+    private static bool IsSuccessfulToolResponse(string response)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            return !document.RootElement.TryGetProperty("success", out var success)
+                || success.ValueKind != JsonValueKind.False;
+        }
+        catch (JsonException)
+        {
+            return true;
         }
     }
 
@@ -368,6 +397,5 @@ public static class ExcelToolsBase
         }, JsonOptions);
     }
 }
-
 
 

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ExcelScreenshotToolRoutingTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ExcelScreenshotToolRoutingTests.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.Core.Commands.Screenshot;
+using Sbroenne.ExcelMcp.Generated;
+using Sbroenne.ExcelMcp.McpServer.Tools;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
+
+[Trait("Category", "Unit")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Screenshot")]
+public sealed class ExcelScreenshotToolRoutingTests
+{
+    [Fact]
+    public void RouteScreenshotAction_CaptureSheet_DoesNotSupplyRangeAddress()
+    {
+        string? command = null;
+        object? arguments = null;
+
+        var response = ExcelScreenshotTool.RouteScreenshotAction(
+            ScreenshotAction.CaptureSheet,
+            "session-1",
+            "Summary",
+            "A1:Z30",
+            ScreenshotQuality.Medium,
+            (routedCommand, _, routedArguments) =>
+            {
+                command = routedCommand;
+                arguments = routedArguments;
+                return """{"success":true}""";
+            });
+
+        Assert.Equal("""{"success":true}""", response);
+        Assert.Equal("screenshot.capture-sheet", command);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(arguments, ExcelToolsBase.JsonOptions));
+        Assert.False(json.RootElement.TryGetProperty("rangeAddress", out _));
+    }
+
+    [Fact]
+    public void RouteScreenshotAction_Capture_SuppliesRangeAddress()
+    {
+        string? command = null;
+        object? arguments = null;
+
+        var response = ExcelScreenshotTool.RouteScreenshotAction(
+            ScreenshotAction.CaptureRange,
+            "session-1",
+            "Summary",
+            "B2:C4",
+            ScreenshotQuality.High,
+            (routedCommand, _, routedArguments) =>
+            {
+                command = routedCommand;
+                arguments = routedArguments;
+                return """{"success":true}""";
+            });
+
+        Assert.Equal("""{"success":true}""", response);
+        Assert.Equal("screenshot.capture", command);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(arguments, ExcelToolsBase.JsonOptions));
+        Assert.Equal("B2:C4", json.RootElement.GetProperty("rangeAddress").GetString());
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ExcelToolsBaseTelemetryTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ExcelToolsBaseTelemetryTests.cs
@@ -47,6 +47,24 @@ public sealed class ExcelToolsBaseTelemetryTests
     }
 
     [Fact]
+    public void ExecuteToolAction_PrimitiveJsonResponse_TracksSuccess()
+    {
+        ToolInvocation? invocation = null;
+
+        var response = ExcelToolsBase.ExecuteToolAction(
+            "chart",
+            "get-axis-number-format",
+            path: null,
+            operation: () => "\"General\"",
+            trackInvocation: (tool, action, duration, success, path) =>
+                invocation = new ToolInvocation(tool, action, duration, success, path));
+
+        Assert.Equal("\"General\"", response);
+        Assert.NotNull(invocation);
+        Assert.True(invocation.Success);
+    }
+
+    [Fact]
     public void ExecuteToolAction_ThrownException_TracksFailureWithoutTelemetryDetails()
     {
         ToolInvocation? invocation = null;

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ExcelToolsBaseTelemetryTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ExcelToolsBaseTelemetryTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.McpServer.Tools;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Unit;
+
+[Trait("Category", "Unit")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Telemetry")]
+public sealed class ExcelToolsBaseTelemetryTests
+{
+    [Fact]
+    public void ExecuteToolAction_SuccessResponse_TracksSuccess()
+    {
+        ToolInvocation? invocation = null;
+
+        var response = ExcelToolsBase.ExecuteToolAction(
+            "range",
+            "get-values",
+            path: null,
+            operation: () => """{"success":true,"value":"private workbook content"}""",
+            trackInvocation: (tool, action, duration, success, path) =>
+                invocation = new ToolInvocation(tool, action, duration, success, path));
+
+        Assert.Equal("""{"success":true,"value":"private workbook content"}""", response);
+        Assert.NotNull(invocation);
+        Assert.True(invocation.Success);
+    }
+
+    [Fact]
+    public void ExecuteToolAction_StructuredFailureResponse_TracksFailure()
+    {
+        ToolInvocation? invocation = null;
+
+        var response = ExcelToolsBase.ExecuteToolAction(
+            "range",
+            "get-values",
+            path: null,
+            operation: () => """{"success":false,"errorMessage":"private workbook details"}""",
+            trackInvocation: (tool, action, duration, success, path) =>
+                invocation = new ToolInvocation(tool, action, duration, success, path));
+
+        Assert.Equal("""{"success":false,"errorMessage":"private workbook details"}""", response);
+        Assert.NotNull(invocation);
+        Assert.False(invocation.Success);
+    }
+
+    [Fact]
+    public void ExecuteToolAction_ThrownException_TracksFailureWithoutTelemetryDetails()
+    {
+        ToolInvocation? invocation = null;
+
+        var response = ExcelToolsBase.ExecuteToolAction(
+            "range",
+            "get-values",
+            path: null,
+            operation: () => throw new InvalidOperationException(
+                @"Private failure at C:\Users\Someone\Secret.xlsx on Sheet1!A1"),
+            trackInvocation: (tool, action, duration, success, path) =>
+                invocation = new ToolInvocation(tool, action, duration, success, path));
+
+        using var json = JsonDocument.Parse(response);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.NotNull(invocation);
+        Assert.Equal(new ToolInvocation("range", "get-values", invocation.DurationMs, false, null), invocation);
+    }
+
+    private sealed record ToolInvocation(
+        string Tool,
+        string Action,
+        long DurationMs,
+        bool Success,
+        string? Path);
+}

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ExcelToolsBaseTelemetryTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ExcelToolsBaseTelemetryTests.cs
@@ -65,6 +65,24 @@ public sealed class ExcelToolsBaseTelemetryTests
     }
 
     [Fact]
+    public void ExecuteToolAction_InvalidJsonResponse_TracksFailure()
+    {
+        ToolInvocation? invocation = null;
+
+        var response = ExcelToolsBase.ExecuteToolAction(
+            "chart",
+            "get-axis-number-format",
+            path: null,
+            operation: () => "not-json",
+            trackInvocation: (tool, action, duration, success, path) =>
+                invocation = new ToolInvocation(tool, action, duration, success, path));
+
+        Assert.Equal("not-json", response);
+        Assert.NotNull(invocation);
+        Assert.False(invocation.Success);
+    }
+
+    [Fact]
     public void ExecuteToolAction_ThrownException_TracksFailureWithoutTelemetryDetails()
     {
         ToolInvocation? invocation = null;


### PR DESCRIPTION
## Summary
- stop `screenshot` / `capture-sheet` from forwarding the range-only default that generated validation rejects
- keep `screenshot` / `capture` forwarding its requested range
- record structured `success:false` MCP responses as failed telemetry without adding response or error details
- add focused routing and telemetry regression tests plus a patch changeset

## Validation
- 40 targeted MCP screenshot and telemetry tests
- Release solution build with zero warnings
- repository COM, coverage, MCP/Core, success-flag, documentation-count, and dynamic-cast checks
- `scripts\Test-E2E.ps1` with desktop Excel
- full pre-commit release artifact validation (CLI, MCP Server, VS Code extension, MCPB, and skills)

## Changeset
- [x] Patch changeset added