### PR TITLE
Fix and clean up VS Code extension feature metadata

### DIFF
--- a/.changeset/warm-ravens-display.md
+++ b/.changeset/warm-ravens-display.md
@@ -2,5 +2,7 @@
 "excelmcp": patch
 ---
 
-**Populate VS Code's Extension Features details for the bundled Excel skill.**
-The Chat Skills table now shows the skill name and description instead of empty placeholders.
+**Improve the VS Code extension's metadata and development guidance.** The Chat
+Skills table now shows the skill name and description instead of empty
+placeholders, package validation prevents incomplete Marketplace metadata, and
+skill installation guidance now reflects the extension's actual bundled files.

--- a/.changeset/warm-ravens-display.md
+++ b/.changeset/warm-ravens-display.md
@@ -1,0 +1,6 @@
+---
+"excelmcp": patch
+---
+
+**Populate VS Code's Extension Features details for the bundled Excel skill.**
+The Chat Skills table now shows the skill name and description instead of empty placeholders.

--- a/skills/excel-cli/README.md
+++ b/skills/excel-cli/README.md
@@ -25,14 +25,8 @@ excelcli -q session close --session 1 --save
 
 ### GitHub Copilot
 
-The [Excel MCP Server VS Code extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp) installs this skill automatically to `~/.copilot/skills/excel-cli/`.
-
-Enable skills in VS Code settings:
-```json
-{
-  "chat.useAgentSkills": true
-}
-```
+The VS Code extension bundles only the MCP Server skill. Install this CLI skill
+separately with `npx skills`, as shown below, after installing `excelcli`.
 
 ### Other Platforms
 

--- a/skills/excel-mcp/README.md
+++ b/skills/excel-mcp/README.md
@@ -13,14 +13,10 @@ Agent Skill for AI assistants using the Excel MCP Server via the Model Context P
 
 ### GitHub Copilot
 
-The [Excel MCP Server VS Code extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp) installs this skill automatically to `~/.copilot/skills/excel-mcp/`.
-
-Enable skills in VS Code settings:
-```json
-{
-  "chat.useAgentSkills": true
-}
-```
+The [Excel MCP Server VS Code extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)
+registers this skill automatically through VS Code's `chatSkills` contribution
+point. It does not copy the skill into a user directory, and no preview setting
+is required.
 
 ### Other Platforms
 

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -15,6 +15,7 @@ out/tests/**
 # Development configuration and tooling
 .vscode/**
 .github/**
+scripts/**
 tsconfig.json
 eslint.config.mjs
 node_modules/**

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -17,7 +17,6 @@ out/tests/**
 .github/**
 scripts/**
 tsconfig.json
-eslint.config.mjs
 node_modules/**
 *.vsix
 .gitignore

--- a/vscode-extension/DEVELOPMENT.md
+++ b/vscode-extension/DEVELOPMENT.md
@@ -1,340 +1,187 @@
-# VS Code Extension Development Notes
+# VS Code Extension Development
 
-## Project Structure
+The Excel MCP Server extension bundles the Windows x64 MCP executable and one
+Agent Skill. Users do not need a separate .NET runtime or CLI installation.
 
-```
+## Project structure
+
+```text
 vscode-extension/
-├── src/
-│   └── extension.ts          # Extension entry point
-├── out/                       # Compiled JavaScript
-│   ├── extension.js
-│   └── extension.js.map
-├── package.json               # Extension manifest
-├── tsconfig.json             # TypeScript config
-├── eslint.config.mjs         # Linting rules
-├── README.md                 # Extension documentation
-├── CHANGELOG.md              # Version history
-├── INSTALL.md                # Installation guide
-├── LICENSE                   # MIT License
-├── icon.png                  # 128x128 extension icon
-├── icon.svg                  # SVG source
-├── skills/                   # Agent skills (copied during build)
-│   ├── excel-mcp/            # MCP server skill
-│   │   └── SKILL.md
-│   ├── excel-cli/            # CLI skill
-│   │   └── SKILL.md
-│   └── shared/               # Shared reference docs
-│       └── *.md
-└── excelmcp-1.0.0.vsix      # Packaged extension
+├── src/extension.ts          # Extension activation and MCP registration
+├── out/                      # Compiled JavaScript
+├── bin/                      # Self-contained MCP Server built for packaging
+├── skills/excel-mcp/         # Build copy of the canonical Agent Skill
+├── scripts/                  # Build-time manifest validation
+├── package.json              # Extension manifest and npm scripts
+├── package-lock.json         # Locked development dependencies
+├── tsconfig.json             # TypeScript compiler settings
+├── .vscodeignore             # Files excluded from the VSIX
+├── README.md                 # Marketplace details page
+├── CHANGELOG.md              # Build copy of the repository changelog
+├── LICENSE                   # Packaged MIT license
+└── icon.png                  # Marketplace icon
 ```
 
-## Key Implementation Details
+Do not edit files under `vscode-extension/skills/excel-mcp/` directly. The
+`copy:skills` script replaces that directory from the canonical
+`skills/excel-mcp/` source and stamps `VERSION` from `package.json`.
 
-### MCP Server Registration
+Do not edit `vscode-extension/CHANGELOG.md` directly. The build copies the
+generated root `CHANGELOG.md` into the extension package.
 
-The extension uses VS Code's `mcpServerDefinitionProvider` contribution point:
+## Contributions
+
+### MCP Server
+
+The manifest declares the provider ID and the extension registers that exact
+ID through VS Code's API:
 
 ```typescript
-vscode.lm.registerMcpServerDefinitionProvider('excelmcp', {
-  provideMcpServerDefinitions: async () => {
-    const serverPath = path.join(context.extensionPath, 'bin', 'Sbroenne.ExcelMcp.McpServer.exe');
-    return [
-      new vscode.McpStdioServerDefinition(
-        'Excel MCP Server',
-        serverPath,
-        [],
-        {} // Optional environment variables
-      )
-    ];
-  }
-})
+vscode.lm.registerMcpServerDefinitionProvider('excel-mcp', {
+  provideMcpServerDefinitions: async () => [
+    new vscode.McpStdioServerDefinition(
+      'excel-mcp',
+      path.join(context.extensionPath, 'bin', 'Sbroenne.ExcelMcp.McpServer.exe'),
+      [],
+      {}
+    )
+  ]
+});
 ```
 
-### Agent Skills Registration
+### Agent Skill
 
-The extension uses VS Code's `chatSkills` contribution point in `package.json` to declaratively register agent skills:
+The `chatSkills` contribution registers the packaged skill:
 
 ```json
 "chatSkills": [
-   {
-      "name": "excel-mcp",
-      "description": "Excel MCP Server skill for Windows workbook automation.",
-      "path": "./skills/excel-mcp/SKILL.md"
-   }
+  {
+    "name": "excel-mcp",
+    "description": "Excel MCP Server skill for Windows workbook automation.",
+    "path": "./skills/excel-mcp/SKILL.md"
+  }
 ]
 ```
 
-The explicit name and description populate VS Code's Extension Features table;
-the matching frontmatter in `SKILL.md` supplies runtime discovery metadata.
-Skills are automatically available to GitHub Copilot when the extension is active.
+VS Code's Extension Features table reads `name` and `description` from the
+manifest. Runtime skill discovery reads the matching frontmatter from
+`SKILL.md`; the build validates that the names agree.
 
-### Activation
+## Prerequisites
 
-- **Activation Event**: `onStartupFinished` - Extension loads when VS Code starts
-- **Welcome Message**: Shows once on first activation
-- **State Management**: Uses `context.globalState` to track welcome message
+- Windows
+- The .NET SDK pinned by the repository `global.json`
+- Node.js and npm
+- Microsoft Excel for end-to-end MCP testing
 
-### Dependencies
-
-- **Runtime**: None - Extension bundles self-contained executables (MCP Server + CLI)
-- **Dev Dependencies**:
-  - `@types/vscode@^1.106.0` - VS Code API types
-  - `@types/node@^22.0.0` - Node.js types
-  - `typescript@^5.9.0` - TypeScript compiler
-  - `@vscode/vsce@^3.0.0` - Extension packaging tool
-  - `eslint` + `typescript-eslint` - Code quality
-
-## Building
+Install locked dependencies:
 
 ```powershell
-npm install          # Install dependencies
-npm run compile      # Compile TypeScript
-npm run watch        # Watch mode for development
-npm run lint         # Run ESLint
-npm run package      # Create VSIX package
+Set-Location vscode-extension
+npm ci
 ```
 
-## Building Bundled Executables
+## Build and validation
 
-The extension includes self-contained MCP server and CLI executables. To update them:
+Run the fast checks while editing:
 
 ```powershell
-# Build MCP server as self-contained single-file exe
-cd d:\source\mcp-server-excel
-dotnet publish src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false -p:PublishReadyToRun=false -p:NuGetAudit=false -o vscode-extension/bin
-
-# Build CLI as self-contained single-file exe
-dotnet publish src/ExcelMcp.CLI/ExcelMcp.CLI.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false -p:PublishReadyToRun=false -p:NuGetAudit=false -o vscode-extension/bin
-
-# Or use the npm script which builds both
-npm run build:all
-
-# Verify the executables work
-vscode-extension/bin/Sbroenne.ExcelMcp.McpServer.exe --version
-vscode-extension/bin/excelcli.exe --version
+npm run compile
+npm run lint
 ```
 
-This creates self-contained executables with the .NET runtime and all dependencies included. No .NET SDK or runtime installation needed on end-user machines.
+`compile` first validates Marketplace assets and feature contribution metadata,
+then compiles TypeScript.
 
-## Testing
-
-### Prerequisites for Testing
-
-The extension uses bundled self-contained executables. For development testing:
+Build the complete release-shaped VSIX:
 
 ```powershell
-# Build both executables (matches production)
-npm run build:all
-
-# Verify bundled executables work
-vscode-extension/bin/Sbroenne.ExcelMcp.McpServer.exe --version
-vscode-extension/bin/excelcli.exe --version
-```
-
-**Why this approach**: The extension bundles self-contained MCP server and CLI executables. No .NET runtime or SDK needed on the target machine.
-
-### Manual Testing
-
-1. **Build the extension**:
-   ```powershell
-   npm run compile
-   ```
-
-2. **Press F5 in VS Code** (opens Extension Development Host)
-
-3. **Check the Debug Console** for activation logs:
-   - ✅ `ExcelMcp extension is now active`
-   - ❌ NO errors about "Cannot read properties of undefined"
-
-4. **In the Extension Development Host**:
-   - Check if extension is loaded: Extensions panel
-   - Check if MCP server is registered: Settings → MCP
-   - Ask GitHub Copilot to list Excel tools
-
-5. **Check Developer Tools Console** (Ctrl+Shift+I):
-   - Go to Console tab
-   - Look for "ExcelMcp:" messages
-   - Verify no errors
-
-### Package Testing
-
-1. **Package the extension**:
-   ```powershell
-   npm run package
-   ```
-
-2. **Install from VSIX**:
-   - `Ctrl+Shift+P` → "Install from VSIX"
-   - Select `excelmcp-1.0.0.vsix`
-
-3. **Verify**:
-   - Extension appears in Extensions panel
-   - Welcome message shows on first activation
-   - GitHub Copilot can access Excel tools
-
-## Publishing
-
-### Automated Publishing (Recommended)
-
-The extension is published with every unified repository release:
-
-```powershell
-# Release all components with the same calculated version
-gh workflow run release.yml -f version_bump=patch
-```
-
-The GitHub Actions workflow will automatically:
-- ✅ **Calculate version** from the latest tag and dispatch input
-- ✅ **Update package.json version** using `npm version` (no manual editing needed)
-- ✅ **Compile changesets** into `CHANGELOG.md` and release notes
-- ✅ **Build and package the extension**
-- ✅ **Publish to VS Code Marketplace** (if `VSCE_TOKEN` secret is configured)
-- ✅ **Build all other components** (MCP Server, CLI, MCPB)
-- ✅ **Create unified GitHub release** with all artifacts
-
-**Important**: The workflow manages version numbers. Do not manually update
-`package.json` before release.
-
-See [MARKETPLACE-PUBLISHING.md](MARKETPLACE-PUBLISHING.md) for setup instructions.
-
-## Changelog Maintenance
-
-Never edit the root `CHANGELOG.md` manually. Add a changeset with
-`npx changeset` for every user-visible change. The unified release workflow
-consumes pending fragments, generates the changelog entry, and copies the
-generated changelog into the extension package.
-
-### Manual Publishing
-
-#### VS Code Marketplace
-
-1. **Create publisher account**: https://marketplace.visualstudio.com/manage
-2. **Generate PAT**: https://dev.azure.com (Marketplace Manage scope)
-3. **Login**: `npx @vscode/vsce login <publisher>`
-4. **Publish**: `npx @vscode/vsce publish`
-
-#### GitHub Releases Only
-
-To create a GitHub release without marketplace publishing:
-
-```powershell
-cd vscode-extension
 npm run package
-# Upload the .vsix file manually to GitHub releases
 ```
 
-## Versioning
+Packaging performs these steps automatically:
 
-**Automatic Version Management** (Recommended):
-The unified release workflow automatically calculates version numbers from the latest git tag:
+1. Publishes the MCP Server as a self-contained Windows x64 executable.
+2. Copies and stamps the canonical Agent Skill.
+3. Copies the generated root changelog.
+4. Validates feature and Marketplace metadata.
+5. Compiles TypeScript and runs `vsce package`.
 
-1. Go to **Actions** → **Release All Components** → **Run workflow**
-2. Select version bump type (patch/minor/major) or enter a custom version
-
-The workflow will:
-- Calculate the next version from the latest git tag
-- Update `package.json` version for VS Code extension
-- Update all component versions (MCP Server, CLI, MCPB manifest)
-- Create git tag and unified GitHub release with all artifacts
-
-**Local Version Testing**:
-If packaging needs a temporary local version:
+To build only the bundled executable:
 
 ```powershell
-npm version patch   # Bumps 1.0.0 → 1.0.1
-npm version minor   # Bumps 1.0.0 → 1.1.0
-npm version major   # Bumps 1.0.0 → 2.0.0
+npm run build:mcp-server
+.\bin\Sbroenne.ExcelMcp.McpServer.exe --version
 ```
 
-Follow Semantic Versioning (SemVer):
-- **Major**: Breaking changes
-- **Minor**: New features
-- **Patch**: Bug fixes
+## Local testing
 
-**Important**: Don't commit local version changes. Releases use workflow inputs.
+### Extension Development Host
 
-## Maintenance
+1. Open the `vscode-extension` folder in VS Code.
+2. Run `npm run compile`.
+3. Press `F5` to open an Extension Development Host.
+4. Confirm the MCP server appears in VS Code's MCP management UI.
+5. Open the extension's Features tab and verify:
+   - MCP Servers shows `excel-mcp` and `Excel MCP Server`.
+   - Chat Skills shows the skill name, description, and path.
 
-### Updating Dependencies
+### Packaged VSIX
 
-```powershell
-npm outdated                    # Check for updates
-npm update                      # Update minor/patch
-npm install @types/vscode@latest --save-dev  # Update major
-```
+1. Run `npm run package`.
+2. Use **Extensions: Install from VSIX...** in VS Code.
+3. Select the generated `excel-mcp-<version>.vsix`.
+4. Reload VS Code and verify the MCP server and Agent Skill.
 
-### VS Code API Updates
+The VSIX is approximately 65 MB. Most of its size is the compressed,
+self-contained MCP Server; the unpacked executable is approximately 150 MB.
 
-When VS Code releases new API features:
-1. Update `engines.vscode` in package.json
-2. Update `@types/vscode` to matching version
-3. Test extension compatibility
-4. Update CHANGELOG
+## Release workflow
+
+For every user-visible extension change:
+
+1. Add a patch changeset from the repository root with `npx changeset`.
+2. Do not manually edit package versions or either changelog copy.
+3. Open a pull request and let CI validate the package.
+4. Use the unified **Release All Components** workflow after merge.
+
+The release workflow calculates one version for all deliverables, compiles the
+changesets into the root changelog, packages the extension, publishes it to the
+VS Code Marketplace, publishes the .NET packages, and creates the GitHub
+release.
 
 ## Troubleshooting
 
-### Build Issues
+### Missing Node modules
 
-**Error: "Cannot find module 'vscode'"**
-- Run `npm install`
+Run `npm ci` from `vscode-extension`.
 
-**Error: "TypeScript compile errors"**
-- Check `tsconfig.json` settings
-- Verify VS Code types version matches engines.vscode
+### MCP Server is missing
 
-### Packaging Issues
+Run `npm run build:mcp-server`, then verify that
+`bin/Sbroenne.ExcelMcp.McpServer.exe --version` succeeds. The manifest provider
+ID and the ID passed to `registerMcpServerDefinitionProvider` must both be
+`excel-mcp`.
 
-**Error: "LICENSE not found"**
-- Ensure LICENSE file exists in extension root
+### Feature metadata validation fails
 
-**Error: "engines.vscode mismatch"**
-- Update package.json `engines.vscode` to match `@types/vscode` version
+Keep the provider ID and label populated. Keep every Chat Skill's manifest
+name synchronized with the `name` field in its `SKILL.md` frontmatter, and
+provide a manifest description for VS Code's Features table.
 
-### Runtime Issues
+### Package contents are wrong
 
-**Extension not activating**
-- Check `activationEvents` in package.json
-- Verify extension ID matches registration
+Review `.vscodeignore`, then run:
 
-**MCP server not found**
-- Ensure bundled executable exists in `bin/Sbroenne.ExcelMcp.McpServer.exe`
-- Run `npm run build:all` to build both MCP server and CLI executables
-- Verify bundled executable runs: `bin/Sbroenne.ExcelMcp.McpServer.exe --version`
+```powershell
+npx vsce ls --tree
+```
 
-**CLI not found**
-- Ensure `bin/excelcli.exe` exists
-- Run `npm run build:all` to build both executables
-
-## Extension Size 
-
-Current size: **~68-70 MB** (includes bundled self-contained MCP server and CLI executables)
-
-The extension includes:
-- Main extension code (~10 KB)
-- Bundled self-contained MCP server (~118 MB uncompressed, ~34 MB compressed)
-- Bundled self-contained CLI (~115 MB uncompressed, ~34 MB compressed)
-- Agent Skills (~130 KB for both excel-mcp and excel-cli)
-
-Benefits of self-contained bundled approach:
-- ✅ Zero-setup installation (no .NET runtime or SDK required)
-- ✅ Version compatibility guaranteed (extension includes matching MCP server + CLI)
-- ✅ Works offline after installation
-- ✅ No dependency on dotnet tool installations
-- ✅ CLI available directly for terminal-based automation
-
-## Future Enhancements
-
-Potential improvements:
-- [ ] Add configuration options for MCP server
-- [ ] Status bar item showing server status
-- [ ] Commands to restart/reload MCP server
-- [ ] Settings for custom tool arguments
-- [ ] Telemetry for usage insights
-- [ ] Automatic update notifications
+Development sources, local VSIX files, dependencies, and build-only scripts
+must not ship in the package.
 
 ## References
 
 - [VS Code Extension API](https://code.visualstudio.com/api)
-- [MCP Documentation](https://modelcontextprotocol.io/)
-- [VS Code Extension Samples](https://github.com/microsoft/vscode-extension-samples)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
 - [Publishing Extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)

--- a/vscode-extension/DEVELOPMENT.md
+++ b/vscode-extension/DEVELOPMENT.md
@@ -56,12 +56,17 @@ The extension uses VS Code's `chatSkills` contribution point in `package.json` t
 
 ```json
 "chatSkills": [
-  { "name": "excel-mcp", "path": "./skills/excel-mcp/SKILL.md" },
-  { "name": "excel-cli", "path": "./skills/excel-cli/SKILL.md" }
+   {
+      "name": "excel-mcp",
+      "description": "Excel MCP Server skill for Windows workbook automation.",
+      "path": "./skills/excel-mcp/SKILL.md"
+   }
 ]
 ```
 
-Skills are automatically available to GitHub Copilot when the extension is active — no file-copying needed.
+The explicit name and description populate VS Code's Extension Features table;
+the matching frontmatter in `SKILL.md` supplies runtime discovery metadata.
+Skills are automatically available to GitHub Copilot when the extension is active.
 
 ### Activation
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -39,7 +39,8 @@ This extension includes an **Agent Skill** following the [agentskills.io](https:
 
 - **[excel-mcp](https://excelmcpserver.dev/skills/)** - MCP Server tool guidance
 
-**VS Code setup:** Enable the preview setting `chat.useAgentSkills` to allow Copilot to load skills. Skills are registered via VS Code's `chatSkills` contribution point and managed automatically.
+The skill is registered automatically through VS Code's `chatSkills`
+contribution point. No separate skill installation or preview setting is needed.
 
 
 ## 💬 Example Prompts

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -59,6 +59,8 @@
     ],
     "chatSkills": [
       {
+        "name": "excel-mcp",
+        "description": "Excel MCP Server skill for Windows workbook automation.",
         "path": "./skills/excel-mcp/SKILL.md"
       }
     ]
@@ -70,7 +72,8 @@
     "build:mcp-server": "npm run clean && npm run clean:bin && cd .. && dotnet publish src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false -p:PublishReadyToRun=false -p:NuGetAudit=false -nodeReuse:false -o vscode-extension/bin --verbosity minimal",
     "copy:changelog": "node -e \"const fs=require('fs'); fs.copyFileSync('../CHANGELOG.md','CHANGELOG.md');\"",
     "vscode:prepublish": "npm run build:mcp-server && npm run copy:skills && npm run copy:changelog && npm run compile",
-    "compile": "tsc -p ./",
+    "validate:features": "node scripts/validate-feature-metadata.mjs",
+    "compile": "npm run validate:features && tsc -p ./",
     "watch": "tsc -watch -p ./",
     "package": "vsce package",
     "lint": "oxlint src -D correctness -D suspicious -D perf --deny-warnings"

--- a/vscode-extension/scripts/validate-feature-metadata.mjs
+++ b/vscode-extension/scripts/validate-feature-metadata.mjs
@@ -1,31 +1,71 @@
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const extensionRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const manifest = JSON.parse(readFileSync(resolve(extensionRoot, 'package.json'), 'utf8'));
+const extensionSource = readFileSync(resolve(extensionRoot, 'src', 'extension.ts'), 'utf8');
+
+function assertText(value, message) {
+  assert.ok(typeof value === 'string' && value.trim().length > 0, message);
+}
+
+function assertPackagedFile(path, label) {
+  assertText(path, `${label} path must be declared.`);
+  const absolutePath = resolve(extensionRoot, path);
+  assert.ok(!relative(extensionRoot, absolutePath).startsWith('..'), `${label} path must stay within the extension: ${path}`);
+  assert.ok(existsSync(absolutePath), `${label} file does not exist: ${path}`);
+  return absolutePath;
+}
+
+assertText(manifest.name, 'Extension name must be declared.');
+assertText(manifest.displayName, 'Extension display name must be declared.');
+assertText(manifest.description, 'Extension description must be declared.');
+assertText(manifest.publisher, 'Extension publisher must be declared.');
+assertText(manifest.version, 'Extension version must be declared.');
+assertText(manifest.engines?.vscode, 'Minimum VS Code engine version must be declared.');
+assert.ok(manifest.categories?.length > 0, 'At least one Marketplace category must be declared.');
+assert.ok(manifest.keywords?.length > 0, 'At least one Marketplace keyword must be declared.');
+
+assertPackagedFile('README.md', 'Marketplace README');
+assertPackagedFile('LICENSE', 'License');
+const iconPath = assertPackagedFile(manifest.icon, 'Marketplace icon');
+const icon = readFileSync(iconPath);
+assert.equal(icon.subarray(1, 4).toString('ascii'), 'PNG', 'Marketplace icon must be a PNG file.');
+assert.ok(icon.length >= 24, 'Marketplace icon is not a valid PNG file.');
+const iconWidth = icon.readUInt32BE(16);
+const iconHeight = icon.readUInt32BE(20);
+assert.ok(iconWidth >= 128 && iconHeight >= 128, `Marketplace icon must be at least 128x128 pixels; found ${iconWidth}x${iconHeight}.`);
 
 const providers = manifest.contributes?.mcpServerDefinitionProviders ?? [];
 assert.ok(providers.length > 0, 'At least one MCP server definition provider must be contributed.');
+const providerIds = new Set();
 for (const provider of providers) {
-  assert.ok(provider.id?.trim(), 'Every MCP server definition provider must have an ID.');
-  assert.ok(provider.label?.trim(), `MCP server definition provider '${provider.id}' must have a label.`);
+  assertText(provider.id, 'Every MCP server definition provider must have an ID.');
+  assertText(provider.label, `MCP server definition provider '${provider.id}' must have a label.`);
+  assert.ok(!providerIds.has(provider.id), `MCP server definition provider ID is duplicated: ${provider.id}`);
+  providerIds.add(provider.id);
+  assert.ok(
+    extensionSource.includes(`registerMcpServerDefinitionProvider('${provider.id}'`),
+    `MCP server definition provider '${provider.id}' must be registered by src/extension.ts.`
+  );
 }
 
 const skills = manifest.contributes?.chatSkills ?? [];
 assert.ok(skills.length > 0, 'At least one chat skill must be contributed.');
+const skillNames = new Set();
 for (const skill of skills) {
-  assert.ok(skill.path?.trim(), 'Every chat skill must have a path.');
-  assert.ok(skill.name?.trim(), `Chat skill '${skill.path}' must declare a display name for the Features tab.`);
-  assert.ok(skill.description?.trim(), `Chat skill '${skill.path}' must declare a description for the Features tab.`);
+  assertText(skill.path, 'Every chat skill must have a path.');
+  assertText(skill.name, `Chat skill '${skill.path}' must declare a display name for the Features tab.`);
+  assertText(skill.description, `Chat skill '${skill.path}' must declare a description for the Features tab.`);
+  assert.ok(!skillNames.has(skill.name), `Chat skill name is duplicated: ${skill.name}`);
+  skillNames.add(skill.name);
 
-  const skillPath = resolve(extensionRoot, skill.path);
-  assert.ok(existsSync(skillPath), `Chat skill file does not exist: ${skill.path}`);
-
+  const skillPath = assertPackagedFile(skill.path, 'Chat skill');
   const skillContents = readFileSync(skillPath, 'utf8');
   const frontmatterName = skillContents.match(/^---\s*\r?\n[\s\S]*?^name:\s*['"]?([^'"\r\n]+)['"]?\s*$[\s\S]*?^---\s*$/m)?.[1]?.trim();
   assert.equal(skill.name, frontmatterName, `Chat skill '${skill.path}' name must match its SKILL.md frontmatter.`);
 }
 
-console.log('VS Code extension feature metadata is complete.');
+console.log('VS Code extension Marketplace and feature metadata is complete.');

--- a/vscode-extension/scripts/validate-feature-metadata.mjs
+++ b/vscode-extension/scripts/validate-feature-metadata.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const extensionRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(readFileSync(resolve(extensionRoot, 'package.json'), 'utf8'));
+
+const providers = manifest.contributes?.mcpServerDefinitionProviders ?? [];
+assert.ok(providers.length > 0, 'At least one MCP server definition provider must be contributed.');
+for (const provider of providers) {
+  assert.ok(provider.id?.trim(), 'Every MCP server definition provider must have an ID.');
+  assert.ok(provider.label?.trim(), `MCP server definition provider '${provider.id}' must have a label.`);
+}
+
+const skills = manifest.contributes?.chatSkills ?? [];
+assert.ok(skills.length > 0, 'At least one chat skill must be contributed.');
+for (const skill of skills) {
+  assert.ok(skill.path?.trim(), 'Every chat skill must have a path.');
+  assert.ok(skill.name?.trim(), `Chat skill '${skill.path}' must declare a display name for the Features tab.`);
+  assert.ok(skill.description?.trim(), `Chat skill '${skill.path}' must declare a description for the Features tab.`);
+
+  const skillPath = resolve(extensionRoot, skill.path);
+  assert.ok(existsSync(skillPath), `Chat skill file does not exist: ${skill.path}`);
+
+  const skillContents = readFileSync(skillPath, 'utf8');
+  const frontmatterName = skillContents.match(/^---\s*\r?\n[\s\S]*?^name:\s*['"]?([^'"\r\n]+)['"]?\s*$[\s\S]*?^---\s*$/m)?.[1]?.trim();
+  assert.equal(skill.name, frontmatterName, `Chat skill '${skill.path}' name must match its SKILL.md frontmatter.`);
+}
+
+console.log('VS Code extension feature metadata is complete.');

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8,8 +8,8 @@ import * as path from 'path';
  * enabling AI assistants like GitHub Copilot to interact with Microsoft Excel
  * through native COM automation.
  *
- * The extension bundles self-contained executables for both the MCP server and CLI -
- * no .NET SDK or runtime installation required.
+ * The extension bundles a self-contained MCP server executable, so no .NET SDK
+ * or runtime installation is required.
  *
  * Agent Skills are registered via the chatSkills contribution point in package.json.
  */


### PR DESCRIPTION
## Summary
Populate the VS Code Extension Features metadata for the bundled Agent Skill and broadly clean up extension packaging guidance and validation.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] 🔧 Maintenance (dependency updates, code cleanup, etc.)

## Related Issues
Closes #824

## Changeset
- [x] Added a changeset (`npx changeset`) describing this change for end users — see `.changeset/README.md`
- [ ] Not applicable (docs/tests/CI/dependency-only) — added `skip-changelog` label instead

## Changes Made
- Add explicit Chat Skill name and description so VS Code's Features table no longer renders placeholders.
- Validate Marketplace identity, assets, icon dimensions, unique contributions, path containment, provider registration parity, and skill frontmatter during compile/package.
- Rewrite stale extension development guidance around the actual single MCP Server and single bundled skill package.
- Correct MCP and CLI skill installation documentation and remove obsolete CLI-bundling claims.
- Exclude build-only validation scripts from the published VSIX.

## Testing Performed
- [x] Excel E2E not applicable because no Core/CLI/MCP runtime path changed
- [x] Ran the relevant feature-specific validation and recorded the exact commands below
- [x] Build produces zero warnings

## Test Commands
```powershell
Set-Location vscode-extension
npm ci
npm run compile
npm run lint
npm run package
npx vsce ls --tree

Set-Location ..
& .\scripts\check-doc-counts.ps1 -SkipBuild
```

Results:
- Marketplace/feature validator passed.
- TypeScript compilation and oxlint passed.
- Release-shaped VSIX packaged successfully (45 files, 64.29 MB).
- Packaged manifest contains populated Chat Skills and MCP Servers metadata.
- Development scripts, docs, source, dependencies, and CLI binaries are absent from the VSIX.
- Documentation count validation passed at 31 tools / 325 operations.

## Core Commands Coverage Checklist ⚠️

**Does this PR add or modify Core Commands methods?** [ ] Yes [x] No

**Coverage Impact**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Code builds with zero warnings
- [x] Appropriate error handling added
- [x] Updated README.md where needed
- [x] No Excel COM behavior changed

## Additional Notes
VS Code currently marks manifest-level Chat Skill name and description as deprecated in favor of skill frontmatter, but its Extension Features renderer still reads only the manifest fields. Keeping both values is required to populate the Features table; validation prevents the skill name from drifting from canonical frontmatter.
