### PR TITLE
Accept explicitly typed ISO date values

### DIFF
--- a/.changeset/graceful-stale-build-save.md
+++ b/.changeset/graceful-stale-build-save.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Stale-build cleanup now preserves unsaved CLI session changes when a shutdown reply is lost.** The cleanup client gives an already-shutting-down daemon time to save and exit before using pipe-scoped forced cleanup.

--- a/.changeset/typed-iso-dates.md
+++ b/.changeset/typed-iso-dates.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": minor
+---
+
+**Range writes now accept explicit ISO date values** (#835): use typed `date`, `datetime`, or `datetime-offset` objects inside the existing `values` array. Excel serials honor the workbook date system, timezone-bearing values normalize to UTC, and plain strings remain text.

--- a/docs/features/CELLS-WORKBOOKS.md
+++ b/docs/features/CELLS-WORKBOOKS.md
@@ -48,6 +48,35 @@ Read and write cell values, formulas, and formatting across any range of cells.
 - **Replace:** Find and replace values in a range
 - **Sort:** Sort a range by one or more columns
 
+### Explicit ISO date values
+
+`range set-values` accepts typed objects inside its existing 2D `values` array:
+
+```json
+[
+  [
+    { "type": "date", "value": "2026-08-27" },
+    { "type": "datetime", "value": "2026-08-27T14:30:00" },
+    {
+      "type": "datetime-offset",
+      "value": "2026-08-27T14:30:00+02:00",
+      "numberFormat": "yyyy-mm-dd hh:mm"
+    }
+  ]
+]
+```
+
+`date` uses the exact `yyyy-MM-dd` form. `datetime` is a local wall-clock value
+without a timezone and allows fractional seconds. `datetime-offset` requires `Z`
+or a numeric offset and is normalized to UTC because Excel cells do not retain
+timezone information. Excel serial values honor the workbook's 1900 or 1904 date
+system.
+
+Typed dates default to `yyyy-mm-dd`; typed datetimes default to
+`yyyy-mm-dd hh:mm:ss`. Set `numberFormat` on a typed object to override the
+default. Existing numbers, booleans, nulls, and strings remain supported, and a
+plain ISO-looking string stays text rather than being guessed as a date.
+
 **Discovery & Utilities:**
 - **Get Used Range:** Get the worksheet's used range
 - **Get Current Region:** Get the contiguous data region around a cell

--- a/scripts/Stop-ExcelMcpProcesses.ps1
+++ b/scripts/Stop-ExcelMcpProcesses.ps1
@@ -55,6 +55,7 @@ $safetyInputs = @(
     (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonStartupLock.cs'),
     (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonTrackingJson.cs'),
     (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\OwnedProcessCleanup.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\PreBuildProcessCleanup.cs'),
     (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\ExcelMcp.Cleanup.csproj'),
     (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\Program.cs'),
     (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\ParameterTransforms.cs'),
@@ -155,7 +156,7 @@ try {
     if ($exitCode -ne 0) {
         Write-Host "  Owned CLI cleanup failed with exit code $exitCode. No process sweep was attempted." -ForegroundColor Yellow
         if ($output) {
-            Write-Status ($output | Out-String).Trim()
+            [Console]::Error.WriteLine(($output | Out-String).Trim())
         }
         exit $exitCode
     }

--- a/skills/excel-mcp/references/range.md
+++ b/skills/excel-mcp/references/range.md
@@ -18,6 +18,25 @@ If you are looking for percentage, currency, date, or text display formatting, u
 If you are looking for auto-fit, width, height, borders, fill, or font styling, use `range_format`.
 If you need the same styling on multiple non-contiguous ranges, use `format-ranges` instead of repeating `format-range`.
 
+## Typed ISO Date Values
+
+Use explicit objects inside the existing `set-values` matrix when a cell must contain an Excel date value:
+
+```text
+range(action: 'set-values', range_address: 'A1:C1', values: [[
+    {"type":"date","value":"2026-08-27"},
+    {"type":"datetime","value":"2026-08-27T14:30:00"},
+    {"type":"datetime-offset","value":"2026-08-27T14:30:00+02:00","numberFormat":"yyyy-mm-dd hh:mm"}
+]])
+```
+
+- `date` requires `yyyy-MM-dd`.
+- `datetime` requires `yyyy-MM-ddTHH:mm:ss`, allows fractional seconds, and must not include a timezone.
+- `datetime-offset` requires `Z` or a numeric offset and is stored as UTC because Excel cells have no timezone.
+- `numberFormat` is optional. Defaults are `yyyy-mm-dd` for dates and `yyyy-mm-dd hh:mm:ss` for both datetime types.
+- Serial values follow the workbook's 1900 or 1904 date system.
+- Plain strings stay text; the server never guesses that an ordinary string is a date.
+
 ## Quick Pattern: Write, Format, Auto-Fit
 
 ```

--- a/skills/shared/range.md
+++ b/skills/shared/range.md
@@ -18,6 +18,25 @@ If you are looking for percentage, currency, date, or text display formatting, u
 If you are looking for auto-fit, width, height, borders, fill, or font styling, use `range_format`.
 If you need the same styling on multiple non-contiguous ranges, use `format-ranges` instead of repeating `format-range`.
 
+## Typed ISO Date Values
+
+Use explicit objects inside the existing `set-values` matrix when a cell must contain an Excel date value:
+
+```text
+range(action: 'set-values', range_address: 'A1:C1', values: [[
+    {"type":"date","value":"2026-08-27"},
+    {"type":"datetime","value":"2026-08-27T14:30:00"},
+    {"type":"datetime-offset","value":"2026-08-27T14:30:00+02:00","numberFormat":"yyyy-mm-dd hh:mm"}
+]])
+```
+
+- `date` requires `yyyy-MM-dd`.
+- `datetime` requires `yyyy-MM-ddTHH:mm:ss`, allows fractional seconds, and must not include a timezone.
+- `datetime-offset` requires `Z` or a numeric offset and is stored as UTC because Excel cells have no timezone.
+- `numberFormat` is optional. Defaults are `yyyy-mm-dd` for dates and `yyyy-mm-dd hh:mm:ss` for both datetime types.
+- Serial values follow the workbook's 1900 or 1904 date system.
+- Plain strings stay text; the server never guesses that an ordinary string is a date.
+
 ## Quick Pattern: Write, Format, Auto-Fit
 
 ```

--- a/specs/RANGE-API-SPECIFICATION.md
+++ b/specs/RANGE-API-SPECIFICATION.md
@@ -82,6 +82,19 @@ range.Value2 = values;  // Bulk write
 object[,] data = range.Value2;  // Bulk read
 ```
 
+`set-values` keeps its 2D array contract and accepts explicit typed date cells:
+
+```json
+[[{"type":"date","value":"2026-08-27"}]]
+```
+
+Supported types are `date` (`yyyy-MM-dd`), `datetime` (ISO local date/time
+without an offset), and `datetime-offset` (ISO date/time with `Z` or a numeric
+offset). Offset values normalize to UTC, serial values honor the workbook's 1900
+or 1904 date system, and an optional `numberFormat` overrides the documented ISO
+default. Primitive values remain supported and strings are never inferred as
+dates.
+
 #### 2. **Formula Operations**  
 ```csharp
 // Excel COM: Range.Formula property (string array)

--- a/src/ExcelMcp.CLI/Infrastructure/PreBuildProcessCleanup.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/PreBuildProcessCleanup.cs
@@ -1,0 +1,103 @@
+using Sbroenne.ExcelMcp.Service;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+internal static class PreBuildProcessCleanup
+{
+    private static readonly TimeSpan GracefulRequestTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan GracefulExitTimeout = TimeSpan.FromSeconds(12);
+
+    internal static Task<OwnedProcessCleanup.CleanupResult> CleanupWithGracefulShutdownAsync(
+        string pipeName,
+        CancellationToken cancellationToken) =>
+        CleanupWithGracefulShutdownAsync(
+            pipeName,
+            cancellationToken,
+            token => RequestGracefulShutdownAsync(pipeName, token));
+
+    internal static async Task<OwnedProcessCleanup.CleanupResult> CleanupWithGracefulShutdownAsync(
+        string pipeName,
+        CancellationToken cancellationToken,
+        Func<CancellationToken, Task<bool>> requestGracefulShutdownAsync)
+    {
+        ArgumentNullException.ThrowIfNull(requestGracefulShutdownAsync);
+
+        var snapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+        if (snapshot.TrackingStatus
+            is DaemonProcessTracker.TrackingRecordStatus.Invalid
+            or DaemonProcessTracker.TrackingRecordStatus.Unreadable)
+        {
+            return await OwnedProcessCleanup.CleanupAsync(
+                pipeName,
+                snapshot,
+                cancellationToken);
+        }
+
+        _ = await requestGracefulShutdownAsync(cancellationToken);
+        // The daemon may begin saving before its reply reaches the cleanup client.
+        // Always allow that tracked generation to exit before force cleanup.
+        _ = await WaitForTrackedDaemonExitAsync(
+            pipeName,
+            snapshot,
+            cancellationToken);
+
+        return await OwnedProcessCleanup.CleanupAsync(
+            pipeName,
+            snapshot,
+            cancellationToken);
+    }
+
+    private static async Task<bool> RequestGracefulShutdownAsync(
+        string pipeName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = new ServiceClient(
+                pipeName,
+                connectTimeout: GracefulRequestTimeout,
+                requestTimeout: GracefulRequestTimeout);
+            var response = await client.SendAsync(
+                new ServiceRequest { Command = "service.shutdown" },
+                GracefulRequestTimeout,
+                cancellationToken);
+            return response.Success;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> WaitForTrackedDaemonExitAsync(
+        string pipeName,
+        OwnedProcessCleanup.ProcessSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        if (!snapshot.DaemonMatched || snapshot.DaemonProcess is not { } expectedDaemon)
+        {
+            return true;
+        }
+
+        var deadline = DateTime.UtcNow + GracefulExitTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var current = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+            if (current.TrackingStatus == DaemonProcessTracker.TrackingRecordStatus.Missing
+                || !current.DaemonMatched
+                || current.DaemonProcess != expectedDaemon)
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
+        }
+
+        return false;
+    }
+}

--- a/src/ExcelMcp.Cleanup/ExcelMcp.Cleanup.csproj
+++ b/src/ExcelMcp.Cleanup/ExcelMcp.Cleanup.csproj
@@ -24,6 +24,8 @@
              Link="Infrastructure\DaemonTrackingJson.cs" />
     <Compile Include="..\ExcelMcp.CLI\Infrastructure\OwnedProcessCleanup.cs"
              Link="Infrastructure\OwnedProcessCleanup.cs" />
+    <Compile Include="..\ExcelMcp.CLI\Infrastructure\PreBuildProcessCleanup.cs"
+             Link="Infrastructure\PreBuildProcessCleanup.cs" />
     <Compile Include="..\ExcelMcp.Service\ServiceSecurity.cs"
              Link="Service\ServiceSecurity.cs" />
     <Compile Include="..\ExcelMcp.Service\ServiceClient.cs"

--- a/src/ExcelMcp.Cleanup/Program.cs
+++ b/src/ExcelMcp.Cleanup/Program.cs
@@ -5,9 +5,6 @@ namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
 
 internal static class Program
 {
-    private static readonly TimeSpan GracefulRequestTimeout = TimeSpan.FromSeconds(3);
-    private static readonly TimeSpan GracefulExitTimeout = TimeSpan.FromSeconds(12);
-
     private static async Task<int> Main()
     {
         var pipeName = Environment.GetEnvironmentVariable("EXCELMCP_CLI_PIPE")
@@ -18,7 +15,9 @@ internal static class Program
         {
             var result = await DaemonStartupLock.WithLockAsync(
                 pipeName,
-                () => CleanupWithGracefulShutdownAsync(pipeName, timeout.Token),
+                () => PreBuildProcessCleanup.CleanupWithGracefulShutdownAsync(
+                    pipeName,
+                    timeout.Token),
                 timeout.Token);
             Console.WriteLine(JsonSerializer.Serialize(new
             {
@@ -37,84 +36,5 @@ internal static class Program
             }));
             return 1;
         }
-    }
-
-    private static async Task<OwnedProcessCleanup.CleanupResult> CleanupWithGracefulShutdownAsync(
-        string pipeName,
-        CancellationToken cancellationToken)
-    {
-        var snapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
-        if (snapshot.TrackingStatus
-            is DaemonProcessTracker.TrackingRecordStatus.Invalid
-            or DaemonProcessTracker.TrackingRecordStatus.Unreadable)
-        {
-            return await OwnedProcessCleanup.CleanupAsync(
-                pipeName,
-                snapshot,
-                cancellationToken);
-        }
-
-        var gracefulAcknowledged = false;
-        try
-        {
-            using var client = new ServiceClient(
-                pipeName,
-                connectTimeout: GracefulRequestTimeout,
-                requestTimeout: GracefulRequestTimeout);
-            var response = await client.SendAsync(
-                new ServiceRequest { Command = "service.shutdown" },
-                GracefulRequestTimeout,
-                cancellationToken);
-            gracefulAcknowledged = response.Success;
-        }
-        catch (IOException)
-        {
-            gracefulAcknowledged = false;
-        }
-        catch (TimeoutException)
-        {
-            gracefulAcknowledged = false;
-        }
-
-        if (gracefulAcknowledged)
-        {
-            _ = await WaitForTrackedDaemonExitAsync(
-                pipeName,
-                snapshot,
-                cancellationToken);
-        }
-
-        return await OwnedProcessCleanup.CleanupAsync(
-            pipeName,
-            snapshot,
-            cancellationToken);
-    }
-
-    private static async Task<bool> WaitForTrackedDaemonExitAsync(
-        string pipeName,
-        OwnedProcessCleanup.ProcessSnapshot snapshot,
-        CancellationToken cancellationToken)
-    {
-        if (!snapshot.DaemonMatched || snapshot.DaemonProcess is not { } expectedDaemon)
-        {
-            return true;
-        }
-
-        var deadline = DateTime.UtcNow + GracefulExitTimeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            var current = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
-            if (current.TrackingStatus == DaemonProcessTracker.TrackingRecordStatus.Missing
-                || !current.DaemonMatched
-                || current.DaemonProcess != expectedDaemon)
-            {
-                return true;
-            }
-
-            await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
-        }
-
-        return false;
     }
 }

--- a/src/ExcelMcp.Core/Commands/Range/IRangeCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Range/IRangeCommands.cs
@@ -12,11 +12,16 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Range;
 ///
 /// BEST PRACTICE: Use 'get-values' to check existing data before overwriting.
 /// Use 'clear-contents' (not 'clear-all') to preserve cell formatting when clearing data.
-/// set-values preserves existing formatting; use set-number-format after if format change needed.
+/// set-values preserves existing formatting for primitive values. Explicit typed date values apply
+/// their numberFormat or the documented ISO default.
 ///
 /// DATA FORMAT: values and formulas are 2D JSON arrays representing rows and columns.
 /// Example: [[row1col1, row1col2], [row2col1, row2col2]]
 /// Single cell returns [[value]] (always 2D).
+/// Explicit dates use {"type":"date","value":"2026-08-27"}, local datetimes use
+/// {"type":"datetime","value":"2026-08-27T14:30:00"}, and timezone-bearing datetimes use
+/// {"type":"datetime-offset","value":"2026-08-27T14:30:00+02:00"}. Ordinary strings are never
+/// guessed as dates.
 ///
 /// REQUIRED PARAMETERS:
 /// - sheetName + rangeAddress for cell operations (e.g., sheetName='Sheet1', rangeAddress='A1:D10')
@@ -28,7 +33,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Range;
 /// </summary>
 [ServiceCategory("range", "Range")]
 [McpTool("range", Title = "Range Operations", Destructive = true, Category = "data",
-    Description = "Core range operations: get/set values and formulas, copy ranges, clear content, discover data regions. Use range_edit for insert/delete/find/sort. Use range_format for styling/validation. Use range_link for hyperlinks/protection. Use calculation_mode for recalculation. EXCEL TABLES: If user asks to 'format as table', 'create a table', 'put data in an Excel Table' — do NOT try to use range for this. Use table(action:'create') on the data range to create a proper Excel Table with filter arrows, banded rows, and automatic expansion. DATA FORMAT: 2D JSON arrays [[row1col1,row1col2],[row2col1,row2col2]]. Single cell returns [[value]]. FILE INPUT: For set-values/set-formulas, provide EITHER inline values/formulas OR a valuesFile/formulasFile path to a .json or .csv file. Prefer file input for large datasets. BEST PRACTICE: get-values before overwriting, clear-contents (not clear-all) to preserve formatting. NAMED RANGES: Use sheetName='' and rangeAddress=namedRangeName.")]
+    Description = "Core range operations: get/set values and formulas, copy ranges, clear content, discover data regions. Use range_edit for insert/delete/find/sort. Use range_format for styling/validation. Use range_link for hyperlinks/protection. Use calculation_mode for recalculation. EXCEL TABLES: If user asks to 'format as table', 'create a table', 'put data in an Excel Table' — do NOT try to use range for this. Use table(action:'create') on the data range to create a proper Excel Table with filter arrows, banded rows, and automatic expansion. DATA FORMAT: 2D JSON arrays [[row1col1,row1col2],[row2col1,row2col2]]. Single cell returns [[value]]. TYPED DATES: Use {\"type\":\"date\",\"value\":\"2026-08-27\"}, {\"type\":\"datetime\",\"value\":\"2026-08-27T14:30:00\"}, or {\"type\":\"datetime-offset\",\"value\":\"2026-08-27T14:30:00+02:00\"}; ordinary strings remain text. FILE INPUT: For set-values/set-formulas, provide EITHER inline values/formulas OR a valuesFile/formulasFile path to a .json or .csv file. Prefer file input for large datasets. BEST PRACTICE: get-values before overwriting, clear-contents (not clear-all) to preserve formatting. NAMED RANGES: Use sheetName='' and rangeAddress=namedRangeName.")]
 public interface IRangeCommands
 {
     // === VALUE OPERATIONS ===
@@ -50,11 +55,16 @@ public interface IRangeCommands
     /// JSON file: must contain a 2D array like [[1,2],[3,4]].
     /// CSV file: rows become array rows, comma-separated values become columns.
     /// Every row must be rectangular and match the target range column count.
+    /// Typed date objects accept type=date with yyyy-MM-dd, type=datetime without a timezone,
+    /// or type=datetime-offset with Z/an offset. Offset values are normalized to UTC because Excel
+    /// stores no timezone. Typed values may include numberFormat; otherwise date uses yyyy-mm-dd and
+    /// both datetime types use yyyy-mm-dd hh:mm:ss. Serial values follow the workbook's 1900/1904
+    /// date system. Ordinary strings and existing primitive values keep their current behavior.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Name of the worksheet containing the range - REQUIRED for cell addresses, use empty string for named ranges only</param>
     /// <param name="rangeAddress">Cell range address matching data dimensions (e.g., 'A1' for [[value]], 'A1:B2' for [[v1,v2],[v3,v4]])</param>
-    /// <param name="values">2D array of values to set - rows are outer array, columns are inner array (e.g., [[1,2,3],[4,5,6]] for 2 rows x 3 cols). Optional if valuesFile is provided.</param>
+    /// <param name="values">2D array of primitive or typed date values. Typed object: {"type":"date|datetime|datetime-offset","value":"ISO 8601","numberFormat":"optional Excel format"}. Optional if valuesFile is provided.</param>
     /// <param name="valuesFile">Path to a JSON or CSV file containing the values. JSON: 2D array. CSV: rows/columns. Alternative to inline values parameter.</param>
     [ServiceAction("set-values")]
     OperationResult SetValues(IExcelBatch batch, string sheetName, [RequiredParameter] string rangeAddress, List<List<object?>>? values = null, string? valuesFile = null);
@@ -301,6 +311,5 @@ public class SortColumn
     /// <summary>Sort direction (true = ascending, false = descending)</summary>
     public bool Ascending { get; set; } = true;
 }
-
 
 

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Values.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Values.cs
@@ -1,4 +1,5 @@
 using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Formatting;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Models;
 using Sbroenne.ExcelMcp.Core.Utilities;
@@ -83,6 +84,7 @@ public partial class RangeCommands
     {
         // Resolve values from inline parameter or file
         var resolvedValues = ParameterTransforms.ResolveValuesOrFile(values, valuesFile);
+        var preparedValues = PrepareCellValues(resolvedValues);
 
         // SMART FORMULA DETECTION: Check if any value starts with "=" and auto-route to SetFormulas
         bool hasFormulas = DetectFormulas(resolvedValues, out var detectedFormulas);
@@ -137,6 +139,8 @@ public partial class RangeCommands
 
                 if (rows > 0 && cols > 0)
                 {
+                    bool use1904DateSystem = Convert.ToBoolean(ctx.Book.Date1904);
+
                     // Create 1-based array for Excel COM compatibility
                     object[,] arrayValues = (object[,])Array.CreateInstance(typeof(object), [rows, cols], [1, 1]);
 
@@ -144,13 +148,14 @@ public partial class RangeCommands
                     {
                         for (int c = 1; c <= cols; c++)
                         {
-                            // Convert JsonElement to proper C# type for COM interop
-                            // MCP framework deserializes JSON to JsonElement, not primitives
-                            arrayValues[r, c] = RangeHelpers.ConvertToCellValue(resolvedValues[r - 1][c - 1]);
+                            arrayValues[r, c] = RangeHelpers.ConvertToCellValue(
+                                preparedValues[r - 1][c - 1],
+                                use1904DateSystem);
                         }
                     }
 
                     range.Value2 = arrayValues;
+                    ApplyTypedNumberFormats(range, preparedValues, ctx.FormatTranslator);
                 }
 
                 setResult.Success = true;
@@ -177,6 +182,70 @@ public partial class RangeCommands
                 ComUtilities.Release(ref range);
             }
         });
+    }
+
+    private static List<List<PreparedCellValue>> PrepareCellValues(
+        List<List<object?>> values)
+    {
+        var prepared = new List<List<PreparedCellValue>>(values.Count);
+        for (int rowIndex = 0; rowIndex < values.Count; rowIndex++)
+        {
+            var row = new List<PreparedCellValue>(values[rowIndex].Count);
+            for (int columnIndex = 0; columnIndex < values[rowIndex].Count; columnIndex++)
+            {
+                row.Add(TypedCellValueParser.Parse(
+                    values[rowIndex][columnIndex],
+                    rowIndex + 1,
+                    columnIndex + 1));
+            }
+
+            prepared.Add(row);
+        }
+
+        return prepared;
+    }
+
+    private static void ApplyTypedNumberFormats(
+        dynamic range,
+        List<List<PreparedCellValue>> values,
+        NumberFormatTranslator formatTranslator)
+    {
+        if (!values.SelectMany(row => row).Any(value => value.IsTypedDate))
+        {
+            return;
+        }
+
+        dynamic? cells = null;
+        try
+        {
+            cells = range.Cells;
+            for (int rowIndex = 0; rowIndex < values.Count; rowIndex++)
+            {
+                for (int columnIndex = 0; columnIndex < values[rowIndex].Count; columnIndex++)
+                {
+                    var value = values[rowIndex][columnIndex];
+                    if (!value.IsTypedDate)
+                    {
+                        continue;
+                    }
+
+                    dynamic? cell = null;
+                    try
+                    {
+                        cell = cells[rowIndex + 1, columnIndex + 1];
+                        cell.NumberFormat = formatTranslator.TranslateToLocale(value.NumberFormat!);
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref cell);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref cells);
+        }
     }
 
     /// <summary>
@@ -229,6 +298,4 @@ public partial class RangeCommands
         }
     }
 }
-
-
 

--- a/src/ExcelMcp.Core/Commands/Range/RangeHelpers.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeHelpers.cs
@@ -118,6 +118,33 @@ public static class RangeHelpers
         // Already a proper type (from CLI or tests)
         return value;
     }
+
+    /// <summary>
+    /// Converts a prepared range value to the COM-compatible value for the workbook's date system.
+    /// </summary>
+    internal static object ConvertToCellValue(
+        PreparedCellValue value,
+        bool use1904DateSystem)
+    {
+        if (value.IsTypedDate)
+        {
+            return TypedCellValueParser.ToExcelSerial(
+                value.DateTimeValue,
+                use1904DateSystem,
+                value.RowIndex,
+                value.ColumnIndex);
+        }
+
+        var primitiveValue = ConvertToCellValue(value.PrimitiveValue);
+        if (primitiveValue is string { Length: > 0 } text)
+        {
+            // A leading apostrophe tells Excel to keep a JSON string as text instead of
+            // locale-coercing date-like or numeric-looking content during the bulk write.
+            return $"'{text}";
+        }
+
+        return primitiveValue;
+    }
 }
 
 /// <summary>
@@ -241,4 +268,3 @@ public partial class RangeCommands
         });
     }
 }
-

--- a/src/ExcelMcp.Core/Commands/Range/RangeHelpers.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeHelpers.cs
@@ -140,7 +140,7 @@ public static class RangeHelpers
         {
             // A leading apostrophe tells Excel to keep a JSON string as text instead of
             // locale-coercing date-like or numeric-looking content during the bulk write.
-            return $"'{text}";
+            return text.StartsWith('\'') ? text : $"'{text}";
         }
 
         return primitiveValue;

--- a/src/ExcelMcp.Core/Commands/Range/TypedCellValue.cs
+++ b/src/ExcelMcp.Core/Commands/Range/TypedCellValue.cs
@@ -1,0 +1,16 @@
+namespace Sbroenne.ExcelMcp.Core.Commands.Range;
+
+/// <summary>
+/// Explicit date value accepted as one cell inside a range set-values matrix.
+/// </summary>
+public sealed class TypedCellValue
+{
+    /// <summary>The date value type.</summary>
+    public TypedCellValueType? Type { get; init; }
+
+    /// <summary>The ISO 8601 value.</summary>
+    public string? Value { get; init; }
+
+    /// <summary>Optional Excel number format. A type-specific ISO format is used when omitted.</summary>
+    public string? NumberFormat { get; init; }
+}

--- a/src/ExcelMcp.Core/Commands/Range/TypedCellValueParser.cs
+++ b/src/ExcelMcp.Core/Commands/Range/TypedCellValueParser.cs
@@ -1,0 +1,262 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Range;
+
+internal static class TypedCellValueParser
+{
+    internal const string DefaultDateNumberFormat = "yyyy-mm-dd";
+    internal const string DefaultDateTimeNumberFormat = "yyyy-mm-dd hh:mm:ss";
+
+    private static readonly string[] s_dateTimeFormats =
+    [
+        "yyyy-MM-dd'T'HH:mm:ss",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF"
+    ];
+
+    private static readonly string[] s_dateTimeOffsetFormats =
+    [
+        "yyyy-MM-dd'T'HH:mm:sszzz",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFzzz"
+    ];
+
+    private static readonly string[] s_utcDateTimeOffsetFormats =
+    [
+        "yyyy-MM-dd'T'HH:mm:ss'Z'",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'"
+    ];
+
+    internal static PreparedCellValue Parse(object? input, int rowIndex, int columnIndex)
+    {
+        if (input is TypedCellValue typedValue)
+        {
+            return ParseTypedValue(typedValue, rowIndex, columnIndex);
+        }
+
+        if (input is JsonElement { ValueKind: JsonValueKind.Object } jsonObject)
+        {
+            return ParseTypedValue(ParseJsonObject(jsonObject, rowIndex, columnIndex), rowIndex, columnIndex);
+        }
+
+        return PreparedCellValue.FromPrimitive(input);
+    }
+
+    internal static double ToExcelSerial(
+        DateTime value,
+        bool use1904DateSystem,
+        int rowIndex,
+        int columnIndex)
+    {
+        var minimum = use1904DateSystem
+            ? new DateTime(1904, 1, 1)
+            : new DateTime(1900, 1, 1);
+
+        if (value < minimum)
+        {
+            var dateSystem = use1904DateSystem ? "1904" : "1900";
+            throw CreateError(
+                rowIndex,
+                columnIndex,
+                $"value must be on or after {minimum:yyyy-MM-dd} for the workbook's {dateSystem} date system.");
+        }
+
+        var wholeDays = (value.Date.Ticks - minimum.Ticks) / TimeSpan.TicksPerDay;
+        var timeOfDay = value.TimeOfDay.Ticks / (double)TimeSpan.TicksPerDay;
+        var serial = wholeDays + timeOfDay;
+
+        // Excel's 1900 system includes the fictitious 1900-02-29 at serial 60.
+        if (!use1904DateSystem)
+        {
+            serial += value < new DateTime(1900, 3, 1) ? 1d : 2d;
+        }
+
+        return serial;
+    }
+
+    private static TypedCellValue ParseJsonObject(
+        JsonElement jsonObject,
+        int rowIndex,
+        int columnIndex)
+    {
+        if (!jsonObject.TryGetProperty("type", out var typeElement)
+            || typeElement.ValueKind != JsonValueKind.String)
+        {
+            throw CreateError(rowIndex, columnIndex, "type is required as a string.");
+        }
+
+        if (!jsonObject.TryGetProperty("value", out var valueElement)
+            || valueElement.ValueKind != JsonValueKind.String)
+        {
+            throw CreateError(rowIndex, columnIndex, "value is required as a string.");
+        }
+
+        string? numberFormat = null;
+        if (jsonObject.TryGetProperty("numberFormat", out var numberFormatElement))
+        {
+            if (numberFormatElement.ValueKind != JsonValueKind.String)
+            {
+                throw CreateError(rowIndex, columnIndex, "numberFormat must be a string when provided.");
+            }
+
+            numberFormat = numberFormatElement.GetString();
+        }
+
+        return new TypedCellValue
+        {
+            Type = ParseType(typeElement.GetString(), rowIndex, columnIndex),
+            Value = valueElement.GetString(),
+            NumberFormat = numberFormat
+        };
+    }
+
+    private static TypedCellValueType ParseType(
+        string? type,
+        int rowIndex,
+        int columnIndex)
+    {
+        return type switch
+        {
+            "date" => TypedCellValueType.Date,
+            "datetime" => TypedCellValueType.DateTime,
+            "datetime-offset" => TypedCellValueType.DateTimeOffset,
+            _ => throw CreateError(
+                rowIndex,
+                columnIndex,
+                $"type '{type}' is invalid. Valid types: date, datetime, datetime-offset.")
+        };
+    }
+
+    private static PreparedCellValue ParseTypedValue(
+        TypedCellValue typedValue,
+        int rowIndex,
+        int columnIndex)
+    {
+        if (!typedValue.Type.HasValue)
+        {
+            throw CreateError(rowIndex, columnIndex, "type is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(typedValue.Value))
+        {
+            throw CreateError(rowIndex, columnIndex, "value is required and must not be empty.");
+        }
+
+        if (typedValue.NumberFormat != null && string.IsNullOrWhiteSpace(typedValue.NumberFormat))
+        {
+            throw CreateError(rowIndex, columnIndex, "numberFormat must not be empty.");
+        }
+
+        var parsedDateTime = typedValue.Type.Value switch
+        {
+            TypedCellValueType.Date => ParseDate(typedValue.Value, rowIndex, columnIndex),
+            TypedCellValueType.DateTime => ParseDateTime(typedValue.Value, rowIndex, columnIndex),
+            TypedCellValueType.DateTimeOffset => ParseDateTimeOffset(typedValue.Value, rowIndex, columnIndex),
+            _ => throw CreateError(
+                rowIndex,
+                columnIndex,
+                $"type '{typedValue.Type}' is invalid. Valid types: date, datetime, datetime-offset.")
+        };
+
+        var defaultNumberFormat = typedValue.Type == TypedCellValueType.Date
+            ? DefaultDateNumberFormat
+            : DefaultDateTimeNumberFormat;
+
+        return PreparedCellValue.FromTypedDate(
+            parsedDateTime,
+            typedValue.NumberFormat ?? defaultNumberFormat,
+            rowIndex,
+            columnIndex);
+    }
+
+    private static DateTime ParseDate(string value, int rowIndex, int columnIndex)
+    {
+        if (!DateOnly.TryParseExact(
+                value,
+                "yyyy-MM-dd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var date))
+        {
+            throw CreateError(
+                rowIndex,
+                columnIndex,
+                $"date value '{value}' is invalid. Expected ISO format yyyy-MM-dd.");
+        }
+
+        return date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified);
+    }
+
+    private static DateTime ParseDateTime(string value, int rowIndex, int columnIndex)
+    {
+        if (!DateTime.TryParseExact(
+                value,
+                s_dateTimeFormats,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var dateTime))
+        {
+            throw CreateError(
+                rowIndex,
+                columnIndex,
+                $"datetime value '{value}' is invalid. Expected yyyy-MM-ddTHH:mm:ss with optional fractional seconds and without a timezone.");
+        }
+
+        return DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified);
+    }
+
+    private static DateTime ParseDateTimeOffset(string value, int rowIndex, int columnIndex)
+    {
+        DateTimeOffset parsed;
+        var parsedSuccessfully = value.EndsWith('Z')
+            ? DateTimeOffset.TryParseExact(
+                value,
+                s_utcDateTimeOffsetFormats,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out parsed)
+            : DateTimeOffset.TryParseExact(
+                value,
+                s_dateTimeOffsetFormats,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out parsed);
+
+        if (!parsedSuccessfully)
+        {
+            throw CreateError(
+                rowIndex,
+                columnIndex,
+                $"datetime-offset value '{value}' is invalid. Expected yyyy-MM-ddTHH:mm:ss with Z or an offset such as +02:00; fractional seconds are optional.");
+        }
+
+        return DateTime.SpecifyKind(parsed.UtcDateTime, DateTimeKind.Unspecified);
+    }
+
+    private static ArgumentException CreateError(
+        int rowIndex,
+        int columnIndex,
+        string message)
+    {
+        return new ArgumentException(
+            $"Invalid typed value at row {rowIndex}, column {columnIndex}: {message}");
+    }
+}
+
+internal readonly record struct PreparedCellValue(
+    object? PrimitiveValue,
+    DateTime DateTimeValue,
+    string? NumberFormat,
+    bool IsTypedDate,
+    int RowIndex,
+    int ColumnIndex)
+{
+    internal static PreparedCellValue FromPrimitive(object? value) =>
+        new(value, default, null, false, 0, 0);
+
+    internal static PreparedCellValue FromTypedDate(
+        DateTime value,
+        string numberFormat,
+        int rowIndex,
+        int columnIndex) =>
+        new(null, value, numberFormat, true, rowIndex, columnIndex);
+}

--- a/src/ExcelMcp.Core/Commands/Range/TypedCellValueType.cs
+++ b/src/ExcelMcp.Core/Commands/Range/TypedCellValueType.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Range;
+
+/// <summary>
+/// Explicit date value types accepted inside a range set-values matrix.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<TypedCellValueType>))]
+public enum TypedCellValueType
+{
+    /// <summary>An ISO calendar date in yyyy-MM-dd form.</summary>
+    [JsonStringEnumMemberName("date")]
+    Date,
+
+    /// <summary>An ISO local date and time without a timezone.</summary>
+    [JsonStringEnumMemberName("datetime")]
+    DateTime,
+
+    /// <summary>An ISO date and time with Z or a numeric UTC offset.</summary>
+    [JsonStringEnumMemberName("datetime-offset")]
+    DateTimeOffset
+}

--- a/tests/ExcelMcp.CLI.Tests/Integration/DaemonForcedStopRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/DaemonForcedStopRegressionTests.cs
@@ -317,6 +317,10 @@ public sealed class DaemonForcedStopRegressionTests
             cleanupScript,
             StringComparison.Ordinal);
         Assert.Contains(
+            @"src\ExcelMcp.CLI\Infrastructure\PreBuildProcessCleanup.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
             @"src\ExcelMcp.CLI\Program.cs",
             cleanupScript,
             StringComparison.Ordinal);
@@ -484,6 +488,37 @@ public sealed class DaemonForcedStopRegressionTests
         {
             StopIfRunning(daemon);
             StopIfRunning(excel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task PreBuildCleanup_LostShutdownReply_AllowsGracefulDaemonExit()
+    {
+        var pipeName = $"excelmcp-lost-shutdown-reply-{Guid.NewGuid():N}";
+        using var daemon = StartShortLivedProcess(seconds: 5);
+
+        try
+        {
+            DaemonProcessTracker.RegisterProcess(
+                pipeName,
+                daemon.Id,
+                daemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+
+            var cleanupResult =
+                await PreBuildProcessCleanup.CleanupWithGracefulShutdownAsync(
+                    pipeName,
+                    CancellationToken.None,
+                    _ => Task.FromResult(false));
+
+            Assert.True(cleanupResult.Success);
+            Assert.True(daemon.WaitForExit(5000));
+            Assert.Equal(0, daemon.ExitCode);
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
             DaemonProcessTracker.Clear(pipeName);
         }
     }
@@ -1269,12 +1304,12 @@ public sealed class DaemonForcedStopRegressionTests
         })!;
     }
 
-    private static Process StartShortLivedProcess()
+    private static Process StartShortLivedProcess(int seconds = 2)
     {
         return Process.Start(new ProcessStartInfo
         {
             FileName = "powershell.exe",
-            Arguments = "-NoProfile -Command \"Start-Sleep -Seconds 2\"",
+            Arguments = $"-NoProfile -Command \"Start-Sleep -Seconds {seconds}\"",
             UseShellExecute = false,
             CreateNoWindow = true
         })!;

--- a/tests/ExcelMcp.CLI.Tests/Integration/PreBuildGracefulSaveAcceptanceTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/PreBuildGracefulSaveAcceptanceTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using Sbroenne.ExcelMcp.CLI.Infrastructure;
 using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
@@ -109,7 +110,11 @@ public sealed class PreBuildGracefulSaveAcceptanceTests : IClassFixture<TempDire
                 },
                 TimeSpan.FromMinutes(4));
 
-            Assert.Equal(0, build.ExitCode);
+            Assert.True(
+                build.ExitCode == 0,
+                $"Release rebuild failed.{Environment.NewLine}" +
+                $"stdout: {build.Stdout}{Environment.NewLine}" +
+                $"stderr: {build.Stderr}");
             Assert.True(
                 selectedDaemon.WaitForExit(15000),
                 $"Selected daemon {selectedDaemon.Id} did not exit.");
@@ -195,7 +200,7 @@ public sealed class PreBuildGracefulSaveAcceptanceTests : IClassFixture<TempDire
             cliPath,
             pipeName,
             ["service", "status", "--quiet"],
-            TimeSpan.FromSeconds(10));
+            DaemonConnectionPolicy.ControlTimeout + TimeSpan.FromSeconds(2));
 
     private static Task<ProcessResult> RunCliAsync(
         string cliPath,

--- a/tests/ExcelMcp.CLI.Tests/Integration/RangeTypedIsoValueCliTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/RangeTypedIsoValueCliTests.cs
@@ -1,0 +1,106 @@
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Collection("Service")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "CLI")]
+[Trait("Layer", "CLI")]
+[Trait("RequiresExcel", "true")]
+public sealed class RangeTypedIsoValueCliTests : IDisposable
+{
+    private readonly string _testFile = Path.Combine(
+        Path.GetTempPath(),
+        $"RangeTypedIsoValueCli_{Guid.NewGuid():N}.xlsx");
+
+    [Fact]
+    public async Task RangeSetValues_TypedIsoDate_RoundTripsThroughCli()
+    {
+        var (createResult, createJson) = await CliProcessHelper.RunJsonAsync(
+            ["session", "create", _testFile],
+            timeoutMs: 60000,
+            diagnosticLabel: "create typed ISO workbook");
+        Assert.Equal(0, createResult.ExitCode);
+        var sessionId = createJson.RootElement.GetProperty("sessionId").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(sessionId));
+        var activeSessionId = sessionId;
+
+        try
+        {
+            const string valuesJson =
+                """[[{"type":"datetime-offset","value":"2026-08-27T03:15:00-04:00","numberFormat":"@"},"2026-08-27"]]""";
+            var (setResult, setJson) = await CliProcessHelper.RunJsonAsync(
+                ["range", "set-values", "--session", sessionId!, "--sheet-name", "Sheet1", "--range-address", "A1:B1", "--values", valuesJson],
+                timeoutMs: 60000,
+                diagnosticLabel: "set typed ISO value");
+            Assert.Equal(0, setResult.ExitCode);
+            Assert.True(setJson.RootElement.GetProperty("success").GetBoolean(), setResult.Stdout);
+
+            var (getResult, getJson) = await CliProcessHelper.RunJsonAsync(
+                ["range", "get-values", "--session", sessionId!, "--sheet-name", "Sheet1", "--range-address", "A1:B1"],
+                timeoutMs: 60000,
+                diagnosticLabel: "get typed ISO value");
+            Assert.Equal(0, getResult.ExitCode);
+            Assert.Equal(
+                new DateTime(2026, 8, 27, 7, 15, 0).ToOADate(),
+                getJson.RootElement.GetProperty("values")[0][0].GetDouble());
+            Assert.Equal("2026-08-27", getJson.RootElement.GetProperty("values")[0][1].GetString());
+
+            var (formatResult, formatJson) = await CliProcessHelper.RunJsonAsync(
+                ["range", "get-number-formats", "--session", sessionId!, "--sheet-name", "Sheet1", "--range-address", "A1:B1"],
+                timeoutMs: 60000,
+                diagnosticLabel: "get typed ISO formats");
+            Assert.Equal(0, formatResult.ExitCode);
+            Assert.Equal(
+                "@",
+                formatJson.RootElement.GetProperty("formats")[0][0].GetString(),
+                StringComparer.OrdinalIgnoreCase);
+
+            var closeResult = await CliProcessHelper.RunAsync(
+                ["session", "close", "--session", activeSessionId!, "--save", "true"],
+                timeoutMs: 60000,
+                diagnosticLabel: "save typed ISO workbook");
+            Assert.Equal(0, closeResult.ExitCode);
+            activeSessionId = null;
+
+            var (openResult, openJson) = await CliProcessHelper.RunJsonAsync(
+                ["session", "open", _testFile],
+                timeoutMs: 60000,
+                diagnosticLabel: "reopen typed ISO workbook");
+            Assert.Equal(0, openResult.ExitCode);
+            activeSessionId = openJson.RootElement.GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(activeSessionId));
+
+            var (persistedResult, persistedJson) = await CliProcessHelper.RunJsonAsync(
+                ["range", "get-values", "--session", activeSessionId!, "--sheet-name", "Sheet1", "--range-address", "A1:B1"],
+                timeoutMs: 60000,
+                diagnosticLabel: "get persisted typed ISO value");
+            Assert.Equal(0, persistedResult.ExitCode);
+            Assert.Equal(
+                new DateTime(2026, 8, 27, 7, 15, 0).ToOADate(),
+                persistedJson.RootElement.GetProperty("values")[0][0].GetDouble());
+            Assert.Equal("2026-08-27", persistedJson.RootElement.GetProperty("values")[0][1].GetString());
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(activeSessionId))
+            {
+                await CliProcessHelper.RunAsync(
+                    ["session", "close", "--session", activeSessionId, "--save", "false"],
+                    timeoutMs: 60000,
+                    diagnosticLabel: "close typed ISO workbook");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFile))
+        {
+            File.Delete(_testFile);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.TypedValues.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.TypedValues.cs
@@ -55,6 +55,31 @@ public partial class RangeCommandsTests
     }
 
     [Fact]
+    public void SetValues_AlreadyPrefixedStrings_RemainTextWithoutVisibleApostrophes()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        var textResult = _commands.SetValues(
+            batch,
+            sheetName,
+            "A1:C1",
+            [["'=1+1", "'2026-08-27", "plain text"]]);
+        var formulaResult = _commands.SetValues(batch, sheetName, "D1", [["=1+1"]]);
+
+        Assert.True(textResult.Success, textResult.ErrorMessage);
+        Assert.True(formulaResult.Success, formulaResult.ErrorMessage);
+        var readResult = _commands.GetValues(batch, sheetName, "A1:D1");
+        Assert.True(readResult.Success, readResult.ErrorMessage);
+        Assert.Equal("=1+1", readResult.Values[0][0]);
+        Assert.Equal("2026-08-27", readResult.Values[0][1]);
+        Assert.Equal("plain text", readResult.Values[0][2]);
+        Assert.Equal(
+            2.0,
+            Convert.ToDouble(readResult.Values[0][3], CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
     public void SetValues_TypedDate_Uses1904WorkbookDateSystem()
     {
         using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.TypedValues.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.TypedValues.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+using System.Text.Json;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
+
+public partial class RangeCommandsTests
+{
+    [Fact]
+    public void SetValues_TypedIsoValues_WriteSerialsFormatsAndPreservePlainStrings()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        using var document = JsonDocument.Parse(
+            """
+            [[
+              {"type":"date","value":"2026-08-27"},
+              {"type":"datetime","value":"2024-02-29T12:34:56.25"},
+              {"type":"datetime-offset","value":"2026-08-27T03:15:00-04:00","numberFormat":"@"},
+              "2026-08-27",
+              "00123"
+            ]]
+            """);
+        var values = document.RootElement[0]
+            .EnumerateArray()
+            .Select(cell => (object?)cell.Clone())
+            .ToList();
+        _commands.SetNumberFormat(batch, sheetName, "D1:E1", "0.00");
+        var expectedDateFormat = batch.Execute((ctx, ct) =>
+            ctx.FormatTranslator.TranslateToLocale("yyyy-mm-dd"));
+        var expectedDateTimeFormat = batch.Execute((ctx, ct) =>
+            ctx.FormatTranslator.TranslateToLocale("yyyy-mm-dd hh:mm:ss"));
+        var expectedPrimitiveFormat = batch.Execute((ctx, ct) =>
+            ctx.FormatTranslator.TranslateToLocale("0.00"));
+
+        var writeResult = _commands.SetValues(batch, sheetName, "A1:E1", [values]);
+
+        Assert.True(writeResult.Success, writeResult.ErrorMessage);
+        var readResult = _commands.GetValues(batch, sheetName, "A1:E1");
+        Assert.True(readResult.Success, readResult.ErrorMessage);
+        Assert.Equal(new DateTime(2026, 8, 27).ToOADate(), Convert.ToDouble(readResult.Values[0][0], CultureInfo.InvariantCulture));
+        Assert.Equal(new DateTime(2024, 2, 29, 12, 34, 56, 250).ToOADate(), Convert.ToDouble(readResult.Values[0][1], CultureInfo.InvariantCulture), 10);
+        Assert.Equal(new DateTime(2026, 8, 27, 7, 15, 0).ToOADate(), Convert.ToDouble(readResult.Values[0][2], CultureInfo.InvariantCulture), 10);
+        Assert.Equal("2026-08-27", readResult.Values[0][3]);
+        Assert.Equal("00123", readResult.Values[0][4]);
+
+        var formatResult = _commands.GetNumberFormats(batch, sheetName, "A1:E1");
+        Assert.True(formatResult.Success, formatResult.ErrorMessage);
+        Assert.Equal(expectedDateFormat, formatResult.Formats[0][0], StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(expectedDateTimeFormat, formatResult.Formats[0][1], StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("@", formatResult.Formats[0][2], StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(expectedPrimitiveFormat, formatResult.Formats[0][3], StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(expectedPrimitiveFormat, formatResult.Formats[0][4], StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SetValues_TypedDate_Uses1904WorkbookDateSystem()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        try
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                ctx.Book.Date1904 = true;
+                return true;
+            });
+            using var document = JsonDocument.Parse("""[[{"type":"date","value":"1904-01-01"}]]""");
+            var values = new List<List<object?>> { new() { document.RootElement[0][0].Clone() } };
+
+            var writeResult = _commands.SetValues(batch, sheetName, "A1", values);
+
+            Assert.True(writeResult.Success, writeResult.ErrorMessage);
+            var readResult = _commands.GetValues(batch, sheetName, "A1");
+            Assert.True(readResult.Success, readResult.ErrorMessage);
+            Assert.Equal(0.0, Convert.ToDouble(readResult.Values[0][0], CultureInfo.InvariantCulture));
+        }
+        finally
+        {
+            batch.Execute((ctx, ct) =>
+            {
+                ctx.Book.Date1904 = false;
+                return true;
+            });
+        }
+    }
+
+    [Fact]
+    public void SetValues_InvalidTypedValue_FailsBeforeExcelWrite()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetValues(batch, sheetName, "A1", [["unchanged"]]);
+        using var document = JsonDocument.Parse("""[[{"type":"datetime","value":"2026-08-27T10:30:00Z"}]]""");
+        var values = new List<List<object?>> { new() { document.RootElement[0][0].Clone() } };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => _commands.SetValues(batch, sheetName, "A1", values));
+
+        Assert.Contains("row 1, column 1", exception.Message, StringComparison.OrdinalIgnoreCase);
+        var readResult = _commands.GetValues(batch, sheetName, "A1");
+        Assert.Equal("unchanged", readResult.Values[0][0]);
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Unit/ParameterTransformsFileTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/ParameterTransformsFileTests.cs
@@ -145,6 +145,21 @@ public sealed class ParameterTransformsFileTests : IDisposable
     }
 
     [Fact]
+    public void ResolveValuesOrFile_JsonFile_PreservesTypedDateObject()
+    {
+        var path = CreateTempFile(
+            "typed-date.json",
+            """[[{"type":"date","value":"2026-08-27","numberFormat":"dd-mmm-yyyy"}]]""");
+
+        var result = ParameterTransforms.ResolveValuesOrFile(null, path);
+
+        var typedValue = Assert.IsType<System.Text.Json.JsonElement>(result[0][0]);
+        Assert.Equal("date", typedValue.GetProperty("type").GetString());
+        Assert.Equal("2026-08-27", typedValue.GetProperty("value").GetString());
+        Assert.Equal("dd-mmm-yyyy", typedValue.GetProperty("numberFormat").GetString());
+    }
+
+    [Fact]
     public void ResolveValuesOrFile_InvalidJson_ThrowsArgumentException()
     {
         var path = CreateTempFile("bad.json", "{ this is not valid }");

--- a/tests/ExcelMcp.Core.Tests/Unit/RangeHelpersValueTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/RangeHelpersValueTests.cs
@@ -1,0 +1,28 @@
+using Sbroenne.ExcelMcp.Core.Commands.Range;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
+
+[Trait("Layer", "Core")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "Range")]
+[Trait("Speed", "Fast")]
+[Trait("RequiresExcel", "false")]
+public sealed class RangeHelpersValueTests
+{
+    [Theory]
+    [InlineData("'=1+1", "'=1+1")]
+    [InlineData("'2026-08-27", "'2026-08-27")]
+    [InlineData("plain text", "'plain text")]
+    [InlineData("2026-08-27", "'2026-08-27")]
+    public void ConvertToCellValue_PreservesExistingTextPrefix(
+        string input,
+        string expected)
+    {
+        var prepared = TypedCellValueParser.Parse(input, 1, 1);
+
+        var result = RangeHelpers.ConvertToCellValue(prepared, use1904DateSystem: false);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Unit/TypedCellValueParserTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/TypedCellValueParserTests.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
+
+[Trait("Layer", "Core")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "Range")]
+[Trait("Speed", "Fast")]
+[Trait("RequiresExcel", "false")]
+public sealed class TypedCellValueParserTests
+{
+    [Theory]
+    [InlineData("""{"type":"date","value":"2026-08-27"}""", "2026-08-27T00:00:00.0000000", "yyyy-mm-dd")]
+    [InlineData("""{"type":"datetime","value":"2024-02-29T12:34:56.25"}""", "2024-02-29T12:34:56.2500000", "yyyy-mm-dd hh:mm:ss")]
+    [InlineData("""{"type":"datetime-offset","value":"2026-08-27T03:15:00-04:00"}""", "2026-08-27T07:15:00.0000000", "yyyy-mm-dd hh:mm:ss")]
+    [InlineData("""{"type":"datetime-offset","value":"2026-08-27T07:15:00Z"}""", "2026-08-27T07:15:00.0000000", "yyyy-mm-dd hh:mm:ss")]
+    public void Parse_ValidTypedValue_ReturnsDeterministicDateTime(
+        string json,
+        string expectedDateTime,
+        string expectedNumberFormat)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        var result = TypedCellValueParser.Parse(document.RootElement, 1, 1);
+
+        Assert.True(result.IsTypedDate);
+        Assert.Equal(DateTime.Parse(expectedDateTime, System.Globalization.CultureInfo.InvariantCulture), result.DateTimeValue);
+        Assert.Equal(DateTimeKind.Unspecified, result.DateTimeValue.Kind);
+        Assert.Equal(expectedNumberFormat, result.NumberFormat);
+    }
+
+    [Fact]
+    public void Parse_CustomNumberFormat_PreservesCallerFormat()
+    {
+        using var document = JsonDocument.Parse(
+            """{"type":"date","value":"2026-08-27","numberFormat":"dd-mmm-yyyy"}""");
+
+        var result = TypedCellValueParser.Parse(document.RootElement, 2, 3);
+
+        Assert.Equal("dd-mmm-yyyy", result.NumberFormat);
+    }
+
+    [Fact]
+    public void Parse_CoreTypedModel_UsesSameContractAsJson()
+    {
+        var input = new TypedCellValue
+        {
+            Type = TypedCellValueType.DateTime,
+            Value = "2026-08-27T14:30:00"
+        };
+
+        var result = TypedCellValueParser.Parse(input, 1, 1);
+
+        Assert.True(result.IsTypedDate);
+        Assert.Equal(new DateTime(2026, 8, 27, 14, 30, 0), result.DateTimeValue);
+        Assert.Equal("yyyy-mm-dd hh:mm:ss", result.NumberFormat);
+    }
+
+    [Fact]
+    public void Parse_OrdinaryIsoString_RemainsAnOrdinaryString()
+    {
+        const string value = "2026-08-27";
+
+        var result = TypedCellValueParser.Parse(value, 1, 1);
+
+        Assert.False(result.IsTypedDate);
+        Assert.Equal(value, result.PrimitiveValue);
+    }
+
+    [Theory]
+    [InlineData("""{"type":"date","value":"2026-08-27T10:30:00"}""", "date", "yyyy-MM-dd")]
+    [InlineData("""{"type":"datetime","value":"2026-08-27T10:30:00Z"}""", "datetime", "without a timezone")]
+    [InlineData("""{"type":"datetime-offset","value":"2026-08-27T10:30:00"}""", "datetime-offset", "with Z or an offset")]
+    [InlineData("""{"type":"date","value":"2026-02-29"}""", "date", "yyyy-MM-dd")]
+    [InlineData("""{"type":"timestamp","value":"2026-08-27"}""", "timestamp", "date, datetime, datetime-offset")]
+    [InlineData("""{"type":"date"}""", "value", "required")]
+    [InlineData("""{"type":"date","value":"2026-08-27","numberFormat":" "}""", "numberFormat", "must not be empty")]
+    public void Parse_InvalidTypedValue_ThrowsCoordinateAwareError(
+        string json,
+        string expectedMessagePart1,
+        string expectedMessagePart2)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => TypedCellValueParser.Parse(document.RootElement, 4, 2));
+
+        Assert.Contains("row 4, column 2", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(expectedMessagePart1, exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(expectedMessagePart2, exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("1900-01-01T00:00:00", false, 1.0)]
+    [InlineData("1900-02-28T00:00:00", false, 59.0)]
+    [InlineData("1900-03-01T00:00:00", false, 61.0)]
+    [InlineData("1904-01-01T00:00:00", true, 0.0)]
+    [InlineData("2024-02-29T12:00:00", false, 45351.5)]
+    [InlineData("2024-02-29T12:00:00", true, 43889.5)]
+    public void ToExcelSerial_UsesWorkbookDateSystem(
+        string dateTime,
+        bool use1904DateSystem,
+        double expected)
+    {
+        var value = DateTime.Parse(dateTime, System.Globalization.CultureInfo.InvariantCulture);
+
+        var result = TypedCellValueParser.ToExcelSerial(value, use1904DateSystem, 1, 1);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToExcelSerial_DateBeforeWorkbookEpoch_ThrowsCoordinateAwareError()
+    {
+        var exception = Assert.Throws<ArgumentException>(
+            () => TypedCellValueParser.ToExcelSerial(new DateTime(1903, 12, 31), true, 3, 5));
+
+        Assert.Contains("row 3, column 5", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("1904 date system", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("1904-01-01", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("2026-08-27T12:34:56.1234567")]
+    [InlineData("2026-08-27T06:32:27.0483540")]
+    public void ToExcelSerial_PreservesSevenDigitFractionalSeconds(string input)
+    {
+        var value = DateTime.ParseExact(
+            input,
+            "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF",
+            System.Globalization.CultureInfo.InvariantCulture);
+
+        var serial = TypedCellValueParser.ToExcelSerial(value, false, 1, 1);
+        var reconstructedTimeTicks = (long)Math.Round(
+            (serial - Math.Truncate(serial)) * TimeSpan.TicksPerDay,
+            MidpointRounding.AwayFromZero);
+
+        Assert.InRange(
+            Math.Abs(reconstructedTimeTicks - value.TimeOfDay.Ticks),
+            0,
+            5);
+
+        var oleDateTicks = (long)Math.Round(
+            (value.ToOADate() - Math.Truncate(value.ToOADate())) * TimeSpan.TicksPerDay,
+            MidpointRounding.AwayFromZero);
+        Assert.True(
+            Math.Abs(oleDateTicks - value.TimeOfDay.Ticks) > 1_000,
+            "The test value must demonstrate the sub-millisecond loss in DateTime.ToOADate().");
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/RangeTypedIsoValueTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/RangeTypedIsoValueTests.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Range")]
+[Trait("RequiresExcel", "true")]
+public sealed class RangeTypedIsoValueTests : McpIntegrationTestBase
+{
+    private readonly string _testExcelFile;
+    private string? _sessionId;
+
+    public RangeTypedIsoValueTests(ITestOutputHelper output)
+        : base(output, "RangeTypedIsoValueClient")
+    {
+        _testExcelFile = Path.Join(CreateTempDirectory("RangeTypedIsoValue"), "TypedIso.xlsx");
+    }
+
+    protected override async Task InitializeTestAsync()
+    {
+        _sessionId = await CreateWorkbookSessionAsync(_testExcelFile);
+    }
+
+    [Fact]
+    public async Task SetValues_TypedIsoDate_RoundTripsThroughMcpProtocol()
+    {
+        var setValuesJson = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-values",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "A1:B1",
+            ["values"] = new object?[][]
+            {
+                [
+                    new { type = "date", value = "2026-08-27", numberFormat = "@" },
+                    "2026-08-27"
+                ]
+            }
+        });
+        AssertSetupSuccess(setValuesJson, "range.set-values typed ISO date");
+
+        var getValuesJson = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "get-values",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "A1:B1"
+        });
+        using var valuesDocument = JsonDocument.Parse(getValuesJson);
+        Assert.True(valuesDocument.RootElement.GetProperty("success").GetBoolean(), getValuesJson);
+        Assert.Equal(new DateTime(2026, 8, 27).ToOADate(), valuesDocument.RootElement.GetProperty("values")[0][0].GetDouble());
+        Assert.Equal("2026-08-27", valuesDocument.RootElement.GetProperty("values")[0][1].GetString());
+
+        var getFormatsJson = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "get-number-formats",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "A1:B1"
+        });
+        using var formatsDocument = JsonDocument.Parse(getFormatsJson);
+        Assert.True(formatsDocument.RootElement.GetProperty("success").GetBoolean(), getFormatsJson);
+        Assert.Equal("@", formatsDocument.RootElement.GetProperty("formats")[0][0].GetString(), StringComparer.OrdinalIgnoreCase);
+
+        await CloseSessionAsync(_sessionId, save: false);
+        _sessionId = null;
+    }
+
+    [Fact]
+    public async Task SetValues_InvalidTypedIsoDate_ReturnsInvalidInputThroughMcpProtocol()
+    {
+        var setValuesJson = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-values",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "A1",
+            ["values"] = new object?[][]
+            {
+                [new { type = "datetime", value = "2026-08-27T10:30:00Z" }]
+            }
+        });
+
+        using var document = ParseJsonResult(setValuesJson, "range.set-values invalid typed ISO date");
+        AssertFailureEnvelope(
+            document.RootElement,
+            "range.set-values invalid typed ISO date",
+            expectedExceptionType: "ArgumentException",
+            expectedErrorCategory: "InvalidInput");
+        Assert.Contains(
+            "row 1, column 1",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+
+        await CloseSessionAsync(_sessionId, save: false);
+        _sessionId = null;
+    }
+}


### PR DESCRIPTION
## Summary
- add typed `date`, `datetime`, and `datetime-offset` cells inside the existing `range set-values` matrix
- parse ISO values deterministically, normalize offset datetimes to UTC, honor 1900/1904 workbook date systems, and apply default or caller-provided number formats
- preserve primitive values and force ordinary JSON strings to remain text instead of allowing Excel locale coercion
- document the shared CLI/MCP contract and add a release changeset

## Validation
- Release solution build with zero warnings
- 55 focused Core parser, file-input, and real-Excel range tests
- CLI transport and save/reopen parity test
- MCP success and invalid-input protocol coverage
- COM leak, generated coverage/naming, MCP-Core parity, success-flag, documentation-count, and dynamic-cast audits
- `scripts/Test-E2E.ps1` including CLI workflow, stale-build save, and MCP all-tools smoke tests
- full pre-commit deliverable checks for CLI, MCP Server, VS Code extension, MCPB, and agent skills

Closes #835