### PR TITLE
fix: include current changelog in releases

### DIFF
--- a/.changeset/fresh-changelogs-arrive.md
+++ b/.changeset/fresh-changelogs-arrive.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Release changelogs now include the version being shipped.** VS Code and MCPB packages receive the newly generated changelog, and each release tag points to the metadata commit containing that release's entry instead of the previous version's changelog.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,13 @@ env:
   DOTNET_VERSION: '10.0.x'
   NODE_VERSION: '22'
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   # =============================================================================
-  # Job 0: Calculate Version and Create Tag
+  # Job 0: Calculate Version
   # =============================================================================
   version:
     name: Calculate Version
@@ -104,7 +108,47 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
   # =============================================================================
-  # Job 1: Build CLI (standalone exe — primary + NuGet pack — secondary)
+  # Job 1: Prepare the changelog before packaging
+  # =============================================================================
+  prepare-release:
+    name: Prepare Release Changelog
+    needs: [version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Install changesets CLI
+      run: npm ci --registry https://registry.npmjs.org/
+
+    - name: Compile changesets into CHANGELOG.md
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $releaseDate = Get-Date -AsUTC -Format 'yyyy-MM-dd'
+        Set-Content -Path release_date.txt -Value $releaseDate -NoNewline
+        ./scripts/Build-Changelog.ps1 -Version "${{ needs.version.outputs.version }}" -Date $releaseDate
+
+    - name: Upload Prepared Changelog
+      uses: actions/upload-artifact@v7
+      with:
+        name: release-changelog
+        path: |
+          CHANGELOG.md
+          release_notes_body.md
+          release_date.txt
+
+  # =============================================================================
+  # Job 2: Build CLI (standalone exe — primary + NuGet pack — secondary)
   # =============================================================================
   build-cli:
     name: CLI
@@ -283,7 +327,7 @@ jobs:
   # =============================================================================
   build-vscode:
     name: VS Code Extension
-    needs: [version]
+    needs: [version, prepare-release]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -312,9 +356,15 @@ jobs:
         .\scripts\Update-ReleaseVersionMetadata.ps1 -Version $env:VERSION
       shell: pwsh
 
-    - name: Sync Extension Changelog
+    - name: Download Prepared Changelog
+      uses: actions/download-artifact@v8
+      with:
+        name: release-changelog
+        path: release-changelog
+
+    - name: Sync Prepared Changelog
       run: |
-        Copy-Item "CHANGELOG.md" "vscode-extension/CHANGELOG.md" -Force
+        Copy-Item "release-changelog/CHANGELOG.md" "CHANGELOG.md" -Force
       shell: pwsh
 
     - name: Install Dependencies
@@ -351,7 +401,7 @@ jobs:
   # =============================================================================
   build-mcpb:
     name: MCPB Bundle
-    needs: [version]
+    needs: [version, prepare-release]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -368,6 +418,16 @@ jobs:
       run: |
         $version = "${{ needs.version.outputs.version }}"
         echo "VERSION=$version" >> $env:GITHUB_ENV
+      shell: pwsh
+
+    - name: Download Prepared Changelog
+      uses: actions/download-artifact@v8
+      with:
+        name: release-changelog
+        path: release-changelog
+
+    - name: Sync Prepared Changelog
+      run: Copy-Item "release-changelog/CHANGELOG.md" "CHANGELOG.md" -Force
       shell: pwsh
 
     - name: Build MCPB Bundle
@@ -500,7 +560,7 @@ jobs:
   # =============================================================================
   create-tag:
     name: Create Git Tag
-    needs: [version, build-cli, build-mcp-server, build-vscode, build-mcpb, build-agent-skills]
+    needs: [version, prepare-release, build-cli, build-mcp-server, build-vscode, build-mcpb, build-agent-skills]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -508,6 +568,110 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install changesets CLI
+        run: npm ci --registry https://registry.npmjs.org/
+
+      - name: Download Prepared Changelog
+        uses: actions/download-artifact@v8
+        with:
+          name: release-changelog
+          path: prepared-release
+
+      - name: Compile and Verify Release Metadata
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $releaseDate = Get-Content -Raw prepared-release/release_date.txt
+          ./scripts/Build-Changelog.ps1 -Version "${{ needs.version.outputs.version }}" -Date $releaseDate
+
+          $generatedChangelog = (Get-FileHash CHANGELOG.md -Algorithm SHA256).Hash
+          $preparedChangelog = (Get-FileHash prepared-release/CHANGELOG.md -Algorithm SHA256).Hash
+          if ($generatedChangelog -ne $preparedChangelog) {
+            throw 'Generated CHANGELOG.md differs from the changelog used to build release artifacts.'
+          }
+
+          $generatedNotes = (Get-FileHash release_notes_body.md -Algorithm SHA256).Hash
+          $preparedNotes = (Get-FileHash prepared-release/release_notes_body.md -Algorithm SHA256).Hash
+          if ($generatedNotes -ne $preparedNotes) {
+            throw 'Generated release notes differ from the notes prepared before artifact builds.'
+          }
+
+      - name: Commit Release Metadata Update
+        id: release_commit
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -euo pipefail
+
+          VERSION=${{ needs.version.outputs.version }}
+          REPO="${{ github.repository }}"
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::RELEASE_PAT secret is not configured. Add an admin Personal Access Token with 'contents: write' as the repo secret RELEASE_PAT so release metadata can be committed back to main."
+            exit 1
+          fi
+
+          # Stage exactly the files Build-Changelog.ps1 touches.
+          git add -A CHANGELOG.md package.json package-lock.json Directory.Build.props \
+            mcpb/manifest.json src/ExcelMcp.McpServer/.mcp/server.json \
+            vscode-extension/package.json vscode-extension/package-lock.json .changeset
+
+          BASE_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
+          if git diff --cached --quiet; then
+            echo "No release metadata changes to commit; tagging main@$BASE_SHA."
+            echo "sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Base the metadata commit on the current main tip so the update is a
+          # fast-forward even when main advanced while release artifacts built.
+          BASE_TREE=$(gh api "repos/$REPO/git/commits/$BASE_SHA" --jq '.tree.sha')
+          echo "Basing release metadata commit on main@$BASE_SHA"
+
+          tree_entries='[]'
+          while IFS=$'\t' read -r status path; do
+            [ -z "$path" ] && continue
+            if [ "$status" = "D" ]; then
+              echo "  delete  $path"
+              entry=$(jq -n --arg path "$path" '{path:$path, mode:"100644", type:"blob", sha:null}')
+            else
+              echo "  write   $path"
+              git show ":$path" | base64 -w0 > blob.b64
+              blob_sha=$(gh api "repos/$REPO/git/blobs" --method POST \
+                -f encoding=base64 -F content=@blob.b64 --jq '.sha')
+              rm -f blob.b64
+              staged_sha=$(git rev-parse ":$path")
+              if [ "$blob_sha" != "$staged_sha" ]; then
+                echo "::error::Uploaded blob for $path does not match the staged content."
+                exit 1
+              fi
+              entry=$(jq -n --arg path "$path" --arg sha "$blob_sha" \
+                '{path:$path, mode:"100644", type:"blob", sha:$sha}')
+            fi
+            tree_entries=$(jq -c --argjson e "$entry" '. + [$e]' <<<"$tree_entries")
+          done < <(git diff --cached --name-status)
+
+          new_tree=$(jq -n --arg base "$BASE_TREE" --argjson tree "$tree_entries" \
+            '{base_tree:$base, tree:$tree}' \
+            | gh api "repos/$REPO/git/trees" --method POST --input - --jq '.sha')
+
+          new_commit=$(jq -n \
+            --arg msg "chore: update release metadata for v${VERSION} [skip ci]" \
+            --arg tree "$new_tree" --arg parent "$BASE_SHA" \
+            '{message:$msg, tree:$tree, parents:[$parent]}' \
+            | gh api "repos/$REPO/git/commits" --method POST --input - --jq '.sha')
+
+          gh api "repos/$REPO/git/refs/heads/main" --method PATCH \
+            -f sha="$new_commit" -F force=false >/dev/null
+          echo "sha=$new_commit" >> "$GITHUB_OUTPUT"
+          echo "Committed release metadata for v${VERSION} to main@$new_commit."
 
       - name: Configure Git
         run: |
@@ -517,8 +681,10 @@ jobs:
       - name: Create and push tag
         run: |
           TAG="${{ needs.version.outputs.tag }}"
-          echo "Creating tag: $TAG"
-          git tag -a "$TAG" -m "Release $TAG"
+          RELEASE_COMMIT="${{ steps.release_commit.outputs.sha }}"
+          git fetch origin main
+          echo "Creating tag $TAG at release metadata commit $RELEASE_COMMIT"
+          git tag -a "$TAG" "$RELEASE_COMMIT" -m "Release $TAG"
           git push origin "$TAG"
 
   # =============================================================================
@@ -604,15 +770,12 @@ jobs:
   # =============================================================================
   create-release:
     name: Create GitHub Release
-    needs: [version, create-tag, publish]
+    needs: [version, prepare-release, create-tag, publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-    # The release metadata commit-back reads main's current tip and writes the new
-    # commit through the Git Data API (see "Commit Release Metadata Update"), so it
-    # does not rebase locally. A shallow checkout is enough here.
     - uses: actions/checkout@v7
 
     - name: Set Version
@@ -629,29 +792,11 @@ jobs:
         echo "Downloaded artifacts:"
         find artifacts -type f -name "*" | head -20
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v7
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-
-    - name: Install changesets CLI
-      run: npm install --no-save --registry https://registry.npmjs.org/
-
-    - name: Compile changesets into CHANGELOG.md
-      id: changelog
-      shell: pwsh
-      env:
-        # @changesets/changelog-github needs a token to look up PR/commit info for changelog entries.
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        $releaseDate = Get-Date -AsUTC -Format 'yyyy-MM-dd'
-        ./scripts/Build-Changelog.ps1 -Version "${{ env.VERSION }}" -Date $releaseDate
-
     - name: Render Release Notes
       shell: pwsh
       run: |
         $template = Get-Content -Raw '.github/release-notes-template.md'
-        $changelogBody = Get-Content -Raw release_notes_body.md
+        $changelogBody = Get-Content -Raw artifacts/release-changelog/release_notes_body.md
         $notes = $template.Replace('{{VERSION}}', $env:VERSION).Replace('{{CHANGELOG}}', $changelogBody.Trim())
         Set-Content -Path release_notes.md -Value $notes -NoNewline
 
@@ -707,106 +852,3 @@ jobs:
           --notes-file release_notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # Commit the changelog and persistent version metadata changes produced by
-    # Build-Changelog.ps1 above (plus consumed changesets) directly back to main.
-    #
-    # WHY THIS USES THE GIT DATA API INSTEAD OF A PR:
-    #
-    # main is protected by a ruleset whose ONLY bypass actor is the "Repository
-    # admin" role (bypass_mode: always). This repo is user-owned, so the
-    # github-actions bot cannot be added as a bypass actor (GitHub only allows
-    # that for GitHub Apps in organizations). The default GITHUB_TOKEN therefore
-    # can neither push to main nor satisfy the required PR / status-check /
-    # Copilot-review rules for a bookkeeping commit.
-    #
-    # RELEASE_PAT is owned by the repo owner, who IS the admin bypass actor, so
-    # an admin-authenticated write to main bypasses those rules. Two earlier
-    # approaches both failed in real releases:
-    #   * `git push HEAD:main` from inside the runner -- rejected by the ruleset
-    #     (v1.10.1); a raw push is not reliably attributed to the PAT's admin
-    #     identity, so the bypass did not apply.
-    #   * changelog PR + `gh pr merge --admin` -- RELEASE_PAT is a fine-grained
-    #     token WITHOUT "pull requests: write", so `createPullRequest` fails with
-    #     "Resource not accessible by personal access token" (this broke v1.10.2).
-    #
-    # The Git Data API path below (create blob -> tree -> commit -> update ref)
-    # only needs "contents: write" -- which the PAT provably has -- and every
-    # call is unambiguously authenticated as the admin bypass actor via gh api,
-    # so the ref update on main is allowed to bypass the ruleset. No side
-    # branch, no PR, nothing to get stuck.
-    - name: Commit Release Metadata Update
-      env:
-        GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-      run: |
-        set -euo pipefail
-
-        VERSION=${{ env.VERSION }}
-        REPO="${{ github.repository }}"
-
-        if [ -z "${GH_TOKEN:-}" ]; then
-          echo "::error::RELEASE_PAT secret is not configured. Add an admin Personal Access Token with 'contents: write' as the repo secret RELEASE_PAT so release metadata can be committed back to main."
-          exit 1
-        fi
-
-        # Stage exactly the files Build-Changelog.ps1 touches.
-        git add -A CHANGELOG.md package.json package-lock.json Directory.Build.props \
-          mcpb/manifest.json src/ExcelMcp.McpServer/.mcp/server.json \
-          vscode-extension/package.json vscode-extension/package-lock.json .changeset
-        if git diff --cached --quiet; then
-          echo "No release metadata changes to commit -- skipping."
-          exit 0
-        fi
-
-        # Base the new commit on the CURRENT tip of main: the release build can
-        # run for a long time, so main may have advanced since this job checked
-        # out. Making our commit's parent that tip keeps the ref update a
-        # fast-forward; if main advances again between this read and the update
-        # below, the ref PATCH fails loudly rather than clobbering that work.
-        BASE_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
-        BASE_TREE=$(gh api "repos/$REPO/git/commits/$BASE_SHA" --jq '.tree.sha')
-        echo "Basing release metadata commit on main@$BASE_SHA"
-
-        # Build Git tree entries from the staged diff: modified/added files get
-        # their normalized staged blob; deleted changeset fragments get sha=null.
-        tree_entries='[]'
-        while IFS=$'\t' read -r status path; do
-          [ -z "$path" ] && continue
-          if [ "$status" = "D" ]; then
-            echo "  delete  $path"
-            entry=$(jq -n --arg path "$path" '{path:$path, mode:"100644", type:"blob", sha:null}')
-          else
-            echo "  write   $path"
-            git show ":$path" | base64 -w0 > blob.b64
-            blob_sha=$(gh api "repos/$REPO/git/blobs" --method POST \
-              -f encoding=base64 -F content=@blob.b64 --jq '.sha')
-            rm -f blob.b64
-            staged_sha=$(git rev-parse ":$path")
-            if [ "$blob_sha" != "$staged_sha" ]; then
-              echo "::error::Uploaded blob for $path does not match the staged content."
-              exit 1
-            fi
-            entry=$(jq -n --arg path "$path" --arg sha "$blob_sha" \
-              '{path:$path, mode:"100644", type:"blob", sha:$sha}')
-          fi
-          tree_entries=$(jq -c --argjson e "$entry" '. + [$e]' <<<"$tree_entries")
-        done < <(git diff --cached --name-status)
-
-        # Create the tree, the commit (parented on the current main tip), and
-        # fast-forward main to it -- all as the admin bypass actor.
-        new_tree=$(jq -n --arg base "$BASE_TREE" --argjson tree "$tree_entries" \
-          '{base_tree:$base, tree:$tree}' \
-          | gh api "repos/$REPO/git/trees" --method POST --input - --jq '.sha')
-
-        new_commit=$(jq -n \
-          --arg msg "chore: update release metadata for v${VERSION} [skip ci]" \
-          --arg tree "$new_tree" --arg parent "$BASE_SHA" \
-          '{message:$msg, tree:$tree, parents:[$parent]}' \
-          | gh api "repos/$REPO/git/commits" --method POST --input - --jq '.sha')
-
-        gh api "repos/$REPO/git/refs/heads/main" --method PATCH \
-          -f sha="$new_commit" -F force=false >/dev/null
-        echo "Committed release metadata for v${VERSION} to main@$new_commit."
-      # Intentionally NOT continue-on-error: a silently swallowed failure here
-      # is exactly what caused several past releases to be missing their
-      # release metadata commit-back. Let it fail loudly so it gets noticed and fixed.

--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -34,7 +34,7 @@ When you run the release workflow, all components are released together:
 6. **GitHub Copilot Plugins** → Republished to the GitHub Copilot plugin marketplace repo via `publish-plugins.yml` with wrapper/bootstrap assets only; the plugins fetch the newest self-contained Windows runtime from the main release on first use (see [Phase 3 Plugin Publishing](../.github/workflows/docs/publish-plugins-setup.md))
 7. **NuGet** → Both packages published to NuGet.org (secondary channel)
 8. **MCP Registry** → Updated after NuGet propagation
-9. **GitHub Release** → Created with all artifacts + auto-PR to update CHANGELOG
+9. **GitHub Release** → Created with all artifacts and the prepared changelog notes
 
 ### Release Artifacts
 
@@ -81,26 +81,29 @@ workflow runs (see [Changelog Generation](#changelog-generation) below).
 
 The workflow will:
 1. Calculate the next version from the latest git tag
-2. Build all components (standalone exes + NuGet packages)
-3. Create and push the git tag (`v1.5.7`)
-4. Publish to NuGet.org, VS Code Marketplace, MCP Registry
-5. Create GitHub Release with all artifacts
-6. Auto-PR to update `CHANGELOG.md`
+2. Compile pending changesets into the current release changelog
+3. Build all components (standalone exes + NuGet packages), packaging that changelog where applicable
+4. Commit the generated release metadata and create the git tag (`v1.5.7`) at that commit
+5. Publish to NuGet.org, VS Code Marketplace, and MCP Registry
+6. Create the GitHub Release with all artifacts and the prepared release notes
 
 ### 3. Monitor Workflow
 
-The main release workflow runs automatically (10 jobs), then the plugin publish workflow runs automatically if the release succeeds:
+The main release workflow runs automatically (11 jobs), then the plugin publish workflow runs automatically if the release succeeds:
 
-1. **build-cli** (3-5 min) → Builds standalone `excelcli.exe` (win-x64, self-contained), creates ZIP + NuGet pack
-2. **build-mcp-server** (4-6 min) → Builds standalone `mcp-excel.exe` (win-x64, self-contained), creates ZIP + NuGet pack
-3. **build-vscode** (5-8 min) → Builds self-contained VSIX (bundles exes), publishes to VS Code Marketplace
-4. **build-mcpb** (3-5 min) → Builds Claude Desktop bundle
-5. **build-agent-skills** (1-2 min) → Builds agent skills ZIP package (for direct skill extraction via `npx skills add`)
-6. **create-tag** → Creates git tag (waits for all builds)
-7. **publish-mcp-registry** (10-30 min) → Waits for NuGet propagation, updates MCP Registry
-8. **publish** → Publishes to NuGet.org and VS Code Marketplace
-9. **create-release** → Creates GitHub Release with all artifacts (release notes generated from compiled changesets), then creates auto-PR to commit the updated CHANGELOG.md
-10. **publish-plugins.yml** (follow-on workflow) → Sync-gated republish of `excel-mcp` and `excel-cli` to `sbroenne/mcp-server-excel-plugins` when plugin-facing install artifacts changed
+1. **version** → Calculates the version from the latest tag and dispatch input
+2. **prepare-release** → Compiles changesets and uploads the changelog and release notes used by packaging jobs
+3. **build-cli** (3-5 min) → Builds standalone `excelcli.exe` (win-x64, self-contained), creates ZIP + NuGet pack
+4. **build-mcp-server** (4-6 min) → Builds standalone `mcp-excel.exe` (win-x64, self-contained), creates ZIP + NuGet pack
+5. **build-vscode** (5-8 min) → Builds the self-contained VSIX with the prepared changelog
+6. **build-mcpb** (3-5 min) → Builds the Claude Desktop bundle with the prepared changelog
+7. **build-agent-skills** (1-2 min) → Builds agent skills ZIP package (for direct skill extraction via `npx skills add`)
+8. **create-tag** → Regenerates and verifies release metadata, commits it to `main`, then tags that exact commit
+9. **publish-mcp-registry** (10-30 min) → Waits for NuGet propagation, updates MCP Registry
+10. **publish** → Publishes to NuGet.org and VS Code Marketplace
+11. **create-release** → Creates the GitHub Release with all artifacts and the prepared release notes
+
+Afterward, **publish-plugins.yml** runs as a follow-on workflow and sync-gates republication of `excel-mcp` and `excel-cli` to `sbroenne/mcp-server-excel-plugins` when plugin-facing install artifacts changed.
 
 ### 4. Verify Release
 
@@ -111,7 +114,7 @@ After workflow completes:
 - [ ] VS Code Marketplace updated (verify self-contained extension works without .NET)
 - [ ] MCP Registry updated
 - [ ] `publish-plugins.yml` completed; if the sync gate detected plugin-facing changes, `sbroenne/mcp-server-excel-plugins` was updated
-- [ ] Auto-PR created and merged to persist the `CHANGELOG.md` / `package.json` / consumed `.changeset/*.md` updates generated during the release
+- [ ] Release tag contains the current version in `CHANGELOG.md` and points to the release metadata commit on `main`
 
 ### 5. Agent Plugin Publishing (Automatic)
 
@@ -207,11 +210,12 @@ The release workflow injects the correct version from the tag.
 
 1. **Every PR** that changes user-visible behavior adds a small markdown fragment via `npx changeset` (from repo root), describing the change in 1-3 end-user-facing sentences. This is committed to `.changeset/<random-name>.md` alongside the PR.
 2. **CI enforces this** via `.github/workflows/changeset-check.yml`, which fails the PR if no fragment was added — unless the PR carries the `skip-changelog` label (docs/tests/CI/dependency-only changes).
-3. **At release time**, the `create-release` job in `release.yml` runs `scripts/Build-Changelog.ps1 -Version <version> -Date <date>`, which:
+3. **At release time**, the `prepare-release` job in `release.yml` runs `scripts/Build-Changelog.ps1 -Version <version> -Date <date>`, which:
    - Runs `npx changeset version` to consume every pending fragment, deleting them.
    - Normalizes the tool's generated version header to this repo's `## [X.Y.Z] - YYYY-MM-DD` (Keep a Changelog) style.
    - Extracts the new section verbatim into `release_notes_body.md`, used directly as the "What's New" body of the GitHub Release.
-4. **The updated `CHANGELOG.md`, `package.json` (a bookkeeping-only root manifest that hosts the changesets tool — never published to npm), and consumed `.changeset/*.md` deletions** are committed via the same auto-PR-to-`main` pattern used previously (branch protection requires a PR; the workflow step uses `continue-on-error: true`).
+4. **Artifact builds** consume that prepared changelog, so packaged VS Code and MCPB changelog files include the version being released.
+5. **After all builds pass**, the `create-tag` job regenerates the metadata using the same release date and verifies it byte-for-byte against the prepared artifact. It commits `CHANGELOG.md`, synchronized version metadata, and consumed `.changeset/*.md` deletions to `main` through the Git Data API, then points the release tag at that exact commit.
 
 Root `package.json` and `.changeset/config.json` (using `@changesets/changelog-github` for PR-linked entries) exist solely to drive this tooling — they have no bearing on the actual MCP Server / CLI / VS Code Extension / MCPB version, which remains fully controlled by the `version_bump` / `custom_version` workflow inputs as described above.
 
@@ -231,7 +235,7 @@ _No pending changes. New entries are added automatically from changesets when a 
 - **Bug fix description** (#124): what was broken and what's fixed now.
 ```
 
-> **Why auto-PR instead of direct push?** Branch protection requires pull requests for all changes to `main`. The `github-actions[bot]` cannot be added to the bypass list in GitHub Rulesets, so the workflow creates a PR with `continue-on-error: true` to handle this gracefully. Unlike the old sed-based rename, a missed merge here only delays committing an already-published release's changelog — it can no longer mislabel released content as "Unreleased" since the section is always left empty going forward.
+> **Why the Git Data API?** Branch protection prevents the default workflow token from pushing the bookkeeping commit directly. `RELEASE_PAT` belongs to the repository administrator and has `contents: write`, allowing the workflow to create a fast-forward metadata commit before tagging without opening a release-time pull request.
 
 ## Required Secrets and Variables
 
@@ -242,6 +246,7 @@ Configure these GitHub repository secrets and variables:
 | Secret | `NUGET_USER` | NuGet.org username (for OIDC trusted publishing) |
 | Secret | `VSCE_TOKEN` | VS Code Marketplace PAT |
 | Secret | `APPINSIGHTS_CONNECTION_STRING` | Application Insights (optional telemetry) |
+| Secret | `RELEASE_PAT` | Repository-admin token with `contents: write` for the pre-tag release metadata commit |
 | Secret | `PLUGINS_REPO_TOKEN` | Cross-repo PAT (`public_repo`) or app token (`contents:write`) for publishing plugins to `sbroenne/mcp-server-excel-plugins` |
 
 > **Notes:**

--- a/tests/ExcelMcp.SkillGeneration.Tests/ReleaseMetadataScriptTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/ReleaseMetadataScriptTests.cs
@@ -329,22 +329,23 @@ public sealed class ReleaseMetadataScriptTests
 
     private static string ExtractWorkflowJob(string workflow, string jobName)
     {
-        var marker = $"{Environment.NewLine}  {jobName}:{Environment.NewLine}";
+        workflow = workflow.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var marker = $"\n  {jobName}:\n";
         var start = workflow.IndexOf(marker, StringComparison.Ordinal);
         Assert.True(start >= 0, $"Workflow job '{jobName}' was not found.");
 
         start += marker.Length;
-        var end = workflow.IndexOf($"{Environment.NewLine}  ", start, StringComparison.Ordinal);
+        var end = workflow.IndexOf("\n  ", start, StringComparison.Ordinal);
         while (end >= 0)
         {
-            var nextLineEnd = workflow.IndexOf(Environment.NewLine, end + Environment.NewLine.Length, StringComparison.Ordinal);
+            var nextLineEnd = workflow.IndexOf('\n', end + 1);
             var line = nextLineEnd >= 0 ? workflow[end..nextLineEnd] : workflow[end..];
-            if (line.Length > Environment.NewLine.Length + 2 && line[Environment.NewLine.Length + 2] != ' ')
+            if (line.Length > 3 && line[3] != ' ')
             {
                 break;
             }
 
-            end = workflow.IndexOf($"{Environment.NewLine}  ", end + Environment.NewLine.Length + 2, StringComparison.Ordinal);
+            end = workflow.IndexOf("\n  ", end + 3, StringComparison.Ordinal);
         }
 
         return end >= 0 ? workflow[start..end] : workflow[start..];

--- a/tests/ExcelMcp.SkillGeneration.Tests/ReleaseMetadataScriptTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/ReleaseMetadataScriptTests.cs
@@ -139,6 +139,48 @@ public sealed class ReleaseMetadataScriptTests
     [Fact]
     [Trait("Category", "Integration")]
     [Trait("Feature", "ReleaseMetadata")]
+    public void ReleaseFlow_PackagesAndTagsCurrentChangelog()
+    {
+        var releaseWorkflow = File.ReadAllText(ReleaseWorkflow);
+        var prepareRelease = ExtractWorkflowJob(releaseWorkflow, "prepare-release");
+        var buildVsCode = ExtractWorkflowJob(releaseWorkflow, "build-vscode");
+        var buildMcpb = ExtractWorkflowJob(releaseWorkflow, "build-mcpb");
+        var createTag = ExtractWorkflowJob(releaseWorkflow, "create-tag");
+        var createRelease = ExtractWorkflowJob(releaseWorkflow, "create-release");
+
+        Assert.Contains("./scripts/Build-Changelog.ps1", prepareRelease, StringComparison.Ordinal);
+        Assert.Contains("name: release-changelog", prepareRelease, StringComparison.Ordinal);
+        Assert.Contains("needs: [version, prepare-release]", buildVsCode, StringComparison.Ordinal);
+        Assert.Contains("name: release-changelog", buildVsCode, StringComparison.Ordinal);
+        Assert.Contains(
+            "Copy-Item \"release-changelog/CHANGELOG.md\" \"CHANGELOG.md\" -Force",
+            buildVsCode,
+            StringComparison.Ordinal);
+        Assert.Contains("needs: [version, prepare-release]", buildMcpb, StringComparison.Ordinal);
+        Assert.Contains("name: release-changelog", buildMcpb, StringComparison.Ordinal);
+        Assert.Contains(
+            "Copy-Item \"release-changelog/CHANGELOG.md\" \"CHANGELOG.md\" -Force",
+            buildMcpb,
+            StringComparison.Ordinal);
+
+        var commitIndex = createTag.IndexOf("Commit Release Metadata Update", StringComparison.Ordinal);
+        var tagIndex = createTag.IndexOf("Create and push tag", StringComparison.Ordinal);
+        Assert.Contains("prepare-release", createTag, StringComparison.Ordinal);
+        Assert.True(commitIndex >= 0, "The tag job must commit the generated release metadata.");
+        Assert.True(tagIndex > commitIndex, "Release metadata must be committed before the tag is created.");
+        Assert.Contains("git tag -a \"$TAG\" \"$RELEASE_COMMIT\"", createTag, StringComparison.Ordinal);
+
+        Assert.Contains(
+            "artifacts/release-changelog/release_notes_body.md",
+            createRelease,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("./scripts/Build-Changelog.ps1", createRelease, StringComparison.Ordinal);
+        Assert.DoesNotContain("Commit Release Metadata Update", createRelease, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "ReleaseMetadata")]
     public async Task UpdateMetadata_StampsSeparatedTopLevelAndPackageVersions()
     {
         var sandbox = CreateSandbox();
@@ -283,6 +325,29 @@ public sealed class ReleaseMetadataScriptTests
         }
 
         return element.GetString()!;
+    }
+
+    private static string ExtractWorkflowJob(string workflow, string jobName)
+    {
+        var marker = $"{Environment.NewLine}  {jobName}:{Environment.NewLine}";
+        var start = workflow.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Workflow job '{jobName}' was not found.");
+
+        start += marker.Length;
+        var end = workflow.IndexOf($"{Environment.NewLine}  ", start, StringComparison.Ordinal);
+        while (end >= 0)
+        {
+            var nextLineEnd = workflow.IndexOf(Environment.NewLine, end + Environment.NewLine.Length, StringComparison.Ordinal);
+            var line = nextLineEnd >= 0 ? workflow[end..nextLineEnd] : workflow[end..];
+            if (line.Length > Environment.NewLine.Length + 2 && line[Environment.NewLine.Length + 2] != ' ')
+            {
+                break;
+            }
+
+            end = workflow.IndexOf($"{Environment.NewLine}  ", end + Environment.NewLine.Length + 2, StringComparison.Ordinal);
+        }
+
+        return end >= 0 ? workflow[start..end] : workflow[start..];
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
## Summary
- generate the current release changelog before VSIX and MCPB packaging
- commit release metadata before tagging and point the tag at that exact commit
- reuse the prepared notes for the GitHub Release
- add release graph regression coverage and update release documentation

Closes #827

## Root cause
`CHANGELOG.md` was compiled only in `create-release`, after the VSIX/MCPB builds and after `create-tag`. The packages and tag therefore contained the previous release's changelog while only `main` received the generated section afterward.

## Validation
- red/green `ReleaseFlow_PackagesAndTagsCurrentChangelog`
- `dotnet test tests/ExcelMcp.SkillGeneration.Tests/ExcelMcp.SkillGeneration.Tests.csproj -c Release --filter "Feature=ReleaseMetadata" --no-restore` (6 passed)
- YAML parse (11 jobs)
- `scripts/pre-commit.ps1` (all checks and release packaging gates passed)
- independent workflow review completed; no remaining verified defects

## Excel E2E
Not applicable: release automation, documentation, and pure workflow regression coverage only.