### PR TITLE
Audit public docs and tool help

### DIFF
--- a/.changeset/clearer-docs-help.md
+++ b/.changeset/clearer-docs-help.md
@@ -1,0 +1,8 @@
+---
+"excelmcp": patch
+---
+
+**Clearer documentation and command help:** `excelcli --help` now presents a
+concise command index, tool descriptions point to valid commands, and public
+documentation accurately explains privacy, packaging, breaking changes, and
+installation workflows.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,14 +13,14 @@ A clear and concise description of what the bug is.
 ## Component
 Which component is this bug related to?
 - [ ] **MCP Server** (Model Context Protocol server for AI assistants - `mcp-excel`)
-- [ ] **CLI** (Command-line interface - `ExcelMcp.exe`)
+- [ ] **CLI** (Command-line interface - `excelcli.exe`)
 - [ ] **Core Library** (Shared functionality)
 - [ ] **Not sure**
 
 ## Command/Usage
 **For CLI:**
-```
-ExcelMcp <command> <arguments>
+```text
+excelcli <command> <action> <arguments>
 ```
 
 **For MCP Server:**
@@ -36,7 +36,7 @@ A clear and concise description of what actually happened.
 
 ## Error Message
 If applicable, paste the full error message:
-```
+```text
 [Error message here]
 ```
 
@@ -45,7 +45,7 @@ If applicable, paste the full error message:
 - **Excel Version**: [e.g. Excel 365, Excel 2019]
 - **ExcelMcp Version**: [e.g. v1.0.0]
 - **.NET Version**: [Run `dotnet --version`]
-- **Installation Method**: [NuGet tool / Binary download / Source build]
+- **Installation Method**: [VS Code extension / MCPB / Copilot plugin / .NET tool / Binary download / Source build]
 - **File Format**: [e.g. .xlsx, .xlsm]
 - **VBA Trust Enabled**: [Yes/No - if VBA-related issue]
 - **AI Assistant** (if using MCP Server): [e.g., GitHub Copilot, Claude Desktop, ChatGPT, etc.]
@@ -60,10 +60,8 @@ If possible, attach a sample Excel file that reproduces the issue (remove sensit
 - [ ] Macro security settings allow programmatic access
 
 ## Steps to Reproduce
-1. Go to '...'  
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+List the exact commands, tool calls, workbook setup, and steps that reproduce
+the problem.
 
 ## Additional Context
 Add any other context about the problem here.

--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -90,7 +90,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 - **Calculation Mode** (3 ops) — Get/set mode, trigger recalculation
 - **Python in Excel** (2 ops) — Set/get Python formulas and results
 - **Screenshot** (2 ops) — Capture ranges/sheets as PNG
-- **File & Session** (6 ops) — Create, open, close, session management
+- **File Operations** (5 ops) — Create, open, close, list, and test files
 - **Window Management** (15 ops) — Show/hide, panes, zoom, display options, positioning
 
 **Complete documentation:** [Full Feature Reference](https://excelmcpserver.dev/features/)

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -62,7 +62,7 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ### Core Operations
 
-- **Power Query** (12 ops) — Create, update, refresh; M code formatting via powerqueryformatter.com
+- **Power Query** (12 ops) — Create, update, refresh; optional remote M code formatting
 - **Data Model/DAX** (20 ops) — Measures, relationships, source metadata, EVALUATE queries
 - **PivotTables** (35 ops) — Fields, grouping, cache options, drill-through, calculations
 - **Excel Tables** (27 ops) — Lifecycle, filtering, sorting, DAX-backed tables
@@ -80,7 +80,7 @@ pwsh -ExecutionPolicy Bypass -File `
 - **What-If Analysis** (8 ops) — Goal Seek, scenarios, summaries, data tables
 - **XML Maps** (6 ops) — Schemas, XPath mapping, secure import/export
 - **Slicers** (8 ops) — Interactive filtering for PivotTables and Tables
-- **Conditional Formatting** (2 ops) — Add rules (cell value, expression), clear
+- **Conditional Formatting** (4 ops) — Add and clear rules; list range or worksheet rules
 - **Named Ranges** (6 ops) — Create, update, delete named ranges
 - **Calculation Mode** (3 ops) — Get/set mode, trigger recalculation (performance optimization)
 - **Python in Excel** (2 ops) — Set/get `=PY()` formulas and results
@@ -89,7 +89,7 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ### File Operations
 
-- **Session Management** (6 ops) — Create, open, close, list sessions
+- **File Operations** (5 ops) — Create, open, close, list, and test files
 - **IRM/AIP Support** — Auto-detects protected files, opens with Excel visible for authentication
 
 **Complete documentation:** [Full Feature Reference](https://excelmcpserver.dev/features/)
@@ -149,12 +149,12 @@ ExcelMcp drives the **actual Excel application** through its official COM API �
 - 👀 **Show Excel Mode** — Watch changes live as AI works
 - 🚀 **First-Run Bootstrap** — Auto-download the newest self-contained MCP runtime when the plugin is first invoked
 
-### Automatic Code Formatting
+### Optional Remote Code Formatting
 
-- **M Code** — Formatted via powerqueryformatter.com (mogularGmbH, MIT License)
-- **DAX** — Formatted via SQLBI Dax.Formatter library
-- Adds ~100-500ms per operation for dramatically improved readability
-- Graceful fallback if formatting unavailable
+- M and DAX code is preserved locally by default.
+- Setting `formatMCode=true` sends M code to powerqueryformatter.com.
+- Setting `formatDax=true` sends DAX to daxformatter.com.
+- Remote formatting requires explicit user consent and adds network latency.
 
 ---
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # hooks.py derives sitemap dates from git history. A shallow checkout
+          # makes the strict MkDocs build fail before the link check can run.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last Updated:** July 9, 2026
+**Last Updated:** August 27, 2026
 
 ## Overview
 
@@ -10,7 +10,9 @@ MCP Server for Excel ("ExcelMcp") is an open-source tool that enables AI assista
 
 **Telemetry applies to the MCP Server only.** The CLI (`excelcli`) and its background daemon send no telemetry of any kind — the code paths described below exist solely in `ExcelMcp.McpServer`.
 
-ExcelMcp's MCP Server collects **limited, anonymous telemetry** to improve the software. Here's what we do and don't collect:
+ExcelMcp's MCP Server collects **limited, anonymous telemetry** to improve the
+software. The statements below describe telemetry collection, not the workbook
+data that a tool returns to your chosen AI assistant.
 
 ### What We DO Collect (Anonymous Telemetry)
 
@@ -24,10 +26,10 @@ ExcelMcp's MCP Server collects **limited, anonymous telemetry** to improve the s
 
 ### What We DO NOT Collect
 
-- ❌ **File contents** - We never collect data from your Excel files
+- ❌ **File contents** - Workbook content is never included in telemetry
 - ❌ **File names or paths** - File paths are hashed locally; actual paths are never transmitted
 - ❌ **Personal information** - No names, emails, or account information
-- ❌ **Spreadsheet data** - Cell values, formulas, and data remain completely private
+- ❌ **Spreadsheet data** - Cell values, formulas, and query results are never included in telemetry
 - ❌ **User accounts** - No registration or sign-in required
 
 ### Purpose of Telemetry
@@ -47,11 +49,18 @@ Telemetry is sent to **Azure Application Insights**, a Microsoft service. Data i
 
 ## How It Works
 
-ExcelMcp operates on your local machine:
+ExcelMcp drives the Excel application on your local machine:
 
 1. **Local Processing** - All Excel operations are performed locally via Microsoft's COM API
 2. **Your Files Stay Local** - Excel files are read from and written to your local filesystem only
-3. **Minimal Network Usage** - The only network traffic is anonymous telemetry to Azure Application Insights
+3. **Tool Results** - Data requested by your AI assistant is returned through
+   your MCP client or CLI process; your assistant's privacy policy governs how
+   it handles that data
+4. **Optional Network Features** - Remote M/DAX formatting and Python in Excel
+   use external services only when you request those features
+5. **Telemetry** - Release builds of the MCP Server can send the anonymous usage
+   metrics listed above to Azure Application Insights; the CLI sends no
+   telemetry
 
 ## Data Flow
 
@@ -60,15 +69,36 @@ When you use ExcelMcp with an AI assistant (like Claude):
 1. You send a request to the AI assistant
 2. The AI assistant calls ExcelMcp tools on your local machine
 3. ExcelMcp performs the requested Excel operations locally
-4. Anonymous usage telemetry is sent to Azure Application Insights
-5. Results are returned to the AI assistant
+4. Requested results are returned to the AI assistant through your MCP client
+5. The MCP Server can send anonymous usage telemetry to Azure Application Insights
 
-**Note:** The AI assistant you use (e.g., Claude) has its own privacy policy governing how it handles your conversations and data. ExcelMcp only handles the local Excel operations and sends anonymous usage metrics.
+Some operations have additional data flows:
+
+- Setting `formatMCode=true` sends the supplied M code to
+  [powerqueryformatter.com](https://powerqueryformatter.com/).
+- Setting `formatDax=true` sends the supplied DAX formula to
+  [DAX Formatter](https://www.daxformatter.com/).
+- Python in Excel sends Python code and referenced worksheet data to Microsoft's
+  cloud execution environment. This feature requires Microsoft 365, internet
+  access, and Python in Excel to be enabled.
+
+Remote formatting is disabled by default and requires explicit consent.
+ExcelMcp preserves M and DAX code locally unless you opt in.
+
+**Note:** The AI assistant you use (for example, Claude or GitHub Copilot) has
+its own privacy policy governing conversations, tool calls, and returned
+workbook data.
 
 ## Third-Party Services
 
 - **Azure Application Insights** - Anonymous telemetry is sent to this Microsoft service. See [Microsoft's Privacy Statement](https://privacy.microsoft.com/privacystatement).
 - **Microsoft Excel** - ExcelMcp requires Microsoft Excel installed on your machine. Excel is subject to Microsoft's privacy policy.
+- **Microsoft Python in Excel** - Python code and referenced worksheet data run
+  in Microsoft's cloud when you use the Python in Excel operations.
+- **Power Query Formatter** - Receives M code only when you set
+  `formatMCode=true`.
+- **DAX Formatter** - Receives DAX formulas only when you set
+  `formatDax=true`.
 - **AI Assistants** - When used with AI assistants like Claude, those services have their own privacy policies.
 
 ## Open Source
@@ -99,4 +129,9 @@ For questions about this privacy policy or the ExcelMcp project:
 
 ---
 
-**Summary:** ExcelMcp processes your Excel files locally on your machine. The MCP Server component collects anonymous usage telemetry (tool usage, performance, errors) to improve the software, but never collects your file contents, file names, or personal information. The CLI sends no telemetry at all.
+**Summary:** ExcelMcp drives local Excel and reads or writes workbook files on
+your machine. Requested tool results can be returned to your chosen AI
+assistant. Remote code formatting and Python in Excel use external services only
+when requested. The MCP Server can send anonymous usage telemetry, but that
+telemetry excludes workbook contents, file names, paths, and personal
+information. The CLI sends no telemetry.

--- a/docs/AUTHOR.md
+++ b/docs/AUTHOR.md
@@ -7,11 +7,17 @@
 
 ### About the Author
 
-Stefan Broenner is the creator and maintainer of ExcelMcp, a command-line interface tool designed specifically for coding agents and developers to automate Microsoft Excel operations. With a focus on creating clean, reliable tools that bridge the gap between AI coding assistants and Excel automation, Stefan has developed ExcelMcp to be the the solution for programmatic Excel manipulation.
+Stefan Broenner is the creator and maintainer of ExcelMcp, an open-source MCP
+Server and CLI that let AI assistants and developers automate Microsoft Excel.
+The project focuses on clear, reliable tools that connect coding agents with
+Excel's native automation capabilities.
 
 ### Project Vision
 
-ExcelMcp was born from the need for a simple, reliable way for coding agents like GitHub Copilot to interact with Excel files. Rather than dealing with complex OpenXML libraries or unreliable automation, ExcelMcp provides direct COM automation that uses Excel's native VBA object model for maximum compatibility and reliability.
+ExcelMcp was born from the need for a reliable way for coding agents such as
+GitHub Copilot to work with Excel. It drives the real Excel application through
+its official COM API, which preserves workbook features and runs operations that
+file-format libraries cannot.
 
 ### Contact
 

--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -1,97 +1,105 @@
 # Breaking Changes
 
-> **Version:** 1.7.0 (MCP-Daemon Unification)  
-> **PR:** [#433](https://github.com/sbroenne/mcp-server-excel/pull/433)  
-> **Date:** February 2026
+This page summarizes changes that require updates to scripts or integrations.
+For the complete release history, see [CHANGELOG.md](../CHANGELOG.md).
 
-**📌 Note for AI Assistants:** LLMs will automatically discover these changes via `tools/list` (MCP) and `--help` (CLI). This document is informational for human developers.
+AI assistants should discover the current contract through MCP `tools/list` or
+`excelcli --help` rather than relying on hardcoded parameter lists.
 
----
+## 2.0.0 - Canonical File Lifecycle
 
-## MCP Server Changes
+Released on August 21, 2026 in
+[#807](https://github.com/sbroenne/mcp-server-excel/pull/807).
 
-### 1. `excelPath` Parameter Removed (11 Tools)
+### File and Session Commands
 
-**Removed from:** `calculation_mode`, `conditionalformat`, `connection`, `namedrange`, `range`, `range_edit`, `range_format`, `range_link`, `table`, `table_column`, `vba`
+The CLI and MCP Server now use the same 5 file operations: `list`, `open`,
+`create`, `close`, and `test`.
 
-**Why:** Daemon architecture — session already knows the file context. Only `sessionId` required.
+- The standalone CLI `save` command was removed. Save when closing a session
+  with `excelcli session close --session <id> --save`.
+- The MCP `close-workbook` no-op was removed. Use `file` with
+  `action: "close"` and set `save` explicitly.
+- File testing now reports openability and IRM/AIP requirements through the
+  same result model used by both entry points.
+- IRM detection now requires the rights-management data-space marker. Ordinary
+  password-encrypted OOXML files are no longer treated as IRM-protected files.
 
----
+### Power Query List Results
 
-### 2. `file` Parameter Renames
+`powerquery list` now returns bounded M previews and exact worksheet/Data Model
+load state instead of serializing full formulas.
 
-- `excelPath` → `path`
-- `showExcel` → `show`
+- Use `powerquery view` to read one query's complete M code.
+- Inspection errors now fail the operation instead of silently omitting a
+  query.
+- `PowerQueryInfo.Formula` remains available for source and binary
+  compatibility, but it is obsolete and excluded from list JSON.
 
----
+### Public Inputs
 
-### 3. `connection` (-4 params)
+CLI, batch JSON, and MCP inputs now use integer seconds for timeouts and enforce
+the same ranges. Inline-or-file inputs are also resolved consistently across
+both entry points. Update scripts that supplied other timeout types or depended
+on entry-point-specific aliases.
 
-**Removed:** `newCommandText`, `newConnectionString`, `newDescription`
+## 1.7.0 - MCP and Daemon Unification
 
-**Why:** `set-properties` reuses existing params instead of separate `new*` versions.
+Released in February 2026 in
+[#433](https://github.com/sbroenne/mcp-server-excel/pull/433).
 
----
+### MCP Server Changes
 
-### 4. `datamodel` (+4 params, 2 renames)
+#### `excelPath` Removed from Session-Based Tools
 
-**Added:** `daxFormulaFile`, `daxQueryFile`, `dmvQueryFile`, `timeout`
+The `excelPath` parameter was removed from `calculation_mode`,
+`conditionalformat`, `connection`, `namedrange`, `range`, `range_edit`,
+`range_format`, `range_link`, `table`, `table_column`, and `vba`. The session
+already identifies the workbook, so these tools require only `sessionId`.
 
-**Renamed:** `formatString` → `formatType`, `newTableName` → `newName`
+#### File Parameter Renames
 
----
+- `excelPath` became `path`.
+- `showExcel` became `show`.
 
-### 5. `datamodel_relationship` (5 action renames + 5 param renames)
+#### Connection Parameters
 
-**Actions renamed:**
-- `list` → `list-relationships`
-- `read` → `read-relationship`
-- `create` → `create-relationship`
-- `update` → `update-relationship`
-- `delete` → `delete-relationship`
+`newCommandText`, `newConnectionString`, and `newDescription` were removed.
+The `set-properties` action now reuses the standard parameters.
 
-**Parameters shortened:** `fromTableName` → `fromTable`, `toTableName` → `toTable`, `fromColumnName` → `fromColumn`, `toColumnName` → `toColumn`, `isActive` → `active`
+#### Data Model Parameters
 
----
+The Data Model tool added `daxFormulaFile`, `daxQueryFile`, `dmvQueryFile`, and
+`timeout`. It also renamed:
 
-## CLI Changes
+- `formatString` to `formatType`
+- `newTableName` to `newName`
 
-### 1. Action Rename
+#### Data Model Relationship Names
 
-`table add-to-datamodel` → `table add-to-data-model`
+Actions were renamed to `list-relationships`, `read-relationship`,
+`create-relationship`, `update-relationship`, and `delete-relationship`.
 
----
+Parameters were shortened:
 
-### 2. Parameter Renames (9 Commands)
+- `fromTableName` to `fromTable`
+- `toTableName` to `toTable`
+- `fromColumnName` to `fromColumn`
+- `toColumnName` to `toColumn`
+- `isActive` to `active`
 
-Short → descriptive naming in: `calculationmode`, `conditionalformat`, `connection`, `datamodel`, `namedrange`, `powerquery`, `vba`
+### CLI Changes
 
-Examples: `--sheet` → `--sheet-name`, `--mcode` → `--m-code`, `--expression` → `--dax-formula`
+- `table add-to-datamodel` became `table add-to-data-model`.
+- Parameters in `calculationmode`, `conditionalformat`, `connection`,
+  `datamodel`, `namedrange`, `powerquery`, and `vba` use descriptive names such
+  as `--sheet-name`, `--m-code`, and `--dax-formula`.
+- PivotTable field and calculation actions moved into the expanded PivotTable
+  command surface.
 
----
+### Updating Existing Integrations
 
-### 3. `pivottable` Command (+23 Actions)
-
-Merged actions from `pivottablefield` and `pivottablecalc` into single command. All original 7 actions preserved.
-
----
-
-## Summary
-
-- **MCP:** 297 → 287 parameters (-10)
-- **CLI:** Parameter renames in 9 commands, 1 action rename, 23 new pivottable actions
-- **Architecture:** Unified daemon service for both MCP and CLI
-
----
-
-## For Human Developers
-
-**Update hardcoded scripts:**
-1. Remove `excelPath` from 11 session-based MCP tools
-2. Update `file`, `connection`, `datamodel`, `datamodel_relationship` parameter names
-3. Update CLI parameter names (use `excelcli <command> --help` to see current names)
-4. Rename `add-to-datamodel` → `add-to-data-model` in table commands
-
-**For AI Assistants:**
-- Query tools dynamically — no hardcoded parameter names needed
-- Use `tools/list` (MCP) or `--help` (CLI) to discover current schemas
+1. Remove `excelPath` from session-based MCP tool calls.
+2. Update the file, connection, Data Model, and relationship parameter names.
+3. Read current CLI parameter names with `excelcli <command> --help`.
+4. Replace `table add-to-datamodel` with `table add-to-data-model`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,7 +44,10 @@ ExcelMcp aims to be the go-to command-line tool for coding agents to interact wi
 
 1. **Create feature branch**: `git checkout -b feature/your-feature`
 2. **Make changes**: Code, tests, documentation
-3. **Run the pre-commit hook**: install it once with `Copy-Item scripts\pre-commit.ps1 .git\hooks\pre-commit`, then let it run on every commit — it enforces 14 automated gates (COM leak detection, MCP/CLI coverage parity, Release build, packaging deliverables, smoke tests, and more). Never bypass it with `--no-verify`.
+3. **Run the pre-commit hook**: follow the
+   [pre-commit setup guide](PRE-COMMIT-SETUP.md), then let it run on every
+   commit. It checks COM cleanup, MCP/CLI parity, the Release build, packaging,
+   smoke tests, and other required gates. Never bypass it with `--no-verify`.
 4. **Push branch**: `git push origin feature/your-feature`
 5. **Create PR**: Use GitHub's PR template
 6. **Address review**: Make requested changes, including any automated review comments (Copilot, GitHub Advanced Security)

--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -20,9 +20,10 @@ The canonical feature reference is organized into intent-based pages under `docs
 Material's search dialog needs the same treatment, but its partial is ~45 lines
 of markup and feature flags, so forking it to add one attribute would pin a
 large slice of Material internals. That one stays a string patch in
-`hooks.py`. `audit_site.py` asserts all four fixes are present in the built
-HTML, so an upstream change that breaks any of them fails the build instead of
-silently regressing accessibility.
+`hooks.py`. `audit_site.py` asserts that these overrides remain active and also
+checks content-image alt text, nested breadcrumbs, metadata, links, and
+machine-readable outputs. An upstream change that breaks them therefore fails
+the build instead of silently regressing accessibility.
 
 ## Setup (one-time)
 
@@ -67,4 +68,3 @@ Two further checks run on a schedule rather than per pull request:
 | --- | --- | --- |
 | `link-check.yml` | Weekly | Runs lychee over the built site and files an issue on link rot. Not a PR check: external endpoints rate-limit and would make it flaky. |
 | `star-history.yml` | Daily, plus PRs touching the scripts | Records and persists the star snapshot. Split out of the Pages build so that job no longer needs `contents: write` while installing pip packages. |
-

--- a/gh-pages/audit_site.py
+++ b/gh-pages/audit_site.py
@@ -15,6 +15,7 @@ fast.
 from __future__ import annotations
 
 import gzip
+import html as html_lib
 import json
 import re
 import sys
@@ -166,6 +167,19 @@ def audit_html(path: Path) -> None:
     for img in re.findall(r"<img\b[^>]*>", html):
         src_match = re.search(r'src=["\']?([^"\'\s>]+)', img)
         src = src_match.group(1) if src_match else ""
+        alt_match = re.search(
+            r'\balt=(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))',
+            img,
+        )
+        alt = ""
+        if alt_match:
+            alt = next(
+                (value for value in alt_match.groups() if value is not None),
+                "",
+            )
+        if not html_lib.unescape(alt).strip():
+            fail(f"{name}: <img> without meaningful alt text: {src or img[:60]}")
+
         parts = urlsplit(src)
         exempt = (
             parts.netloc in BADGE_HOSTS
@@ -484,6 +498,70 @@ def audit_jsonld(html_files: list[Path]) -> None:
                 fail(f"{page_name(path)}: invalid JSON-LD: {exc}")
 
 
+def audit_breadcrumbs(html_files: list[Path]) -> None:
+    """Nested documentation pages must expose their section in breadcrumbs."""
+    sections = {
+        "features": ("Features", f"{SITE_URL}features/"),
+        "guides": ("Guides", f"{SITE_URL}guides/"),
+        "reference": ("Reference", f"{SITE_URL}reference/"),
+    }
+    flat_sections = {
+        "installation-cli/index.html": ("Installation", f"{SITE_URL}installation/"),
+        "installation-mcp-server/index.html": (
+            "Installation",
+            f"{SITE_URL}installation/",
+        ),
+    }
+
+    for path in html_files:
+        name = page_name(path)
+        parent = flat_sections.get(name)
+        if parent is None:
+            parts = name.split("/")
+            if len(parts) >= 3 and parts[0] in sections:
+                parent = sections[parts[0]]
+        if parent is None:
+            continue
+
+        html_text = path.read_text(encoding="utf-8", errors="replace")
+        breadcrumb = None
+        for block in re.findall(
+            r'<script type=["\']?application/ld\+json["\']?>(.*?)</script>',
+            html_text,
+            re.DOTALL,
+        ):
+            try:
+                data = json.loads(block)
+            except json.JSONDecodeError:
+                continue
+            if data.get("@type") == "BreadcrumbList":
+                breadcrumb = data
+                break
+
+        if breadcrumb is None:
+            fail(f"{name}: no BreadcrumbList structured data")
+            continue
+
+        items = breadcrumb.get("itemListElement", [])
+        expected_name, expected_url = parent
+        if len(items) < 3:
+            fail(
+                f"{name}: breadcrumb omits parent section {expected_name} "
+                f"(found {len(items)} items, want at least 3)"
+            )
+            continue
+
+        section_item = items[-2]
+        if (
+            section_item.get("name") != expected_name
+            or section_item.get("item") != expected_url
+        ):
+            fail(
+                f"{name}: breadcrumb parent is not "
+                f"{expected_name} ({expected_url})"
+            )
+
+
 def main() -> int:
     if not SITE_DIR.is_dir():
         print(f"ERROR: {SITE_DIR} not found - run 'mkdocs build' first", file=sys.stderr)
@@ -506,6 +584,7 @@ def main() -> int:
     audit_offsite_links(html_files)
     audit_accessibility(html_files)
     audit_jsonld(html_files)
+    audit_breadcrumbs(html_files)
     audit_sitemap()
     audit_llms(html_files)
     audit_tools_json()

--- a/gh-pages/docs/assets/stylesheets/extra.css
+++ b/gh-pages/docs/assets/stylesheets/extra.css
@@ -12,7 +12,7 @@
   --md-accent-fg-color: #107c41;
 
   --mcp-hero-bg-1: #217346; /* Excel green */
-  --mcp-hero-bg-2: #33a85c; /* Excel green (lighter) */
+  --mcp-hero-bg-2: #1d7a4c; /* Keeps white text above WCAG AA contrast */
 }
 
 /* Dark mode: lift the greens slightly for contrast on the slate background */

--- a/gh-pages/overrides/main.html
+++ b/gh-pages/overrides/main.html
@@ -153,6 +153,12 @@
   {% if page.url.startswith("features/") and page.url != "features/" %}
     {% set _ = crumbs.append({"name": "Features", "url": "https://excelmcpserver.dev/features/"}) %}
   {% endif %}
+  {% if page.url.startswith("guides/") and page.url != "guides/" %}
+    {% set _ = crumbs.append({"name": "Guides", "url": "https://excelmcpserver.dev/guides/"}) %}
+  {% endif %}
+  {% if page.url.startswith("reference/") and page.url != "reference/" %}
+    {% set _ = crumbs.append({"name": "Reference", "url": "https://excelmcpserver.dev/reference/"}) %}
+  {% endif %}
   {% if page.url in ["installation-cli/", "installation-mcp-server/"] %}
     {% set _ = crumbs.append({"name": "Installation", "url": "https://excelmcpserver.dev/installation/"}) %}
   {% endif %}

--- a/mcpb/BUILD.md
+++ b/mcpb/BUILD.md
@@ -1,141 +1,148 @@
-# MCPB Build & Packaging Guide
+# MCPB Build and Packaging Guide
 
-This document contains developer information for building and submitting the Excel MCP Server to the Claude Desktop directory.
+This guide explains how maintainers build the Excel MCP Server bundle for
+Claude Desktop. End-user installation instructions are in
+[README.md](README.md).
 
 ## Directory Contents
 
-```
+```text
 mcpb/
-├── Build-McpBundle.ps1   # Packaging script
-├── manifest.json         # MCPB manifest for Claude directory
-├── icon-512.png          # Server icon (512x512 PNG)
-├── README.md             # End-user documentation (ships with package)
-├── BUILD.md              # This file (developer documentation)
-└── artifacts/            # Build output (gitignored)
+|-- Build-McpBundle.ps1   # Packaging script
+|-- manifest.json         # MCPB manifest
+|-- icon-512.png          # Package icon
+|-- README.md             # End-user documentation included in the bundle
+|-- BUILD.md              # This maintainer guide
+`-- artifacts/            # Generated output (gitignored)
 ```
 
 ## Prerequisites
 
 - .NET 10 SDK
-- Windows x64 development machine
+- Windows to run the packaged executable verification
 
-## Building the MCPB Package
+The script can cross-compile on another operating system, but it skips the
+Windows executable launch check.
 
-From the `mcpb` directory:
+## Build the Bundle
+
+Run the script from the `mcpb` directory:
 
 ```powershell
 .\Build-McpBundle.ps1
 ```
 
-This creates `mcpb/artifacts/ExcelMcp.McpServer-win-x64.zip`.
-
-### Build Options
+The default output is `artifacts\excel-mcp-{version}.mcpb`. The version comes
+from `Directory.Build.props` unless you pass it explicitly.
 
 ```powershell
-# Specify version
-.\Build-McpBundle.ps1 -Version "1.2.0"
+# Use an explicit version
+.\Build-McpBundle.ps1 -Version "1.2.3"
 
-# Custom output directory
-.\Build-McpBundle.ps1 -OutputDir "./dist"
+# Write artifacts to another directory
+.\Build-McpBundle.ps1 -OutputDir ".\dist"
 ```
 
 ## Package Contents
 
-The MCPB zip file contains:
+An `.mcpb` file is a ZIP-compatible archive with this layout:
 
+```text
+excel-mcp-{version}.mcpb
+|-- manifest.json
+|-- icon-512.png
+|-- README.md
+|-- LICENSE
+|-- CHANGELOG.md
+`-- server/
+    `-- excel-mcp-server.exe
 ```
-ExcelMcp.McpServer-win-x64.zip/
-├── Sbroenne.ExcelMcp.McpServer.exe  # Self-contained executable (~15 MB)
-├── .mcp/
-│   └── server.json                   # MCP server configuration
-├── manifest.json                     # MCPB manifest
-├── README.md                         # End-user documentation
-└── icon-512.png                      # Server icon (512x512)
-```
 
-## Release Workflow
+`Build-McpBundle.ps1` publishes the MCP Server as a self-contained Windows x64
+single-file executable, renames it to match the manifest entry point, copies
+the package metadata, and verifies the executable on Windows.
 
-1. **Create GitHub Release:**
-   - Tag format: `v1.x.x`
-   - Upload `ExcelMcp.McpServer-win-x64.zip` as release asset
+## Manifest and Tool Metadata
 
-2. **Update manifest.json download URL:**
-   - Verify the `install.win32.download` URL points to the release asset
-   - URL format: `https://github.com/sbroenne/mcp-server-excel/releases/latest/download/ExcelMcp.McpServer-win-x64.zip`
-
-3. **Submit to Claude Directory:**
-   - Follow Anthropic's submission process
-   - Include the manifest.json content
-
-## Manifest Schema
-
-The manifest follows MCPB version 0.3 specification:
+`manifest.json` follows MCPB manifest version 0.3 and declares the packaged
+binary entry point:
 
 ```json
 {
-  "manifestVersion": "0.3",
+  "manifest_version": "0.3",
   "server": {
-    "id": "excel-mcp-server",
-    "name": "Excel MCP Server",
     "type": "binary",
-    "platforms": ["win32"]
-  },
-  "install": {
-    "win32": {
-      "download": "https://github.com/.../ExcelMcp.McpServer-win-x64.zip",
-      "command": "Sbroenne.ExcelMcp.McpServer.exe"
+    "entry_point": "server/excel-mcp-server",
+    "mcp_config": {
+      "command": "${__dirname}/server/excel-mcp-server",
+      "args": [],
+      "env": {}
     }
   }
 }
 ```
 
-## Tool Annotations
+The build stamps the package version into a staged copy of the manifest. Do not
+add a release download URL or an `install.win32` block; the executable is
+included in the bundle.
 
-All 22 MCP tools include the `Destructive = true` annotation since they can modify Excel files:
+The MCP Server generates its 31 tool schemas from the Core contracts and manual
+MCP tool definitions. Destructive metadata is set per tool: most tools can
+modify workbooks, while tools such as `screenshot` and `window` do not modify
+workbook content.
 
-```csharp
-[McpServerTool(Name = "range", Title = "Excel Range Operations", Destructive = true)]
+## Release Workflow
+
+The unified release workflow builds and publishes the MCPB artifact with the
+MCP Server, CLI, VS Code extension, and NuGet packages. Do not edit the manifest
+or upload a differently named ZIP by hand.
+
+See [Release Strategy](../docs/RELEASE-STRATEGY.md) for the release process. To
+rebuild locally before a release:
+
+```powershell
+.\Build-McpBundle.ps1
 ```
+
+## Verify the Archive
+
+PowerShell's `Expand-Archive` expects a `.zip` extension. Copy the generated
+bundle before inspecting it:
+
+```powershell
+$bundle = Get-ChildItem .\artifacts\excel-mcp-*.mcpb |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1
+$zip = [IO.Path]::ChangeExtension($bundle.FullName, ".zip")
+Copy-Item $bundle.FullName $zip
+Expand-Archive $zip -DestinationPath .\test-extract
+Get-ChildItem .\test-extract -Recurse
+Remove-Item $zip
+Remove-Item .\test-extract -Recurse
+```
+
+The packaging script also prints every archive entry after a successful build.
 
 ## Technical Notes
 
 ### Why Self-Contained?
 
-- Users don't need .NET SDK installed
-- Avoids version conflicts
-- Single executable deployment (~15 MB compressed)
+- Users do not need the .NET runtime or SDK.
+- The package uses the same tested runtime as the standalone release.
+- A single executable avoids local dependency version conflicts.
 
 ### Why No Trimming?
 
-Excel COM interop uses `Type.GetTypeFromProgID()` which requires reflection. Trimming would break COM activation with IL2072 errors.
+Excel COM interop relies on runtime type activation and reflection. Trimming can
+remove required interop metadata, so the package sets `PublishTrimmed=false`.
 
-### Why Windows x64 Only?
+### Why Windows x64?
 
-- COM interop requires Windows
-- x64 is the most common architecture
-- ARM64 Windows can run x64 binaries via emulation
+- Excel COM automation requires Windows.
+- Windows on ARM can run the x64 package through emulation.
 
-## Verification
+## Submission References
 
-After building, verify the package:
-
-```powershell
-# List zip contents
-Expand-Archive ./artifacts/ExcelMcp.McpServer-win-x64.zip -DestinationPath ./test-extract
-dir ./test-extract
-Remove-Item -Recurse ./test-extract
-```
-
-## Submission Guidelines Reference
-
-See the [MCPB Submission Guide](https://support.claude.com/en/articles/12922832-local-mcp-server-submission-guide) for:
-- Tool annotation requirements (readOnlyHint, destructiveHint)
-- README requirements (minimum 3 examples with expected behavior)
-- Privacy policy requirements
-- manifest_version requirements (≥ 0.3)
-
-## Links
-
-- [MCPB Specification](https://modelcontextprotocol.io/docs/registry)
-- [Claude Desktop Documentation](https://docs.anthropic.com/claude/docs/claude-for-desktop)
-- [Submission Guidelines](https://support.claude.com/en/articles/12922832-local-mcp-server-submission-guide)
+- [MCPB submission guide](https://support.claude.com/en/articles/12922832-local-mcp-server-submission-guide)
+- [Claude Desktop documentation](https://support.claude.com/)
+- [MCP documentation](https://modelcontextprotocol.io/)

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -58,7 +58,7 @@ These examples work with any Excel file, including a new empty workbook.
 
 ### Example 3: Power Query and Data Model Analysis
 
-**You say:** *"Use Power Query to import this CSV file: C:/Data/products.csv. Add the data to the Data Model and create measures for Total Revenue and Average Rating."*
+**You say:** *"Use Power Query to import this CSV file: C:\Data\products.csv. Add the data to the Data Model and create measures for Total Revenue and Average Rating."*
 
 **What happens:**
 - Imports the CSV using Power Query
@@ -88,12 +88,17 @@ These examples work with any Excel file, including a new empty workbook.
 
 ## Privacy & Security
 
-Excel MCP Server runs **entirely on your computer**. Your Excel data:
-- Never leaves your machine
-- Is not sent to any external servers
-- Is not used for training AI models
+Excel MCP Server drives the Excel application on your computer. Workbook files
+stay on your local filesystem, but requested tool results are returned to
+Claude through the MCP client.
 
-**Anonymous Telemetry:** We collect anonymous usage statistics (tool usage, performance metrics, error rates) to improve the software. No file contents, file names, or personal data are collected.
+**Optional network features:** Remote M/DAX formatting sends only the supplied
+code and requires explicit consent. Python in Excel runs Python code and
+referenced worksheet data in Microsoft's cloud.
+
+**Anonymous telemetry:** The MCP Server collects tool usage, performance, and
+error-rate metrics. Telemetry excludes file contents, file names, paths, and
+personal data.
 
 See our complete [Privacy Policy](https://excelmcpserver.dev/privacy/).
 

--- a/src/ExcelMcp.ComInterop/README.md
+++ b/src/ExcelMcp.ComInterop/README.md
@@ -19,25 +19,31 @@ This library provides Excel-specific COM object lifecycle management and OLE mes
 ## Usage Example
 
 ```csharp
+using Excel = Microsoft.Office.Interop.Excel;
 using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
 
-// Use ExcelSession for safe Excel automation
-await using var session = await ExcelSession.BeginAsync("path/to/workbook.xlsx");
-await using var batch = await session.BeginBatchAsync();
+using var batch = ExcelSession.BeginBatch(@"C:\Data\workbook.xlsx");
 
-await batch.ExecuteAsync<int>(async (ctx, ct) => 
+batch.Execute((ctx, ct) =>
 {
-    // Access Excel workbook through ctx.Book
-    dynamic worksheets = ctx.Book.Worksheets;
-    dynamic sheet = worksheets.Item[1];
-    
-    // Perform Excel operations
-    sheet.Name = "UpdatedSheet";
-    
-    return 0;
+    Excel.Sheets? worksheets = null;
+    Excel.Worksheet? sheet = null;
+
+    try
+    {
+        worksheets = ctx.Book.Worksheets;
+        sheet = (Excel.Worksheet)worksheets[1];
+        sheet.Name = "UpdatedSheet";
+    }
+    finally
+    {
+        ComUtilities.Release(ref sheet);
+        ComUtilities.Release(ref worksheets);
+    }
 });
 
-await batch.Save();
+batch.Save();
 ```
 
 ## Key Classes
@@ -59,4 +65,3 @@ await batch.Save();
 - ✅ Windows ARM64
 - ❌ Linux (Excel COM not available)
 - ❌ macOS (Excel COM not available)
-

--- a/src/ExcelMcp.Core/Commands/DataModel/IDataModelRelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/DataModel/IDataModelRelCommands.cs
@@ -24,7 +24,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 /// </summary>
 [ServiceCategory("datamodelrel", "DataModelRel")]
 [McpTool("datamodel_relationship", Title = "Data Model Relationship Operations", Destructive = true, Category = "analysis",
-    Description = "Data Model relationships - link tables for cross-table DAX calculations. CRITICAL: Deleting/recreating tables removes ALL their relationships. Use list before table operations to backup. REQUIREMENTS: Both tables in Data Model, compatible column types. From=many-side (detail), To=one-side (lookup). ACTIVE VS INACTIVE: One active relationship per table pair. Use DAX USERELATIONSHIP() for inactive. TIMEOUT: 2 min. Use datamodel for tables and DAX measures.")]
+    Description = "Data Model relationships - link tables for cross-table DAX calculations. CRITICAL: Deleting or recreating tables removes all their relationships. Use list-relationships before table operations to back them up. REQUIREMENTS: Both tables must be in the Data Model with compatible column types. From=many-side (detail), To=one-side (lookup). ACTIVE VS INACTIVE: One active relationship per table pair. Use DAX USERELATIONSHIP() for inactive relationships. TIMEOUT: 2 minutes. Use datamodel for tables and DAX measures.")]
 public interface IDataModelRelCommands
 {
     /// <summary>

--- a/src/ExcelMcp.Core/Commands/QueryTable/IQueryTableCommands.cs
+++ b/src/ExcelMcp.Core/Commands/QueryTable/IQueryTableCommands.cs
@@ -10,7 +10,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 /// </summary>
 [ServiceCategory("querytable", "QueryTable")]
 [McpTool("querytable", Title = "QueryTable Import Operations", Destructive = true, Category = "query",
-    Description = "Local Excel COM QueryTable lifecycle and configuration. Supports text/CSV imports via TEXT; and legacy HTML web imports via URL;. Use powerquery for modern connectors and transformations. QueryTables do not expose Power Query M, cloud data types, workbook coauthor presence, sharing, mentions, assignments, or other Microsoft 365 service APIs.")]
+    Description = "Local Excel COM QueryTable lifecycle and configuration. Supports text and CSV imports from local files, plus legacy HTML web imports. Use powerquery for modern connectors and transformations. QueryTables do not expose Power Query M, cloud data types, workbook coauthor presence, sharing, mentions, assignments, or other Microsoft 365 service APIs.")]
 public interface IQueryTableCommands
 {
     /// <summary>Lists all worksheet QueryTables in the workbook.</summary>

--- a/src/ExcelMcp.Core/Commands/Sheet/ISheetCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Sheet/ISheetCommands.cs
@@ -6,16 +6,13 @@ namespace Sbroenne.ExcelMcp.Core.Commands;
 
 /// <summary>
 /// Worksheet lifecycle management: create, rename, copy, delete, move, list sheets.
-/// Use range for data operations. Use sheetstyle for tab colors and visibility.
+/// Use range for data operations. Use worksheetstyle for tab colors and visibility.
 ///
 /// ATOMIC OPERATIONS: 'copy-to-file' and 'move-to-file' don't require a session -
 /// they open/close files automatically.
 ///
 /// POSITIONING: For 'move', 'copy-to-file', 'move-to-file' - use 'before' OR 'after'
 /// (not both) to position the sheet relative to another. If neither specified, moves to end.
-/// 
-/// NOTE: MCP tool is manually implemented in ExcelWorksheetTool.cs to properly handle
-/// mixed session requirements (copy-to-file and move-to-file are atomic and don't need sessions).
 /// </summary>
 [ServiceCategory("sheet", "Sheet")]
 public interface ISheetCommands
@@ -126,6 +123,5 @@ public interface ISheetCommands
         string? beforeSheet = null,
         string? afterSheet = null);
 }
-
 
 

--- a/src/ExcelMcp.Generators/ServiceRegistryGenerator.cs
+++ b/src/ExcelMcp.Generators/ServiceRegistryGenerator.cs
@@ -171,15 +171,19 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         sb.AppendLine($"        public static readonly string[] ValidActions = [{actionList}];");
         sb.AppendLine();
 
-        // Generate Description constant for CLI help
-        var escapedDescription = (info.XmlDocSummary ?? $"{info.CategoryPascal} operations")
+        // Top-level CLI help is a command index. Keep the detailed interface
+        // guidance in action/option help instead of repeating it for every command.
+        var fullDescription = info.XmlDocSummary ?? $"{info.CategoryPascal} operations";
+        var sentenceEnd = fullDescription.IndexOf(". ", StringComparison.Ordinal);
+        var shortDescription = sentenceEnd >= 0
+            ? fullDescription.Substring(0, sentenceEnd + 1)
+            : fullDescription;
+        var escapedDescription = shortDescription
             .Replace("\\", "\\\\")
             .Replace("\"", "\\\"")
-            .Replace("\r", "")
-            .Replace("\n", " ")
             .Trim();
         sb.AppendLine("        /// <summary>");
-        sb.AppendLine("        /// Human-readable description from interface XML documentation.");
+        sb.AppendLine("        /// Concise description from the first sentence of interface XML documentation.");
         sb.AppendLine("        /// </summary>");
         sb.AppendLine($"        public const string Description = \"{escapedDescription}\";");
         sb.AppendLine();

--- a/tests/ExcelMcp.CLI.Tests/Unit/ActionValidatorTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/ActionValidatorTests.cs
@@ -99,6 +99,37 @@ public sealed class ActionValidatorTests
         Assert.Contains("read-connection", actual);
     }
 
+    [Fact]
+    public void SheetDescription_DoesNotReferenceUnregisteredStyleCommand()
+    {
+        Assert.DoesNotContain(
+            "Use sheetstyle",
+            ServiceRegistry.Sheet.Description,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GeneratedCommandDescriptions_AreConcise()
+    {
+        var offenders = typeof(ServiceRegistry)
+            .GetNestedTypes(BindingFlags.Public)
+            .Select(type => new
+            {
+                type.Name,
+                Description = type
+                    .GetField("Description", BindingFlags.Public | BindingFlags.Static)?
+                    .GetRawConstantValue() as string
+            })
+            .Where(item => item.Description is { Length: > 180 })
+            .Select(item => $"{item.Name} ({item.Description!.Length} characters)")
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "Top-level CLI command descriptions must stay under 180 characters: " +
+            string.Join(", ", offenders));
+    }
+
     private static string[] GetExpectedActions(Type enumType, Type registryType)
     {
         // Find ToActionString method in the ServiceRegistry nested type (e.g., ServiceRegistry.Range.ToActionString)
@@ -154,4 +185,3 @@ public sealed class ActionValidatorTests
         public IReadOnlyList<string> Raw { get; } = Array.Empty<string>();
     }
 }
-

--- a/vscode-extension/PUBLISHER-GUIDE.md
+++ b/vscode-extension/PUBLISHER-GUIDE.md
@@ -216,9 +216,9 @@ gh workflow run release.yml -f version_bump=patch
 ## Security Best Practices
 
 1. **Never commit tokens** to Git (use GitHub secrets only)
-2. **Set token expiration** to 1 year, renew before expiry
+2. **Set token expiration** to 6-12 months and renew before expiry
 3. **Use minimum scopes** (only Marketplace → Manage)
-4. **Rotate tokens annually** for security
+4. **Rotate tokens every 6-12 months**
 5. **Monitor usage** in Azure DevOps PAT settings
 
 ---


### PR DESCRIPTION
## Summary
- audit and correct public Markdown, package guidance, privacy details, breaking changes, and tool descriptions
- improve GitHub Pages breadcrumbs, accessibility contrast, image-alt checks, and structured-data validation
- reduce `excelcli --help` from a 50 KB wall of text to a concise command index
- repair the scheduled link-check workflow and keep generated documentation sources aligned

## Validation
- full repository pre-commit hook
- Release solution build and generated skill refresh
- CLI and MCP Excel end-to-end tests
- strict MkDocs build, site audit, and deploy-path audit
- MCPB, VS Code extension, CLI, MCP Server, and Agent Skills packaging