### PR TITLE
Fix analytics artifact restoration

### DIFF
--- a/scripts/Persist-UsageAnalytics.ps1
+++ b/scripts/Persist-UsageAnalytics.ps1
@@ -64,7 +64,7 @@ if ($refResult.ExitCode -ne 0) {
 }
 
 $contentResult = Invoke-GitHubApi @(
-    "api", "repos/$Repository/contents/$RemotePath" + "?ref=$Branch"
+    "api", ("repos/$Repository/contents/$RemotePath" + "?ref=$Branch")
 )
 $contentText = @($contentResult.Output) -join "`n"
 $existingSha = $null

--- a/scripts/Restore-UsageAnalytics.ps1
+++ b/scripts/Restore-UsageAnalytics.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path -LiteralPath $resolvedReportPath -PathType Leaf)) {
 }
 
 $result = & $ApiInvoker -Arguments @(
-    "api", "repos/$Repository/contents/$RemotePath" + "?ref=$Branch"
+    "api", ("repos/$Repository/contents/$RemotePath" + "?ref=$Branch")
 )
 if ($null -eq $result -or
     $null -eq $result.PSObject.Properties["ExitCode"] -or

--- a/scripts/Test-UsageAnalytics.ps1
+++ b/scripts/Test-UsageAnalytics.ps1
@@ -241,6 +241,10 @@ Investigate the 12 background task problems before changing behavior.
         -TempPath $testRoot `
         -ApiInvoker $persistInvoker
     Assert-True (($requests | Where-Object {
+        $_ -eq "api repos/owner/repository/contents/.github/usage-analytics.json?ref=analytics-data"
+    }).Count -eq 1) `
+        "Persist script split the branch query into a second API endpoint."
+    Assert-True (($requests | Where-Object {
         $_ -like "api --silent --method PUT repos/owner/repository/contents/.github/usage-analytics.json --input *"
     }).Count -eq 1) `
         "Persist script did not write through the Contents API."
@@ -251,8 +255,10 @@ Investigate the 12 background task problems before changing behavior.
     $bootstrapPath = Write-TestFile "bootstrap.json" ($report | ConvertTo-Json -Depth 10)
     $restoredText = [IO.File]::ReadAllText($reportPath)
     $restoredContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($restoredText))
+    $restoreRequests = [Collections.Generic.List[string]]::new()
     $restoreInvoker = {
         param([string[]]$Arguments)
+        $restoreRequests.Add(($Arguments -join " "))
         [pscustomobject]@{
             ExitCode = 0
             Output = @((@{ content = $restoredContent } | ConvertTo-Json -Compress))
@@ -264,6 +270,9 @@ Investigate the 12 background task problems before changing behavior.
         -ReportPath $bootstrapPath `
         -RemotePath ".github/usage-analytics.json" `
         -ApiInvoker $restoreInvoker
+    Assert-True ($restoreRequests[0] -eq
+        "api repos/owner/repository/contents/.github/usage-analytics.json?ref=analytics-data") `
+        "Restore script split the branch query into a second API endpoint."
     Assert-True ([IO.File]::ReadAllText($bootstrapPath) -eq $restoredText) `
         "Restore script did not replace the bootstrap report."
     $testsRun++


### PR DESCRIPTION
## Summary
Fixes the GitHub Pages analytics artifact restore/persist calls that failed during the first Pages deployment after #816.

PowerShell parsed the Contents API endpoint and the `?ref=` branch expression as separate arguments. Parenthesizing the complete expression now passes one endpoint argument to `gh api` for both restoration and persistence.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changeset
- [x] Not applicable (CI/automation-only) — add the `skip-changelog` label

## Changes Made
- Pass the persist Contents API endpoint and branch query as one argument.
- Pass the restore Contents API endpoint and branch query as one argument.
- Assert the exact `gh api` argument shape for both paths.

## Testing Performed
- [x] Excel E2E not applicable because no Core/CLI/MCP runtime path changed
- [x] Ran the focused analytics script tests and repository audit gates
- [x] Build produces zero warnings

## Test Commands
```powershell
& .\scripts\Test-UsageAnalytics.ps1
& .\scripts\check-com-leaks.ps1
& .\scripts\audit-core-coverage.ps1 -CheckNaming -FailOnGaps
& .\scripts\check-mcp-core-implementations.ps1
& .\scripts\check-success-flag.ps1
& .\scripts\check-doc-counts.ps1
& .\scripts\check-dynamic-casts.ps1
dotnet restore Sbroenne.ExcelMcp.sln
dotnet build Sbroenne.ExcelMcp.sln -c Release --no-restore
```

## Core Commands Coverage Checklist

**Does this PR add or modify Core Commands methods?** [ ] Yes [x] No

## Additional Notes
The PR intentionally contains only the two analytics scripts and their focused test script. It does not release a package.