### PR TITLE
Reject unsafe merged-cell writes

### DIFF
--- a/.changeset/merged-cell-writes-report-errors.md
+++ b/.changeset/merged-cell-writes-report-errors.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Merged-cell writes now fail clearly instead of reporting false success** (#831). `set-values` and `set-formulas` identify affected merged ranges and explain whether to write to the top-left cell or unmerge the range.

--- a/skills/excel-cli/references/range.md
+++ b/skills/excel-cli/references/range.md
@@ -28,6 +28,10 @@ range(action: 'set-number-format', range_address: 'C2:D4', format_code: '$#,##0.
 range_format(action: 'auto-fit-columns', range_address: 'A:D')
 ```
 
+## Writes to Merged Cells
+
+`set-values` and `set-formulas` reject writes that include merged cells unless the target is only the merged range's top-left cell. The error lists the affected merged ranges. Write to that top-left cell when changing one merged value, or unmerge the range before writing a larger grid.
+
 ## Quick Pattern: Repeated Section Headers
 
 Use `format-ranges` when the same header or section style repeats across disjoint ranges on one sheet:

--- a/skills/excel-mcp/references/range.md
+++ b/skills/excel-mcp/references/range.md
@@ -26,6 +26,10 @@ range(action: 'set-number-format', range_address: 'C2:D4', format_code: '$#,##0.
 range_format(action: 'auto-fit-columns', range_address: 'A:D')
 ```
 
+## Writes to Merged Cells
+
+`set-values` and `set-formulas` reject writes that include merged cells unless the target is only the merged range's top-left cell. The error lists the affected merged ranges. Write to that top-left cell when changing one merged value, or unmerge the range before writing a larger grid.
+
 ## Quick Pattern: Repeated Section Headers
 
 Use `format-ranges` when the same header or section style repeats across disjoint ranges on one sheet:

--- a/skills/shared/range.md
+++ b/skills/shared/range.md
@@ -26,6 +26,10 @@ range(action: 'set-number-format', range_address: 'C2:D4', format_code: '$#,##0.
 range_format(action: 'auto-fit-columns', range_address: 'A:D')
 ```
 
+## Writes to Merged Cells
+
+`set-values` and `set-formulas` reject writes that include merged cells unless the target is only the merged range's top-left cell. The error lists the affected merged ranges. Write to that top-left cell when changing one merged value, or unmerge the range before writing a larger grid.
+
 ## Quick Pattern: Repeated Section Headers
 
 Use `format-ranges` when the same header or section style repeats across disjoint ranges on one sheet:

--- a/src/ExcelMcp.Core/Commands/Range/IRangeCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Range/IRangeCommands.cs
@@ -28,7 +28,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Range;
 /// </summary>
 [ServiceCategory("range", "Range")]
 [McpTool("range", Title = "Range Operations", Destructive = true, Category = "data",
-    Description = "Core range operations: get/set values and formulas, copy ranges, clear content, discover data regions. Use range_edit for insert/delete/find/sort. Use range_format for styling/validation. Use range_link for hyperlinks/protection. Use calculation_mode for recalculation. EXCEL TABLES: If user asks to 'format as table', 'create a table', 'put data in an Excel Table' — do NOT try to use range for this. Use table(action:'create') on the data range to create a proper Excel Table with filter arrows, banded rows, and automatic expansion. DATA FORMAT: 2D JSON arrays [[row1col1,row1col2],[row2col1,row2col2]]. Single cell returns [[value]]. FILE INPUT: For set-values/set-formulas, provide EITHER inline values/formulas OR a valuesFile/formulasFile path to a .json or .csv file. Prefer file input for large datasets. BEST PRACTICE: get-values before overwriting, clear-contents (not clear-all) to preserve formatting. NAMED RANGES: Use sheetName='' and rangeAddress=namedRangeName.")]
+    Description = "Core range operations: get/set values and formulas, copy ranges, clear content, discover data regions. Use range_edit for insert/delete/find/sort. Use range_format for styling/validation. Use range_link for hyperlinks/protection. Use calculation_mode for recalculation. EXCEL TABLES: If user asks to 'format as table', 'create a table', 'put data in an Excel Table' — do NOT try to use range for this. Use table(action:'create') on the data range to create a proper Excel Table with filter arrows, banded rows, and automatic expansion. DATA FORMAT: 2D JSON arrays [[row1col1,row1col2],[row2col1,row2col2]]. Single cell returns [[value]]. MERGED CELLS: Writes that intersect merged cells fail unless the target is only the merged range's top-left cell; the error identifies affected merged ranges. FILE INPUT: For set-values/set-formulas, provide EITHER inline values/formulas OR a valuesFile/formulasFile path to a .json or .csv file. Prefer file input for large datasets. BEST PRACTICE: get-values before overwriting, clear-contents (not clear-all) to preserve formatting. NAMED RANGES: Use sheetName='' and rangeAddress=namedRangeName.")]
 public interface IRangeCommands
 {
     // === VALUE OPERATIONS ===
@@ -50,6 +50,7 @@ public interface IRangeCommands
     /// JSON file: must contain a 2D array like [[1,2],[3,4]].
     /// CSV file: rows become array rows, comma-separated values become columns.
     /// Every row must be rectangular and match the target range column count.
+    /// Writes that intersect merged cells fail unless the target is only the merged range's top-left cell.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Name of the worksheet containing the range - REQUIRED for cell addresses, use empty string for named ranges only</param>
@@ -75,6 +76,7 @@ public interface IRangeCommands
     /// Sets formulas in a range from 2D array or file.
     /// Provide EITHER formulas (inline JSON 2D array) OR formulasFile (path to .json file), not both.
     /// Every row must be rectangular and match the target range column count.
+    /// Writes that intersect merged cells fail unless the target is only the merged range's top-left cell.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Name of the worksheet containing the range</param>
@@ -301,6 +303,5 @@ public class SortColumn
     /// <summary>Sort direction (true = ascending, false = descending)</summary>
     public bool Ascending { get; set; } = true;
 }
-
 
 

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
@@ -198,6 +198,8 @@ public partial class RangeCommands
                     throw new InvalidOperationException(specificError ?? RangeHelpers.GetResolveError(sheetName, rangeAddress));
                 }
 
+                ValidateMergedCellsForWrite((Excel.Range)range, rangeAddress, ct);
+
                 // Calculation suppressed here (not in ExcelWriteGuard) because Data Model ops need it enabled
                 originalCalculation = (int)ctx.App.Calculation;
                 if (originalCalculation != -4135) // xlCalculationManual
@@ -260,5 +262,3 @@ public partial class RangeCommands
         });
     }
 }
-
-

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Values.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Values.cs
@@ -120,6 +120,8 @@ public partial class RangeCommands
                     throw new InvalidOperationException(specificError ?? RangeHelpers.GetResolveError(sheetName, rangeAddress));
                 }
 
+                ValidateMergedCellsForWrite((Excel.Range)range, rangeAddress, ct);
+
                 // Calculation suppressed here (not in ExcelWriteGuard) because Data Model ops need it enabled
                 originalCalculation = (int)ctx.App.Calculation;
                 if (originalCalculation != -4135) // xlCalculationManual
@@ -179,6 +181,57 @@ public partial class RangeCommands
         });
     }
 
+    private static void ValidateMergedCellsForWrite(
+        Excel.Range range,
+        string requestedRangeAddress,
+        CancellationToken cancellationToken)
+    {
+        object? mergeCells = range.MergeCells;
+        bool? isMergedState = GetMergeCellsState(mergeCells);
+        if (isMergedState == false)
+        {
+            return;
+        }
+
+        if (isMergedState == true && Convert.ToInt64(range.CountLarge) == 1)
+        {
+            Excel.Range? mergeArea = null;
+            try
+            {
+                mergeArea = range.MergeArea;
+                if (range.Row == mergeArea.Row && range.Column == mergeArea.Column)
+                {
+                    return;
+                }
+
+                ThrowMergedCellWriteError(
+                    requestedRangeAddress,
+                    [mergeArea.Address[true, true]]);
+            }
+            finally
+            {
+                ComUtilities.Release(ref mergeArea);
+            }
+        }
+
+        var mergedRanges = CollectMergedRanges(range, cancellationToken);
+        if (mergedRanges.Count > 0)
+        {
+            ThrowMergedCellWriteError(requestedRangeAddress, mergedRanges);
+        }
+    }
+
+    private static void ThrowMergedCellWriteError(
+        string requestedRangeAddress,
+        List<string> mergedRanges)
+    {
+        string rangeLabel = mergedRanges.Count == 1 ? "Merged range" : "Merged ranges";
+        throw new InvalidOperationException(
+            $"Cannot write to range '{requestedRangeAddress}' because the write intersects merged cells. " +
+            $"{rangeLabel}: {string.Join(", ", mergedRanges)}. " +
+            "Write only to each merged range's top-left cell, or unmerge the affected range before writing.");
+    }
+
     /// <summary>
     /// Detects formulas in value array (strings starting with =)
     /// Returns true if any formulas detected, outputs formula array
@@ -229,6 +282,3 @@ public partial class RangeCommands
         }
     }
 }
-
-
-

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Values.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Values.cs
@@ -272,6 +272,77 @@ public partial class RangeCommandsTests
     }
 
     [Fact]
+    public void SetValues_MergedNonAnchorCell_ThrowsAndPreservesExistingValue()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.SetValues(batch, sheetName, "A1", [["Original"]]);
+        _commands.MergeCells(batch, sheetName, "A1:B1");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _commands.SetValues(batch, sheetName, "B1", [["Updated"]]));
+
+        Assert.Contains("$A$1:$B$1", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("top-left", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unmerge", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        var readResult = _commands.GetValues(batch, sheetName, "A1");
+        Assert.Equal("Original", readResult.Values[0][0]);
+    }
+
+    [Fact]
+    public void SetValues_MergedTopLeftCell_WritesAndRetainsValue()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.MergeCells(batch, sheetName, "A1:B1");
+
+        var result = _commands.SetValues(batch, sheetName, "A1", [["Updated"]]);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var readResult = _commands.GetValues(batch, sheetName, "A1");
+        Assert.Equal("Updated", readResult.Values[0][0]);
+    }
+
+    [Fact]
+    public void SetValues_RangeIntersectingMergedCells_ThrowsBeforeWriting()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.SetValues(batch, sheetName, "A1", [["Anchor"]]);
+        _commands.SetValues(batch, sheetName, "C1", [["Outside"]]);
+        _commands.MergeCells(batch, sheetName, "A1:B1");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _commands.SetValues(
+                batch,
+                sheetName,
+                "A1:C1",
+                [["New anchor", "Discarded", "New outside"]]));
+
+        Assert.Contains("$A$1:$B$1", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("Anchor", _commands.GetValues(batch, sheetName, "A1").Values[0][0]);
+        Assert.Equal("Outside", _commands.GetValues(batch, sheetName, "C1").Values[0][0]);
+    }
+
+    [Fact]
+    public void SetValues_FormulaInMergedNonAnchorCell_Throws()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.MergeCells(batch, sheetName, "A1:B1");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _commands.SetValues(batch, sheetName, "B1", [["=1+1"]]));
+
+        Assert.Contains("$A$1:$B$1", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void GetValues_InvalidRange_ReportsSheetAndAddress()
     {
         using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
@@ -286,6 +357,4 @@ public partial class RangeCommandsTests
     }
 
 }
-
-
 

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/RangeMergedCellWriteRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/RangeMergedCellWriteRegressionTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Range")]
+[Trait("RequiresExcel", "true")]
+public sealed class RangeMergedCellWriteRegressionTests : McpIntegrationTestBase
+{
+    private readonly string _testExcelFile;
+    private string? _sessionId;
+
+    public RangeMergedCellWriteRegressionTests(ITestOutputHelper output)
+        : base(output, "RangeMergedCellWriteRegressionClient")
+    {
+        _testExcelFile = Path.Join(CreateTempDirectory("RangeMergedCellWrite"), "MergedCellWrite.xlsx");
+    }
+
+    protected override async Task InitializeTestAsync()
+    {
+        _sessionId = await CreateWorkbookSessionAsync(_testExcelFile);
+    }
+
+    [Fact]
+    public async Task SetValues_MergedNonAnchorCell_ReturnsActionableFailureViaMcp()
+    {
+        AssertSuccess(
+            await CallToolAsync("range", new Dictionary<string, object?>
+            {
+                ["action"] = "set-values",
+                ["session_id"] = _sessionId,
+                ["sheet_name"] = "Sheet1",
+                ["range_address"] = "A1",
+                ["values"] = new List<List<object?>> { new() { "Original" } }
+            }),
+            "range.set-values initial value");
+
+        AssertSuccess(
+            await CallToolAsync("range_format", new Dictionary<string, object?>
+            {
+                ["action"] = "merge-cells",
+                ["session_id"] = _sessionId,
+                ["sheet_name"] = "Sheet1",
+                ["range_address"] = "A1:B1"
+            }),
+            "range_format.merge-cells");
+
+        var failedWriteJson = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-values",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "B1",
+            ["values"] = new List<List<object?>> { new() { "Updated" } }
+        });
+
+        using var failedWrite = ParseJsonResult(failedWriteJson, "range.set-values merged non-anchor");
+        AssertFailureEnvelope(
+            failedWrite.RootElement,
+            "range.set-values merged non-anchor",
+            nameof(InvalidOperationException));
+
+        string? errorMessage = failedWrite.RootElement.GetProperty("errorMessage").GetString();
+        Assert.Contains("$A$1:$B$1", errorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("top-left", errorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unmerge", errorMessage, StringComparison.OrdinalIgnoreCase);
+
+        var readJson = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "get-values",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "A1"
+        });
+
+        using var read = JsonDocument.Parse(readJson);
+        Assert.Equal("Original", read.RootElement.GetProperty("values")[0][0].GetString());
+    }
+}


### PR DESCRIPTION
## Summary
- reject `set-values` and `set-formulas` writes that intersect merged cells
- allow a single write to the merged range's top-left cell
- return the affected merged ranges with clear remediation
- add Core and MCP regression coverage plus shared guidance

Closes #831

## Validation
- focused Core range write tests
- MCP protocol regression test
- Release solution build
- repository COM, coverage, parity, success-flag, docs, and dynamic-cast checks
- local CLI and MCP Excel end-to-end tests
- VS Code, MCPB, CLI, MCP server, and skills package validation