### PR TITLE
Add workbook integrity validation

### DIFF
--- a/.changeset/calm-books-verify.md
+++ b/.changeset/calm-books-verify.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": minor
+---
+
+**Validate workbook integrity before delivery.** The new read-only `workbook validate-integrity` action reports formula errors, broken references, external-link status, table and header problems, likely calculated-column inconsistencies, and caller-supplied control-total mismatches through grouped typed findings.

--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -68,7 +68,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## What You Can Do
 
-**31 feature command categories with 325 operations** for comprehensive Excel automation:
+**31 feature command categories with 326 operations** for comprehensive Excel automation:
 
 - **Power Query** (12 ops) — Create, update, refresh queries; M code management
 - **Data Model/DAX** (20 ops) — Measures, relationships, source metadata, EVALUATE queries
@@ -77,7 +77,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 - **Charts and Chart Config** (33 ops) — Combo series, plotting, placement, formatting
 - **Ranges** (51 ops) — Values, formulas, hyperlinks, threaded comments, formatting
 - **Worksheets** (33 ops) — Lifecycle, outlines, protection, notes, images, shapes
-- **Workbooks** (15 ops) — Metadata, properties, Save As/copy, PDF/XPS, external links
+- **Workbooks** (16 ops) — Integrity validation, metadata, properties, Save As/copy, PDF/XPS, external links
 - **VBA** (6 ops) — Module management and execution
 - **Connections** (11 ops) — OLEDB/ODBC management and refresh control
 - **QueryTables** (9 ops) — Text/CSV and legacy HTML imports

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -58,7 +58,7 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ## What You Can Do
 
-**31 specialized tools with 325 operations** for comprehensive Excel automation:
+**31 specialized tools with 326 operations** for comprehensive Excel automation:
 
 ### Core Operations
 
@@ -69,7 +69,7 @@ pwsh -ExecutionPolicy Bypass -File `
 - **Charts** (33 ops) — Combo series, plotting, placement, formatting, labels, trendlines
 - **Ranges** (51 ops) — Values, formulas, hyperlinks, threaded comments, formatting, validation
 - **Worksheets** (33 ops) — Lifecycle, outlines, protection, notes, images, shapes, page setup
-- **Workbooks** (15 ops) — Metadata, properties, Save As/copy, PDF/XPS, external links
+- **Workbooks** (16 ops) — Integrity validation, metadata, properties, Save As/copy, PDF/XPS, external links
 
 ### Advanced Features
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # ExcelMcp - Complete Feature Reference
 
-**31 specialized tools with 325 operations for comprehensive Excel automation**
+**31 specialized tools with 326 operations for comprehensive Excel automation**
 
 Excel MCP Server automates the real Microsoft Excel application through four focused capability areas. Start with the category that matches your goal, or use the quick reference below.
 
@@ -37,5 +37,6 @@ cover the most common jobs end to end:
 | Visualize data | `chart` |
 | Update parameters | `namedrange` (write operation) |
 | Manage formulas | `range` (set-formulas) |
+| Validate workbook integrity | `workbook` (validate-integrity) |
 | Format data | `range` / `range_format` (`format-range`, `format-ranges`, `validate-range`) |
 | Script automation | `vba` (run macro) |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ its official COM API. It can refresh Power Query, recalculate formulas, evaluate
 DAX, run VBA and Python `=PY()`, and preserve PivotTables, charts, macros, the
 Data Model, and workbook formatting.
 
-**31 tools with 325 operations** cover end-to-end Excel automation.
+**31 tools with 326 operations** cover end-to-end Excel automation.
 
 > [!IMPORTANT]
 > Requires **Windows**, **Microsoft Excel 2016 or later**, and an interactive
@@ -55,7 +55,7 @@ while automating them.
 - **[Automation & advanced](https://excelmcpserver.dev/features/automation-advanced/):**
   VBA, Python in Excel, Goal Seek, scenarios, data tables, windows, and XML Maps.
 
-Explore the [complete reference for all 325 operations](https://excelmcpserver.dev/features/).
+Explore the [complete reference for all 326 operations](https://excelmcpserver.dev/features/).
 
 ## See It in Action
 

--- a/docs/COPILOT-PLUGIN-DISTRIBUTION.md
+++ b/docs/COPILOT-PLUGIN-DISTRIBUTION.md
@@ -6,7 +6,7 @@ This document outlines how the Excel MCP Server and Excel CLI are distributed as
 
 ExcelMcp is published as **two complementary plugins** in the GitHub Copilot plugin marketplace:
 
-- **`excel-mcp`** — MCP Server with 31 tools (325 operations) for conversational AI (Claude Desktop, Copilot chat)
+- **`excel-mcp`** — MCP Server with 31 tools (326 operations) for conversational AI (Claude Desktop, Copilot chat)
 - **`excel-cli`** — CLI-only skill for coding agents (token-efficient, `--help` discoverable)
 
 Both plugins are maintained in a separate published repository and auto-synced from this source repo.
@@ -67,7 +67,7 @@ copilot plugin install excel-cli@mcp-server-excel-plugins
 
 ### Excel MCP Plugin
 
-Provides the full MCP Server with 31 tools (325 operations) for conversational AI:
+Provides the full MCP Server with 31 tools (326 operations) for conversational AI:
 
 ```powershell
 copilot plugin install excel-mcp@mcp-server-excel-plugins

--- a/docs/features/CELLS-WORKBOOKS.md
+++ b/docs/features/CELLS-WORKBOOKS.md
@@ -155,9 +155,9 @@ Add, rename, move, and manage worksheets — including tab colors, visibility, p
 
 ---
 
-## 📘 Workbook (15 operations)
+## 📘 Workbook (16 operations)
 
-Manage workbook metadata, protection, document properties, file variants, exports, and external links.
+Manage workbook metadata, protection, integrity, document properties, file variants, exports, and external links.
 
 **Operations:**
 - **Set Protection:** Protect or unprotect the current workbook, optionally with a password
@@ -165,6 +165,7 @@ Manage workbook metadata, protection, document properties, file variants, export
 - **Set View Options:** Toggle workbook window gridlines and headings on or off
 - **Get View Options:** Read back workbook window gridlines and headings state
 - **Get Info:** Read workbook name, path, format, saved/read-only state, and protection metadata
+- **Validate Integrity:** Read formula errors and broken references, external-link status, table/header problems, likely calculated-column inconsistencies, and caller-supplied control totals without recalculating, refreshing, editing, or saving. Findings are grouped by severity and category and identify deterministic checks versus calculated-column heuristics.
 - **List/Get/Set/Delete Document Properties:** Manage built-in and custom workbook properties
 - **Save As:** Save as `.xlsx`, `.xlsm`, `.xlsb`, or `.xls` and move the active session to the new path
 - **Save Copy As:** Create a same-format copy without changing the active workbook

--- a/docs/guides/EXCEL-COM-VS-FILE-PARSERS.md
+++ b/docs/guides/EXCEL-COM-VS-FILE-PARSERS.md
@@ -73,7 +73,7 @@ The dividing line in practice: **generating a new simple file** favours parsers;
 
 Raw COM automation from a script is possible but unpleasant — STA threading, COM
 object lifetime, message filters, and Excel process cleanup are all easy to get
-wrong and leak `EXCEL.EXE` processes. ExcelMcp handles that layer and exposes 325
+wrong and leak `EXCEL.EXE` processes. ExcelMcp handles that layer and exposes 326
 operations across 31 tools through two equal entry points:
 
 - an **MCP server** for conversational AI clients (Claude, Copilot, Cursor)

--- a/gh-pages/docs/faq.md
+++ b/gh-pages/docs/faq.md
@@ -31,7 +31,7 @@ possible - you don't need to memorize it.
 
 ### CLI or MCP Server - which should I install?
 
-Both expose the **same 325 operations**. Use the **MCP Server** for
+Both expose the **same 326 operations**. Use the **MCP Server** for
 conversational AI (Claude Desktop, VS Code Chat); use the **CLI** (`excelcli`)
 for coding agents and scripting, where it uses ~64% fewer tokens. You can
 install both. See [Installation](installation.md).

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,6 +1,6 @@
 ---
 title: Excel Automation Features
-description: Explore 31 Excel automation tools and 325 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
+description: Explore 31 Excel automation tools and 326 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
 keywords: "Excel automation features, Excel MCP tools, Power Query automation, DAX, PivotTables, VBA, Excel AI"
 ---
 
@@ -11,7 +11,7 @@ keywords: "Excel automation features, Excel MCP tools, Power Query automation, D
   <figcaption>A PivotTable — revenue by region and quarter with grand totals — created in the real Excel application from a plain-language request.</figcaption>
 </figure>
 
-Excel MCP Server provides **31 specialized tools and 325 operations** for
+Excel MCP Server provides **31 specialized tools and 326 operations** for
 automating the real Microsoft Excel application. You can ask your AI assistant
 in plain language—the reference pages below are for discovering what is
 possible and looking up individual operations.

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -132,7 +132,7 @@ hide:
 
 </div>
 
-[See all 31 tools and 325 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 31 tools and 326 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## Popular guides
 

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -13,7 +13,7 @@ Excel MCP Server lets you automate Excel through conversation with Claude:
 - **Automate** - VBA macros, batch operations, data refresh
 - **Agent Mode** - Say "show me Excel" and watch AI work in real-time, side-by-side with Claude
 
-**31 tools with 325 operations** for comprehensive Excel automation.
+**31 tools with 326 operations** for comprehensive Excel automation.
 
 ## Requirements
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Excel (Windows)",
   "version": "2.0.5",
   "description": "Manage Sheets, Power Query, DAX, VBA, PowerPivot, Tables, Ranges, Charts, Formatting, Validation & more - requires Excel to be installed",
-  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 325 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
+  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 326 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/skills/excel-cli/references/cli-commands.md
+++ b/skills/excel-cli/references/cli-commands.md
@@ -4,7 +4,7 @@
 
 ### analysis
 
-Excel what-if analysis with Goal Seek, scenarios, scenario reports, and one- or two-variable data tables. Solver is excluded because it is an optional VBA add-in that must be enabled by the user and is not part of the Excel PIA
+Excel what-if analysis with Goal Seek, scenarios, scenario reports, and one- or two-variable data tables
 
 **Actions:** `goal-seek`, `list-scenarios`, `create-scenario`, `update-scenario`, `show-scenario`, `delete-scenario`, `create-scenario-summary`, `create-data-table`
 
@@ -40,7 +40,7 @@ Execute multiple commands from a JSON file or stdin. Outputs NDJSON (one result 
 
 ### calculationmode
 
-Control Excel recalculation (automatic vs manual). Set manual mode before bulk writes for faster performance, then recalculate once at the end
+Control Excel recalculation (automatic vs manual)
 
 **Actions:** `get-mode`, `set-mode`, `calculate`
 
@@ -55,7 +55,7 @@ Control Excel recalculation (automatic vs manual). Set manual mode before bulk w
 
 ### chart
 
-Chart lifecycle - create, read, move, and delete embedded charts. POSITIONING (choose one): - targetRange (PREFERRED): Cell range like 'F2:K15' — positions chart within cells, no point math needed. - left/top: Manual positioning in points (72 points = 1 inch). - Neither: Auto-positions chart below all existing content (used range + other charts). COLLISION DETECTION: All create/move/fit-to-range operations automatically check for overlaps with data and other charts. Warnings are returned in the result message if collisions are detected. Always verify layout with screenshot(capture) and an explicit range that includes the chart. CHART TYPES: 70+ types available including Column, Line, Pie, Bar, Area, XY Scatter. CREATE OPTIONS: - create-from-range: Create from cell range (e.g., 'A1:D10') - create-from-table: Create from Excel Table (uses table's data range) - create-from-pivottable: Create and verify a live PivotChart link; never falls back to a regular chart Use chartconfig for series, titles, legends, styles, placement mode
+Chart lifecycle - create, read, move, and delete embedded charts
 
 **Actions:** `list`, `read`, `create-from-range`, `create-from-table`, `create-from-pivottable`, `delete`, `move`, `fit-to-range`
 
@@ -78,7 +78,7 @@ Chart lifecycle - create, read, move, and delete embedded charts. POSITIONING (c
 
 ### chartconfig
 
-Chart configuration - data source, series, type, title, axis labels, legend, and styling. SERIES MANAGEMENT: - add-series: Add data series with valuesRange (required) and optional categoryRange - remove-series: Remove series by 1-based index - set-source-range: Replace entire chart data source TITLES AND LABELS: - set-title: Set chart title (empty string hides title) - set-axis-title: Set axis labels (Category, Value, CategorySecondary, ValueSecondary) CHART STYLES: 1-48 (built-in Excel styles with different color schemes) DATA LABELS: Show values, percentages, series/category names. Positions: Center, InsideEnd, InsideBase, OutsideEnd, BestFit. TRENDLINES: Linear, Exponential, Logarithmic, Polynomial (order 2-6), Power, MovingAverage. PLACEMENT MODE: - 1: Move and size with cells - 2: Move but don't size with cells - 3: Don't move or size with cells (free floating) Use chart for lifecycle operations (create, delete, move, fit-to-range)
+Chart configuration - data source, series, type, title, axis labels, legend, and styling
 
 **Actions:** `set-source-range`, `add-series`, `remove-series`, `set-chart-type`, `set-title`, `set-axis-title`, `get-axis-number-format`, `set-axis-number-format`, `show-legend`, `set-style`, `set-placement`, `set-data-labels`, `get-axis-scale`, `set-axis-scale`, `get-gridlines`, `set-gridlines`, `set-series-format`, `set-series-chart-type`, `get-plot-options`, `set-plot-options`, `set-area-format`, `list-trendlines`, `add-trendline`, `delete-trendline`, `set-trendline`
 
@@ -142,7 +142,7 @@ Chart configuration - data source, series, type, title, axis labels, legend, and
 
 ### conditionalformat
 
-Conditional formatting - visual rules based on cell values. TYPES: cellValue (requires operatorType+formula1), expression (formula only), colorScale, dataBar, iconSet, top10, aboveAverage, timePeriod, uniqueValues, blanksCondition. Both camelCase and kebab-case accepted. FORMAT: interiorColor/fontColor as #RRGGBB, fontBold/Italic, borderStyle/Color. Visual rule types use dedicated parameters on add-rule and return their type-specific configuration from list-rules / list-worksheet-rules. OPERATORS: equal, notEqual, greater, less, greaterEqual, lessEqual, between, notBetween. For 'between' and 'notBetween', both formula1 and formula2 are required
+Conditional formatting - visual rules based on cell values
 
 **Actions:** `add-rule`, `clear-rules`, `list-rules`, `list-worksheet-rules`
 
@@ -199,7 +199,7 @@ Conditional formatting - visual rules based on cell values. TYPES: cellValue (re
 
 ### connection
 
-Data connections (OLEDB, ODBC, ODC import). TEXT/WEB/CSV: Use querytable for direct local imports or powerquery for transformations. Power Query connections auto-redirect to powerquery. TIMEOUT: 30 min auto-timeout for refresh/load-to
+Data connections (OLEDB, ODBC, ODC import)
 
 **Actions:** `list`, `view`, `create`, `refresh`, `get-refresh-status`, `cancel-refresh`, `delete`, `load-to`, `get-properties`, `set-properties`, `test`
 
@@ -220,7 +220,7 @@ Data connections (OLEDB, ODBC, ODC import). TEXT/WEB/CSV: Use querytable for dir
 
 ### datamodel
 
-Data Model (Power Pivot) - DAX measures and table management. CRITICAL: WORKSHEET TABLES AND DATA MODEL ARE SEPARATE! - After table append changes, Data Model still has OLD data - MUST call refresh to sync changes - Power Query refresh auto-syncs (no manual refresh needed) PREREQUISITE: Tables must be added to the Data Model first. Use table add-to-datamodel for worksheet tables, or powerquery to import and load data directly to the Data Model. DAX MEASURES: - Create with DAX formulas like 'SUM(Sales[Amount])' - DAX formulas are preserved exactly by default - Set formatDax=true only with user consent; it sends formulas to daxformatter.com - Read operations return raw DAX as stored DAX EVALUATE QUERIES: - Use evaluate to execute DAX EVALUATE queries against the Data Model - Returns tabular results from queries like 'EVALUATE TableName' - Supports complex DAX: SUMMARIZE, FILTER, CALCULATETABLE, TOPN, etc. DMV (DYNAMIC MANAGEMENT VIEW) QUERIES: - Use execute-dmv to query Data Model metadata via SQL-like syntax - Syntax: SELECT * FROM $SYSTEM.SchemaRowset (ONLY SELECT * supported) - Use DISCOVER_SCHEMA_ROWSETS to list all available DMVs Use datamodelrel for relationships between tables
+Data Model (Power Pivot) - DAX measures and table management
 
 **Actions:** `list-tables`, `list-columns`, `read-table`, `read-info`, `read-connection`, `list-measures`, `read`, `delete-measure`, `delete-table`, `rename-table`, `refresh`, `create-measure`, `update-measure`, `evaluate`, `execute-dmv`
 
@@ -245,7 +245,7 @@ Data Model (Power Pivot) - DAX measures and table management. CRITICAL: WORKSHEE
 
 ### datamodelrelationship
 
-Data Model relationships - link tables for cross-table DAX calculations. CRITICAL: Deleting or recreating tables removes ALL their relationships. Use list-relationships before table operations to backup, then recreate relationships after schema changes. RELATIONSHIP REQUIREMENTS: - Both tables must exist in the Data Model first - Columns must have compatible data types - fromTable/fromColumn = many-side (detail table, foreign key) - toTable/toColumn = one-side (lookup table, primary key) ACTIVE VS INACTIVE: - Only ONE active relationship can exist between two tables - Use active=false when creating alternative paths - DAX USERELATIONSHIP() activates inactive relationships
+Data Model relationships - link tables for cross-table DAX calculations
 
 **Actions:** `list-relationships`, `read-relationship`, `create-relationship`, `update-relationship`, `delete-relationship`
 
@@ -261,7 +261,7 @@ Data Model relationships - link tables for cross-table DAX calculations. CRITICA
 
 ### diag
 
-Diagnostic commands for testing CLI/MCP infrastructure without Excel. These commands validate parameter parsing, routing, JSON serialization, and error handling — no Excel COM session needed
+Diagnostic commands for testing CLI/MCP infrastructure without Excel
 
 **Actions:** `ping`, `echo`, `validate-params`
 
@@ -277,7 +277,7 @@ Diagnostic commands for testing CLI/MCP infrastructure without Excel. These comm
 
 ### drawing
 
-Worksheet drawing objects and sparklines. OBJECTS: list/read/update/delete images, AutoShapes, text boxes, connectors, and worksheet Forms controls. SHAPE TYPES: common geometric, arrow, and flowchart AutoShapes. FORMATTING: geometry, text, fill/line/font colors, rotation, visibility, locking, placement, and alternative text. FORMS CONTROLS: safe worksheet Forms controls only. linkedCell applies to CheckBox, DropDown, ListBox, OptionButton, ScrollBar, and Spinner; inputRange applies only to DropDown and ListBox. ActiveX/OLE controls and macro assignment are intentionally excluded. SPARKLINES: list/read/create/update/delete line, column, and win/loss sparklines. COLORS: use #RRGGBB hexadecimal values
+Worksheet drawing objects and sparklines
 
 **Actions:** `list-objects`, `get-object`, `add-image`, `add-shape`, `add-text-box`, `add-connector`, `add-form-control`, `update-object`, `delete-object`, `list-sparklines`, `get-sparkline`, `add-sparkline`, `update-sparkline`, `delete-sparkline`
 
@@ -322,7 +322,7 @@ Worksheet drawing objects and sparklines. OBJECTS: list/read/update/delete image
 
 ### namedrange
 
-Named ranges for formulas/parameters. LIST: returns visible user-defined names; hidden/internal Excel names are omitted before value inspection, and large ranges return metadata without materializing values. CREATE/UPDATE: value is cell reference (e.g., 'Sheet1!$A$1'). WRITE: value is data to store. TIP: use range get-values/set-values with the named range as the range address for bulk data read/write
+Named ranges for formulas/parameters
 
 **Actions:** `list`, `write`, `read`, `update`, `create`, `delete`
 
@@ -336,7 +336,7 @@ Named ranges for formulas/parameters. LIST: returns visible user-defined names; 
 
 ### pivottable
 
-PivotTable lifecycle management: create from various sources, list, read details, refresh, and delete. Use pivottablefield for field operations, pivottablecalc for calculated fields and layout. BEST PRACTICE: Use 'list' before creating. Prefer 'refresh' or field modifications over delete+recreate. Delete+recreate loses field configurations, filters, sorting, and custom layouts. REFRESH: Call 'refresh' after configuring fields with pivottablefield to update the visual display. This is especially important for OLAP/Data Model PivotTables where field operations are structural only and don't automatically trigger a visual refresh. CREATE OPTIONS: - 'create-from-range': Use source sheet and range address for data range - 'create-from-table': Use an Excel Table (ListObject) as source - 'create-from-datamodel': Use a Power Pivot Data Model table as source
+PivotTable lifecycle management: create from various sources, list, read details, refresh, and delete
 
 **Actions:** `list`, `read`, `create-from-range`, `create-from-table`, `create-from-datamodel`, `delete`, `refresh`, `get-cache-options`, `set-cache-options`, `drill-through`
 
@@ -360,7 +360,7 @@ PivotTable lifecycle management: create from various sources, list, read details
 
 ### pivottablecalc
 
-PivotTable calculated fields/members, layout configuration, and data extraction. Use pivottable for lifecycle, pivottablefield for field placement. CALCULATED FIELDS (for regular PivotTables): - Create custom fields using formulas like '=Revenue-Cost' or '=Quantity*UnitPrice' - Can reference existing fields by name - After creating, use pivottablefield add-value-field to add to Values area - For complex multi-table calculations, prefer DAX measures with datamodel CALCULATED MEMBERS (for OLAP/Data Model PivotTables only): - Create using MDX expressions - Member types: Member, Set, Measure LAYOUT OPTIONS: - 0 = Compact (default, fields in single column) - 1 = Tabular (each field in separate column - best for export/analysis) - 2 = Outline (hierarchical with expand/collapse)
+PivotTable calculated fields/members, layout configuration, and data extraction
 
 **Actions:** `get-data`, `create-calculated-field`, `list-calculated-fields`, `delete-calculated-field`, `list-calculated-members`, `create-calculated-member`, `delete-calculated-member`, `set-layout`, `set-subtotals`, `set-grand-totals`
 
@@ -383,7 +383,7 @@ PivotTable calculated fields/members, layout configuration, and data extraction.
 
 ### pivottablefield
 
-PivotTable field management: add/remove/configure fields, filtering, sorting, and grouping. Use pivottable for lifecycle, pivottablecalc for calculated fields and layout. IMPORTANT: Field operations modify structure only. Call pivottable refresh after configuring fields to update the visual display, especially for OLAP/Data Model PivotTables. FIELD AREAS: - Row fields: Group data by categories (add-row-field) - Column fields: Create column headers (add-column-field) - Value fields: Aggregate numeric data with Sum, Count, Average, etc. (add-value-field) - Filter fields: Add report-level filters (add-filter-field) AGGREGATION FUNCTIONS: Sum, Count, Average, Max, Min, Product, CountNumbers, StdDev, StdDevP, Var, VarP GROUPING: - Date fields: Group by Days, Months, Quarters, Years (group-by-date) - Numeric fields: Group by ranges with start/end/interval (group-by-numeric) NUMBER FORMAT: Use US format codes like '#,##0.00' for currency or '0.00%' for percentages
+PivotTable field management: add/remove/configure fields, filtering, sorting, and grouping
 
 **Actions:** `list-fields`, `add-row-field`, `add-column-field`, `add-value-field`, `add-filter-field`, `remove-field`, `set-field-function`, `set-field-name`, `set-field-format`, `set-field-filter`, `sort-field`, `group-by-date`, `group-by-numeric`, `group-items`, `ungroup-field`
 
@@ -409,7 +409,7 @@ PivotTable field management: add/remove/configure fields, filtering, sorting, an
 
 ### powerquery
 
-Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACTICE): 1. evaluate - Test M code WITHOUT persisting (catches syntax errors, validates sources, shows data preview) 2. create/update - Store VALIDATED query in workbook 3. refresh/load-to - Load data to destination Skip evaluate only for trivial literal tables. IF CREATE/UPDATE FAILS: Use evaluate to get the actual M engine error message, fix code, retry. DATETIME COLUMNS: Always include Table.TransformColumnTypes() in M code to set column types explicitly. Without explicit types, dates may be stored as numbers and Data Model relationships may fail. DESTINATIONS: 'worksheet' (default), 'data-model' (for DAX), 'both', 'connection-only'. Values are case-insensitive and unknown values are rejected. Use 'data-model' to load to Power Pivot, then use datamodel to create DAX measures. M-CODE: Preserved exactly by default. Set formatMCode=true only with explicit user consent; it sends M code to powerqueryformatter.com. TARGET CELL: targetCellAddress places tables without clearing sheet. TIMEOUT: Refresh accepts a caller timeout; load-to uses the fixed 30-minute data-operation timeout. READS: list returns compact metadata, exact load state, and an M preview of at most 80 characters. Use view for one query's full M code
+Power Query M code and data loading
 
 **Actions:** `list`, `view`, `refresh`, `get-load-config`, `delete`, `create`, `update`, `load-to`, `refresh-all`, `rename`, `unload`, `evaluate`
 
@@ -431,7 +431,7 @@ Power Query M code and data loading. TEST-FIRST DEVELOPMENT WORKFLOW (BEST PRACT
 
 ### pythoninexcel
 
-Microsoft 365 "Python in Excel" (=PY()) formulas. REQUIRES: a real Excel session signed into a licensed Microsoft 365 account with Python in Excel enabled, plus internet access — the Python code executes in a Microsoft-hosted cloud sandbox, not locally. Not available offline or with perpetual-license Excel. SET-FORMULA writes '=PY("<code>", returnType)' via Range.Formula2. returnType 0 = "Excel Value" (a plain value/array), 1 = "Python Object" (a rich data type card, e.g. a DataFrame). The returnType argument must always be passed explicitly — omitting it causes a #NAME? error. GET-RESULT reads the computed value back, polling until the cloud round-trip finishes (a fresh formula reads as #BUSY! while the cloud Python sandbox is still computing). Completion is detected deterministically from Excel's calculation state plus a per-cell #BUSY! guard, so a converged result is not confused with the in-flight #BUSY! placeholder. If the cloud backend is still busy at the deadline (e.g. a cold start), GET-RESULT reports that and asks the caller to retry or raise maxWaitSeconds rather than returning a placeholder. If Excel evaluates PY() as #NAME?, both actions report that Python in Excel is unavailable in the current session instead of returning the raw worksheet error. DATA BINDING: reference live worksheet data inside the Python code with xl("A1:A6"), xl("Sheet1!A1:A6"), or a named range xl("MyRange") — all work when the formula is authored via this tool, the same as if typed interactively. TIP: xl() returns a pandas DataFrame/Series (not a plain list) unless you pass headers explicitly; prefer pandas methods (.sum()/.mean()/.max()) over Python builtins (sum()/len()) to avoid getting a Series back instead of a scalar total
+Microsoft 365 "Python in Excel" (=PY()) formulas
 
 **Actions:** `set-formula`, `get-result`
 
@@ -447,7 +447,7 @@ Microsoft 365 "Python in Excel" (=PY()) formulas. REQUIRES: a real Excel session
 
 ### querytable
 
-Worksheet QueryTable lifecycle and configuration for local COM text, CSV, and legacy web imports. Use powerquery for modern connectors and transformations
+Worksheet QueryTable lifecycle and configuration for local COM text, CSV, and legacy web imports
 
 **Actions:** `list`, `view`, `create-text`, `create-web`, `set-properties`, `refresh`, `get-refresh-status`, `cancel-refresh`, `delete`
 
@@ -475,7 +475,7 @@ Worksheet QueryTable lifecycle and configuration for local COM text, CSV, and le
 
 ### range
 
-Core range operations: get/set values and formulas, copy ranges, clear content, and discover data regions. Use rangeedit for insert/delete/find/sort. Use rangeformat for styling/validation. Use rangelink for hyperlinks and cell protection. Calculation mode and explicit recalculation are handled by calculationmode. BEST PRACTICE: Use 'get-values' to check existing data before overwriting. Use 'clear-contents' (not 'clear-all') to preserve cell formatting when clearing data. set-values preserves existing formatting; use set-number-format after if format change needed. DATA FORMAT: values and formulas are 2D JSON arrays representing rows and columns. Example: [[row1col1, row1col2], [row2col1, row2col2]] Single cell returns [[value]] (always 2D). REQUIRED PARAMETERS: - sheetName + rangeAddress for cell operations (e.g., sheetName='Sheet1', rangeAddress='A1:D10') - For named ranges, use sheetName='' (empty string) and rangeAddress='MyNamedRange' COPY OPERATIONS: Specify source and target sheet/range for copy operations. NUMBER FORMATS: Use US locale format codes (e.g., '#,##0.00', 'mm/dd/yyyy', '0.00%')
+Core range operations: get/set values and formulas, copy ranges, clear content, and discover data regions
 
 **Actions:** `get-values`, `set-values`, `get-formulas`, `set-formulas`, `validate-formulas`, `clear-all`, `clear-contents`, `clear-formats`, `copy`, `copy-values`, `copy-formulas`, `get-number-formats`, `set-number-format`, `set-number-formats`, `get-used-range`, `get-current-region`, `get-info`
 
@@ -500,7 +500,7 @@ Core range operations: get/set values and formulas, copy ranges, clear content, 
 
 ### rangeedit
 
-Range editing operations: insert/delete cells, rows, and columns; find/replace text; sort data. Use range for values/formulas/copy/clear operations. INSERT/DELETE CELLS: Specify shift direction to control how surrounding cells move. - Insert: 'Down' or 'Right' - Delete: 'Up' or 'Left' INSERT/DELETE ROWS: Use row range like '5:10' to insert/delete rows 5-10. INSERT/DELETE COLUMNS: Use column range like 'B:D' to insert/delete columns B-D. FIND/REPLACE: Search within the specified range with optional case/cell matching. - Find returns up to 10 matching cell addresses with total count. - Replace modifies all matches by default. SORT: Specify sortColumns as array of {columnIndex: 1, ascending: true} objects. Column indices are 1-based relative to the range
+Range editing operations: insert/delete cells, rows, and columns; find/replace text; sort data
 
 **Actions:** `insert-cells`, `delete-cells`, `insert-rows`, `delete-rows`, `insert-columns`, `delete-columns`, `find`, `replace`, `sort`
 
@@ -522,7 +522,7 @@ Range editing operations: insert/delete cells, rows, and columns; find/replace t
 
 ### rangeformat
 
-Range formatting operations: apply styles, set fonts/colors/borders, add data validation, merge cells, auto-fit dimensions. Use range tool for values/formulas/copy/clear operations. set-style: Apply a named Excel style (Heading 1, Good, Bad, Neutral, Normal). Best for semantic status labels (Good/Bad/Neutral have fill colours and are theme-aware) and document hierarchy (Heading 1/2/3). NOTE: Heading styles do NOT apply a fill colour — use format-range when you need a coloured header row. format-range: Apply any combination of bold, fillColor, fontColor, alignment, borders. Required whenever you need a fill colour or custom branding. Pass ALL desired properties in a SINGLE call — do not call format-range multiple times for the same range. format-ranges: Apply one shared formatting payload to multiple ranges on the same worksheet. Prefer this over repeated format-range calls when the same styling applies to multiple non-contiguous targets. All target ranges are validated before formatting begins. If any target range is invalid, nothing is formatted. COLORS: Hex '#RRGGBB' (e.g., '#FF0000' for red, '#00FF00' for green) FONT: size in points (e.g., 12, 14, 16), alignment: 'left', 'center', 'right' / 'top', 'middle', 'bottom' DATA VALIDATION: Restrict cell input with validation rules: - Types: 'list', 'whole', 'decimal', 'date', 'time', 'textLength', 'custom' - For list validation, formula1 is the list source (e.g., '=$A$1:$A$10' or '"Option1,Option2,Option3"') - Operators: 'between', 'notBetween', 'equal', 'notEqual', 'greaterThan', 'lessThan', 'greaterThanOrEqual', 'lessThanOrEqual' MERGE: Combines cells into one. Only top-left cell value is preserved
+Range formatting operations: apply styles, set fonts/colors/borders, add data validation, merge cells, auto-fit dimensions
 
 **Actions:** `set-style`, `get-style`, `format-range`, `format-ranges`, `validate-range`, `get-validation`, `remove-validation`, `auto-fit-columns`, `auto-fit-rows`, `merge-cells`, `unmerge-cells`, `get-merge-info`, `set-column-width`, `set-row-height`
 
@@ -567,7 +567,7 @@ Range formatting operations: apply styles, set fonts/colors/borders, add data va
 
 ### rangelink
 
-Hyperlink, threaded comment, and cell protection operations for Excel ranges. Use range for values/formulas, rangeformat for styling. HYPERLINKS: - 'add-hyperlink': Add an external or internal workbook hyperlink - 'update-hyperlink': Update the target or display metadata of an existing hyperlink - 'remove-hyperlink': Remove hyperlink(s) from cells while keeping the cell content - 'list-hyperlinks': Get all hyperlinks on a worksheet - 'get-hyperlink': Get hyperlink details for a specific cell CELL PROTECTION: - 'set-cell-lock': Lock or unlock cells (only effective when sheet protection is enabled) - 'get-cell-lock': Check if cells are locked Note: Cell locking only takes effect when the worksheet is protected
+Hyperlink, threaded comment, and cell protection operations for Excel ranges
 
 **Actions:** `add-hyperlink`, `update-hyperlink`, `remove-hyperlink`, `list-hyperlinks`, `get-hyperlink`, `add-threaded-comment`, `list-threaded-comments`, `add-threaded-comment-reply`, `delete-threaded-comment`, `set-cell-lock`, `get-cell-lock`
 
@@ -587,7 +587,7 @@ Hyperlink, threaded comment, and cell protection operations for Excel ranges. Us
 
 ### screenshot
 
-Capture Excel worksheet content as images for visual verification. Photographs the live Excel window and crops to the requested range, so the image shows exactly what Excel displays: formatting, conditional formatting, charts, and all visual elements. Works on protected worksheets and never touches the workbook or the clipboard. ACTIONS: - capture: Capture a specific range as an image - capture-sheet: Capture the worksheet's used cell range. For chart-only sheets or charts beyond used cells, use capture with an explicit range. REQUIREMENTS: Excel is briefly shown and brought to the front, so an interactive desktop session is required. Capture fails on a locked desktop or a disconnected Remote Desktop session. LARGE RANGES: Ranges wider or taller than the Excel window are zoomed to fit, then captured in several passes and stitched together. Very large ranges are truncated to their top-left portion, which is reported in the result message. RETURNS: Base64-encoded image data with dimensions metadata. For MCP: returned as native ImageContent (no file handling needed). For CLI: use --output <path> to save the image directly to a PNG/JPEG file instead of returning base64 inline. Quality defaults to Medium (JPEG 75% scale) which is 4-8x smaller than High (PNG). Use High only when fine detail inspection is needed
+Capture Excel worksheet content as images for visual verification
 
 **Actions:** `capture`, `capture-sheet`
 
@@ -662,7 +662,7 @@ Test file existence, validity, openability, and IRM/AIP read-only requirements
 
 ### sheet
 
-Worksheet lifecycle management: create, rename, copy, delete, move, list sheets. Use range for data operations. Use sheetstyle for tab colors and visibility. ATOMIC OPERATIONS: 'copy-to-file' and 'move-to-file' don't require a session - they open/close files automatically. POSITIONING: For 'move', 'copy-to-file', 'move-to-file' - use 'before' OR 'after' (not both) to position the sheet relative to another. If neither specified, moves to end. NOTE: MCP tool is manually implemented in ExcelWorksheetTool.cs to properly handle mixed session requirements (copy-to-file and move-to-file are atomic and don't need sessions)
+Worksheet lifecycle management: create, rename, copy, delete, move, list sheets
 
 **Actions:** `list`, `create`, `rename`, `copy`, `delete`, `move`, `copy-to-file`, `move-to-file`
 
@@ -685,7 +685,7 @@ Worksheet lifecycle management: create, rename, copy, delete, move, list sheets.
 
 ### slicer
 
-Slicer visual filters for PivotTables and Excel Tables. PIVOTTABLE SLICERS: create-slicer, list-slicers, set-slicer-selection, delete-slicer. TABLE SLICERS: create-table-slicer, list-table-slicers, set-table-slicer-selection, delete-table-slicer. NAMING: Auto-generate descriptive names like {FieldName}Slicer (e.g., RegionSlicer). SELECTION: selectedItems as list of strings. Empty list clears filter (shows all items). Set clearFirst=false to add to existing selection
+Slicer visual filters for PivotTables and Excel Tables
 
 **Actions:** `create-slicer`, `list-slicers`, `set-slicer-selection`, `delete-slicer`, `create-table-slicer`, `list-table-slicers`, `set-table-slicer-selection`, `delete-table-slicer`
 
@@ -705,7 +705,7 @@ Slicer visual filters for PivotTables and Excel Tables. PIVOTTABLE SLICERS: crea
 
 ### table
 
-Excel Tables (ListObjects) - lifecycle and data operations. Tables provide structured references, automatic formatting, and Data Model integration. BEST PRACTICE: Use 'list' to check existing tables before creating. Prefer 'append'/'resize'/'rename' over delete+recreate to preserve references. WARNING: Deleting tables used as PivotTable sources or in Data Model relationships will break those objects. DATA MODEL WORKFLOW: To analyze worksheet data with DAX/Power Pivot: 1. Create or identify an Excel Table on a worksheet 2. Use 'add-to-datamodel' to add the table to Power Pivot 3. Then use datamodel to create DAX measures on it DAX-BACKED TABLES: Create tables populated by DAX EVALUATE queries: - 'create-from-dax': Create a new table backed by a DAX query (e.g., SUMMARIZE, FILTER) - 'update-dax': Update the DAX query for an existing DAX-backed table - 'get-dax': Get the DAX query info for a table (check if it's DAX-backed) Related: tablecolumn (filter/sort/columns), datamodel (DAX measures, evaluate queries)
+Excel Tables (ListObjects) - lifecycle and data operations
 
 **Actions:** `list`, `create`, `rename`, `delete`, `read`, `resize`, `toggle-totals`, `set-column-total`, `append`, `get-data`, `set-style`, `add-to-data-model`, `create-from-dax`, `update-dax`, `get-dax`
 
@@ -732,7 +732,7 @@ Excel Tables (ListObjects) - lifecycle and data operations. Tables provide struc
 
 ### tablecolumn
 
-Table column, filtering, and sorting operations for Excel Tables (ListObjects). Use table for table-level lifecycle and data operations. FILTERING: - 'apply-filter': Simple criteria filter (e.g., ">100", "=Active", "<>Closed") - 'apply-filter-values': Filter by exact values (provide list of values to include) - 'clear-filters': Remove all active filters - 'get-filters': See current filter state SORTING: - 'sort': Single column sort (ascending/descending) - 'sort-multi': Multi-column sort (provide list of {columnName, ascending} objects) COLUMN MANAGEMENT: - 'add-column'/'remove-column'/'rename-column': Modify table structure NUMBER FORMATS: Use US locale format codes (e.g., '#,##0.00', '0%', 'yyyy-mm-dd')
+Table column, filtering, and sorting operations for Excel Tables (ListObjects)
 
 **Actions:** `apply-filter`, `apply-filter-values`, `clear-filters`, `get-filters`, `add-column`, `remove-column`, `rename-column`, `get-structured-reference`, `sort`, `sort-multi`, `get-column-number-format`, `set-column-number-format`
 
@@ -754,7 +754,7 @@ Table column, filtering, and sorting operations for Excel Tables (ListObjects). 
 
 ### vba
 
-VBA module and procedure operations for macro-enabled workbooks (.xlsm). PREREQUISITES: - Workbook must be macro-enabled (.xlsm) - VBA trust must be enabled manually in Excel for project access SCOPE: - List and view existing VBA components and their procedures - Import creates new standard modules from inline code or a file - Update/delete works on existing VBA components by name - Run executes a procedure by name RUN: procedureName format is 'Module.Procedure' (e.g., 'Module1.MySub'). ExcelMcp does not configure VBA trust settings for you
+VBA module and procedure operations for macro-enabled workbooks (.xlsm)
 
 **Actions:** `list`, `view`, `import`, `update`, `run`, `delete`
 
@@ -771,7 +771,7 @@ VBA module and procedure operations for macro-enabled workbooks (.xlsm). PREREQU
 
 ### window
 
-Control Excel window visibility, position, state, status bar, and worksheet-specific views. Use to show/hide Excel, bring it to front, reposition, maximize/minimize, freeze panes, split panes, set zoom, and control gridlines, headings, outline symbols, and formula display. Set status bar text to give users real-time feedback during operations. VISIBILITY: 'show' makes Excel visible AND brings to front. 'hide' hides Excel. Visibility changes are reflected in session metadata (session list shows updated state). WINDOW STATE values: 'normal', 'minimized', 'maximized'. ARRANGE presets: 'left-half', 'right-half', 'top-half', 'bottom-half', 'center', 'full-screen'. STATUS BAR: 'set-status-bar' displays text in Excel's status bar. 'clear-status-bar' restores default. WORKSHEET VIEW: View properties belong to a workbook window and apply to the named active worksheet. 'freeze-panes' uses row and column counts above/left of the pane boundary. 'set-split' creates movable panes and disables frozen panes. Zoom must be between 10 and 400 percent
+Control Excel window visibility, position, state, status bar, and worksheet-specific views
 
 **Actions:** `show`, `hide`, `bring-to-front`, `get-info`, `set-state`, `set-position`, `arrange`, `set-status-bar`, `clear-status-bar`, `get-view`, `freeze-panes`, `unfreeze-panes`, `set-split`, `set-zoom`, `set-display-options`
 
@@ -799,13 +799,17 @@ Control Excel window visibility, position, state, status bar, and worksheet-spec
 
 ### workbook
 
-Manage workbook metadata, document properties, Save As/copy operations, fixed-format exports, and external Excel links. SAVE-AS formats: auto, xlsx, xlsm, xlsb, xls. The active session follows the new workbook path. FIXED FORMAT: PDF or XPS with standard or minimum quality. DOCUMENT PROPERTIES: built-in properties can be read/updated; custom properties can be created, updated, and deleted. EXTERNAL LINKS: discovers, updates, or permanently breaks Excel workbook links. Printing and print preview are intentionally excluded because default-printer output and modal preview are unsafe for unattended automation
+Manage workbook metadata, integrity validation, document properties, Save As/copy operations, fixed-format exports, and external Excel links
 
-**Actions:** `get-info`, `list-document-properties`, `get-document-property`, `set-document-property`, `delete-document-property`, `save-as`, `save-copy-as`, `export-fixed-format`, `list-external-links`, `update-external-link`, `break-external-link`, `set-protection`, `get-protection`, `set-view-options`, `get-view-options`
+**Actions:** `get-info`, `validate-integrity`, `list-document-properties`, `get-document-property`, `set-document-property`, `delete-document-property`, `save-as`, `save-copy-as`, `export-fixed-format`, `list-external-links`, `update-external-link`, `break-external-link`, `set-protection`, `get-protection`, `set-view-options`, `get-view-options`
 
 | Parameter | Description |
 |-----------|-------------|
 | `--session` | Session ID from 'session open' command |
+| `--checks` | Checks to run; omit for formulas, links, tables, and supplied control totals (valid for: validate-integrity) (JSON format) |
+| `--worksheet-names` | Optional worksheet names limiting formula and table checks (valid for: validate-integrity) (JSON format) |
+| `--control-totals` | Expected numeric cells with optional absolute tolerances (valid for: validate-integrity) (JSON format) |
+| `--max-findings` | Maximum finding details to return; counts still include omitted details. Range: 1-10000. (valid for: validate-integrity) |
 | `--include-built-in` | (valid for: list-document-properties) |
 | `--include-custom` | (valid for: list-document-properties) |
 | `--property-name` | Document property name (required for: get-document-property, set-document-property, delete-document-property) (valid for: get-document-property, set-document-property, delete-document-property) |
@@ -830,7 +834,7 @@ Manage workbook metadata, document properties, Save As/copy operations, fixed-fo
 
 ### worksheetstyle
 
-Worksheet styling, visibility, protection, grouping, and outline operations. Use sheet for lifecycle operations (create, rename, copy, delete, move). TAB COLORS: Use RGB values (0-255 each) to set custom tab colors for visual organization. VISIBILITY LEVELS: - 'visible': Normal visible sheet - 'hidden': Hidden but accessible via Format > Sheet > Unhide - 'veryhidden': Only accessible via VBA (protection against casual unhiding) PROTECTION: Protect a worksheet to lock its contents and structure, or unprotect it. OUTLINES: Group or ungroup row/column ranges, configure summary positions, show a specific row/column outline level, inspect grouping state, or clear all groups
+Worksheet styling, visibility, protection, grouping, and outline operations
 
 **Actions:** `set-tab-color`, `get-tab-color`, `clear-tab-color`, `set-protection`, `get-protection`, `set-comment`, `get-comment`, `clear-comment`, `add-image`, `get-image-count`, `add-shape`, `get-shape-count`, `set-page-setup`, `get-page-setup`, `set-visibility`, `get-visibility`, `show`, `hide`, `very-hide`, `group`, `ungroup`, `get-outline-info`, `set-outline-settings`, `show-outline-levels`, `clear-outline`
 
@@ -863,7 +867,7 @@ Worksheet styling, visibility, protection, grouping, and outline operations. Use
 
 ### xmlmap
 
-Manage workbook XML maps and exchange XML data without interactive dialogs. SECURITY: Schemas and XML data are parsed from supplied content with DTD processing disabled. XSD import/include/redefine dependencies and XML schema-location attributes are rejected to prevent implicit network or file access. IMPORT MODES: Provide mapName to import into existing mapped cells. Omit mapName and provide sheetName plus startCell to let Excel create a map and XML table at that destination
+Manage workbook XML maps and exchange XML data without interactive dialogs
 
 **Actions:** `list`, `add`, `map-range`, `import-xml`, `export-xml`, `delete`
 

--- a/skills/excel-cli/references/workbook.md
+++ b/skills/excel-cli/references/workbook.md
@@ -2,7 +2,7 @@
 
 # Workbook Lifecycle
 
-Use the `workbook` tool or CLI command group for workbook-level metadata, file variants, publishing, and external links. Use `file` only for opening, creating, listing, and closing sessions.
+Use the `workbook` tool or CLI command group for workbook-level metadata, integrity checks, file variants, publishing, and external links. Use `file` only for opening, creating, listing, and closing sessions.
 
 ## Metadata and document properties
 
@@ -11,6 +11,15 @@ Use the `workbook` tool or CLI command group for workbook-level metadata, file v
 - `get-document-property` and `set-document-property` require `scope`: `built-in` or `custom`.
 - Built-in properties can be read and updated but not deleted.
 - Missing custom properties are created as string properties by `set-document-property`; `delete-document-property` removes custom properties only.
+
+## Integrity validation
+
+- `validate-integrity` is read-only. It does not calculate, refresh, update links, edit, or save the workbook.
+- Omit `checks` to inspect formula errors, external links, and tables; caller-supplied control totals are also checked when present. Use `worksheet_names` to limit formula and table scans in large workbooks.
+- Control-total entries require `sheetName`, single-cell `cellAddress`, finite numeric `expectedValue`, and an optional non-negative absolute `tolerance`.
+- Run `calculation_mode calculate` first when current calculated results are required. Validation reports manual or incomplete calculation state instead of changing it.
+- `success` means the validation operation completed; use `overallStatus` for workbook integrity. `failed` means at least one error; `passed-with-warnings` contains only warnings; `passed` has neither. Findings are grouped by severity/category. Formula, link, table-structure, header, and control-total findings are deterministic for current workbook state; calculated-column findings are heuristic.
+- `max_findings` limits returned details, not counts. Check `findingsTruncated` before assuming every finding is present in the response.
 
 ## Save and publish
 

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -12,7 +12,7 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
 
 # Excel MCP Server Skill
 
-Provides 325 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
+Provides 326 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
 
 ## Workflow Checklist
 

--- a/skills/excel-mcp/references/workbook.md
+++ b/skills/excel-mcp/references/workbook.md
@@ -1,6 +1,6 @@
 # Workbook Lifecycle
 
-Use the `workbook` tool or CLI command group for workbook-level metadata, file variants, publishing, and external links. Use `file` only for opening, creating, listing, and closing sessions.
+Use the `workbook` tool or CLI command group for workbook-level metadata, integrity checks, file variants, publishing, and external links. Use `file` only for opening, creating, listing, and closing sessions.
 
 ## Metadata and document properties
 
@@ -9,6 +9,15 @@ Use the `workbook` tool or CLI command group for workbook-level metadata, file v
 - `get-document-property` and `set-document-property` require `scope`: `built-in` or `custom`.
 - Built-in properties can be read and updated but not deleted.
 - Missing custom properties are created as string properties by `set-document-property`; `delete-document-property` removes custom properties only.
+
+## Integrity validation
+
+- `validate-integrity` is read-only. It does not calculate, refresh, update links, edit, or save the workbook.
+- Omit `checks` to inspect formula errors, external links, and tables; caller-supplied control totals are also checked when present. Use `worksheet_names` to limit formula and table scans in large workbooks.
+- Control-total entries require `sheetName`, single-cell `cellAddress`, finite numeric `expectedValue`, and an optional non-negative absolute `tolerance`.
+- Run `calculation_mode calculate` first when current calculated results are required. Validation reports manual or incomplete calculation state instead of changing it.
+- `success` means the validation operation completed; use `overallStatus` for workbook integrity. `failed` means at least one error; `passed-with-warnings` contains only warnings; `passed` has neither. Findings are grouped by severity/category. Formula, link, table-structure, header, and control-total findings are deterministic for current workbook state; calculated-column findings are heuristic.
+- `max_findings` limits returned details, not counts. Check `findingsTruncated` before assuming every finding is present in the response.
 
 ## Save and publish
 

--- a/skills/shared/workbook.md
+++ b/skills/shared/workbook.md
@@ -1,6 +1,6 @@
 # Workbook Lifecycle
 
-Use the `workbook` tool or CLI command group for workbook-level metadata, file variants, publishing, and external links. Use `file` only for opening, creating, listing, and closing sessions.
+Use the `workbook` tool or CLI command group for workbook-level metadata, integrity checks, file variants, publishing, and external links. Use `file` only for opening, creating, listing, and closing sessions.
 
 ## Metadata and document properties
 
@@ -9,6 +9,15 @@ Use the `workbook` tool or CLI command group for workbook-level metadata, file v
 - `get-document-property` and `set-document-property` require `scope`: `built-in` or `custom`.
 - Built-in properties can be read and updated but not deleted.
 - Missing custom properties are created as string properties by `set-document-property`; `delete-document-property` removes custom properties only.
+
+## Integrity validation
+
+- `validate-integrity` is read-only. It does not calculate, refresh, update links, edit, or save the workbook.
+- Omit `checks` to inspect formula errors, external links, and tables; caller-supplied control totals are also checked when present. Use `worksheet_names` to limit formula and table scans in large workbooks.
+- Control-total entries require `sheetName`, single-cell `cellAddress`, finite numeric `expectedValue`, and an optional non-negative absolute `tolerance`.
+- Run `calculation_mode calculate` first when current calculated results are required. Validation reports manual or incomplete calculation state instead of changing it.
+- `success` means the validation operation completed; use `overallStatus` for workbook integrity. `failed` means at least one error; `passed-with-warnings` contains only warnings; `passed` has neither. Findings are grouped by severity/category. Formula, link, table-structure, header, and control-total findings are deterministic for current workbook state; calculated-column findings are heuristic.
+- `max_findings` limits returned details, not counts. Check `findingsTruncated` before assuming every finding is present in the response.
 
 ## Save and publish
 

--- a/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+++ b/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
@@ -24,7 +24,7 @@
     <!-- NuGet Package Configuration (secondary distribution — primary is standalone exe) -->
     <PackageId>Sbroenne.ExcelMcp.CLI</PackageId>
     <Title>ExcelMcp CLI</Title>
-    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 325 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
+    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 326 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
     <PackageTags>excel;cli;powerquery;dax;power-pivot;automation;com;rpa;ci-cd;scripting;github-copilot;mcp;windows;dotnet-tool;sbroenne;excel-automation;vba;pivottables;excel-tables;batch-processing;devops</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/sbroenne/mcp-server-excel/releases for release notes</PackageReleaseNotes>

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides 31 feature command categories with 325 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
+The CLI provides 31 feature command categories with 326 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|
@@ -48,7 +48,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## 📋 What You Can Do
 
-ExcelMcp.CLI provides **325 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
+ExcelMcp.CLI provides **326 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
 
 Drives the **actual Excel application** via COM — not a file-format parser — so live operations (Power Query refresh, recalculation, DAX evaluation, VBA execution) run for real and existing workbooks stay intact.
 

--- a/src/ExcelMcp.Core/Commands/Workbook/IWorkbookCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/IWorkbookCommands.cs
@@ -5,21 +5,36 @@ using Sbroenne.ExcelMcp.Core.Models;
 namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
 
 /// <summary>
-/// Manage workbook metadata, document properties, Save As/copy operations, fixed-format exports, and external Excel links.
+/// Manage workbook metadata, integrity validation, document properties, Save As/copy operations, fixed-format exports, and external Excel links.
 /// SAVE-AS formats: auto, xlsx, xlsm, xlsb, xls. The active session follows the new workbook path.
 /// FIXED FORMAT: PDF or XPS with standard or minimum quality.
 /// DOCUMENT PROPERTIES: built-in properties can be read/updated; custom properties can be created, updated, and deleted.
+/// INTEGRITY: read-only checks for formula errors, external links, tables, and caller-supplied control totals.
 /// EXTERNAL LINKS: discovers, updates, or permanently breaks Excel workbook links.
 /// Printing and print preview are intentionally excluded because default-printer output and modal preview are unsafe for unattended automation.
 /// </summary>
 [ServiceCategory("workbook", "Workbook")]
 [McpTool("workbook", Title = "Workbook Operations", Destructive = true, Category = "structure",
-    Description = "Manage workbook metadata, document properties, Save As/copy operations, fixed-format PDF/XPS exports, and external Excel links. SAVE-AS formats: auto, xlsx, xlsm, xlsb, xls; the active session follows the new path. DOCUMENT PROPERTIES: built-in properties can be read/updated; custom properties can be created, updated, and deleted. EXTERNAL LINKS: list, update, or permanently break Excel workbook links. Printing and print preview are excluded because default-printer output and modal preview are unsafe for unattended automation.")]
+    Description = "Manage workbook metadata, read-only integrity validation, document properties, Save As/copy operations, fixed-format PDF/XPS exports, and external Excel links. INTEGRITY: validates formula results, external links, worksheet tables, and caller-supplied control totals without calculating, refreshing, editing, or saving. SAVE-AS formats: auto, xlsx, xlsm, xlsb, xls; the active session follows the new path. DOCUMENT PROPERTIES: built-in properties can be read/updated; custom properties can be created, updated, and deleted. EXTERNAL LINKS: list, update, or permanently break Excel workbook links. Printing and print preview are excluded because default-printer output and modal preview are unsafe for unattended automation.")]
 public interface IWorkbookCommands
 {
     /// <summary>Gets metadata for the active workbook.</summary>
     [ServiceAction("get-info")]
     WorkbookInfoResult GetInfo(IExcelBatch batch);
+
+    /// <summary>Performs read-only workbook integrity checks without calculating, refreshing, editing, or saving.</summary>
+    /// <param name="batch">Excel batch session</param>
+    /// <param name="checks">Checks to run; omit for formulas, links, tables, and supplied control totals</param>
+    /// <param name="worksheetNames">Optional worksheet names limiting formula and table checks</param>
+    /// <param name="controlTotals">Expected numeric cells with optional absolute tolerances</param>
+    /// <param name="maxFindings">Maximum finding details to return; counts still include omitted details. Range: 1-10000.</param>
+    [ServiceAction("validate-integrity")]
+    WorkbookIntegrityResult ValidateIntegrity(
+        IExcelBatch batch,
+        List<WorkbookIntegrityCheck>? checks = null,
+        List<string>? worksheetNames = null,
+        List<WorkbookControlTotalExpectation>? controlTotals = null,
+        int maxFindings = 500);
 
     /// <summary>Lists built-in and/or custom workbook document properties.</summary>
     [ServiceAction("list-document-properties")]

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookCommands.Integrity.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookCommands.Integrity.cs
@@ -1,0 +1,1507 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Utilities;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+public partial class WorkbookCommands
+{
+    private const int MaximumIntegrityFindings = 10_000;
+    private const int ExcelNoMatchingCellsHResult = unchecked((int)0x800A03EC);
+
+    /// <inheritdoc />
+    public WorkbookIntegrityResult ValidateIntegrity(
+        IExcelBatch batch,
+        List<WorkbookIntegrityCheck>? checks = null,
+        List<string>? worksheetNames = null,
+        List<WorkbookControlTotalExpectation>? controlTotals = null,
+        int maxFindings = 500)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ValidateIntegrityInputs(checks, worksheetNames, controlTotals, maxFindings);
+
+        var selectedChecks = ResolveChecks(checks, controlTotals);
+        var selectedWorksheetNames = worksheetNames is null
+            ? null
+            : new HashSet<string>(worksheetNames, StringComparer.OrdinalIgnoreCase);
+        var result = new WorkbookIntegrityResult
+        {
+            FilePath = batch.WorkbookPath,
+            CheckedChecks = selectedChecks
+        };
+
+        return batch.Execute((context, cancellationToken) =>
+        {
+            bool wasSaved = context.Book.Saved;
+            try
+            {
+                var findings = new IntegrityFindingCollector(result, maxFindings);
+                ReadCalculationState(context.App, result, selectedChecks, findings);
+
+                if (selectedChecks.Contains(WorkbookIntegrityCheck.FormulaErrors) ||
+                    selectedChecks.Contains(WorkbookIntegrityCheck.Tables))
+                {
+                    ValidateWorksheets(
+                        context.Book,
+                        selectedChecks,
+                        selectedWorksheetNames,
+                        result,
+                        findings,
+                        cancellationToken);
+                }
+
+                if (selectedChecks.Contains(WorkbookIntegrityCheck.ExternalLinks))
+                {
+                    ValidateExternalLinks(context.Book, findings, cancellationToken);
+                }
+
+                if (selectedChecks.Contains(WorkbookIntegrityCheck.ControlTotals))
+                {
+                    ValidateControlTotals(
+                        context.Book,
+                        controlTotals!,
+                        result,
+                        findings,
+                        cancellationToken);
+                }
+
+                findings.Complete();
+                result.Success = true;
+                return result;
+            }
+            finally
+            {
+                if (context.Book.Saved != wasSaved)
+                {
+                    context.Book.Saved = wasSaved;
+                }
+            }
+        });
+    }
+
+    private static void ValidateIntegrityInputs(
+        List<WorkbookIntegrityCheck>? checks,
+        List<string>? worksheetNames,
+        List<WorkbookControlTotalExpectation>? controlTotals,
+        int maxFindings)
+    {
+        if (maxFindings is < 1 or > MaximumIntegrityFindings)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxFindings),
+                maxFindings,
+                $"Maximum findings must be between 1 and {MaximumIntegrityFindings}.");
+        }
+
+        if (checks is { Count: 0 })
+        {
+            throw new ArgumentException("At least one integrity check is required when checks are supplied.", nameof(checks));
+        }
+
+        if (checks is not null)
+        {
+            foreach (var check in checks)
+            {
+                if (!Enum.IsDefined(check))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(checks), check, "Unknown workbook integrity check.");
+                }
+            }
+
+            if (checks.Contains(WorkbookIntegrityCheck.ControlTotals) &&
+                controlTotals is not { Count: > 0 })
+            {
+                throw new ArgumentException(
+                    "Control-total expectations are required when the control-totals check is selected.",
+                    nameof(controlTotals));
+            }
+
+            if (!checks.Contains(WorkbookIntegrityCheck.ControlTotals) &&
+                controlTotals is { Count: > 0 })
+            {
+                throw new ArgumentException(
+                    "Control-total expectations require the control-totals check when checks are supplied.",
+                    nameof(controlTotals));
+            }
+        }
+
+        if (worksheetNames is { Count: 0 })
+        {
+            throw new ArgumentException(
+                "At least one worksheet name is required when worksheetNames is supplied.",
+                nameof(worksheetNames));
+        }
+
+        if (worksheetNames is not null)
+        {
+            if (checks is not null &&
+                !checks.Contains(WorkbookIntegrityCheck.FormulaErrors) &&
+                !checks.Contains(WorkbookIntegrityCheck.Tables))
+            {
+                throw new ArgumentException(
+                    "Worksheet names apply only to formula-errors and tables checks.",
+                    nameof(worksheetNames));
+            }
+
+            foreach (var worksheetName in worksheetNames)
+            {
+                if (string.IsNullOrWhiteSpace(worksheetName))
+                {
+                    throw new ArgumentException("Worksheet names cannot be empty.", nameof(worksheetNames));
+                }
+            }
+        }
+
+        if (controlTotals is null)
+        {
+            return;
+        }
+
+        if (controlTotals.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one control-total expectation is required when controlTotals is supplied.",
+                nameof(controlTotals));
+        }
+
+        for (int index = 0; index < controlTotals.Count; index++)
+        {
+            var expectation = controlTotals[index]
+                ?? throw new ArgumentException($"Control total at index {index} cannot be null.", nameof(controlTotals));
+            if (string.IsNullOrWhiteSpace(expectation.SheetName))
+            {
+                throw new ArgumentException(
+                    $"Control total at index {index} requires a worksheet name.",
+                    nameof(controlTotals));
+            }
+
+            if (string.IsNullOrWhiteSpace(expectation.CellAddress))
+            {
+                throw new ArgumentException(
+                    $"Control total at index {index} requires a cell address.",
+                    nameof(controlTotals));
+            }
+
+            if (!expectation.ExpectedValue.HasValue ||
+                !double.IsFinite(expectation.ExpectedValue.Value))
+            {
+                throw new ArgumentException(
+                    $"Control total at index {index} requires a finite expected value.",
+                    nameof(controlTotals));
+            }
+
+            if (!double.IsFinite(expectation.Tolerance) || expectation.Tolerance < 0)
+            {
+                throw new ArgumentException(
+                    $"Control total at index {index} requires a finite, non-negative tolerance.",
+                    nameof(controlTotals));
+            }
+        }
+    }
+
+    private static List<WorkbookIntegrityCheck> ResolveChecks(
+        List<WorkbookIntegrityCheck>? checks,
+        List<WorkbookControlTotalExpectation>? controlTotals)
+    {
+        if (checks is not null)
+        {
+            return checks.Distinct().ToList();
+        }
+
+        var result = new List<WorkbookIntegrityCheck>
+        {
+            WorkbookIntegrityCheck.FormulaErrors,
+            WorkbookIntegrityCheck.ExternalLinks,
+            WorkbookIntegrityCheck.Tables
+        };
+        if (controlTotals is { Count: > 0 })
+        {
+            result.Add(WorkbookIntegrityCheck.ControlTotals);
+        }
+
+        return result;
+    }
+
+    private static void ReadCalculationState(
+        Excel.Application application,
+        WorkbookIntegrityResult result,
+        List<WorkbookIntegrityCheck> checks,
+        IntegrityFindingCollector findings)
+    {
+        var calculationMode = application.Calculation;
+        var calculationState = application.CalculationState;
+        result.CalculationMode = calculationMode switch
+        {
+            Excel.XlCalculation.xlCalculationAutomatic => "automatic",
+            Excel.XlCalculation.xlCalculationManual => "manual",
+            Excel.XlCalculation.xlCalculationSemiautomatic => "semi-automatic",
+            _ => Convert.ToInt32(calculationMode, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture)
+        };
+        result.CalculationState = calculationState switch
+        {
+            Excel.XlCalculationState.xlDone => "done",
+            Excel.XlCalculationState.xlCalculating => "calculating",
+            Excel.XlCalculationState.xlPending => "pending",
+            _ => Convert.ToInt32(calculationState, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture)
+        };
+
+        bool readsCalculatedValues =
+            checks.Contains(WorkbookIntegrityCheck.FormulaErrors) ||
+            checks.Contains(WorkbookIntegrityCheck.ControlTotals);
+        if (!readsCalculatedValues)
+        {
+            return;
+        }
+
+        if (calculationMode == Excel.XlCalculation.xlCalculationManual)
+        {
+            findings.Add(new WorkbookIntegrityFinding
+            {
+                Code = "manual-calculation",
+                Severity = WorkbookIntegritySeverity.Warning,
+                Category = WorkbookIntegrityCategory.CalculationState,
+                Reliability = WorkbookIntegrityReliability.Heuristic,
+                Message = "Workbook calculation mode is manual, so cached formula and control-total values may be stale.",
+                SuggestedRemediation = "Calculate the workbook, then run integrity validation again."
+            });
+        }
+
+        if (calculationState != Excel.XlCalculationState.xlDone)
+        {
+            findings.Add(new WorkbookIntegrityFinding
+            {
+                Code = "calculation-incomplete",
+                Severity = WorkbookIntegritySeverity.Warning,
+                Category = WorkbookIntegrityCategory.CalculationState,
+                Reliability = WorkbookIntegrityReliability.Heuristic,
+                Message = $"Workbook calculation state is {result.CalculationState}, so calculated values may be incomplete.",
+                SuggestedRemediation = "Wait for calculation to finish, then run integrity validation again."
+            });
+        }
+    }
+
+    private static void ValidateWorksheets(
+        Excel.Workbook workbook,
+        List<WorkbookIntegrityCheck> checks,
+        HashSet<string>? selectedWorksheetNames,
+        WorkbookIntegrityResult result,
+        IntegrityFindingCollector findings,
+        CancellationToken cancellationToken)
+    {
+        Excel.Sheets? worksheets = null;
+        var unmatchedNames = selectedWorksheetNames is null
+            ? null
+            : new HashSet<string>(selectedWorksheetNames, StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            worksheets = workbook.Worksheets;
+            int worksheetCount = worksheets.Count;
+            for (int index = 1; index <= worksheetCount; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.Worksheet? worksheet = null;
+                try
+                {
+                    worksheet = (Excel.Worksheet)worksheets.Item[index];
+                    string worksheetName = worksheet.Name;
+                    if (selectedWorksheetNames is not null &&
+                        !selectedWorksheetNames.Contains(worksheetName))
+                    {
+                        continue;
+                    }
+
+                    unmatchedNames?.Remove(worksheetName);
+                    result.CheckedWorksheets.Add(worksheetName);
+                    if (checks.Contains(WorkbookIntegrityCheck.FormulaErrors))
+                    {
+                        ValidateFormulaErrors(worksheet, worksheetName, findings, cancellationToken);
+                    }
+
+                    if (checks.Contains(WorkbookIntegrityCheck.Tables))
+                    {
+                        ValidateTables(worksheet, worksheetName, findings, cancellationToken);
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref worksheet);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref worksheets);
+        }
+
+        if (unmatchedNames is { Count: > 0 })
+        {
+            throw new InvalidOperationException(
+                $"Worksheet(s) not found: {string.Join(", ", unmatchedNames.Order(StringComparer.OrdinalIgnoreCase))}.");
+        }
+    }
+
+    private static void ValidateFormulaErrors(
+        Excel.Worksheet worksheet,
+        string worksheetName,
+        IntegrityFindingCollector findings,
+        CancellationToken cancellationToken)
+    {
+        Excel.Range? usedRange = null;
+        Excel.Range? errorRange = null;
+        Excel.Areas? areas = null;
+        var reportedErrorCells = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            usedRange = worksheet.UsedRange;
+            try
+            {
+                errorRange = usedRange.SpecialCells(
+                    Excel.XlCellType.xlCellTypeFormulas,
+                    Excel.XlSpecialCellsValue.xlErrors);
+            }
+            catch (COMException exception) when (exception.HResult == ExcelNoMatchingCellsHResult)
+            {
+                ScanFormulaErrorsInRange(
+                    usedRange,
+                    worksheetName,
+                    findings,
+                    reportedErrorCells,
+                    cancellationToken);
+                ValidateBrokenReferenceTokens(
+                    usedRange,
+                    worksheetName,
+                    findings,
+                    reportedErrorCells,
+                    cancellationToken);
+                return;
+            }
+
+            areas = errorRange.Areas;
+            int areaCount = areas.Count;
+            for (int areaIndex = 1; areaIndex <= areaCount; areaIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.Range? area = null;
+                try
+                {
+                    area = areas.Item[areaIndex];
+                    var (rowCount, columnCount) = GetRangeDimensions(area);
+                    int startRow = area.Row;
+                    int startColumn = area.Column;
+                    object values = area.Value2;
+                    object formulas = area.Formula2;
+
+                    for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        for (int columnOffset = 0; columnOffset < columnCount; columnOffset++)
+                        {
+                            if ((columnOffset & 255) == 0)
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                            }
+
+                            object? value = GetMatrixValue(values, rowOffset, columnOffset);
+                            string cellAddress = GetCellAddress(
+                                startRow + rowOffset,
+                                startColumn + columnOffset);
+                            if (!ExcelErrorMapper.TryGet(value, out int errorCode, out var error))
+                            {
+                                if (value is int unknownErrorCode)
+                                {
+                                    reportedErrorCells.Add(cellAddress);
+                                    findings.Add(new WorkbookIntegrityFinding
+                                    {
+                                        Code = "formula-error-unknown",
+                                        Severity = WorkbookIntegritySeverity.Error,
+                                        Category = WorkbookIntegrityCategory.FormulaError,
+                                        Reliability = WorkbookIntegrityReliability.Deterministic,
+                                        Message = ExcelErrorMapper.GetMessage(unknownErrorCode),
+                                        SuggestedRemediation = "Open the affected cell in Excel and review its formula and precedents.",
+                                        SheetName = worksheetName,
+                                        CellAddress = cellAddress,
+                                        Formula = Convert.ToString(
+                                            GetMatrixValue(formulas, rowOffset, columnOffset),
+                                            CultureInfo.InvariantCulture),
+                                        ErrorName = "#ERROR!",
+                                        ErrorCode = unknownErrorCode,
+                                        ActualValue = unknownErrorCode
+                                    });
+                                }
+
+                                continue;
+                            }
+
+                            string? formula = Convert.ToString(
+                                GetMatrixValue(formulas, rowOffset, columnOffset),
+                                CultureInfo.InvariantCulture);
+                            var category = error.Name == "#REF!"
+                                ? WorkbookIntegrityCategory.BrokenReference
+                                : WorkbookIntegrityCategory.FormulaError;
+                            reportedErrorCells.Add(cellAddress);
+                            findings.Add(new WorkbookIntegrityFinding
+                            {
+                                Code = category == WorkbookIntegrityCategory.BrokenReference
+                                    ? "broken-formula-reference"
+                                    : "formula-error",
+                                Severity = IsTransientFormulaState(error.Name)
+                                    ? WorkbookIntegritySeverity.Warning
+                                    : WorkbookIntegritySeverity.Error,
+                                Category = category,
+                                Reliability = WorkbookIntegrityReliability.Deterministic,
+                                Message = $"{error.Name} - {error.Description}",
+                                SuggestedRemediation = error.Suggestion,
+                                SheetName = worksheetName,
+                                CellAddress = cellAddress,
+                                Formula = formula,
+                                ErrorName = error.Name,
+                                ErrorCode = errorCode,
+                                ActualValue = error.Name
+                            });
+                        }
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref area);
+                }
+            }
+
+            ValidateBrokenReferenceTokens(
+                usedRange,
+                worksheetName,
+                findings,
+                reportedErrorCells,
+                cancellationToken);
+        }
+        finally
+        {
+            ComUtilities.Release(ref areas);
+            ComUtilities.Release(ref errorRange);
+            ComUtilities.Release(ref usedRange);
+        }
+    }
+
+    private static bool IsTransientFormulaState(string errorName) =>
+        errorName is "#GETTING_DATA" or "#CONNECT!" or "#BUSY!";
+
+    private static void ScanFormulaErrorsInRange(
+        Excel.Range range,
+        string worksheetName,
+        IntegrityFindingCollector findings,
+        HashSet<string> reportedErrorCells,
+        CancellationToken cancellationToken)
+    {
+        var (rowCount, columnCount) = GetRangeDimensions(range);
+        int startRow = range.Row;
+        int startColumn = range.Column;
+        object values = range.Value2;
+        object formulas = range.Formula2;
+
+        for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            for (int columnOffset = 0; columnOffset < columnCount; columnOffset++)
+            {
+                if ((columnOffset & 255) == 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                object? value = GetMatrixValue(values, rowOffset, columnOffset);
+                if (value is not int possibleErrorCode)
+                {
+                    continue;
+                }
+
+                string cellAddress = GetCellAddress(
+                    startRow + rowOffset,
+                    startColumn + columnOffset);
+                string? formula = Convert.ToString(
+                    GetMatrixValue(formulas, rowOffset, columnOffset),
+                    CultureInfo.InvariantCulture);
+                if (formula?.StartsWith('=') != true)
+                {
+                    continue;
+                }
+
+                reportedErrorCells.Add(cellAddress);
+                if (!ExcelErrorMapper.TryGet(possibleErrorCode, out var error))
+                {
+                    findings.Add(new WorkbookIntegrityFinding
+                    {
+                        Code = "formula-error-unknown",
+                        Severity = WorkbookIntegritySeverity.Error,
+                        Category = WorkbookIntegrityCategory.FormulaError,
+                        Reliability = WorkbookIntegrityReliability.Deterministic,
+                        Message = ExcelErrorMapper.GetMessage(possibleErrorCode),
+                        SuggestedRemediation = "Open the affected cell in Excel and review its formula and precedents.",
+                        SheetName = worksheetName,
+                        CellAddress = cellAddress,
+                        Formula = formula,
+                        ErrorName = "#ERROR!",
+                        ErrorCode = possibleErrorCode,
+                        ActualValue = possibleErrorCode
+                    });
+                    continue;
+                }
+
+                var category = error.Name == "#REF!"
+                    ? WorkbookIntegrityCategory.BrokenReference
+                    : WorkbookIntegrityCategory.FormulaError;
+                findings.Add(new WorkbookIntegrityFinding
+                {
+                    Code = category == WorkbookIntegrityCategory.BrokenReference
+                        ? "broken-formula-reference"
+                        : "formula-error",
+                    Severity = IsTransientFormulaState(error.Name)
+                        ? WorkbookIntegritySeverity.Warning
+                        : WorkbookIntegritySeverity.Error,
+                    Category = category,
+                    Reliability = WorkbookIntegrityReliability.Deterministic,
+                    Message = $"{error.Name} - {error.Description}",
+                    SuggestedRemediation = error.Suggestion,
+                    SheetName = worksheetName,
+                    CellAddress = cellAddress,
+                    Formula = formula,
+                    ErrorName = error.Name,
+                    ErrorCode = possibleErrorCode,
+                    ActualValue = error.Name
+                });
+            }
+        }
+    }
+
+    private static void ValidateBrokenReferenceTokens(
+        Excel.Range usedRange,
+        string worksheetName,
+        IntegrityFindingCollector findings,
+        HashSet<string> reportedErrorCells,
+        CancellationToken cancellationToken)
+    {
+        object hasFormula = usedRange.HasFormula;
+        if (hasFormula is bool hasAnyFormula && !hasAnyFormula)
+        {
+            return;
+        }
+
+        Excel.Range? formulaCells = null;
+        Excel.Areas? areas = null;
+        try
+        {
+            try
+            {
+                formulaCells = usedRange.SpecialCells(Excel.XlCellType.xlCellTypeFormulas);
+            }
+            catch (COMException exception) when (exception.HResult == ExcelNoMatchingCellsHResult)
+            {
+                ScanBrokenReferenceTokensInRange(
+                    usedRange,
+                    worksheetName,
+                    findings,
+                    reportedErrorCells,
+                    cancellationToken);
+                return;
+            }
+
+            areas = formulaCells.Areas;
+            int areaCount = areas.Count;
+            for (int areaIndex = 1; areaIndex <= areaCount; areaIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.Range? area = null;
+                try
+                {
+                    area = areas.Item[areaIndex];
+                    ScanBrokenReferenceTokensInRange(
+                        area,
+                        worksheetName,
+                        findings,
+                        reportedErrorCells,
+                        cancellationToken);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref area);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref areas);
+            ComUtilities.Release(ref formulaCells);
+        }
+    }
+
+    private static void ScanBrokenReferenceTokensInRange(
+        Excel.Range range,
+        string worksheetName,
+        IntegrityFindingCollector findings,
+        HashSet<string> reportedErrorCells,
+        CancellationToken cancellationToken)
+    {
+        var (rowCount, columnCount) = GetRangeDimensions(range);
+        int startRow = range.Row;
+        int startColumn = range.Column;
+        object formulas = range.Formula2;
+        for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            for (int columnOffset = 0; columnOffset < columnCount; columnOffset++)
+            {
+                string cellAddress = GetCellAddress(
+                    startRow + rowOffset,
+                    startColumn + columnOffset);
+                if (reportedErrorCells.Contains(cellAddress))
+                {
+                    continue;
+                }
+
+                string? formula = Convert.ToString(
+                    GetMatrixValue(formulas, rowOffset, columnOffset),
+                    CultureInfo.InvariantCulture);
+                if (formula?.StartsWith('=') != true ||
+                    !ContainsBrokenReferenceTokenOutsideString(formula))
+                {
+                    continue;
+                }
+
+                findings.Add(new WorkbookIntegrityFinding
+                {
+                    Code = "broken-reference-token",
+                    Severity = WorkbookIntegritySeverity.Error,
+                    Category = WorkbookIntegrityCategory.BrokenReference,
+                    Reliability = WorkbookIntegrityReliability.Deterministic,
+                    Message = "Formula contains a broken #REF! reference even though error handling may hide it.",
+                    SuggestedRemediation = "Replace the #REF! token with a valid cell, range, sheet, or workbook reference.",
+                    SheetName = worksheetName,
+                    CellAddress = cellAddress,
+                    Formula = formula,
+                    ErrorName = "#REF!"
+                });
+            }
+        }
+    }
+
+    private static bool ContainsBrokenReferenceTokenOutsideString(string formula)
+    {
+        bool inString = false;
+        for (int index = 0; index <= formula.Length - 5; index++)
+        {
+            if (formula[index] == '"')
+            {
+                if (inString && index + 1 < formula.Length && formula[index + 1] == '"')
+                {
+                    index++;
+                    continue;
+                }
+
+                inString = !inString;
+                continue;
+            }
+
+            if (!inString &&
+                formula.AsSpan(index).StartsWith("#REF!".AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void ValidateExternalLinks(
+        Excel.Workbook workbook,
+        IntegrityFindingCollector findings,
+        CancellationToken cancellationToken)
+    {
+        foreach (string source in GetExternalLinkSources(workbook))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int status;
+            try
+            {
+                status = Convert.ToInt32(
+                    workbook.LinkInfo(source, Excel.XlLinkInfo.xlLinkInfoStatus),
+                    CultureInfo.InvariantCulture);
+            }
+            catch (COMException exception) when (exception.HResult == ExcelNoMatchingCellsHResult)
+            {
+                findings.Add(new WorkbookIntegrityFinding
+                {
+                    Code = "external-link-status-unavailable",
+                    Severity = WorkbookIntegritySeverity.Warning,
+                    Category = WorkbookIntegrityCategory.ExternalLink,
+                    Reliability = WorkbookIntegrityReliability.Deterministic,
+                    Message = $"Excel could not determine the status of external link '{source}'.",
+                    SuggestedRemediation = "Open or update the source workbook, then validate the workbook again.",
+                    LinkSource = source,
+                    LinkStatus = "indeterminate"
+                });
+                continue;
+            }
+
+            var linkStatus = MapExternalLinkStatus(status);
+            findings.Add(new WorkbookIntegrityFinding
+            {
+                Code = linkStatus.Code,
+                Severity = linkStatus.Severity,
+                Category = WorkbookIntegrityCategory.ExternalLink,
+                Reliability = WorkbookIntegrityReliability.Deterministic,
+                Message = linkStatus.Message,
+                SuggestedRemediation = linkStatus.SuggestedRemediation,
+                LinkSource = source,
+                LinkStatus = linkStatus.Status
+            });
+        }
+    }
+
+    private static ExternalLinkValidationStatus MapExternalLinkStatus(int status) =>
+        status switch
+        {
+            0 => new(
+                "external-link-ok",
+                "ok",
+                WorkbookIntegritySeverity.Information,
+                "Excel reports that the external workbook link is healthy.",
+                "No action is required."),
+            1 => new(
+                "external-link-missing-file",
+                "missing-file",
+                WorkbookIntegritySeverity.Error,
+                "The source file for an external workbook link is missing.",
+                "Restore the source file, update the link source, or explicitly break the link."),
+            2 => new(
+                "external-link-missing-sheet",
+                "missing-sheet",
+                WorkbookIntegritySeverity.Error,
+                "The source worksheet for an external workbook link is missing.",
+                "Restore the source worksheet, update dependent formulas, or explicitly break the link."),
+            3 => new(
+                "external-link-old",
+                "old",
+                WorkbookIntegritySeverity.Warning,
+                "The external workbook link may be out of date.",
+                "Update the link, then validate the workbook again."),
+            4 => new(
+                "external-link-source-not-calculated",
+                "source-not-calculated",
+                WorkbookIntegritySeverity.Warning,
+                "The external link source has not been calculated.",
+                "Calculate and save the source workbook, update the link, then validate again."),
+            5 => new(
+                "external-link-indeterminate",
+                "indeterminate",
+                WorkbookIntegritySeverity.Warning,
+                "Excel could not determine the external workbook link status.",
+                "Open or update the source workbook, then validate the workbook again."),
+            6 => new(
+                "external-link-not-started",
+                "not-started",
+                WorkbookIntegritySeverity.Warning,
+                "Excel has not started resolving the external workbook link.",
+                "Update the link, then validate the workbook again."),
+            7 => new(
+                "external-link-invalid-name",
+                "invalid-name",
+                WorkbookIntegritySeverity.Error,
+                "The external workbook link contains an invalid defined name.",
+                "Correct the source name or dependent formula."),
+            8 => new(
+                "external-link-source-not-open",
+                "source-not-open",
+                WorkbookIntegritySeverity.Information,
+                "The external workbook link source is not open.",
+                "No action is required unless current source values are needed."),
+            9 => new(
+                "external-link-source-open",
+                "source-open",
+                WorkbookIntegritySeverity.Information,
+                "The external workbook link source is open.",
+                "No action is required."),
+            10 => new(
+                "external-link-copied-values",
+                "copied-values",
+                WorkbookIntegritySeverity.Information,
+                "Excel is using copied values for the external workbook link.",
+                "Update the link if current source values are required."),
+            _ => new(
+                "external-link-unknown-status",
+                $"unknown-{status}",
+                WorkbookIntegritySeverity.Warning,
+                $"Excel returned unknown external link status {status}.",
+                "Update the link, then validate the workbook again.")
+        };
+
+    private static void ValidateTables(
+        Excel.Worksheet worksheet,
+        string worksheetName,
+        IntegrityFindingCollector findings,
+        CancellationToken cancellationToken)
+    {
+        Excel.ListObjects? tables = null;
+        try
+        {
+            tables = worksheet.ListObjects;
+            int tableCount = tables.Count;
+            for (int tableIndex = 1; tableIndex <= tableCount; tableIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.ListObject? table = null;
+                try
+                {
+                    table = tables.Item[tableIndex];
+                    string tableName = table.Name;
+                    ValidateTableStructure(
+                        worksheetName,
+                        table,
+                        tableName,
+                        findings,
+                        cancellationToken);
+                    ValidateCalculatedColumns(
+                        worksheetName,
+                        table,
+                        tableName,
+                        findings,
+                        cancellationToken);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref table);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref tables);
+        }
+    }
+
+    private static void ValidateTableStructure(
+        string worksheetName,
+        Excel.ListObject table,
+        string tableName,
+        IntegrityFindingCollector findings,
+        CancellationToken cancellationToken)
+    {
+        Excel.Range? tableRange = null;
+        Excel.Range? headerRange = null;
+        Excel.Range? dataBodyRange = null;
+        Excel.ListColumns? columns = null;
+        Excel.ListRows? rows = null;
+        try
+        {
+            tableRange = table.Range;
+            columns = table.ListColumns;
+            rows = table.ListRows;
+            var (_, tableColumnCount) = GetRangeDimensions(tableRange);
+            int listColumnCount = columns.Count;
+            if (tableColumnCount != listColumnCount)
+            {
+                findings.Add(CreateTableFinding(
+                    tableName,
+                    worksheetName,
+                    "table-column-count-mismatch",
+                    WorkbookIntegritySeverity.Error,
+                    WorkbookIntegrityCategory.TableStructure,
+                    $"Table range has {tableColumnCount} columns but Excel reports {listColumnCount} table columns.",
+                    "Resize or recreate the table so its range and column collection agree."));
+            }
+
+            if (!table.ShowHeaders)
+            {
+                findings.Add(CreateTableFinding(
+                    tableName,
+                    worksheetName,
+                    "table-headers-hidden",
+                    WorkbookIntegritySeverity.Warning,
+                    WorkbookIntegrityCategory.TableHeader,
+                    "Table headers are hidden.",
+                    "Show the table header row before delivering the workbook."));
+            }
+            else
+            {
+                headerRange = table.HeaderRowRange;
+                if (headerRange is null)
+                {
+                    findings.Add(CreateTableFinding(
+                        tableName,
+                        worksheetName,
+                        "table-header-range-missing",
+                        WorkbookIntegritySeverity.Error,
+                        WorkbookIntegrityCategory.TableStructure,
+                        "Excel reports visible table headers but no header range.",
+                        "Resize or recreate the table."));
+                }
+                else
+                {
+                    var (_, headerColumnCount) = GetRangeDimensions(headerRange);
+                    if (headerColumnCount != listColumnCount)
+                    {
+                        findings.Add(CreateTableFinding(
+                            tableName,
+                            worksheetName,
+                            "table-header-count-mismatch",
+                            WorkbookIntegritySeverity.Error,
+                            WorkbookIntegrityCategory.TableStructure,
+                            $"Table header range has {headerColumnCount} cells but Excel reports {listColumnCount} columns.",
+                            "Resize or recreate the table so every column has one header."));
+                    }
+
+                    ValidateTableHeaders(
+                        worksheetName,
+                        tableName,
+                        headerRange,
+                        headerColumnCount,
+                        findings,
+                        cancellationToken);
+                }
+            }
+
+            dataBodyRange = table.DataBodyRange;
+            int listRowCount = rows.Count;
+            if (dataBodyRange is null)
+            {
+                if (listRowCount != 0)
+                {
+                    findings.Add(CreateTableFinding(
+                        tableName,
+                        worksheetName,
+                        "table-data-range-missing",
+                        WorkbookIntegritySeverity.Error,
+                        WorkbookIntegrityCategory.TableStructure,
+                        $"Excel reports {listRowCount} table rows but no data range.",
+                        "Resize or recreate the table."));
+                }
+            }
+            else
+            {
+                var (dataRowCount, dataColumnCount) = GetRangeDimensions(dataBodyRange);
+                if (dataRowCount != listRowCount || dataColumnCount != listColumnCount)
+                {
+                    findings.Add(CreateTableFinding(
+                        tableName,
+                        worksheetName,
+                        "table-data-dimensions-mismatch",
+                        WorkbookIntegritySeverity.Error,
+                        WorkbookIntegrityCategory.TableStructure,
+                        $"Table data range is {dataRowCount} by {dataColumnCount}, but Excel reports {listRowCount} rows and {listColumnCount} columns.",
+                        "Resize or recreate the table so its data range matches its row and column collections."));
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref rows);
+            ComUtilities.Release(ref columns);
+            ComUtilities.Release(ref dataBodyRange);
+            ComUtilities.Release(ref headerRange);
+            ComUtilities.Release(ref tableRange);
+        }
+    }
+
+    private static void ValidateTableHeaders(
+        string worksheetName,
+        string tableName,
+        Excel.Range headerRange,
+        int headerColumnCount,
+        IntegrityFindingCollector findings,
+        CancellationToken cancellationToken)
+    {
+        object values = headerRange.Value2;
+        var seenHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (int columnOffset = 0; columnOffset < headerColumnCount; columnOffset++)
+        {
+            if ((columnOffset & 255) == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            object? value = GetMatrixValue(values, 0, columnOffset);
+            string address = GetCellAddress(headerRange.Row, headerRange.Column + columnOffset);
+            if (ExcelErrorMapper.TryGet(value, out int errorCode, out var error))
+            {
+                var finding = CreateTableFinding(
+                    tableName,
+                    worksheetName,
+                    "table-header-error",
+                    WorkbookIntegritySeverity.Error,
+                    WorkbookIntegrityCategory.TableHeader,
+                    $"Table header contains {error.Name}.",
+                    "Replace the header error with a unique text label.");
+                finding.CellAddress = address;
+                finding.ErrorName = error.Name;
+                finding.ErrorCode = errorCode;
+                findings.Add(finding);
+                continue;
+            }
+
+            string header = Convert.ToString(value, CultureInfo.InvariantCulture)?.Trim() ?? string.Empty;
+            if (header.Length == 0)
+            {
+                var finding = CreateTableFinding(
+                    tableName,
+                    worksheetName,
+                    "table-header-empty",
+                    WorkbookIntegritySeverity.Error,
+                    WorkbookIntegrityCategory.TableHeader,
+                    "Table header is empty.",
+                    "Assign a unique text label to every table column.");
+                finding.CellAddress = address;
+                findings.Add(finding);
+            }
+            else if (!seenHeaders.Add(header))
+            {
+                var finding = CreateTableFinding(
+                    tableName,
+                    worksheetName,
+                    "table-header-duplicate",
+                    WorkbookIntegritySeverity.Error,
+                    WorkbookIntegrityCategory.TableHeader,
+                    $"Table header '{header}' is duplicated.",
+                    "Assign a unique text label to every table column.");
+                finding.CellAddress = address;
+                finding.ColumnName = header;
+                findings.Add(finding);
+            }
+        }
+    }
+
+    private static void ValidateCalculatedColumns(
+        string worksheetName,
+        Excel.ListObject table,
+        string tableName,
+        IntegrityFindingCollector findings,
+        CancellationToken cancellationToken)
+    {
+        Excel.ListColumns? columns = null;
+        try
+        {
+            columns = table.ListColumns;
+            int columnCount = columns.Count;
+            for (int columnIndex = 1; columnIndex <= columnCount; columnIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.ListColumn? column = null;
+                Excel.Range? dataRange = null;
+                try
+                {
+                    column = columns.Item[columnIndex];
+                    string columnName = column.Name;
+                    dataRange = column.DataBodyRange;
+                    if (dataRange is null)
+                    {
+                        continue;
+                    }
+
+                    var (rowCount, dataColumnCount) = GetRangeDimensions(dataRange);
+                    if (rowCount < 2 || dataColumnCount != 1)
+                    {
+                        continue;
+                    }
+
+                    object rawFormulas = dataRange.Formula2R1C1;
+                    var formulas = new string?[rowCount];
+                    var formulaCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    int formulaCellCount = 0;
+                    for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+                    {
+                        if ((rowOffset & 1023) == 0)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+
+                        string? formula = Convert.ToString(
+                            GetMatrixValue(rawFormulas, rowOffset, 0),
+                            CultureInfo.InvariantCulture);
+                        if (formula?.StartsWith('=') != true)
+                        {
+                            continue;
+                        }
+
+                        formulas[rowOffset] = formula;
+                        formulaCellCount++;
+                        formulaCounts[formula] = formulaCounts.GetValueOrDefault(formula) + 1;
+                    }
+
+                    if (formulaCellCount == 0)
+                    {
+                        continue;
+                    }
+
+                    var dominant = formulaCounts
+                        .OrderByDescending(pair => pair.Value)
+                        .ThenBy(pair => pair.Key, StringComparer.Ordinal)
+                        .First();
+                    if (dominant.Value * 2 < rowCount)
+                    {
+                        continue;
+                    }
+
+                    for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+                    {
+                        if ((rowOffset & 1023) == 0)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+
+                        string? formula = formulas[rowOffset];
+                        if (string.Equals(formula, dominant.Key, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        var finding = CreateTableFinding(
+                            tableName,
+                            worksheetName,
+                            "calculated-column-inconsistent",
+                            WorkbookIntegritySeverity.Warning,
+                            WorkbookIntegrityCategory.CalculatedColumn,
+                            $"Table column '{columnName}' differs from its dominant calculated-column formula.",
+                            "Confirm the outlier is intentional or restore the column's calculated formula.",
+                            WorkbookIntegrityReliability.Heuristic);
+                        finding.ColumnName = columnName;
+                        finding.CellAddress = GetCellAddress(dataRange.Row + rowOffset, dataRange.Column);
+                        finding.Formula = formula;
+                        findings.Add(finding);
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref dataRange);
+                    ComUtilities.Release(ref column);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref columns);
+        }
+    }
+
+    private static WorkbookIntegrityFinding CreateTableFinding(
+        string tableName,
+        string worksheetName,
+        string code,
+        WorkbookIntegritySeverity severity,
+        WorkbookIntegrityCategory category,
+        string message,
+        string remediation,
+        WorkbookIntegrityReliability reliability = WorkbookIntegrityReliability.Deterministic) =>
+        new()
+        {
+            Code = code,
+            Severity = severity,
+            Category = category,
+            Reliability = reliability,
+            Message = message,
+            SuggestedRemediation = remediation,
+            SheetName = worksheetName,
+            TableName = tableName
+        };
+
+    private static void ValidateControlTotals(
+        Excel.Workbook workbook,
+        List<WorkbookControlTotalExpectation> controlTotals,
+        WorkbookIntegrityResult result,
+        IntegrityFindingCollector findings,
+        CancellationToken cancellationToken)
+    {
+        foreach (var worksheetExpectations in controlTotals.GroupBy(
+                     expectation => expectation.SheetName,
+                     StringComparer.OrdinalIgnoreCase))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Excel.Worksheet? worksheet = null;
+            try
+            {
+                worksheet = FindWorksheetIgnoreCase(
+                    workbook,
+                    worksheetExpectations.Key,
+                    cancellationToken)
+                    ?? throw new InvalidOperationException(
+                        $"Worksheet '{worksheetExpectations.Key}' was not found for control totals.");
+                string actualWorksheetName = worksheet.Name;
+                if (!result.CheckedWorksheets.Contains(actualWorksheetName, StringComparer.OrdinalIgnoreCase))
+                {
+                    result.CheckedWorksheets.Add(actualWorksheetName);
+                }
+
+                foreach (var expectation in worksheetExpectations)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Excel.Range? range = null;
+                    try
+                    {
+                        try
+                        {
+                            range = worksheet.Range[expectation.CellAddress];
+                        }
+                        catch (COMException exception) when (exception.HResult == ExcelNoMatchingCellsHResult)
+                        {
+                            throw new ArgumentException(
+                                $"Control total at '{expectation.SheetName}!{expectation.CellAddress}' does not contain a valid cell address.",
+                                nameof(controlTotals),
+                                exception);
+                        }
+
+                        var (rowCount, columnCount) = GetRangeDimensions(range);
+                        if (rowCount != 1 || columnCount != 1)
+                        {
+                            throw new ArgumentException(
+                                $"Control total '{expectation.SheetName}!{expectation.CellAddress}' must identify one cell.",
+                                nameof(controlTotals));
+                        }
+
+                        object? actualValue = range.Value2;
+                        if (ExcelErrorMapper.TryGet(actualValue, out int errorCode, out var error))
+                        {
+                            findings.Add(CreateControlTotalFinding(
+                                expectation,
+                                actualWorksheetName,
+                                range,
+                                "control-total-formula-error",
+                                $"{error.Name} prevents the control total from being compared.",
+                                error.Name,
+                                error.Name,
+                                errorCode));
+                            continue;
+                        }
+
+                        if (!TryConvertFiniteNumber(actualValue, out double actualNumber))
+                        {
+                            findings.Add(CreateControlTotalFinding(
+                                expectation,
+                                actualWorksheetName,
+                                range,
+                                "control-total-non-numeric",
+                                "Control-total cell does not contain a finite numeric value.",
+                                actualValue,
+                                errorName: null));
+                            continue;
+                        }
+
+                        double expectedValue = expectation.ExpectedValue!.Value;
+                        if (Math.Abs(actualNumber - expectedValue) > expectation.Tolerance)
+                        {
+                            findings.Add(CreateControlTotalFinding(
+                                expectation,
+                                actualWorksheetName,
+                                range,
+                                "control-total-mismatch",
+                                $"Control total is {actualNumber.ToString("R", CultureInfo.InvariantCulture)}; expected {expectedValue.ToString("R", CultureInfo.InvariantCulture)} within {expectation.Tolerance.ToString("R", CultureInfo.InvariantCulture)}.",
+                                actualNumber,
+                                errorName: null));
+                        }
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref range);
+                    }
+                }
+            }
+            finally
+            {
+                ComUtilities.Release(ref worksheet);
+            }
+        }
+    }
+
+    private static WorkbookIntegrityFinding CreateControlTotalFinding(
+        WorkbookControlTotalExpectation expectation,
+        string worksheetName,
+        Excel.Range range,
+        string code,
+        string message,
+        object? actualValue,
+        string? errorName,
+        int? errorCode = null) =>
+        new()
+        {
+            Code = code,
+            Severity = WorkbookIntegritySeverity.Error,
+            Category = WorkbookIntegrityCategory.ControlTotal,
+            Reliability = WorkbookIntegrityReliability.Deterministic,
+            Message = message,
+            SuggestedRemediation = "Review the source data or update the caller-supplied expected control total.",
+            SheetName = worksheetName,
+            CellAddress = GetCellAddress(range.Row, range.Column),
+            ErrorName = errorName,
+            ErrorCode = errorCode,
+            ExpectedValue = expectation.ExpectedValue,
+            ActualValue = actualValue,
+            Tolerance = expectation.Tolerance
+        };
+
+    private static Excel.Worksheet? FindWorksheetIgnoreCase(
+        Excel.Workbook workbook,
+        string worksheetName,
+        CancellationToken cancellationToken)
+    {
+        Excel.Sheets? worksheets = null;
+        try
+        {
+            worksheets = workbook.Worksheets;
+            int worksheetCount = worksheets.Count;
+            for (int index = 1; index <= worksheetCount; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.Worksheet? worksheet = null;
+                try
+                {
+                    worksheet = (Excel.Worksheet)worksheets.Item[index];
+                    if (string.Equals(worksheet.Name, worksheetName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var match = worksheet;
+                        worksheet = null;
+                        return match;
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref worksheet);
+                }
+            }
+
+            return null;
+        }
+        finally
+        {
+            ComUtilities.Release(ref worksheets);
+        }
+    }
+
+    private static bool TryConvertFiniteNumber(object? value, out double number)
+    {
+        if (value is not (byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal))
+        {
+            number = default;
+            return false;
+        }
+
+        number = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+        return double.IsFinite(number);
+    }
+
+    private static (int Rows, int Columns) GetRangeDimensions(Excel.Range range)
+    {
+        Excel.Range? rows = null;
+        Excel.Range? columns = null;
+        try
+        {
+            rows = range.Rows;
+            columns = range.Columns;
+            return (Convert.ToInt32(rows.Count, CultureInfo.InvariantCulture),
+                Convert.ToInt32(columns.Count, CultureInfo.InvariantCulture));
+        }
+        finally
+        {
+            ComUtilities.Release(ref columns);
+            ComUtilities.Release(ref rows);
+        }
+    }
+
+    private static object? GetMatrixValue(object value, int rowOffset, int columnOffset)
+    {
+        if (value is not object[,] matrix)
+        {
+            return rowOffset == 0 && columnOffset == 0 ? value : null;
+        }
+
+        return matrix[
+            matrix.GetLowerBound(0) + rowOffset,
+            matrix.GetLowerBound(1) + columnOffset];
+    }
+
+    private static string GetCellAddress(int row, int column)
+    {
+        string columnName = string.Empty;
+        while (column > 0)
+        {
+            column--;
+            columnName = Convert.ToChar('A' + (column % 26), CultureInfo.InvariantCulture) + columnName;
+            column /= 26;
+        }
+
+        return columnName + row.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private readonly record struct ExternalLinkValidationStatus(
+        string Code,
+        string Status,
+        WorkbookIntegritySeverity Severity,
+        string Message,
+        string SuggestedRemediation);
+
+    private sealed class IntegrityFindingCollector
+    {
+        private readonly Dictionary<(WorkbookIntegritySeverity Severity, WorkbookIntegrityCategory Category), int> _counts = [];
+        private readonly List<WorkbookIntegrityFinding> _retainedFindings = [];
+        private readonly WorkbookIntegrityResult _result;
+        private readonly int _maxFindings;
+
+        internal IntegrityFindingCollector(WorkbookIntegrityResult result, int maxFindings)
+        {
+            _result = result;
+            _maxFindings = maxFindings;
+        }
+
+        internal void Add(WorkbookIntegrityFinding finding)
+        {
+            var key = (finding.Severity, finding.Category);
+            _counts[key] = _counts.GetValueOrDefault(key) + 1;
+            _result.FindingCount++;
+            switch (finding.Severity)
+            {
+                case WorkbookIntegritySeverity.Error:
+                    _result.ErrorCount++;
+                    break;
+                case WorkbookIntegritySeverity.Warning:
+                    _result.WarningCount++;
+                    break;
+                case WorkbookIntegritySeverity.Information:
+                    _result.InformationCount++;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(finding), finding.Severity, "Unknown finding severity.");
+            }
+
+            if (_retainedFindings.Count < _maxFindings)
+            {
+                _retainedFindings.Add(finding);
+            }
+            else
+            {
+                _result.FindingsTruncated = true;
+            }
+        }
+
+        internal void Complete()
+        {
+            _result.OverallStatus = _result.ErrorCount > 0
+                ? WorkbookIntegrityStatus.Failed
+                : _result.WarningCount > 0
+                    ? WorkbookIntegrityStatus.PassedWithWarnings
+                    : WorkbookIntegrityStatus.Passed;
+
+            _result.Groups = _counts
+                .OrderBy(pair => pair.Key.Severity)
+                .ThenBy(pair => pair.Key.Category)
+                .Select(pair => new WorkbookIntegrityFindingGroup
+                {
+                    Severity = pair.Key.Severity,
+                    Category = pair.Key.Category,
+                    Count = pair.Value,
+                    Findings = _retainedFindings
+                        .Where(finding =>
+                            finding.Severity == pair.Key.Severity &&
+                            finding.Category == pair.Key.Category)
+                        .ToList()
+                })
+                .ToList();
+        }
+    }
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookControlTotalExpectation.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookControlTotalExpectation.cs
@@ -1,0 +1,17 @@
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>Expected numeric value for one control-total cell.</summary>
+public sealed class WorkbookControlTotalExpectation
+{
+    /// <summary>Worksheet containing the control-total cell.</summary>
+    public string SheetName { get; set; } = string.Empty;
+
+    /// <summary>Single-cell A1 address to compare.</summary>
+    public string CellAddress { get; set; } = string.Empty;
+
+    /// <summary>Required expected finite numeric value.</summary>
+    public double? ExpectedValue { get; set; }
+
+    /// <summary>Allowed non-negative absolute difference from the expected value.</summary>
+    public double Tolerance { get; set; }
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityCategory.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityCategory.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>Workbook concern represented by an integrity finding.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WorkbookIntegrityCategory>))]
+public enum WorkbookIntegrityCategory
+{
+    /// <summary>A formula currently evaluates to an Excel error.</summary>
+    [JsonStringEnumMemberName("formula-error")]
+    FormulaError,
+
+    /// <summary>A formula contains a broken cell, range, sheet, or workbook reference.</summary>
+    [JsonStringEnumMemberName("broken-reference")]
+    BrokenReference,
+
+    /// <summary>An external Excel workbook link and its current status.</summary>
+    [JsonStringEnumMemberName("external-link")]
+    ExternalLink,
+
+    /// <summary>A likely calculated-column formula inconsistency.</summary>
+    [JsonStringEnumMemberName("calculated-column")]
+    CalculatedColumn,
+
+    /// <summary>An inconsistency in an Excel table's structural ranges or collections.</summary>
+    [JsonStringEnumMemberName("table-structure")]
+    TableStructure,
+
+    /// <summary>A missing, hidden, empty, duplicated, or error-valued table header.</summary>
+    [JsonStringEnumMemberName("table-header")]
+    TableHeader,
+
+    /// <summary>A caller-supplied expected numeric cell does not match.</summary>
+    [JsonStringEnumMemberName("control-total")]
+    ControlTotal,
+
+    /// <summary>Workbook calculation settings may make cached values stale.</summary>
+    [JsonStringEnumMemberName("calculation-state")]
+    CalculationState
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityCheck.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityCheck.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>Workbook areas available to integrity validation.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WorkbookIntegrityCheck>))]
+public enum WorkbookIntegrityCheck
+{
+    /// <summary>Find cells whose formulas currently evaluate to Excel errors.</summary>
+    [JsonStringEnumMemberName("formula-errors")]
+    FormulaErrors,
+
+    /// <summary>Inspect external Excel workbook links and their current status.</summary>
+    [JsonStringEnumMemberName("external-links")]
+    ExternalLinks,
+
+    /// <summary>Inspect table structure, headers, and calculated-column consistency.</summary>
+    [JsonStringEnumMemberName("tables")]
+    Tables,
+
+    /// <summary>Compare caller-supplied expected numeric cells.</summary>
+    [JsonStringEnumMemberName("control-totals")]
+    ControlTotals
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityFinding.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityFinding.cs
@@ -1,0 +1,73 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>One workbook integrity concern with structured context and remediation.</summary>
+public sealed class WorkbookIntegrityFinding
+{
+    /// <summary>Stable machine-readable finding code.</summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>Finding severity.</summary>
+    public WorkbookIntegritySeverity Severity { get; set; }
+
+    /// <summary>Finding category.</summary>
+    public WorkbookIntegrityCategory Category { get; set; }
+
+    /// <summary>Whether the finding is directly observed or inferred.</summary>
+    public WorkbookIntegrityReliability Reliability { get; set; }
+
+    /// <summary>Human-readable description of the problem.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>Suggested corrective action.</summary>
+    public string SuggestedRemediation { get; set; } = string.Empty;
+
+    /// <summary>Affected worksheet, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SheetName { get; set; }
+
+    /// <summary>Affected A1 cell address, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CellAddress { get; set; }
+
+    /// <summary>Affected formula text, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Formula { get; set; }
+
+    /// <summary>Canonical Excel error name, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ErrorName { get; set; }
+
+    /// <summary>Raw Excel COM error code, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ErrorCode { get; set; }
+
+    /// <summary>Affected table name, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TableName { get; set; }
+
+    /// <summary>Affected table column name, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ColumnName { get; set; }
+
+    /// <summary>External workbook link source, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LinkSource { get; set; }
+
+    /// <summary>Normalized Excel link status, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LinkStatus { get; set; }
+
+    /// <summary>Caller-supplied expected control-total value, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? ExpectedValue { get; set; }
+
+    /// <summary>Observed value or canonical error name, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object? ActualValue { get; set; }
+
+    /// <summary>Caller-supplied absolute control-total tolerance, when applicable.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Tolerance { get; set; }
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityFindingGroup.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityFindingGroup.cs
@@ -1,0 +1,17 @@
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>Integrity findings sharing one severity and category.</summary>
+public sealed class WorkbookIntegrityFindingGroup
+{
+    /// <summary>Severity shared by the group.</summary>
+    public WorkbookIntegritySeverity Severity { get; set; }
+
+    /// <summary>Category shared by the group.</summary>
+    public WorkbookIntegrityCategory Category { get; set; }
+
+    /// <summary>Total matching findings, including details omitted by the result limit.</summary>
+    public int Count { get; set; }
+
+    /// <summary>Retained finding details for this group.</summary>
+    public List<WorkbookIntegrityFinding> Findings { get; set; } = [];
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityReliability.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityReliability.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>Whether a finding is directly reported by Excel or inferred from a pattern.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WorkbookIntegrityReliability>))]
+public enum WorkbookIntegrityReliability
+{
+    /// <summary>The finding is based on directly observable workbook state.</summary>
+    [JsonStringEnumMemberName("deterministic")]
+    Deterministic,
+
+    /// <summary>The finding is inferred and may represent intentional workbook design.</summary>
+    [JsonStringEnumMemberName("heuristic")]
+    Heuristic
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityResult.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityResult.cs
@@ -1,0 +1,40 @@
+using Sbroenne.ExcelMcp.Core.Models;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>Result of read-only workbook integrity validation.</summary>
+public sealed class WorkbookIntegrityResult : ResultBase
+{
+    /// <summary>Overall integrity outcome based on the highest finding severity.</summary>
+    public WorkbookIntegrityStatus OverallStatus { get; set; }
+
+    /// <summary>Calculation mode observed without changing it.</summary>
+    public string CalculationMode { get; set; } = string.Empty;
+
+    /// <summary>Calculation state observed without waiting or recalculating.</summary>
+    public string CalculationState { get; set; } = string.Empty;
+
+    /// <summary>Checks that were run.</summary>
+    public List<WorkbookIntegrityCheck> CheckedChecks { get; set; } = [];
+
+    /// <summary>Worksheets inspected by scoped checks or control totals.</summary>
+    public List<string> CheckedWorksheets { get; set; } = [];
+
+    /// <summary>Total number of findings, including omitted details.</summary>
+    public int FindingCount { get; set; }
+
+    /// <summary>Number of error findings.</summary>
+    public int ErrorCount { get; set; }
+
+    /// <summary>Number of warning findings.</summary>
+    public int WarningCount { get; set; }
+
+    /// <summary>Number of informational findings.</summary>
+    public int InformationCount { get; set; }
+
+    /// <summary>Whether finding details were omitted because the result limit was reached.</summary>
+    public bool FindingsTruncated { get; set; }
+
+    /// <summary>Findings grouped by severity and category.</summary>
+    public List<WorkbookIntegrityFindingGroup> Groups { get; set; } = [];
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegritySeverity.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegritySeverity.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>Severity assigned to an integrity finding.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WorkbookIntegritySeverity>))]
+public enum WorkbookIntegritySeverity
+{
+    /// <summary>A workbook integrity failure.</summary>
+    [JsonStringEnumMemberName("error")]
+    Error,
+
+    /// <summary>A condition that needs review but may be intentional or temporary.</summary>
+    [JsonStringEnumMemberName("warning")]
+    Warning,
+
+    /// <summary>Context that does not fail validation.</summary>
+    [JsonStringEnumMemberName("information")]
+    Information
+}

--- a/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityStatus.cs
+++ b/src/ExcelMcp.Core/Commands/Workbook/WorkbookIntegrityStatus.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Workbook;
+
+/// <summary>Overall workbook integrity outcome.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WorkbookIntegrityStatus>))]
+public enum WorkbookIntegrityStatus
+{
+    /// <summary>No errors or warnings were found.</summary>
+    [JsonStringEnumMemberName("passed")]
+    Passed,
+
+    /// <summary>No errors were found, but one or more warnings need review.</summary>
+    [JsonStringEnumMemberName("passed-with-warnings")]
+    PassedWithWarnings,
+
+    /// <summary>One or more integrity errors were found.</summary>
+    [JsonStringEnumMemberName("failed")]
+    Failed
+}

--- a/src/ExcelMcp.Generators/ServiceRegistryGenerator.cs
+++ b/src/ExcelMcp.Generators/ServiceRegistryGenerator.cs
@@ -1679,7 +1679,7 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         sb.AppendLine("    internal static T? DeserializeList<T>(string? json) where T : class");
         sb.AppendLine("    {");
         sb.AppendLine("        if (string.IsNullOrWhiteSpace(json)) return null;");
-        sb.AppendLine("        return System.Text.Json.JsonSerializer.Deserialize<T>(json)");
+        sb.AppendLine("        return System.Text.Json.JsonSerializer.Deserialize<T>(json, DispatchJsonOptions)");
         sb.AppendLine("            ?? throw new System.Text.Json.JsonException($\"Failed to deserialize list from JSON: {json}\");");
         sb.AppendLine("    }");
         sb.AppendLine("}");

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -63,9 +63,9 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**31 specialized tools with 325 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
+**31 specialized tools with 326 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
 
-📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 325 operations, grouped by category
+📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 326 operations, grouped by category
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/tests/ExcelMcp.CLI.Tests/Integration/WorkbookIntegrityCliParityTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/WorkbookIntegrityCliParityTests.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Collection("Service")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "Workbook")]
+[Trait("Layer", "CLI")]
+[Trait("RequiresExcel", "true")]
+public sealed class WorkbookIntegrityCliParityTests : IDisposable
+{
+    private static readonly string[][] ReferenceErrorFormula = [["=INDIRECT(\"A0\")"]];
+
+    private readonly string _testFile =
+        Path.Join(Path.GetTempPath(), $"WorkbookIntegrityCli_{Guid.NewGuid():N}.xlsx");
+
+    [Fact]
+    public async Task ValidateIntegrity_ReturnsTypedCanonicalFindingThroughCli()
+    {
+        ExcelSession.CreateNew(
+            _testFile,
+            isMacroEnabled: false,
+            (context, cancellationToken) => 0,
+            CancellationToken.None);
+
+        var open = await CliProcessHelper.RunAsync(["session", "open", _testFile]);
+        Assert.Equal(0, open.ExitCode);
+        using var openDocument = JsonDocument.Parse(open.Stdout);
+        string? sessionId = openDocument.RootElement.GetProperty("sessionId").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(sessionId));
+
+        try
+        {
+            string formulas = JsonSerializer.Serialize(ReferenceErrorFormula);
+            var set = await CliProcessHelper.RunAsync(
+                [
+                    "range", "set-formulas",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "A1",
+                    "--formulas", formulas
+                ]);
+            Assert.Equal(0, set.ExitCode);
+
+            var validate = await CliProcessHelper.RunAsync(
+                [
+                    "workbook", "validate-integrity",
+                    "--session", sessionId!,
+                    "--checks", """["formula-errors"]""",
+                    "--worksheet-names", """["Sheet1"]""",
+                    "--max-findings", "10"
+                ]);
+
+            Assert.Equal(0, validate.ExitCode);
+            AssertIntegrityReferenceError(validate.Stdout);
+
+            var setValue = await CliProcessHelper.RunAsync(
+                [
+                    "range", "set-values",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "B1",
+                    "--values", "[[100]]"
+                ]);
+            Assert.Equal(0, setValue.ExitCode);
+
+            var controlTotal = await CliProcessHelper.RunAsync(
+                [
+                    "workbook", "validate-integrity",
+                    "--session", sessionId!,
+                    "--checks", """["control-totals"]""",
+                    "--control-totals", """[{"sheetName":"Sheet1","cellAddress":"B1","expectedValue":100,"tolerance":0}]"""
+                ]);
+            Assert.Equal(0, controlTotal.ExitCode);
+            using var controlDocument = JsonDocument.Parse(controlTotal.Stdout);
+            Assert.Equal("passed", controlDocument.RootElement.GetProperty("overallStatus").GetString());
+            Assert.Equal(
+                "control-totals",
+                controlDocument.RootElement.GetProperty("checkedChecks")[0].GetString());
+        }
+        finally
+        {
+            await CliProcessHelper.RunAsync(
+                ["session", "close", "--session", sessionId!, "--save", "false"]);
+        }
+    }
+
+    private static void AssertIntegrityReferenceError(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.Equal("failed", root.GetProperty("overallStatus").GetString());
+        Assert.Equal(1, root.GetProperty("findingCount").GetInt32());
+        Assert.False(root.GetProperty("findingsTruncated").GetBoolean());
+        Assert.Equal("formula-errors", root.GetProperty("checkedChecks")[0].GetString());
+
+        var group = Assert.Single(root.GetProperty("groups").EnumerateArray());
+        Assert.Equal("error", group.GetProperty("severity").GetString());
+        Assert.Equal("broken-reference", group.GetProperty("category").GetString());
+
+        var finding = Assert.Single(group.GetProperty("findings").EnumerateArray());
+        Assert.Equal("broken-formula-reference", finding.GetProperty("code").GetString());
+        Assert.Equal("deterministic", finding.GetProperty("reliability").GetString());
+        Assert.Equal("Sheet1", finding.GetProperty("sheetName").GetString());
+        Assert.Equal("A1", finding.GetProperty("cellAddress").GetString());
+        Assert.Equal("=INDIRECT(\"A0\")", finding.GetProperty("formula").GetString());
+        Assert.Equal("#REF!", finding.GetProperty("errorName").GetString());
+        Assert.Equal(-2146826265, finding.GetProperty("errorCode").GetInt32());
+    }
+
+    public void Dispose()
+    {
+        if (!File.Exists(_testFile))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(_testFile);
+        }
+        catch (IOException)
+        {
+            // The session close path reports cleanup failures; deletion is only fixture cleanup.
+        }
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Workbook/WorkbookIntegrityCommandsTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Workbook/WorkbookIntegrityCommandsTests.cs
@@ -1,0 +1,550 @@
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Table;
+using Sbroenne.ExcelMcp.Core.Commands.Workbook;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Workbook;
+
+[Trait("Layer", "Core")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Feature", "Workbook")]
+[Trait("RequiresExcel", "true")]
+public sealed class WorkbookIntegrityCommandsTests : IClassFixture<FileTestsFixture>
+{
+    private readonly WorkbookCommands _commands = new();
+    private readonly FileTestsFixture _fixture;
+
+    public WorkbookIntegrityCommandsTests(FileTestsFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void ValidateIntegrity_CleanWorkbook_ReturnsPassedWithoutChangingWorkbook()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        SetAutomaticCalculation(batch);
+        bool savedBefore = batch.Execute((context, _) => context.Book.Saved);
+
+        var result = _commands.ValidateIntegrity(batch);
+
+        Assert.True(result.Success);
+        Assert.Equal(WorkbookIntegrityStatus.Passed, result.OverallStatus);
+        Assert.Equal(0, result.FindingCount);
+        Assert.Empty(result.Groups);
+        Assert.False(result.FindingsTruncated);
+        Assert.Equal(3, result.CheckedChecks.Count);
+        Assert.False(string.IsNullOrWhiteSpace(result.CalculationMode));
+        Assert.False(string.IsNullOrWhiteSpace(result.CalculationState));
+        Assert.Equal(savedBefore, batch.Execute((context, _) => context.Book.Saved));
+    }
+
+    [Fact]
+    public void ValidateIntegrity_FormulaErrors_UsesCanonicalErrorsAndGroupsBrokenReferences()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        WriteFormulas(batch, "A1:C1", ["=1/0", "=INDIRECT(\"A0\")", "=1+1"]);
+
+        var result = _commands.ValidateIntegrity(
+            batch,
+            checks: [WorkbookIntegrityCheck.FormulaErrors],
+            worksheetNames: ["Sheet1"],
+            maxFindings: 1);
+
+        Assert.True(result.Success);
+        Assert.Equal(WorkbookIntegrityStatus.Failed, result.OverallStatus);
+        Assert.Equal(2, result.ErrorCount);
+        Assert.Equal(2, result.FindingCount);
+        Assert.Equal(2, result.Groups.Sum(group => group.Count));
+        Assert.True(result.FindingsTruncated);
+        Assert.Single(result.CheckedWorksheets);
+
+        var retainedFinding = Assert.Single(result.Groups.SelectMany(group => group.Findings));
+        Assert.Equal(WorkbookIntegrityReliability.Deterministic, retainedFinding.Reliability);
+        Assert.True(retainedFinding.ErrorName is "#DIV/0!" or "#REF!");
+        Assert.StartsWith("=", retainedFinding.Formula, StringComparison.Ordinal);
+        Assert.True(retainedFinding.CellAddress is "A1" or "B1");
+
+        Assert.Contains(result.Groups, group =>
+            group.Category == WorkbookIntegrityCategory.FormulaError ||
+            group.Category == WorkbookIntegrityCategory.BrokenReference);
+    }
+
+    [Fact]
+    public void ValidateIntegrity_WorksheetFilter_ExcludesUnselectedSheets()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        AddWorksheetWithReferenceError(batch, "Excluded");
+
+        var result = _commands.ValidateIntegrity(
+            batch,
+            checks: [WorkbookIntegrityCheck.FormulaErrors],
+            worksheetNames: ["Sheet1"]);
+
+        Assert.Equal(WorkbookIntegrityStatus.Passed, result.OverallStatus);
+        Assert.Equal("Sheet1", Assert.Single(result.CheckedWorksheets));
+        Assert.Equal(0, result.FindingCount);
+    }
+
+    [Fact]
+    public void ValidateIntegrity_BrokenReferenceHiddenByIfError_IsStillReported()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        WriteFormulas(batch, "A1:B1", ["=IFERROR(#REF!,0)", "=\"#REF!\""]);
+
+        var result = _commands.ValidateIntegrity(
+            batch,
+            checks: [WorkbookIntegrityCheck.FormulaErrors],
+            worksheetNames: ["Sheet1"]);
+
+        Assert.Equal(WorkbookIntegrityStatus.Failed, result.OverallStatus);
+        var finding = Assert.Single(result.Groups
+            .Where(group => group.Category == WorkbookIntegrityCategory.BrokenReference)
+            .SelectMany(group => group.Findings));
+        Assert.Equal("broken-reference-token", finding.Code);
+        Assert.Equal("A1", finding.CellAddress);
+        Assert.Equal(WorkbookIntegrityReliability.Deterministic, finding.Reliability);
+    }
+
+    [Fact]
+    public void ValidateIntegrity_ManualCalculation_ReportsHeuristicWarningWithoutCalculating()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        batch.Execute((context, _) =>
+        {
+            context.App.Calculation = Excel.XlCalculation.xlCalculationManual;
+            return 0;
+        });
+
+        try
+        {
+            var result = _commands.ValidateIntegrity(
+                batch,
+                checks: [WorkbookIntegrityCheck.FormulaErrors],
+                worksheetNames: ["Sheet1"]);
+
+            Assert.Equal(WorkbookIntegrityStatus.PassedWithWarnings, result.OverallStatus);
+            Assert.Equal("manual", result.CalculationMode);
+            var finding = Assert.Single(result.Groups
+                .Where(group => group.Category == WorkbookIntegrityCategory.CalculationState)
+                .SelectMany(group => group.Findings));
+            Assert.Equal("manual-calculation", finding.Code);
+            Assert.Equal(WorkbookIntegrityReliability.Heuristic, finding.Reliability);
+        }
+        finally
+        {
+            SetAutomaticCalculation(batch);
+        }
+    }
+
+    [Fact]
+    public void ValidateIntegrity_ControlTotals_HonorsAbsoluteTolerance()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        WriteValues(batch, "B2", 100.005d);
+
+        var passing = _commands.ValidateIntegrity(
+            batch,
+            checks: [WorkbookIntegrityCheck.ControlTotals],
+            controlTotals:
+            [
+                new WorkbookControlTotalExpectation
+                {
+                    SheetName = "sheet1",
+                    CellAddress = "B2",
+                    ExpectedValue = 100d,
+                    Tolerance = 0.01d
+                }
+            ]);
+        var failing = _commands.ValidateIntegrity(
+            batch,
+            checks: [WorkbookIntegrityCheck.ControlTotals],
+            controlTotals:
+            [
+                new WorkbookControlTotalExpectation
+                {
+                    SheetName = "Sheet1",
+                    CellAddress = "B2",
+                    ExpectedValue = 99d,
+                    Tolerance = 0.1d
+                }
+            ]);
+
+        Assert.Equal(WorkbookIntegrityStatus.Passed, passing.OverallStatus);
+        Assert.Equal("Sheet1", Assert.Single(passing.CheckedWorksheets));
+        Assert.Equal(WorkbookIntegrityStatus.Failed, failing.OverallStatus);
+        var finding = Assert.Single(failing.Groups.SelectMany(group => group.Findings));
+        Assert.Equal(WorkbookIntegrityCategory.ControlTotal, finding.Category);
+        Assert.Equal(99d, finding.ExpectedValue);
+        Assert.Equal(100.005d, finding.ActualValue);
+        Assert.Equal(0.1d, finding.Tolerance);
+        Assert.Equal("Sheet1", finding.SheetName);
+        Assert.Equal("B2", finding.CellAddress);
+    }
+
+    [Fact]
+    public void ValidateIntegrity_InvalidScopedArguments_AreRejectedClearly()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        var missingExpectations = Assert.Throws<ArgumentException>(() =>
+            _commands.ValidateIntegrity(
+                batch,
+                checks: [WorkbookIntegrityCheck.ControlTotals]));
+        Assert.Equal("controlTotals", missingExpectations.ParamName);
+
+        var irrelevantWorksheetFilter = Assert.Throws<ArgumentException>(() =>
+            _commands.ValidateIntegrity(
+                batch,
+                checks: [WorkbookIntegrityCheck.ExternalLinks],
+                worksheetNames: ["Sheet1"]));
+        Assert.Equal("worksheetNames", irrelevantWorksheetFilter.ParamName);
+
+        var ignoredExpectations = Assert.Throws<ArgumentException>(() =>
+            _commands.ValidateIntegrity(
+                batch,
+                checks: [WorkbookIntegrityCheck.FormulaErrors],
+                controlTotals:
+                [
+                    new WorkbookControlTotalExpectation
+                    {
+                        SheetName = "Sheet1",
+                        CellAddress = "A1",
+                        ExpectedValue = 1d
+                    }
+                ]));
+        Assert.Equal("controlTotals", ignoredExpectations.ParamName);
+
+        var missingExpectedValue = Assert.Throws<ArgumentException>(() =>
+            _commands.ValidateIntegrity(
+                batch,
+                checks: [WorkbookIntegrityCheck.ControlTotals],
+                controlTotals:
+                [
+                    new WorkbookControlTotalExpectation
+                    {
+                        SheetName = "Sheet1",
+                        CellAddress = "A1"
+                    }
+                ]));
+        Assert.Equal("controlTotals", missingExpectedValue.ParamName);
+        Assert.Contains("finite expected value", missingExpectedValue.Message, StringComparison.Ordinal);
+
+        var invalidAddress = Assert.Throws<ArgumentException>(() =>
+            _commands.ValidateIntegrity(
+                batch,
+                checks: [WorkbookIntegrityCheck.ControlTotals],
+                controlTotals:
+                [
+                    new WorkbookControlTotalExpectation
+                    {
+                        SheetName = "Sheet1",
+                        CellAddress = "not a cell",
+                        ExpectedValue = 1d
+                    }
+                ]));
+        Assert.Equal("controlTotals", invalidAddress.ParamName);
+        Assert.Contains("valid cell address", invalidAddress.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateIntegrity_TableCheck_FlagsCalculatedColumnOutlierAsHeuristic()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        WriteTableData(batch);
+        var tableCommands = new TableCommands();
+        tableCommands.Create(batch, "Sheet1", "IntegrityTable", "A1:B4");
+        WriteTableFormulaOutlier(batch);
+
+        var result = _commands.ValidateIntegrity(
+            batch,
+            checks: [WorkbookIntegrityCheck.Tables],
+            worksheetNames: ["Sheet1"]);
+
+        Assert.Equal(WorkbookIntegrityStatus.PassedWithWarnings, result.OverallStatus);
+        var finding = Assert.Single(result.Groups
+            .Where(group => group.Category == WorkbookIntegrityCategory.CalculatedColumn)
+            .SelectMany(group => group.Findings));
+        Assert.Equal(WorkbookIntegritySeverity.Warning, finding.Severity);
+        Assert.Equal(WorkbookIntegrityReliability.Heuristic, finding.Reliability);
+        Assert.Equal("IntegrityTable", finding.TableName);
+        Assert.Equal("Result", finding.ColumnName);
+        Assert.Equal("B4", finding.CellAddress);
+    }
+
+    [Fact]
+    public void ValidateIntegrity_TableCheck_FlagsHiddenHeadersAsDeterministicWarning()
+    {
+        var testFile = _fixture.CreateTestFile();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        WriteTableData(batch);
+        var tableCommands = new TableCommands();
+        tableCommands.Create(batch, "Sheet1", "HiddenHeaderTable", "A1:B4");
+        SetTableHeadersVisible(batch, visible: false);
+
+        var result = _commands.ValidateIntegrity(
+            batch,
+            checks: [WorkbookIntegrityCheck.Tables]);
+
+        Assert.Equal(WorkbookIntegrityStatus.PassedWithWarnings, result.OverallStatus);
+        var finding = Assert.Single(result.Groups
+            .Where(group => group.Category == WorkbookIntegrityCategory.TableHeader)
+            .SelectMany(group => group.Findings));
+        Assert.Equal("table-headers-hidden", finding.Code);
+        Assert.Equal(WorkbookIntegrityReliability.Deterministic, finding.Reliability);
+        Assert.Equal("HiddenHeaderTable", finding.TableName);
+    }
+
+    [Fact]
+    public void ValidateIntegrity_MissingExternalWorkbook_ReportsBrokenLink()
+    {
+        var sourcePath = _fixture.CreateTestFile();
+        var targetPath = _fixture.CreateTestFile();
+        WriteExternalFormula(targetPath, sourcePath);
+        System.IO.File.Delete(sourcePath);
+
+        using var batch = ExcelSession.BeginBatch(targetPath);
+        var result = _commands.ValidateIntegrity(
+            batch,
+            checks: [WorkbookIntegrityCheck.ExternalLinks]);
+
+        Assert.Equal(WorkbookIntegrityStatus.Failed, result.OverallStatus);
+        var finding = Assert.Single(result.Groups
+            .Where(group => group.Category == WorkbookIntegrityCategory.ExternalLink)
+            .SelectMany(group => group.Findings));
+        Assert.Equal(WorkbookIntegritySeverity.Error, finding.Severity);
+        Assert.Equal(WorkbookIntegrityReliability.Deterministic, finding.Reliability);
+        Assert.Equal("missing-file", finding.LinkStatus);
+        Assert.Equal(Path.GetFullPath(sourcePath), finding.LinkSource, ignoreCase: true);
+    }
+
+    private static void WriteFormulas(IExcelBatch batch, string address, string[] formulas)
+    {
+        batch.Execute((context, _) =>
+        {
+            Excel.Sheets? worksheets = null;
+            Excel.Worksheet? sheet = null;
+            Excel.Range? range = null;
+            try
+            {
+                worksheets = context.Book.Worksheets;
+                sheet = (Excel.Worksheet)worksheets.Item[1];
+                range = sheet.Range[address];
+                object[,] values = (object[,])Array.CreateInstance(
+                    typeof(object),
+                    [1, formulas.Length],
+                    [1, 1]);
+                for (int column = 1; column <= formulas.Length; column++)
+                {
+                    values[1, column] = formulas[column - 1];
+                }
+
+                range.Formula2 = values;
+                context.App.Calculation = Excel.XlCalculation.xlCalculationAutomatic;
+                context.App.CalculateFull();
+            }
+            finally
+            {
+                ComUtilities.Release(ref range);
+                ComUtilities.Release(ref sheet);
+                ComUtilities.Release(ref worksheets);
+            }
+
+            return 0;
+        });
+    }
+
+    private static void AddWorksheetWithReferenceError(IExcelBatch batch, string worksheetName)
+    {
+        batch.Execute((context, _) =>
+        {
+            Excel.Sheets? worksheets = null;
+            Excel.Worksheet? worksheet = null;
+            Excel.Range? cell = null;
+            try
+            {
+                worksheets = context.Book.Worksheets;
+                worksheet = (Excel.Worksheet)worksheets.Add();
+                worksheet.Name = worksheetName;
+                cell = worksheet.Range["A1"];
+                cell.Formula2 = "=INDIRECT(\"A0\")";
+                context.App.Calculation = Excel.XlCalculation.xlCalculationAutomatic;
+                context.App.CalculateFull();
+            }
+            finally
+            {
+                ComUtilities.Release(ref cell);
+                ComUtilities.Release(ref worksheet);
+                ComUtilities.Release(ref worksheets);
+            }
+
+            return 0;
+        });
+    }
+
+    private static void WriteValues(IExcelBatch batch, string address, object value)
+    {
+        batch.Execute((context, _) =>
+        {
+            Excel.Sheets? worksheets = null;
+            Excel.Worksheet? sheet = null;
+            Excel.Range? range = null;
+            try
+            {
+                worksheets = context.Book.Worksheets;
+                sheet = (Excel.Worksheet)worksheets.Item[1];
+                range = sheet.Range[address];
+                context.App.Calculation = Excel.XlCalculation.xlCalculationAutomatic;
+                range.Value2 = value;
+            }
+            finally
+            {
+                ComUtilities.Release(ref range);
+                ComUtilities.Release(ref sheet);
+                ComUtilities.Release(ref worksheets);
+            }
+
+            return 0;
+        });
+    }
+
+    private static void SetAutomaticCalculation(IExcelBatch batch)
+    {
+        batch.Execute((context, _) =>
+        {
+            context.App.Calculation = Excel.XlCalculation.xlCalculationAutomatic;
+            return 0;
+        });
+    }
+
+    private static void WriteTableData(IExcelBatch batch)
+    {
+        batch.Execute((context, _) =>
+        {
+            Excel.Sheets? worksheets = null;
+            Excel.Worksheet? sheet = null;
+            Excel.Range? range = null;
+            try
+            {
+                worksheets = context.Book.Worksheets;
+                sheet = (Excel.Worksheet)worksheets.Item[1];
+                range = sheet.Range["A1:B4"];
+                range.Value2 = new object?[,]
+                {
+                    { "Input", "Result" },
+                    { 1d, null },
+                    { 2d, null },
+                    { 3d, null }
+                };
+            }
+            finally
+            {
+                ComUtilities.Release(ref range);
+                ComUtilities.Release(ref sheet);
+                ComUtilities.Release(ref worksheets);
+            }
+
+            return 0;
+        });
+    }
+
+    private static void WriteTableFormulaOutlier(IExcelBatch batch)
+    {
+        batch.Execute((context, _) =>
+        {
+            Excel.Sheets? worksheets = null;
+            Excel.Worksheet? sheet = null;
+            Excel.Range? formulas = null;
+            Excel.Range? outlier = null;
+            try
+            {
+                worksheets = context.Book.Worksheets;
+                sheet = (Excel.Worksheet)worksheets.Item[1];
+                formulas = sheet.Range["B2:B3"];
+                formulas.Formula2R1C1 = "=RC[-1]*2";
+                outlier = sheet.Range["B4"];
+                outlier.Value2 = 999d;
+            }
+            finally
+            {
+                ComUtilities.Release(ref outlier);
+                ComUtilities.Release(ref formulas);
+                ComUtilities.Release(ref sheet);
+                ComUtilities.Release(ref worksheets);
+            }
+
+            return 0;
+        });
+    }
+
+    private static void SetTableHeadersVisible(IExcelBatch batch, bool visible)
+    {
+        batch.Execute((context, _) =>
+        {
+            Excel.Sheets? worksheets = null;
+            Excel.Worksheet? sheet = null;
+            Excel.ListObjects? tables = null;
+            Excel.ListObject? table = null;
+            try
+            {
+                worksheets = context.Book.Worksheets;
+                sheet = (Excel.Worksheet)worksheets.Item[1];
+                tables = sheet.ListObjects;
+                table = tables.Item[1];
+                table.ShowHeaders = visible;
+            }
+            finally
+            {
+                ComUtilities.Release(ref table);
+                ComUtilities.Release(ref tables);
+                ComUtilities.Release(ref sheet);
+                ComUtilities.Release(ref worksheets);
+            }
+
+            return 0;
+        });
+    }
+
+    private static void WriteExternalFormula(string workbookPath, string sourcePath)
+    {
+        var sourceDirectory = Path.GetDirectoryName(sourcePath)!.Replace("'", "''", StringComparison.Ordinal);
+        var sourceFileName = Path.GetFileName(sourcePath);
+        var formula = $"='{sourceDirectory}\\[{sourceFileName}]Sheet1'!$A$1";
+
+        using var batch = ExcelSession.BeginBatch(workbookPath);
+        batch.Execute((context, _) =>
+        {
+            Excel.Sheets? worksheets = null;
+            Excel.Worksheet? sheet = null;
+            Excel.Range? cell = null;
+            try
+            {
+                worksheets = context.Book.Worksheets;
+                sheet = (Excel.Worksheet)worksheets.Item[1];
+                cell = sheet.Range["A1"];
+                cell.Formula = formula;
+            }
+            finally
+            {
+                ComUtilities.Release(ref cell);
+                ComUtilities.Release(ref sheet);
+                ComUtilities.Release(ref worksheets);
+            }
+
+            return 0;
+        });
+        batch.Save();
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Unit/ServiceRegistryJsonParsingTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/ServiceRegistryJsonParsingTests.cs
@@ -1,13 +1,15 @@
 using System.Text.Json;
+using Sbroenne.ExcelMcp.Core.Commands.Workbook;
 using Sbroenne.ExcelMcp.Generated;
 using Xunit;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
 
 /// <summary>
-/// Unit tests for ServiceRegistry.DeserializeNestedCollection (generated helper).
+/// Unit tests for generated ServiceRegistry collection deserialization helpers.
 /// Covers bug regressions for issue #521:
 ///   --values inline JSON loses string quotes in PowerShell (stdin sentinel + better error).
+/// Covers typed object-list binding used by workbook integrity control totals.
 /// These tests must FAIL before the fix and PASS after.
 /// </summary>
 [Trait("Layer", "Core")]
@@ -34,6 +36,30 @@ public sealed class ServiceRegistryJsonParsingTests
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
             throw; // unreachable
         }
+    }
+
+    private static T? DeserializeList<T>(string json) where T : class
+    {
+        var method = _registryType.GetMethod(
+            "DeserializeList",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var genericMethod = method.MakeGenericMethod(typeof(T));
+        return (T?)genericMethod.Invoke(null, [json]);
+    }
+
+    [Fact]
+    public void DeserializeList_ComplexCamelCaseObjects_PreservesFields()
+    {
+        const string json =
+            """[{"sheetName":"Summary","cellAddress":"B20","expectedValue":12345.67,"tolerance":0.01}]""";
+
+        var result = DeserializeList<List<WorkbookControlTotalExpectation>>(json);
+
+        var expectation = Assert.Single(result!);
+        Assert.Equal("Summary", expectation.SheetName);
+        Assert.Equal("B20", expectation.CellAddress);
+        Assert.Equal(12345.67d, expectation.ExpectedValue);
+        Assert.Equal(0.01d, expectation.Tolerance);
     }
 
     /// <summary>

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/WorkbookIntegrityProtocolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/WorkbookIntegrityProtocolTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Workbook")]
+[Trait("RequiresExcel", "true")]
+public sealed class WorkbookIntegrityProtocolTests : McpIntegrationTestBase
+{
+    private static readonly string[][] ReferenceErrorFormula = [["=INDIRECT(\"A0\")"]];
+    private static readonly string[] FormulaErrorChecks = ["formula-errors"];
+    private static readonly string[] ControlTotalChecks = ["control-totals"];
+    private static readonly object[][] ControlTotalValue = [[100d]];
+    private static readonly Dictionary<string, object?>[] ControlTotals =
+    [
+        new()
+        {
+            ["sheetName"] = "Sheet1",
+            ["cellAddress"] = "B1",
+            ["expectedValue"] = 100d,
+            ["tolerance"] = 0d
+        }
+    ];
+
+    private readonly string _testExcelFile;
+    private string? _sessionId;
+
+    public WorkbookIntegrityProtocolTests(ITestOutputHelper output)
+        : base(output, "WorkbookIntegrityProtocolClient")
+    {
+        _testExcelFile = Path.Join(
+            CreateTempDirectory("WorkbookIntegrityProtocol"),
+            "WorkbookIntegrity.xlsx");
+    }
+
+    protected override async Task InitializeTestAsync()
+    {
+        _sessionId = await CreateWorkbookSessionAsync(_testExcelFile);
+    }
+
+    [Fact]
+    public async Task ValidateIntegrity_ReturnsTypedCanonicalFindingThroughMcp()
+    {
+        var setJson = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-formulas",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "A1",
+            ["formulas"] = ReferenceErrorFormula
+        });
+        AssertSetupSuccess(setJson, "range.set-formulas");
+
+        var resultJson = await CallToolAsync("workbook", new Dictionary<string, object?>
+        {
+            ["action"] = "validate-integrity",
+            ["session_id"] = _sessionId,
+            ["checks"] = FormulaErrorChecks,
+            ["worksheet_names"] = """["Sheet1"]""",
+            ["max_findings"] = 10
+        });
+
+        AssertIntegrityReferenceError(resultJson);
+
+        var setValueJson = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-values",
+            ["session_id"] = _sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "B1",
+            ["values"] = ControlTotalValue
+        });
+        AssertSetupSuccess(setValueJson, "range.set-values");
+
+        var controlTotalJson = await CallToolAsync("workbook", new Dictionary<string, object?>
+        {
+            ["action"] = "validate-integrity",
+            ["session_id"] = _sessionId,
+            ["checks"] = ControlTotalChecks,
+            ["control_totals"] = ControlTotals
+        });
+        using (var controlDocument = JsonDocument.Parse(controlTotalJson))
+        {
+            var root = controlDocument.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(), controlTotalJson);
+            Assert.Equal("passed", root.GetProperty("overallStatus").GetString());
+            Assert.Equal("control-totals", root.GetProperty("checkedChecks")[0].GetString());
+        }
+
+        await CloseSessionAsync(_sessionId, save: false);
+        _sessionId = null;
+    }
+
+    private static void AssertIntegrityReferenceError(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("success").GetBoolean(), json);
+        Assert.Equal("failed", root.GetProperty("overallStatus").GetString());
+        Assert.Equal(1, root.GetProperty("findingCount").GetInt32());
+        Assert.False(root.GetProperty("findingsTruncated").GetBoolean());
+        Assert.Equal("formula-errors", root.GetProperty("checkedChecks")[0].GetString());
+
+        var group = Assert.Single(root.GetProperty("groups").EnumerateArray());
+        Assert.Equal("error", group.GetProperty("severity").GetString());
+        Assert.Equal("broken-reference", group.GetProperty("category").GetString());
+
+        var finding = Assert.Single(group.GetProperty("findings").EnumerateArray());
+        Assert.Equal("broken-formula-reference", finding.GetProperty("code").GetString());
+        Assert.Equal("deterministic", finding.GetProperty("reliability").GetString());
+        Assert.Equal("Sheet1", finding.GetProperty("sheetName").GetString());
+        Assert.Equal("A1", finding.GetProperty("cellAddress").GetString());
+        Assert.Equal("=INDIRECT(\"A0\")", finding.GetProperty("formula").GetString());
+        Assert.Equal("#REF!", finding.GetProperty("errorName").GetString());
+        Assert.Equal(-2146826265, finding.GetProperty("errorCode").GetInt32());
+    }
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -19,7 +19,7 @@ Other tools (openpyxl-based MCP servers and Agent Skills, including Anthropic's 
 
 ## Key features
 
-The Excel MCP Server (excel-mcp) provides **31 specialized tools with 325 operations** for comprehensive Excel automation:
+The Excel MCP Server (excel-mcp) provides **31 specialized tools with 326 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query & M code** - Create, edit and optimize M code. Import from files, databases and APIs. Refresh queries and manage load destinations.
 - 🧮 **Power Pivot & DAX** - Build Data Models, create DAX measures and manage table relationships. Full Power Pivot automation.
@@ -31,7 +31,7 @@ The Excel MCP Server (excel-mcp) provides **31 specialized tools with 325 operat
 - 🐍 **Python in Excel** - Write and run `=PY()` formulas that execute in Excel's cloud Python engine — process worksheet data with pandas, NumPy and more, from your AI assistant.
 - 🧪 **LLM-tested quality** - Tool behavior validated with real LLM workflows using [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering), so AI assistants reliably understand and use every operation.
 
-📚 **[See all 31 tools and 325 operations →](https://excelmcpserver.dev/features/)**
+📚 **[See all 31 tools and 326 operations →](https://excelmcpserver.dev/features/)**
 
 ### Agent Skills (Bundled)
 


### PR DESCRIPTION
## Summary

- add read-only `workbook validate-integrity` across Core, generated Service, CLI, and MCP surfaces
- report typed findings for formula errors, broken references, external links, table structure and headers, calculated-column inconsistencies, calculation state, and caller-supplied control totals
- support worksheet/check filters, absolute control-total tolerances, cancellation checkpoints, deterministic versus heuristic reliability, and bounded finding details with complete counts
- update shared agent guidance, generated references, user documentation, plugin/package metadata, and the operation count to 326

## Validation

- focused Core workbook integrity tests with real Excel
- focused MCP protocol and CLI parity tests with real Excel
- Release build with zero warnings
- COM leak, Core coverage/naming, MCP/Core implementation, success-flag, documentation-count, and dynamic-cast audits
- full `scripts\Test-E2E.ps1`
- normal pre-commit hook including release deliverables, VS Code package, MCPB, and agent skills

## Stack

This PR is based on `sbroenne-canonical-formula-errors` / #843 and reuses its canonical Excel formula error model.

Closes #834