### PR TITLE
Add atomic range-to-table conversion

### DIFF
--- a/.changeset/atomic-tables-land.md
+++ b/.changeset/atomic-tables-land.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": minor
+---
+
+**Atomic range-to-table conversion** (#839): Preflight, explicitly normalize merged or invalid headers, create and style a table, validate formulas and calculated columns, and restore the affected range when a later conversion step fails.

--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -68,12 +68,12 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## What You Can Do
 
-**31 feature command categories with 326 operations** for comprehensive Excel automation:
+**31 feature command categories with 327 operations** for comprehensive Excel automation:
 
 - **Power Query** (12 ops) — Create, update, refresh queries; M code management
 - **Data Model/DAX** (20 ops) — Measures, relationships, source metadata, EVALUATE queries
 - **PivotTables** (35 ops) — Fields, grouping, cache options, drill-through
-- **Excel Tables** (27 ops) — Lifecycle, filtering, sorting, DAX-backed tables
+- **Excel Tables** (29 ops) — Lifecycle, preflight, atomic conversion, filtering, sorting, DAX-backed tables
 - **Charts and Chart Config** (33 ops) — Combo series, plotting, placement, formatting
 - **Ranges** (51 ops) — Values, formulas, hyperlinks, threaded comments, formatting
 - **Worksheets** (33 ops) — Lifecycle, outlines, protection, notes, images, shapes

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -58,14 +58,14 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ## What You Can Do
 
-**31 specialized tools with 326 operations** for comprehensive Excel automation:
+**31 specialized tools with 327 operations** for comprehensive Excel automation:
 
 ### Core Operations
 
 - **Power Query** (12 ops) — Create, update, refresh; optional remote M code formatting
 - **Data Model/DAX** (20 ops) — Measures, relationships, source metadata, EVALUATE queries
 - **PivotTables** (35 ops) — Fields, grouping, cache options, drill-through, calculations
-- **Excel Tables** (27 ops) — Lifecycle, filtering, sorting, DAX-backed tables
+- **Excel Tables** (29 ops) — Lifecycle, preflight, atomic conversion, filtering, sorting, DAX-backed tables
 - **Charts** (33 ops) — Combo series, plotting, placement, formatting, labels, trendlines
 - **Ranges** (51 ops) — Values, formulas, hyperlinks, threaded comments, formatting, validation
 - **Worksheets** (33 ops) — Lifecycle, outlines, protection, notes, images, shapes, page setup

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # ExcelMcp - Complete Feature Reference
 
-**31 specialized tools with 326 operations for comprehensive Excel automation**
+**31 specialized tools with 327 operations for comprehensive Excel automation**
 
 Excel MCP Server automates the real Microsoft Excel application through four focused capability areas. Start with the category that matches your goal, or use the quick reference below.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ its official COM API. It can refresh Power Query, recalculate formulas, evaluate
 DAX, run VBA and Python `=PY()`, and preserve PivotTables, charts, macros, the
 Data Model, and workbook formatting.
 
-**31 tools with 326 operations** cover end-to-end Excel automation.
+**31 tools with 327 operations** cover end-to-end Excel automation.
 
 > [!IMPORTANT]
 > Requires **Windows**, **Microsoft Excel 2016 or later**, and an interactive
@@ -55,7 +55,7 @@ while automating them.
 - **[Automation & advanced](https://excelmcpserver.dev/features/automation-advanced/):**
   VBA, Python in Excel, Goal Seek, scenarios, data tables, windows, and XML Maps.
 
-Explore the [complete reference for all 326 operations](https://excelmcpserver.dev/features/).
+Explore the [complete reference for all 327 operations](https://excelmcpserver.dev/features/).
 
 ## See It in Action
 

--- a/docs/COPILOT-PLUGIN-DISTRIBUTION.md
+++ b/docs/COPILOT-PLUGIN-DISTRIBUTION.md
@@ -6,7 +6,7 @@ This document outlines how the Excel MCP Server and Excel CLI are distributed as
 
 ExcelMcp is published as **two complementary plugins** in the GitHub Copilot plugin marketplace:
 
-- **`excel-mcp`** — MCP Server with 31 tools (326 operations) for conversational AI (Claude Desktop, Copilot chat)
+- **`excel-mcp`** — MCP Server with 31 tools (327 operations) for conversational AI (Claude Desktop, Copilot chat)
 - **`excel-cli`** — CLI-only skill for coding agents (token-efficient, `--help` discoverable)
 
 Both plugins are maintained in a separate published repository and auto-synced from this source repo.
@@ -67,7 +67,7 @@ copilot plugin install excel-cli@mcp-server-excel-plugins
 
 ### Excel MCP Plugin
 
-Provides the full MCP Server with 31 tools (326 operations) for conversational AI:
+Provides the full MCP Server with 31 tools (327 operations) for conversational AI:
 
 ```powershell
 copilot plugin install excel-mcp@mcp-server-excel-plugins

--- a/docs/features/DATA-ANALYTICS.md
+++ b/docs/features/DATA-ANALYTICS.md
@@ -83,7 +83,7 @@ Build a Power Pivot Data Model — manage tables, DAX measures, and relationship
 
 ---
 
-## 📇 Excel Tables (ListObjects) (28 operations)
+## 📇 Excel Tables (ListObjects) (29 operations)
 
 Create and manage Excel Tables (ListObjects) — structured ranges with styling, filtering, and sorting.
 
@@ -91,6 +91,7 @@ Create and manage Excel Tables (ListObjects) — structured ranges with styling,
 - **List:** List Excel Tables in a worksheet or workbook
 - **Read:** Get table structure (columns, range, style)
 - **Preflight:** Non-destructively check the effective range, merged cells, blank or duplicate headers, excluded contiguous columns, and formulas that may be unsafe to sort. Deterministic problems block creation; uncertain adjacency and formula findings are warnings.
+- **Convert Range:** Preflight a range with an existing header row, apply only explicitly requested merged-header/header normalization, create and style the table, validate formulas and calculated columns, and restore the affected range when a later step fails. This is operation-level rollback, not a workbook-wide transaction; use Create for headerless ranges.
 - **Create:** Create a new Excel Table from a range
 - **Rename:** Rename an existing table
 - **Resize:** Resize table range to match new data bounds

--- a/gh-pages/docs/faq.md
+++ b/gh-pages/docs/faq.md
@@ -31,7 +31,7 @@ possible - you don't need to memorize it.
 
 ### CLI or MCP Server - which should I install?
 
-Both expose the **same 326 operations**. Use the **MCP Server** for
+Both expose the **same 327 operations**. Use the **MCP Server** for
 conversational AI (Claude Desktop, VS Code Chat); use the **CLI** (`excelcli`)
 for coding agents and scripting, where it uses ~64% fewer tokens. You can
 install both. See [Installation](installation.md).

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,6 +1,6 @@
 ---
 title: Excel Automation Features
-description: Explore 31 Excel automation tools and 326 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
+description: Explore 31 Excel automation tools and 327 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
 keywords: "Excel automation features, Excel MCP tools, Power Query automation, DAX, PivotTables, VBA, Excel AI"
 ---
 
@@ -11,7 +11,7 @@ keywords: "Excel automation features, Excel MCP tools, Power Query automation, D
   <figcaption>A PivotTable — revenue by region and quarter with grand totals — created in the real Excel application from a plain-language request.</figcaption>
 </figure>
 
-Excel MCP Server provides **31 specialized tools and 326 operations** for
+Excel MCP Server provides **31 specialized tools and 327 operations** for
 automating the real Microsoft Excel application. You can ask your AI assistant
 in plain language—the reference pages below are for discovering what is
 possible and looking up individual operations.

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -132,7 +132,7 @@ hide:
 
 </div>
 
-[See all 31 tools and 326 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 31 tools and 327 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## Popular guides
 

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -13,7 +13,7 @@ Excel MCP Server lets you automate Excel through conversation with Claude:
 - **Automate** - VBA macros, batch operations, data refresh
 - **Agent Mode** - Say "show me Excel" and watch AI work in real-time, side-by-side with Claude
 
-**31 tools with 326 operations** for comprehensive Excel automation.
+**31 tools with 327 operations** for comprehensive Excel automation.
 
 ## Requirements
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Excel (Windows)",
   "version": "2.0.5",
   "description": "Manage Sheets, Power Query, DAX, VBA, PowerPivot, Tables, Ranges, Charts, Formatting, Validation & more - requires Excel to be installed",
-  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 326 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
+  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 327 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -12,7 +12,7 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
 
 # Excel MCP Server Skill
 
-Provides 326 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
+Provides 327 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
 
 ## Workflow Checklist
 

--- a/skills/excel-mcp/references/table.md
+++ b/skills/excel-mcp/references/table.md
@@ -5,7 +5,7 @@
 Excel Tables on worksheets are NOT automatically in the Data Model (Power Pivot).
 To analyze worksheet data with DAX measures:
 
-1. Ensure data is formatted as an Excel Table (use preflight, then create if needed)
+1. Ensure data is formatted as an Excel Table (prefer convert-range when cleanup or rollback may be needed)
 2. Use `add-to-data-model` action to add the table to Power Pivot
 3. Then use `datamodel` to create DAX measures on it
 
@@ -13,6 +13,7 @@ To analyze worksheet data with DAX measures:
 
 - create: Create NEW table from a range (requires `sheet_name`, `table_name`, and `range_address`). Pass `table_style` here to style at creation time.
 - preflight: Check a proposed table without changing the workbook. It returns the effective range, typed findings, and `safeToCreate`. Merged cells plus blank or duplicate headers are blockers. Excluded contiguous columns and formulas that may be unsafe to sort are heuristic warnings.
+- convert-range: Preflight, optionally normalize merged headers and invalid headers through explicit policies, create/style the table, validate formulas and calculated columns, and restore the affected range if a later step fails. It requires an existing header row (`has_headers=true`) and defaults only report blockers. This is operation-level rollback for the effective range, not a workbook-wide transaction.
 - read: Get table metadata (range, columns, style, row counts)
 - get-data: Get actual table DATA as 2D array (use `visible_only=true` for filtered data)
 - rename: Rename an existing table
@@ -34,7 +35,7 @@ Excel Tables manage their own header/row/totals formatting through table styles.
 | Goal | Correct approach |
 |------|-----------------|
 | Style a table | `table(action: 'set-style', table_style: 'TableStyleMedium2')` |
-| Style at creation | `table(action: 'create', table_style: 'TableStyleMedium2', ...)` |
+| Style at creation | `table(action: 'convert-range', table_style: 'TableStyleMedium2', ...)` |
 | Custom branding on table | Use a Medium/Dark table style that matches your palette — avoid overriding individual cells |
 
 Common table style choices:
@@ -84,7 +85,8 @@ Example DAX queries for create-from-dax:
 - Using datamodel to add tables (it only manages existing Data Model tables)
 - Confusing get-data (returns cell values) with read (returns metadata)
 - Forgetting `has_headers` when creating tables from headerless data
-- Skipping preflight when warnings about excluded columns or formula sorting need human review. Create always enforces deterministic blockers, but warnings do not block it.
+- Using normalization policies without reviewing the returned header changes. `convert-range` defaults to reporting blockers; normalization must be explicit.
+- Treating `convert-range` as a workbook transaction. Its rollback covers the effective source range and newly created table while Excel remains responsive.
 
 **Server-specific quirks**:
 

--- a/skills/shared/table.md
+++ b/skills/shared/table.md
@@ -5,7 +5,7 @@
 Excel Tables on worksheets are NOT automatically in the Data Model (Power Pivot).
 To analyze worksheet data with DAX measures:
 
-1. Ensure data is formatted as an Excel Table (use preflight, then create if needed)
+1. Ensure data is formatted as an Excel Table (prefer convert-range when cleanup or rollback may be needed)
 2. Use `add-to-data-model` action to add the table to Power Pivot
 3. Then use `datamodel` to create DAX measures on it
 
@@ -13,6 +13,7 @@ To analyze worksheet data with DAX measures:
 
 - create: Create NEW table from a range (requires `sheet_name`, `table_name`, and `range_address`). Pass `table_style` here to style at creation time.
 - preflight: Check a proposed table without changing the workbook. It returns the effective range, typed findings, and `safeToCreate`. Merged cells plus blank or duplicate headers are blockers. Excluded contiguous columns and formulas that may be unsafe to sort are heuristic warnings.
+- convert-range: Preflight, optionally normalize merged headers and invalid headers through explicit policies, create/style the table, validate formulas and calculated columns, and restore the affected range if a later step fails. It requires an existing header row (`has_headers=true`) and defaults only report blockers. This is operation-level rollback for the effective range, not a workbook-wide transaction.
 - read: Get table metadata (range, columns, style, row counts)
 - get-data: Get actual table DATA as 2D array (use `visible_only=true` for filtered data)
 - rename: Rename an existing table
@@ -34,7 +35,7 @@ Excel Tables manage their own header/row/totals formatting through table styles.
 | Goal | Correct approach |
 |------|-----------------|
 | Style a table | `table(action: 'set-style', table_style: 'TableStyleMedium2')` |
-| Style at creation | `table(action: 'create', table_style: 'TableStyleMedium2', ...)` |
+| Style at creation | `table(action: 'convert-range', table_style: 'TableStyleMedium2', ...)` |
 | Custom branding on table | Use a Medium/Dark table style that matches your palette — avoid overriding individual cells |
 
 Common table style choices:
@@ -84,7 +85,8 @@ Example DAX queries for create-from-dax:
 - Using datamodel to add tables (it only manages existing Data Model tables)
 - Confusing get-data (returns cell values) with read (returns metadata)
 - Forgetting `has_headers` when creating tables from headerless data
-- Skipping preflight when warnings about excluded columns or formula sorting need human review. Create always enforces deterministic blockers, but warnings do not block it.
+- Using normalization policies without reviewing the returned header changes. `convert-range` defaults to reporting blockers; normalization must be explicit.
+- Treating `convert-range` as a workbook transaction. Its rollback covers the effective source range and newly created table while Excel remains responsive.
 
 **Server-specific quirks**:
 

--- a/src/ExcelMcp.CLI/Commands/BatchCommand.cs
+++ b/src/ExcelMcp.CLI/Commands/BatchCommand.cs
@@ -161,7 +161,12 @@ internal sealed class BatchCommand : AsyncCommand<BatchCommand.Settings>
                 Command = cmd.Command,
                 Success = response.Success,
                 Result = response.Success ? TryParseJsonElement(response.Result) : null,
-                Error = response.ErrorMessage
+                Error = response.ErrorMessage,
+                ErrorCategory = response.ErrorCategory,
+                ExceptionType = response.ExceptionType,
+                HResult = response.HResult,
+                InnerError = response.InnerError,
+                Details = TryParseJsonElement(response.ErrorDetails)
             };
 
             Console.WriteLine(JsonSerializer.Serialize(output, BatchJsonOptions));
@@ -328,5 +333,20 @@ internal sealed class BatchCommand : AsyncCommand<BatchCommand.Settings>
 
         [JsonPropertyName("error")]
         public string? Error { get; init; }
+
+        [JsonPropertyName("errorCategory")]
+        public string? ErrorCategory { get; init; }
+
+        [JsonPropertyName("exceptionType")]
+        public string? ExceptionType { get; init; }
+
+        [JsonPropertyName("hresult")]
+        public string? HResult { get; init; }
+
+        [JsonPropertyName("innerError")]
+        public string? InnerError { get; init; }
+
+        [JsonPropertyName("details")]
+        public JsonElement? Details { get; init; }
     }
 }

--- a/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+++ b/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
@@ -24,7 +24,7 @@
     <!-- NuGet Package Configuration (secondary distribution — primary is standalone exe) -->
     <PackageId>Sbroenne.ExcelMcp.CLI</PackageId>
     <Title>ExcelMcp CLI</Title>
-    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 326 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
+    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 327 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
     <PackageTags>excel;cli;powerquery;dax;power-pivot;automation;com;rpa;ci-cd;scripting;github-copilot;mcp;windows;dotnet-tool;sbroenne;excel-automation;vba;pivottables;excel-tables;batch-processing;devops</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/sbroenne/mcp-server-excel/releases for release notes</PackageReleaseNotes>

--- a/src/ExcelMcp.CLI/Infrastructure/CliErrorOutput.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/CliErrorOutput.cs
@@ -17,6 +17,7 @@ internal static class CliErrorOutput
             null,
             ex.InnerException?.Message,
             null,
+            null,
             null));
         return 1;
     }
@@ -31,6 +32,7 @@ internal static class CliErrorOutput
             response.ExceptionType,
             response.HResult,
             response.InnerError,
+            response.ErrorDetails,
             null,
             null));
         return 1;
@@ -49,6 +51,7 @@ internal static class CliErrorOutput
             response.ExceptionType,
             response.HResult,
             response.InnerError,
+            response.ErrorDetails,
             daemonState,
             running));
         return 1;
@@ -56,7 +59,7 @@ internal static class CliErrorOutput
 
     public static int WriteError(string errorMessage, string? errorCategory = null)
     {
-        Console.WriteLine(Serialize(errorMessage, errorCategory, null, null, null, null, null, null, null));
+        Console.WriteLine(Serialize(errorMessage, errorCategory, null, null, null, null, null, null, null, null));
         return 1;
     }
 
@@ -68,6 +71,7 @@ internal static class CliErrorOutput
         string? exceptionType,
         string? hresult,
         string? innerError,
+        string? errorDetails,
         string? daemonState,
         bool? running)
     {
@@ -83,9 +87,21 @@ internal static class CliErrorOutput
             ExceptionType = exceptionType,
             HResult = hresult,
             InnerError = innerError,
+            Details = DeserializeErrorDetails(errorDetails),
             DaemonState = daemonState,
             Running = running
         }, ServiceProtocol.JsonOptions);
+    }
+
+    private static JsonElement? DeserializeErrorDetails(string? errorDetails)
+    {
+        if (string.IsNullOrWhiteSpace(errorDetails))
+        {
+            return null;
+        }
+
+        using JsonDocument document = JsonDocument.Parse(errorDetails);
+        return document.RootElement.Clone();
     }
 
     private sealed class ErrorEnvelope
@@ -116,6 +132,9 @@ internal static class CliErrorOutput
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? InnerError { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public JsonElement? Details { get; init; }
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? DaemonState { get; init; }

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides 31 feature command categories with 326 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
+The CLI provides 31 feature command categories with 327 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|
@@ -48,7 +48,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## 📋 What You Can Do
 
-ExcelMcp.CLI provides **326 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
+ExcelMcp.CLI provides **327 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
 
 Drives the **actual Excel application** via COM — not a file-format parser — so live operations (Power Query refresh, recalculation, DAX evaluation, VBA execution) run for real and existing workbooks stay intact.
 

--- a/src/ExcelMcp.ComInterop/ServiceClient/ServiceProtocol.cs
+++ b/src/ExcelMcp.ComInterop/ServiceClient/ServiceProtocol.cs
@@ -80,8 +80,10 @@ public sealed class ServiceResponse
     /// <summary>Inner exception details, when available.</summary>
     public string? InnerError { get; init; }
 
+    /// <summary>JSON-serialized structured failure details, when available.</summary>
+    public string? ErrorDetails { get; init; }
+
     /// <summary>JSON-serialized result data.</summary>
     public string? Result { get; init; }
 }
-
 

--- a/src/ExcelMcp.ComInterop/Session/BatchExecutionCancellation.cs
+++ b/src/ExcelMcp.ComInterop/Session/BatchExecutionCancellation.cs
@@ -1,0 +1,54 @@
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+/// <summary>
+/// Carries transport cancellation into Core commands without exposing transport
+/// concerns on every generated command contract.
+/// </summary>
+public static class BatchExecutionCancellation
+{
+    private static readonly AsyncLocal<CancellationToken> CurrentToken = new();
+    private static readonly AsyncLocal<bool> CooperativeCleanup = new();
+
+    /// <summary>
+    /// Gets the cancellation token for the current service request.
+    /// </summary>
+    public static CancellationToken Current => CurrentToken.Value;
+
+    /// <summary>
+    /// Gets whether the current operation must finish bounded cleanup before returning.
+    /// </summary>
+    public static bool RequiresCooperativeCleanup => CooperativeCleanup.Value;
+
+    /// <summary>
+    /// Pushes a cancellation token for the current asynchronous request flow.
+    /// </summary>
+    public static IDisposable Push(
+        CancellationToken cancellationToken,
+        bool requiresCooperativeCleanup = false)
+    {
+        CancellationToken previous = CurrentToken.Value;
+        bool previousCleanup = CooperativeCleanup.Value;
+        CurrentToken.Value = cancellationToken;
+        CooperativeCleanup.Value = requiresCooperativeCleanup;
+        return new CancellationScope(previous, previousCleanup);
+    }
+
+    private sealed class CancellationScope(
+        CancellationToken previous,
+        bool previousCleanup) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            CurrentToken.Value = previous;
+            CooperativeCleanup.Value = previousCleanup;
+            _disposed = true;
+        }
+    }
+}

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -721,6 +721,24 @@ internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed != 0, nameof(ExcelBatch));
+        CancellationToken ambientCancellationToken = BatchExecutionCancellation.Current;
+        bool requiresCooperativeCleanup =
+            BatchExecutionCancellation.RequiresCooperativeCleanup
+            && !cancellationToken.CanBeCanceled;
+        bool usesAmbientCancellation =
+            requiresCooperativeCleanup && ambientCancellationToken.CanBeCanceled;
+        using var ambientTimeoutCts = requiresCooperativeCleanup
+            ? new CancellationTokenSource(_operationTimeout)
+            : null;
+        using var ambientLinkedCts = usesAmbientCancellation
+            ? CancellationTokenSource.CreateLinkedTokenSource(
+                ambientCancellationToken,
+                ambientTimeoutCts!.Token)
+            : null;
+        if (requiresCooperativeCleanup)
+        {
+            cancellationToken = ambientLinkedCts?.Token ?? ambientTimeoutCts!.Token;
+        }
 
         // Fail fast if a previous operation timed out or was cancelled while the STA thread
         // was stuck in IDispatch.Invoke. The STA thread cannot process new work items until
@@ -817,21 +835,87 @@ internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState
                 return tcs.Task.WaitAsync(timeoutCts.Token).GetAwaiter().GetResult();
             }
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (
+            requiresCooperativeCleanup
+                ? ambientTimeoutCts!.IsCancellationRequested
+                    && !ambientCancellationToken.IsCancellationRequested
+                : !cancellationToken.IsCancellationRequested)
         {
-            // Session timeout occurred (not caller cancellation) — only happens in the else branch
-            _logger.LogError("Operation timed out after {Timeout} for {FileName}", _operationTimeout, Path.GetFileName(_workbookPath));
-            _operationTimedOut = true; // Mark timeout for aggressive cleanup during disposal
+            if (!requiresCooperativeCleanup)
+            {
+                _logger.LogError(
+                    "Operation timed out after {Timeout} for {FileName}",
+                    _operationTimeout,
+                    Path.GetFileName(_workbookPath));
+                _operationTimedOut = true;
+                throw new TimeoutException(
+                    $"Excel operation timed out after {_operationTimeout.TotalSeconds} seconds for '{Path.GetFileName(_workbookPath)}'. " +
+                    "Excel may be unresponsive or the operation is taking longer than expected.");
+            }
+
+            _logger.LogDebug(
+                "Operation timeout reached for {FileName}; waiting for bounded cooperative cleanup",
+                Path.GetFileName(_workbookPath));
+            try
+            {
+                _ = tcs.Task
+                    .WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+                throw new TimeoutException(
+                    $"Excel operation timed out after {_operationTimeout.TotalSeconds} seconds for '{Path.GetFileName(_workbookPath)}', but cooperative cleanup completed.");
+            }
+            catch (TimeoutException)
+            {
+                _logger.LogError(
+                    "Operation timed out and cleanup did not complete for {FileName}",
+                    Path.GetFileName(_workbookPath));
+                _operationTimedOut = true;
+                throw new TimeoutException(
+                    $"Excel operation timed out after {_operationTimeout.TotalSeconds} seconds for '{Path.GetFileName(_workbookPath)}'. " +
+                    "Excel may be unresponsive and cleanup did not complete within 30 seconds.");
+            }
+
             throw new TimeoutException(
-                $"Excel operation timed out after {_operationTimeout.TotalSeconds} seconds for '{Path.GetFileName(_workbookPath)}'. " +
-                "Excel may be unresponsive or the operation is taking longer than expected. " +
-                "Consider increasing timeoutSeconds when opening the session.");
+                $"Excel operation exceeded the {_operationTimeout.TotalSeconds}-second timeout for '{Path.GetFileName(_workbookPath)}' and completed during cleanup grace.");
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (
+            requiresCooperativeCleanup
+                ? ambientCancellationToken.IsCancellationRequested
+                : cancellationToken.IsCancellationRequested)
         {
-            _logger.LogDebug("Operation cancelled or timed out for {FileName}", Path.GetFileName(_workbookPath));
-            _operationTimedOut = true; // STA thread may still be blocked — session is unusable
-            throw;
+            if (!requiresCooperativeCleanup)
+            {
+                _operationTimedOut = true;
+                throw;
+            }
+
+            _logger.LogDebug(
+                "Operation cancellation requested for {FileName}; waiting for bounded cooperative cleanup",
+                Path.GetFileName(_workbookPath));
+            try
+            {
+                _ = tcs.Task
+                    .WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            catch (TimeoutException)
+            {
+                _operationTimedOut = true;
+                throw new TimeoutException(
+                    $"Excel operation cancellation cleanup did not complete within 30 seconds for '{Path.GetFileName(_workbookPath)}'.");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+
+            throw new OperationCanceledException(
+                usesAmbientCancellation ? ambientCancellationToken : cancellationToken);
         }
     }
 

--- a/src/ExcelMcp.Core/Commands/Table/ITableCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Table/ITableCommands.cs
@@ -27,7 +27,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Table;
 /// </summary>
 [ServiceCategory("table", "Table")]
 [McpTool("table", Title = "Table Operations", Destructive = true, Category = "data",
-    Description = "Excel Tables (ListObjects) - lifecycle and data operations. SAFE CREATION: Use preflight to inspect merged cells, headers, excluded contiguous columns, formula-sort risks, and the effective range without changing the workbook. Create runs the same checks and rejects deterministic blockers; heuristic warnings remain advisory. CONVERT TO TABLE: Write data to a range, then use create. STYLING: Pass tableStyle on create or use set-style later; never apply range_format to table headers or data rows. Prefer append/resize/rename over delete+recreate. Deleting tables used by PivotTables or the Data Model breaks those objects. Use table_column for filtering, sorting, and columns.")]
+    Description = "Excel Tables (ListObjects) - lifecycle and data operations. SAFE CREATION: Use preflight to inspect a proposed range, or convert-range for explicit merged-header/header policies plus operation-level rollback and post-create validation. Create rejects deterministic preflight blockers; heuristic warnings remain advisory. STYLING: Pass tableStyle on create/convert-range or use set-style later; never apply range_format to table headers or data rows. Prefer append/resize/rename over delete+recreate. Deleting tables used by PivotTables or the Data Model breaks those objects. Use table_column for filtering, sorting, and columns.")]
 public interface ITableCommands
 {
     /// <summary>
@@ -47,6 +47,30 @@ public interface ITableCommands
     /// <param name="hasHeaders">True if the first row contains column headers (default: true)</param>
     [ServiceAction("preflight")]
     TablePreflightResult Preflight(IExcelBatch batch, string sheetName, string tableName, string rangeAddress, bool hasHeaders = true);
+
+    /// <summary>
+    /// Converts a range to a table as one operation with scoped rollback.
+    /// Preflights first, applies only explicitly requested header normalization,
+    /// validates the resulting table, and restores the source range if a later step fails.
+    /// This is not a workbook-wide transaction.
+    /// </summary>
+    /// <param name="sheetName">Name of the worksheet containing the source range</param>
+    /// <param name="tableName">Name for the new table (must be unique in workbook)</param>
+    /// <param name="rangeAddress">Cell range address, or one cell to expand to its CurrentRegion</param>
+    /// <param name="hasHeaders">Must be true. Use create for headerless ranges because Excel inserts a new header row.</param>
+    /// <param name="tableStyle">Optional table style name</param>
+    /// <param name="mergedHeaderPolicy">Report merged headers or explicitly unmerge and fill them</param>
+    /// <param name="headerPolicy">Report invalid headers or explicitly normalize them</param>
+    [ServiceAction("convert-range")]
+    TableRangeConversionResult ConvertRange(
+        IExcelBatch batch,
+        string sheetName,
+        string tableName,
+        string rangeAddress,
+        bool hasHeaders = true,
+        string? tableStyle = null,
+        [FromString] TableMergedHeaderPolicy mergedHeaderPolicy = TableMergedHeaderPolicy.Report,
+        [FromString] TableHeaderPolicy headerPolicy = TableHeaderPolicy.Report);
 
     /// <summary>
     /// Creates a new Excel Table from a range after running the same checks as Preflight.

--- a/src/ExcelMcp.Core/Commands/Table/TableCommands.ConvertRange.cs
+++ b/src/ExcelMcp.Core/Commands/Table/TableCommands.ConvertRange.cs
@@ -1,0 +1,1752 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
+using Sbroenne.ExcelMcp.Core.Models;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Table;
+
+/// <summary>
+/// Atomic range-to-table conversion.
+/// </summary>
+public partial class TableCommands
+{
+    private const string RollbackSheetPrefix = "__ExcelMcpTblRb_";
+
+    /// <inheritdoc />
+    public TableRangeConversionResult ConvertRange(
+        IExcelBatch batch,
+        string sheetName,
+        string tableName,
+        string rangeAddress,
+        bool hasHeaders = true,
+        string? tableStyle = null,
+        TableMergedHeaderPolicy mergedHeaderPolicy = TableMergedHeaderPolicy.Report,
+        TableHeaderPolicy headerPolicy = TableHeaderPolicy.Report)
+    {
+        ValidateCreateInputs(sheetName, tableName, rangeAddress);
+        ValidateConversionPolicies(hasHeaders, mergedHeaderPolicy, headerPolicy);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? effectiveRange = null;
+            dynamic? listObjects = null;
+            dynamic? newTable = null;
+            RangeRollbackSnapshot? snapshot = null;
+            var stage = TableConversionFailureStage.Preflight;
+            var sourceMutationStarted = false;
+            var result = new TableRangeConversionResult
+            {
+                FilePath = batch.WorkbookPath,
+                SheetName = sheetName,
+                TableName = tableName,
+                RequestedRange = rangeAddress,
+                MergedHeaderPolicy = mergedHeaderPolicy,
+                HeaderPolicy = headerPolicy
+            };
+
+            try
+            {
+                ct.ThrowIfCancellationRequested();
+                sheet = ComUtilities.FindSheet(ctx.Book, sheetName)
+                    ?? throw new InvalidOperationException($"Sheet '{sheetName}' not found.");
+                effectiveRange = ResolveEffectiveRange(sheet, rangeAddress);
+                result.EffectiveRange = effectiveRange.Address;
+
+                TablePreflightResult preflight = AnalyzePreflight(
+                    ctx.Book,
+                    effectiveRange,
+                    batch.WorkbookPath,
+                    sheetName,
+                    tableName,
+                    rangeAddress,
+                    hasHeaders,
+                    ct);
+                AddConversionOnlyBlockers(effectiveRange, preflight, ct);
+                result.PreflightFindings = preflight.Findings;
+
+                List<TablePreflightFinding> unhandledBlockers = GetUnhandledConversionBlockers(
+                    sheet,
+                    effectiveRange,
+                    preflight,
+                    hasHeaders,
+                    mergedHeaderPolicy,
+                    headerPolicy,
+                    ct);
+                if (unhandledBlockers.Count > 0)
+                {
+                    throw CreateConversionException(
+                        stage,
+                        result,
+                        $"Table '{tableName}' cannot be converted because preflight found blocking issues. " +
+                        string.Join(" ", unhandledBlockers.Select(finding => finding.Message)));
+                }
+
+                stage = TableConversionFailureStage.Snapshot;
+                ct.ThrowIfCancellationRequested();
+                snapshot = RangeRollbackSnapshot.Create(ctx.Book, sheet, effectiveRange, ct);
+
+                stage = TableConversionFailureStage.Normalization;
+                if (mergedHeaderPolicy == TableMergedHeaderPolicy.UnmergeAndFill)
+                {
+                    sourceMutationStarted |= preflight.Findings.Any(
+                        finding => finding.Kind == TablePreflightFindingKind.MergedCells
+                            && finding.Addresses.Count > 0);
+                    NormalizeMergedHeaders(
+                        sheet,
+                        effectiveRange,
+                        preflight,
+                        result.NormalizedMergedRanges,
+                        ct);
+                }
+
+                if (headerPolicy == TableHeaderPolicy.Normalize)
+                {
+                    sourceMutationStarted |= preflight.Findings.Any(
+                        finding => finding.Kind is TablePreflightFindingKind.BlankHeaders
+                            or TablePreflightFindingKind.DuplicateHeaders);
+                    NormalizeHeaders(
+                        effectiveRange,
+                        result.HeaderChanges,
+                        ct);
+                }
+
+                ct.ThrowIfCancellationRequested();
+                TablePreflightResult normalizedPreflight = AnalyzePreflight(
+                    ctx.Book,
+                    effectiveRange,
+                    batch.WorkbookPath,
+                    sheetName,
+                    tableName,
+                    rangeAddress,
+                    hasHeaders,
+                    ct);
+                List<TablePreflightFinding> remainingBlockers = normalizedPreflight.Findings
+                    .Where(finding => finding.Severity == TablePreflightSeverity.Blocker)
+                    .ToList();
+                if (remainingBlockers.Count > 0)
+                {
+                    throw new InvalidOperationException(
+                        "Explicit normalization did not resolve all table creation blockers. " +
+                        string.Join(" ", remainingBlockers.Select(finding => finding.Message)));
+                }
+
+                List<string> expectedHeaders = ReadHeaderValues(effectiveRange, ct);
+                stage = TableConversionFailureStage.Creation;
+                ct.ThrowIfCancellationRequested();
+                listObjects = sheet.ListObjects;
+                sourceMutationStarted = true;
+                int headerOption = hasHeaders ? 1 : 0;
+                newTable = listObjects.Add(1, effectiveRange, null, headerOption);
+                newTable.Name = tableName;
+
+                if (!string.IsNullOrWhiteSpace(tableStyle))
+                {
+                    stage = TableConversionFailureStage.Styling;
+                    ct.ThrowIfCancellationRequested();
+                    newTable.TableStyle = tableStyle;
+                }
+
+                stage = TableConversionFailureStage.Validation;
+                ct.ThrowIfCancellationRequested();
+                result.Validation = ValidateConvertedTable(
+                    newTable,
+                    effectiveRange,
+                    snapshot,
+                    tableName,
+                    tableStyle,
+                    hasHeaders,
+                    expectedHeaders,
+                    ct);
+                if (!result.Validation.IsValid)
+                {
+                    throw new InvalidOperationException(
+                        "The created table failed validation. " +
+                        string.Join(" ", result.Validation.Findings.Select(finding => finding.Message)));
+                }
+
+                result.Table = ReadConvertedTableInfo(newTable, sheetName, tableName);
+
+                stage = TableConversionFailureStage.Rollback;
+                snapshot.DeleteBackup();
+                result.Rollback = new TableRollbackResult();
+                result.Success = true;
+                return result;
+            }
+            catch (TableRangeConversionException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                var rollback = new TableRollbackResult
+                {
+                    Required = sourceMutationStarted,
+                    Attempted = sourceMutationStarted
+                };
+
+                if (sourceMutationStarted && snapshot != null && sheet != null && effectiveRange != null)
+                {
+                    var rollbackErrors = new List<string>();
+                    try
+                    {
+                        RemoveCreatedTable(sheet, effectiveRange, snapshot, ref newTable);
+                    }
+                    catch (Exception removeException)
+                    {
+                        rollbackErrors.Add(
+                            $"Created table removal failed: {removeException.GetType().Name}: {removeException.Message}");
+                    }
+
+                    try
+                    {
+                        snapshot.Restore(effectiveRange);
+                    }
+                    catch (Exception restoreException)
+                    {
+                        rollbackErrors.Add(
+                            $"Range restoration failed: {restoreException.GetType().Name}: {restoreException.Message}");
+                    }
+
+                    try
+                    {
+                        rollback.Verified = !TableExists(ctx.Book, tableName)
+                            && snapshot.Verify(effectiveRange, ct: CancellationToken.None);
+                        if (!rollback.Verified)
+                        {
+                            rollbackErrors.Add(
+                                "The restored range did not match the captured values, formulas, representative formatting, or merged ranges.");
+                        }
+                    }
+                    catch (Exception verificationException)
+                    {
+                        rollbackErrors.Add(
+                            $"Rollback verification failed: {verificationException.GetType().Name}: {verificationException.Message}");
+                    }
+
+                    if (rollback.Verified)
+                    {
+                        try
+                        {
+                            snapshot.DeleteBackup();
+                            rollback.Completed = true;
+                        }
+                        catch (Exception cleanupException)
+                        {
+                            rollback.Verified = false;
+                            rollbackErrors.Add(
+                                $"Rollback snapshot cleanup failed: {cleanupException.GetType().Name}: {cleanupException.Message}");
+                        }
+                    }
+
+                    if (!rollback.Verified)
+                    {
+                        rollback.RecoverySheetName = snapshot.BackupSheetName;
+                    }
+
+                    rollback.ErrorMessage = rollbackErrors.Count == 0
+                        ? null
+                        : string.Join(" ", rollbackErrors);
+                }
+                else if (snapshot != null)
+                {
+                    try
+                    {
+                        snapshot.DeleteBackup();
+                    }
+                    catch (Exception cleanupException)
+                    {
+                        rollback.ErrorMessage =
+                            $"Rollback snapshot cleanup failed: {cleanupException.GetType().Name}: {cleanupException.Message}";
+                        rollback.RecoverySheetName = snapshot.BackupSheetName;
+                    }
+                }
+
+                var failedStage = rollback.ErrorMessage != null
+                    ? TableConversionFailureStage.Rollback
+                    : stage;
+                if (ex is OperationCanceledException cancellationException)
+                {
+                    throw CreateConversionException(
+                        failedStage,
+                        result,
+                        BuildConversionFailureMessage(tableName, stage, cancellationException, rollback),
+                        rollback,
+                        cancellationException);
+                }
+
+                throw CreateConversionException(
+                    failedStage,
+                    result,
+                    BuildConversionFailureMessage(tableName, stage, ex, rollback),
+                    rollback,
+                    ex);
+            }
+            finally
+            {
+                snapshot?.Dispose();
+                ComUtilities.Release(ref newTable);
+                ComUtilities.Release(ref listObjects);
+                ComUtilities.Release(ref effectiveRange);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+    }
+
+    private static void ValidateConversionPolicies(
+        bool hasHeaders,
+        TableMergedHeaderPolicy mergedHeaderPolicy,
+        TableHeaderPolicy headerPolicy)
+    {
+        if (!Enum.IsDefined(mergedHeaderPolicy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(mergedHeaderPolicy));
+        }
+
+        if (!Enum.IsDefined(headerPolicy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(headerPolicy));
+        }
+
+        if (!hasHeaders)
+        {
+            throw new ArgumentException(
+                "convert-range requires hasHeaders=true because Excel inserts a new header row for headerless ranges. Use table create for headerless data.");
+        }
+    }
+
+    private static List<TablePreflightFinding> GetUnhandledConversionBlockers(
+        Excel.Worksheet sheet,
+        Excel.Range effectiveRange,
+        TablePreflightResult preflight,
+        bool hasHeaders,
+        TableMergedHeaderPolicy mergedHeaderPolicy,
+        TableHeaderPolicy headerPolicy,
+        CancellationToken ct)
+    {
+        var blockers = new List<TablePreflightFinding>();
+        foreach (TablePreflightFinding finding in preflight.Findings)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (finding.Severity != TablePreflightSeverity.Blocker)
+            {
+                continue;
+            }
+
+            bool handled = finding.Kind switch
+            {
+                TablePreflightFindingKind.MergedCells =>
+                    hasHeaders
+                    && mergedHeaderPolicy == TableMergedHeaderPolicy.UnmergeAndFill
+                    && finding.Addresses.All(address =>
+                        IsContainedHeaderMerge(sheet, effectiveRange, address)),
+                TablePreflightFindingKind.BlankHeaders
+                    or TablePreflightFindingKind.DuplicateHeaders =>
+                    hasHeaders && headerPolicy == TableHeaderPolicy.Normalize,
+                _ => false
+            };
+
+            if (!handled)
+            {
+                blockers.Add(finding);
+            }
+        }
+
+        return blockers;
+    }
+
+    private static void AddConversionOnlyBlockers(
+        Excel.Range effectiveRange,
+        TablePreflightResult preflight,
+        CancellationToken ct)
+    {
+        Excel.Range? rows = null;
+        Excel.Range? columns = null;
+        Excel.Range? headerRange = null;
+        Excel.Range? headerCells = null;
+        try
+        {
+            rows = effectiveRange.Rows;
+            columns = effectiveRange.Columns;
+            int rowCount = Convert.ToInt32(rows.Count, CultureInfo.InvariantCulture);
+            if (rowCount < 2)
+            {
+                preflight.Findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.HeaderOnlyRange,
+                    Severity = TablePreflightSeverity.Blocker,
+                    Addresses = [effectiveRange.Address],
+                    Message = "The effective range contains only a header row, so Excel would insert a data row and shift following cells.",
+                    Remediation = "Include at least one data row before converting the range."
+                });
+            }
+
+            headerRange = rows[1];
+            headerCells = headerRange.Cells;
+            int columnCount = Convert.ToInt32(columns.Count, CultureInfo.InvariantCulture);
+            var lossyAddresses = new List<string>();
+            for (int index = 1; index <= columnCount; index++)
+            {
+                ct.ThrowIfCancellationRequested();
+                Excel.Range? cell = null;
+                try
+                {
+                    cell = headerCells[1, index];
+                    object? value = cell.Value2;
+                    string formula = Convert.ToString(
+                        cell.Formula2,
+                        CultureInfo.InvariantCulture) ?? string.Empty;
+                    string text = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+                    if (formula.StartsWith('=')
+                        || value is not null and not DBNull and not string
+                        || text.Length > 255)
+                    {
+                        lossyAddresses.Add(cell.Address);
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref cell);
+                }
+            }
+
+            if (lossyAddresses.Count > 0)
+            {
+                preflight.Findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.LossyHeaders,
+                    Severity = TablePreflightSeverity.Blocker,
+                    Addresses = lossyAddresses,
+                    Message = "One or more headers contain formulas, non-text values, or more than 255 characters that Excel would silently convert or truncate.",
+                    Remediation = "Replace the listed headers with text values of at most 255 characters before converting."
+                });
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref headerCells);
+            ComUtilities.Release(ref headerRange);
+            ComUtilities.Release(ref columns);
+            ComUtilities.Release(ref rows);
+        }
+    }
+
+    private static bool IsContainedHeaderMerge(
+        Excel.Worksheet sheet,
+        Excel.Range effectiveRange,
+        string address)
+    {
+        Excel.Range? mergedRange = null;
+        Excel.Range? mergedRows = null;
+        Excel.Range? mergedColumns = null;
+        Excel.Range? effectiveRows = null;
+        Excel.Range? effectiveColumns = null;
+        try
+        {
+            mergedRange = sheet.Range[address];
+            mergedRows = mergedRange.Rows;
+            mergedColumns = mergedRange.Columns;
+            effectiveRows = effectiveRange.Rows;
+            effectiveColumns = effectiveRange.Columns;
+
+            int mergedRow = Convert.ToInt32(mergedRange.Row, CultureInfo.InvariantCulture);
+            int mergedColumn = Convert.ToInt32(mergedRange.Column, CultureInfo.InvariantCulture);
+            int mergedRowCount = Convert.ToInt32(mergedRows.Count, CultureInfo.InvariantCulture);
+            int mergedColumnCount = Convert.ToInt32(mergedColumns.Count, CultureInfo.InvariantCulture);
+            int effectiveRow = Convert.ToInt32(effectiveRange.Row, CultureInfo.InvariantCulture);
+            int effectiveColumn = Convert.ToInt32(effectiveRange.Column, CultureInfo.InvariantCulture);
+            int effectiveRowCount = Convert.ToInt32(effectiveRows.Count, CultureInfo.InvariantCulture);
+            int effectiveColumnCount = Convert.ToInt32(effectiveColumns.Count, CultureInfo.InvariantCulture);
+
+            return mergedRow == effectiveRow
+                && mergedRowCount == 1
+                && mergedColumn >= effectiveColumn
+                && mergedColumn + mergedColumnCount <= effectiveColumn + effectiveColumnCount
+                && mergedRow < effectiveRow + effectiveRowCount;
+        }
+        finally
+        {
+            ComUtilities.Release(ref effectiveColumns);
+            ComUtilities.Release(ref effectiveRows);
+            ComUtilities.Release(ref mergedColumns);
+            ComUtilities.Release(ref mergedRows);
+            ComUtilities.Release(ref mergedRange);
+        }
+    }
+
+    private static void NormalizeMergedHeaders(
+        Excel.Worksheet sheet,
+        Excel.Range effectiveRange,
+        TablePreflightResult preflight,
+        List<string> normalizedRanges,
+        CancellationToken ct)
+    {
+        TablePreflightFinding? mergedFinding = preflight.Findings.FirstOrDefault(
+            finding => finding.Kind == TablePreflightFindingKind.MergedCells);
+        if (mergedFinding == null)
+        {
+            return;
+        }
+
+        foreach (string address in mergedFinding.Addresses)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!IsContainedHeaderMerge(sheet, effectiveRange, address))
+            {
+                throw new InvalidOperationException(
+                    $"Merged range '{address}' is not wholly contained in the table header row.");
+            }
+
+            Excel.Range? mergedRange = null;
+            Excel.Range? mergedCells = null;
+            Excel.Range? firstCell = null;
+            try
+            {
+                mergedRange = sheet.Range[address];
+                mergedCells = mergedRange.Cells;
+                firstCell = mergedCells[1, 1];
+                object? value = firstCell.Value2;
+                mergedRange.UnMerge();
+                mergedRange.Value2 = value;
+                normalizedRanges.Add(address);
+            }
+            finally
+            {
+                ComUtilities.Release(ref firstCell);
+                ComUtilities.Release(ref mergedCells);
+                ComUtilities.Release(ref mergedRange);
+            }
+        }
+
+    }
+
+    private static void NormalizeHeaders(
+        Excel.Range effectiveRange,
+        List<TableHeaderChange> changes,
+        CancellationToken ct)
+    {
+        Excel.Range? rows = null;
+        Excel.Range? columns = null;
+        Excel.Range? headerRange = null;
+        Excel.Range? headerCells = null;
+        try
+        {
+            rows = effectiveRange.Rows;
+            columns = effectiveRange.Columns;
+            headerRange = rows[1];
+            headerCells = headerRange.Cells;
+            object values = headerRange.Value2;
+            int count = Convert.ToInt32(columns.Count, CultureInfo.InvariantCulture);
+            int row = Convert.ToInt32(effectiveRange.Row, CultureInfo.InvariantCulture);
+            int firstColumn = Convert.ToInt32(effectiveRange.Column, CultureInfo.InvariantCulture);
+            var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            for (int offset = 0; offset < count; offset++)
+            {
+                ct.ThrowIfCancellationRequested();
+                object? rawValue = GetMatrixValue(values, 0, offset);
+                string? original = Convert.ToString(rawValue, CultureInfo.InvariantCulture);
+                string trimmed = original?.Trim() ?? string.Empty;
+                TableHeaderChangeReason? reason = null;
+                string candidate = trimmed;
+
+                if (trimmed.Length == 0)
+                {
+                    reason = TableHeaderChangeReason.Blank;
+                    candidate = $"Column{offset + 1}";
+                }
+                else if (used.Contains(trimmed))
+                {
+                    reason = TableHeaderChangeReason.Duplicate;
+                    candidate = trimmed;
+                }
+
+                string unique = EnsureUniqueHeader(candidate, used);
+                if (reason.HasValue || !string.Equals(unique, candidate, StringComparison.Ordinal))
+                {
+                    reason ??= TableHeaderChangeReason.Duplicate;
+                    Excel.Range? cell = null;
+                    try
+                    {
+                        cell = headerCells[1, offset + 1];
+                        cell.Value2 = unique;
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref cell);
+                    }
+
+                    changes.Add(new TableHeaderChange
+                    {
+                        Address = GetAbsoluteAddress(firstColumn + offset, row),
+                        OriginalValue = original,
+                        NewValue = unique,
+                        Reason = reason.Value
+                    });
+                }
+
+                used.Add(unique);
+            }
+
+        }
+        finally
+        {
+            ComUtilities.Release(ref headerCells);
+            ComUtilities.Release(ref headerRange);
+            ComUtilities.Release(ref columns);
+            ComUtilities.Release(ref rows);
+        }
+    }
+
+    private static string EnsureUniqueHeader(string candidate, HashSet<string> used)
+    {
+        if (!used.Contains(candidate))
+        {
+            return candidate;
+        }
+
+        for (int suffix = 2; ; suffix++)
+        {
+            string suffixText = $"_{suffix}";
+            int maximumBaseLength = 255 - suffixText.Length;
+            string baseName = candidate.Length > maximumBaseLength
+                ? candidate[..maximumBaseLength]
+                : candidate;
+            string unique = baseName + suffixText;
+            if (!used.Contains(unique))
+            {
+                return unique;
+            }
+        }
+    }
+
+    private static List<string> ReadHeaderValues(
+        Excel.Range effectiveRange,
+        CancellationToken ct)
+    {
+        Excel.Range? rows = null;
+        Excel.Range? columns = null;
+        Excel.Range? headerRange = null;
+        try
+        {
+            rows = effectiveRange.Rows;
+            columns = effectiveRange.Columns;
+            headerRange = rows[1];
+            object values = headerRange.Value2;
+            int count = Convert.ToInt32(columns.Count, CultureInfo.InvariantCulture);
+            var headers = new List<string>(count);
+            for (int offset = 0; offset < count; offset++)
+            {
+                ct.ThrowIfCancellationRequested();
+                headers.Add(
+                    Convert.ToString(
+                        GetMatrixValue(values, 0, offset),
+                        CultureInfo.InvariantCulture) ?? string.Empty);
+            }
+
+            return headers;
+        }
+        finally
+        {
+            ComUtilities.Release(ref headerRange);
+            ComUtilities.Release(ref columns);
+            ComUtilities.Release(ref rows);
+        }
+    }
+
+    private static TableConversionValidationResult ValidateConvertedTable(
+        dynamic table,
+        Excel.Range effectiveRange,
+        RangeRollbackSnapshot snapshot,
+        string expectedName,
+        string? expectedStyle,
+        bool hasHeaders,
+        IReadOnlyList<string> expectedHeaders,
+        CancellationToken ct)
+    {
+        var validation = new TableConversionValidationResult();
+        Excel.Range? tableRange = null;
+        Excel.Range? dataBodyRange = null;
+        dynamic? tableStyle = null;
+        try
+        {
+            tableRange = table.Range;
+            string actualRange = tableRange.Address;
+            string actualName = table.Name;
+            if (!string.Equals(actualName, expectedName, StringComparison.Ordinal)
+                || !string.Equals(actualRange, effectiveRange.Address, StringComparison.OrdinalIgnoreCase))
+            {
+                validation.Findings.Add(new TableConversionValidationFinding
+                {
+                    Kind = TableConversionValidationFindingKind.TableMismatch,
+                    Addresses = [actualRange],
+                    Message = $"Created table identity or range did not match '{expectedName}' at '{effectiveRange.Address}'."
+                });
+            }
+
+            if (!string.IsNullOrWhiteSpace(expectedStyle))
+            {
+                tableStyle = table.TableStyle;
+                string actualStyle = tableStyle?.Name?.ToString() ?? string.Empty;
+                if (!string.Equals(actualStyle, expectedStyle, StringComparison.OrdinalIgnoreCase))
+                {
+                    validation.Findings.Add(new TableConversionValidationFinding
+                    {
+                        Kind = TableConversionValidationFindingKind.StyleMismatch,
+                        Addresses = [actualRange],
+                        Message = $"Table style '{expectedStyle}' was not applied."
+                    });
+                }
+
+            }
+
+            List<string> actualHeaders = ReadTableColumnNames(table);
+            if (!actualHeaders.SequenceEqual(expectedHeaders, StringComparer.Ordinal))
+            {
+                validation.Findings.Add(new TableConversionValidationFinding
+                {
+                    Kind = TableConversionValidationFindingKind.TableMismatch,
+                    Addresses = [actualRange],
+                    Message = "Excel changed one or more table headers during conversion."
+                });
+            }
+
+            validation.ShowTotals = table.ShowTotals;
+            if (validation.ShowTotals)
+            {
+                validation.Findings.Add(new TableConversionValidationFinding
+                {
+                    Kind = TableConversionValidationFindingKind.UnexpectedTotalsRow,
+                    Addresses = [actualRange],
+                    Message = "Excel unexpectedly enabled a totals row during range conversion."
+                });
+            }
+
+            if (!snapshot.SourceContentMatches(effectiveRange, hasHeaders, ct))
+            {
+                validation.Findings.Add(new TableConversionValidationFinding
+                {
+                    Kind = TableConversionValidationFindingKind.SourceContentChanged,
+                    Addresses = [effectiveRange.Address],
+                    Message = "Non-header source values or formulas changed during table creation."
+                });
+            }
+
+            dataBodyRange = table.DataBodyRange;
+            if (dataBodyRange != null)
+            {
+                InspectCalculatedColumns(table, dataBodyRange, validation, ct);
+            }
+
+            validation.IsValid = validation.Findings.Count == 0;
+            return validation;
+        }
+        finally
+        {
+            ComUtilities.Release(ref tableStyle);
+            ComUtilities.Release(ref dataBodyRange);
+            ComUtilities.Release(ref tableRange);
+        }
+    }
+
+    private static void InspectCalculatedColumns(
+        dynamic table,
+        Excel.Range dataBodyRange,
+        TableConversionValidationResult validation,
+        CancellationToken ct)
+    {
+        Excel.Range? rows = null;
+        Excel.Range? columnsRange = null;
+        dynamic? listColumns = null;
+        try
+        {
+            rows = dataBodyRange.Rows;
+            columnsRange = dataBodyRange.Columns;
+            listColumns = table.ListColumns;
+            int rowCount = Convert.ToInt32(rows.Count, CultureInfo.InvariantCulture);
+            int columnCount = Convert.ToInt32(columnsRange.Count, CultureInfo.InvariantCulture);
+            int firstRow = Convert.ToInt32(dataBodyRange.Row, CultureInfo.InvariantCulture);
+            int firstColumn = Convert.ToInt32(dataBodyRange.Column, CultureInfo.InvariantCulture);
+            object formulas = dataBodyRange.FormulaR1C1;
+            dataBodyRange.Calculate();
+            AddFormulaErrorFindings(dataBodyRange, validation, ct);
+
+            for (int columnOffset = 0; columnOffset < columnCount; columnOffset++)
+            {
+                string? pattern = null;
+                var formulaAddresses = new List<string>();
+                var inconsistentAddresses = new List<string>();
+
+                for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    object? formulaValue = GetMatrixValue(formulas, rowOffset, columnOffset);
+                    string formula = Convert.ToString(formulaValue, CultureInfo.InvariantCulture) ?? string.Empty;
+                    string address = GetAbsoluteAddress(firstColumn + columnOffset, firstRow + rowOffset);
+                    if (!formula.StartsWith('='))
+                    {
+                        if (pattern != null)
+                        {
+                            inconsistentAddresses.Add(address);
+                        }
+
+                        continue;
+                    }
+
+                    validation.FormulaCellsChecked++;
+                    formulaAddresses.Add(address);
+                    if (pattern == null)
+                    {
+                        pattern = formula;
+                    }
+                    else if (!string.Equals(pattern, formula, StringComparison.Ordinal))
+                    {
+                        inconsistentAddresses.Add(address);
+                    }
+                }
+
+                if (formulaAddresses.Count == 0)
+                {
+                    continue;
+                }
+
+                if (formulaAddresses.Count != rowCount)
+                {
+                    for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+                    {
+                        string formula = Convert.ToString(
+                            GetMatrixValue(formulas, rowOffset, columnOffset),
+                            CultureInfo.InvariantCulture) ?? string.Empty;
+                        if (!formula.StartsWith('='))
+                        {
+                            inconsistentAddresses.Add(
+                                GetAbsoluteAddress(firstColumn + columnOffset, firstRow + rowOffset));
+                        }
+                    }
+                }
+
+                if (inconsistentAddresses.Count > 0)
+                {
+                    validation.Findings.Add(new TableConversionValidationFinding
+                    {
+                        Kind = TableConversionValidationFindingKind.InconsistentCalculatedColumn,
+                        Addresses = inconsistentAddresses.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                        Message = "A formula-bearing table column is not a consistent calculated column."
+                    });
+                    continue;
+                }
+
+                dynamic? column = null;
+                try
+                {
+                    column = listColumns.Item(columnOffset + 1);
+                    validation.CalculatedColumns.Add(column.Name?.ToString() ?? string.Empty);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref column);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref listColumns);
+            ComUtilities.Release(ref columnsRange);
+            ComUtilities.Release(ref rows);
+        }
+    }
+
+    private static void AddFormulaErrorFindings(
+        Excel.Range dataBodyRange,
+        TableConversionValidationResult validation,
+        CancellationToken ct)
+    {
+        const int ExcelNoCellsFound = unchecked((int)0x800A03EC);
+        Excel.Range? errorCells = null;
+        try
+        {
+            errorCells = dataBodyRange.SpecialCells(
+                Excel.XlCellType.xlCellTypeFormulas,
+                Excel.XlSpecialCellsValue.xlErrors);
+            string address = errorCells.Address;
+            validation.Findings.Add(new TableConversionValidationFinding
+            {
+                Kind = TableConversionValidationFindingKind.FormulaError,
+                Addresses = [address],
+                Message = $"Formula cells '{address}' evaluate to Excel errors."
+            });
+        }
+        catch (COMException ex) when (ex.HResult == ExcelNoCellsFound)
+        {
+            List<string> addresses = FindFormulaErrorsByCell(dataBodyRange, ct);
+            if (addresses.Count > 0)
+            {
+                validation.Findings.Add(new TableConversionValidationFinding
+                {
+                    Kind = TableConversionValidationFindingKind.FormulaError,
+                    Addresses = addresses,
+                    Message = $"Formula cells '{string.Join(", ", addresses)}' evaluate to Excel errors."
+                });
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref errorCells);
+        }
+    }
+
+    private static List<string> FindFormulaErrorsByCell(
+        Excel.Range dataBodyRange,
+        CancellationToken ct)
+    {
+        Excel.Range? rows = null;
+        Excel.Range? columns = null;
+        Excel.Range? cells = null;
+        var addresses = new List<string>();
+        try
+        {
+            rows = dataBodyRange.Rows;
+            columns = dataBodyRange.Columns;
+            cells = dataBodyRange.Cells;
+            int rowCount = Convert.ToInt32(rows.Count, CultureInfo.InvariantCulture);
+            int columnCount = Convert.ToInt32(columns.Count, CultureInfo.InvariantCulture);
+            for (int row = 1; row <= rowCount; row++)
+            {
+                for (int column = 1; column <= columnCount; column++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    Excel.Range? cell = null;
+                    try
+                    {
+                        cell = cells[row, column];
+                        string formula = Convert.ToString(
+                            cell.Formula2,
+                            CultureInfo.InvariantCulture) ?? string.Empty;
+                        if (!formula.StartsWith('='))
+                        {
+                            continue;
+                        }
+
+                        object? value = cell.Value2;
+                        string text = Convert.ToString(cell.Text, CultureInfo.InvariantCulture) ?? string.Empty;
+                        if (value is ErrorWrapper
+                            || value is not string && IsExcelErrorText(text))
+                        {
+                            addresses.Add(cell.Address);
+                        }
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref cell);
+                    }
+                }
+            }
+
+            return addresses;
+        }
+        finally
+        {
+            ComUtilities.Release(ref cells);
+            ComUtilities.Release(ref columns);
+            ComUtilities.Release(ref rows);
+        }
+    }
+
+    private static bool IsExcelErrorText(string text)
+    {
+        string[] errors =
+        [
+            "#NULL!",
+            "#DIV/0!",
+            "#VALUE!",
+            "#REF!",
+            "#NAME?",
+            "#NUM!",
+            "#N/A",
+            "#GETTING_DATA",
+            "#SPILL!",
+            "#CALC!",
+            "#FIELD!",
+            "#BLOCKED!",
+            "#UNKNOWN!",
+            "#CONNECT!",
+            "#BUSY!"
+        ];
+        return errors.Any(error => text.StartsWith(error, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static List<string> ReadTableColumnNames(dynamic table)
+    {
+        dynamic? columns = null;
+        try
+        {
+            columns = table.ListColumns;
+            var names = new List<string>();
+            for (int index = 1; index <= columns.Count; index++)
+            {
+                dynamic? column = null;
+                try
+                {
+                    column = columns.Item(index);
+                    names.Add(column.Name?.ToString() ?? string.Empty);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref column);
+                }
+            }
+
+            return names;
+        }
+        finally
+        {
+            ComUtilities.Release(ref columns);
+        }
+    }
+
+    private static TableInfo ReadConvertedTableInfo(dynamic table, string sheetName, string tableName)
+    {
+        Excel.Range? tableRange = null;
+        Excel.Range? dataBodyRange = null;
+        Excel.Range? dataBodyRows = null;
+        dynamic? columns = null;
+        dynamic? tableStyle = null;
+        try
+        {
+            tableRange = table.Range;
+            dataBodyRange = table.DataBodyRange;
+            dataBodyRows = dataBodyRange?.Rows;
+            columns = table.ListColumns;
+            tableStyle = table.TableStyle;
+            var names = new List<string>();
+            for (int index = 1; index <= columns.Count; index++)
+            {
+                dynamic? column = null;
+                try
+                {
+                    column = columns.Item(index);
+                    names.Add(column.Name?.ToString() ?? string.Empty);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref column);
+                }
+            }
+
+            return new TableInfo
+            {
+                Name = tableName,
+                SheetName = sheetName,
+                Range = tableRange.Address,
+                HasHeaders = table.ShowHeaders,
+                TableStyle = tableStyle?.Name?.ToString() ?? string.Empty,
+                RowCount = dataBodyRows == null ? 0 : Convert.ToInt32(dataBodyRows.Count, CultureInfo.InvariantCulture),
+                ColumnCount = Convert.ToInt32(columns.Count, CultureInfo.InvariantCulture),
+                Columns = names,
+                ShowTotals = table.ShowTotals
+            };
+        }
+        finally
+        {
+            ComUtilities.Release(ref tableStyle);
+            ComUtilities.Release(ref columns);
+            ComUtilities.Release(ref dataBodyRows);
+            ComUtilities.Release(ref dataBodyRange);
+            ComUtilities.Release(ref tableRange);
+        }
+    }
+
+    private static void RemoveCreatedTable(
+        Excel.Worksheet sheet,
+        Excel.Range effectiveRange,
+        RangeRollbackSnapshot snapshot,
+        ref dynamic? table)
+    {
+        if (table != null)
+        {
+            table.Unlist();
+            ComUtilities.Release(ref table);
+            return;
+        }
+
+        dynamic? listObjects = null;
+        try
+        {
+            listObjects = sheet.ListObjects;
+            for (int index = listObjects.Count; index >= 1; index--)
+            {
+                dynamic? candidate = null;
+                Excel.Range? candidateRange = null;
+                try
+                {
+                    candidate = listObjects.Item(index);
+                    string candidateName = candidate.Name?.ToString() ?? string.Empty;
+                    candidateRange = candidate.Range;
+                    if (!snapshot.ExistingTableNames.Contains(candidateName)
+                        && string.Equals(
+                            candidateRange.Address,
+                            effectiveRange.Address,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        candidate.Unlist();
+                        return;
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref candidateRange);
+                    ComUtilities.Release(ref candidate);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref listObjects);
+        }
+    }
+
+    private static TableRangeConversionException CreateConversionException(
+        TableConversionFailureStage stage,
+        TableRangeConversionResult result,
+        string message,
+        TableRollbackResult? rollback = null,
+        Exception? innerException = null)
+    {
+        return new TableRangeConversionException(
+            message,
+            new TableRangeConversionFailureDetails
+            {
+                FailureStage = stage,
+                WasCancelled = innerException is OperationCanceledException
+                    && BatchExecutionCancellation.Current.IsCancellationRequested,
+                WasTimedOut = innerException is OperationCanceledException
+                    && !BatchExecutionCancellation.Current.IsCancellationRequested,
+                SheetName = result.SheetName,
+                TableName = result.TableName,
+                RequestedRange = result.RequestedRange,
+                EffectiveRange = string.IsNullOrEmpty(result.EffectiveRange) ? null : result.EffectiveRange,
+                PreflightFindings = result.PreflightFindings,
+                HeaderChanges = result.HeaderChanges,
+                Validation = result.Validation,
+                Rollback = rollback ?? result.Rollback
+            },
+            innerException);
+    }
+
+    private static string BuildConversionFailureMessage(
+        string tableName,
+        TableConversionFailureStage stage,
+        Exception exception,
+        TableRollbackResult rollback)
+    {
+        string rollbackStatus = !rollback.Required
+            ? "No source rollback was required."
+            : rollback.Verified
+                ? "The original range state was restored and verified."
+                : $"The original range state could not be fully verified after rollback. {rollback.ErrorMessage}";
+        return $"Table '{tableName}' conversion failed during {stage}. " +
+            $"{exception.GetType().Name}: {exception.Message} {rollbackStatus}";
+    }
+
+    private sealed class RangeRollbackSnapshot : IDisposable
+    {
+        private readonly Excel.Worksheet _sourceSheet;
+        private readonly object? _formulaState;
+        private readonly object? _valueState;
+        private readonly object? _numberFormatState;
+        private readonly List<string> _mergedRanges;
+        private Excel.Worksheet? _backupSheet;
+        private Excel.Range? _backupRange;
+        private bool _deleted;
+
+        private RangeRollbackSnapshot(
+            Excel.Worksheet sourceSheet,
+            object? formulaState,
+            object? valueState,
+            object? numberFormatState,
+            List<string> mergedRanges,
+            HashSet<string> existingTableNames,
+            Excel.Worksheet backupSheet,
+            Excel.Range backupRange)
+        {
+            _sourceSheet = sourceSheet;
+            _formulaState = formulaState;
+            _valueState = valueState;
+            _numberFormatState = numberFormatState;
+            _mergedRanges = mergedRanges;
+            ExistingTableNames = existingTableNames;
+            _backupSheet = backupSheet;
+            _backupRange = backupRange;
+        }
+
+        internal HashSet<string> ExistingTableNames { get; }
+
+        internal string? BackupSheetName => _backupSheet?.Name;
+
+        internal static RangeRollbackSnapshot Create(
+            Excel.Workbook workbook,
+            Excel.Worksheet sourceSheet,
+            Excel.Range sourceRange,
+            CancellationToken ct)
+        {
+            Excel.Sheets? worksheets = null;
+            Excel.Worksheet? afterSheet = null;
+            Excel.Worksheet? backupSheet = null;
+            Excel.Range? backupRange = null;
+            try
+            {
+                ct.ThrowIfCancellationRequested();
+                object? formulas = sourceRange.Formula2;
+                object? values = sourceRange.Value2;
+                object? numberFormats = sourceRange.NumberFormat;
+                List<string> merges = RangeMergeDiscovery.CollectMergedRanges(sourceRange, ct);
+                HashSet<string> existingTables = CollectTableNames(workbook, ct);
+
+                worksheets = workbook.Worksheets;
+                afterSheet = (Excel.Worksheet)worksheets[worksheets.Count];
+                backupSheet = (Excel.Worksheet)worksheets.Add(After: afterSheet);
+                backupSheet.Name = CreateUniqueRollbackSheetName(workbook);
+                backupSheet.Visible = Excel.XlSheetVisibility.xlSheetVeryHidden;
+                backupRange = backupSheet.Range[sourceRange.Address];
+                sourceRange.Copy(backupRange);
+                backupRange.Formula2 = formulas;
+                var snapshot = new RangeRollbackSnapshot(
+                    sourceSheet,
+                    formulas,
+                    values,
+                    numberFormats,
+                    merges,
+                    existingTables,
+                    backupSheet,
+                    backupRange);
+                backupSheet = null;
+                backupRange = null;
+                return snapshot;
+            }
+            catch (Exception snapshotException)
+            {
+                if (backupSheet != null)
+                {
+                    try
+                    {
+                        TryDeleteSheet(backupSheet);
+                    }
+                    catch (Exception cleanupException)
+                    {
+                        throw new AggregateException(
+                            "Rollback snapshot creation and cleanup both failed.",
+                            snapshotException,
+                            cleanupException);
+                    }
+                }
+
+                throw;
+            }
+            finally
+            {
+                ComUtilities.Release(ref backupRange);
+                ComUtilities.Release(ref backupSheet);
+                ComUtilities.Release(ref afterSheet);
+                ComUtilities.Release(ref worksheets);
+            }
+        }
+
+        internal void Restore(Excel.Range targetRange)
+        {
+            if (_backupRange == null)
+            {
+                throw new InvalidOperationException("The rollback snapshot is no longer available.");
+            }
+
+            targetRange.UnMerge();
+            targetRange.Clear();
+            _backupRange.Copy(targetRange);
+            targetRange.UnMerge();
+            targetRange.Formula2 = _formulaState;
+
+            foreach (string address in _mergedRanges)
+            {
+                Excel.Range? mergedRange = null;
+                try
+                {
+                    mergedRange = _sourceSheet.Range[address];
+                    mergedRange.Merge();
+                }
+                finally
+                {
+                    ComUtilities.Release(ref mergedRange);
+                }
+            }
+        }
+
+        internal bool Verify(Excel.Range targetRange, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Excel.Range? backupRange = _backupRange;
+            if (backupRange == null)
+            {
+                return false;
+            }
+
+            return ContentStateEquals(targetRange)
+                && StateEquals(_numberFormatState, targetRange.NumberFormat)
+                && FormatsEqual(backupRange, targetRange, ct)
+                && MergedRangesEqual(targetRange, ct);
+        }
+
+        internal bool SourceContentMatches(
+            Excel.Range currentRange,
+            bool hasHeaders,
+            CancellationToken ct)
+        {
+            Excel.Range? rows = null;
+            Excel.Range? dataRange = null;
+            Excel.Range? dataColumns = null;
+            try
+            {
+                rows = currentRange.Rows;
+                int rowCount = Convert.ToInt32(rows.Count, CultureInfo.InvariantCulture);
+                int firstDataRow = hasHeaders ? 2 : 1;
+                if (rowCount < firstDataRow)
+                {
+                    return true;
+                }
+
+                dataRange = rows[$"{firstDataRow}:{rowCount}"];
+                dataColumns = dataRange.Columns;
+                object currentFormulas = dataRange.Formula2;
+                int columnCount = Convert.ToInt32(dataColumns.Count, CultureInfo.InvariantCulture);
+                int dataRowCount = rowCount - firstDataRow + 1;
+
+                for (int rowOffset = 0; rowOffset < dataRowCount; rowOffset++)
+                {
+                    for (int columnOffset = 0; columnOffset < columnCount; columnOffset++)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        int snapshotRowOffset = rowOffset + firstDataRow - 1;
+                        object? originalFormula = GetMatrixValue(_formulaState!, snapshotRowOffset, columnOffset);
+                        object? currentFormula = GetMatrixValue(currentFormulas, rowOffset, columnOffset);
+                        bool originallyFormula = Convert.ToString(
+                            originalFormula,
+                            CultureInfo.InvariantCulture)?.StartsWith('=') == true;
+                        if (originallyFormula)
+                        {
+                            if (Convert.ToString(currentFormula, CultureInfo.InvariantCulture)?.StartsWith('=') != true)
+                            {
+                                return false;
+                            }
+                        }
+                        else if (!ScalarEquals(originalFormula, currentFormula))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+            finally
+            {
+                ComUtilities.Release(ref dataColumns);
+                ComUtilities.Release(ref dataRange);
+                ComUtilities.Release(ref rows);
+            }
+        }
+
+        private bool ContentStateEquals(Excel.Range targetRange)
+        {
+            Excel.Range? rows = null;
+            Excel.Range? columns = null;
+            try
+            {
+                rows = targetRange.Rows;
+                columns = targetRange.Columns;
+                int rowCount = Convert.ToInt32(rows.Count, CultureInfo.InvariantCulture);
+                int columnCount = Convert.ToInt32(columns.Count, CultureInfo.InvariantCulture);
+                object currentFormulas = targetRange.Formula2;
+                object currentValues = targetRange.Value2;
+
+                for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+                {
+                    for (int columnOffset = 0; columnOffset < columnCount; columnOffset++)
+                    {
+                        object? originalFormula = GetMatrixValue(
+                            _formulaState!,
+                            rowOffset,
+                            columnOffset);
+                        object? currentFormula = GetMatrixValue(
+                            currentFormulas,
+                            rowOffset,
+                            columnOffset);
+                        bool isFormula = Convert.ToString(
+                            originalFormula,
+                            CultureInfo.InvariantCulture)?.StartsWith('=') == true;
+                        if (isFormula)
+                        {
+                            if (!ScalarEquals(originalFormula, currentFormula))
+                            {
+                                return false;
+                            }
+                        }
+                        else if (!ScalarEquals(
+                            GetMatrixValue(_valueState!, rowOffset, columnOffset),
+                            GetMatrixValue(currentValues, rowOffset, columnOffset)))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+            finally
+            {
+                ComUtilities.Release(ref columns);
+                ComUtilities.Release(ref rows);
+            }
+        }
+
+        internal void DeleteBackup()
+        {
+            if (_deleted)
+            {
+                return;
+            }
+
+            if (_backupSheet != null)
+            {
+                TryDeleteSheet(_backupSheet);
+            }
+
+            ComUtilities.Release(ref _backupRange);
+            ComUtilities.Release(ref _backupSheet);
+            _deleted = true;
+        }
+
+        public void Dispose()
+        {
+            ComUtilities.Release(ref _backupRange);
+            ComUtilities.Release(ref _backupSheet);
+        }
+
+        private bool MergedRangesEqual(Excel.Range targetRange, CancellationToken ct)
+        {
+            List<string> restored = RangeMergeDiscovery.CollectMergedRanges(targetRange, ct);
+            return _mergedRanges.OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                .SequenceEqual(
+                    restored.OrderBy(value => value, StringComparer.OrdinalIgnoreCase),
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static bool FormatsEqual(
+            Excel.Range expectedRange,
+            Excel.Range actualRange,
+            CancellationToken ct)
+        {
+            Excel.Range? expectedRows = null;
+            Excel.Range? expectedColumns = null;
+            Excel.Range? expectedCells = null;
+            Excel.Range? actualRows = null;
+            Excel.Range? actualColumns = null;
+            Excel.Range? actualCells = null;
+            try
+            {
+                expectedRows = expectedRange.Rows;
+                expectedColumns = expectedRange.Columns;
+                expectedCells = expectedRange.Cells;
+                actualRows = actualRange.Rows;
+                actualColumns = actualRange.Columns;
+                actualCells = actualRange.Cells;
+                int rowCount = Convert.ToInt32(expectedRows.Count, CultureInfo.InvariantCulture);
+                int columnCount = Convert.ToInt32(expectedColumns.Count, CultureInfo.InvariantCulture);
+                if (rowCount != Convert.ToInt32(actualRows.Count, CultureInfo.InvariantCulture)
+                    || columnCount != Convert.ToInt32(actualColumns.Count, CultureInfo.InvariantCulture))
+                {
+                    return false;
+                }
+
+                for (int row = 1; row <= rowCount; row++)
+                {
+                    for (int column = 1; column <= columnCount; column++)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        if (CaptureCellFormat(expectedCells, row, column)
+                            != CaptureCellFormat(actualCells, row, column))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+            finally
+            {
+                ComUtilities.Release(ref actualCells);
+                ComUtilities.Release(ref actualColumns);
+                ComUtilities.Release(ref actualRows);
+                ComUtilities.Release(ref expectedCells);
+                ComUtilities.Release(ref expectedColumns);
+                ComUtilities.Release(ref expectedRows);
+            }
+        }
+
+        private static CellFormatSample CaptureCellFormat(
+            Excel.Range cells,
+            int row,
+            int column)
+        {
+            Excel.Range? cell = null;
+            Excel.Font? font = null;
+            Excel.Interior? interior = null;
+            Excel.Borders? borders = null;
+            try
+            {
+                cell = cells[row, column];
+                font = cell.Font;
+                interior = cell.Interior;
+                borders = cell.Borders;
+                return new CellFormatSample(
+                    row,
+                    column,
+                    FormatValue(cell.NumberFormat),
+                    FormatValue(cell.Style),
+                    FormatValue(cell.HorizontalAlignment),
+                    FormatValue(cell.VerticalAlignment),
+                    FormatValue(cell.WrapText),
+                    FormatValue(font.Name),
+                    FormatValue(font.Size),
+                    FormatValue(font.Bold),
+                    FormatValue(font.Italic),
+                    FormatValue(font.Color),
+                    FormatValue(interior.Color),
+                    FormatValue(interior.Pattern),
+                    CaptureBorder(borders, Excel.XlBordersIndex.xlEdgeLeft),
+                    CaptureBorder(borders, Excel.XlBordersIndex.xlEdgeTop),
+                    CaptureBorder(borders, Excel.XlBordersIndex.xlEdgeRight),
+                    CaptureBorder(borders, Excel.XlBordersIndex.xlEdgeBottom));
+            }
+            finally
+            {
+                ComUtilities.Release(ref borders);
+                ComUtilities.Release(ref interior);
+                ComUtilities.Release(ref font);
+                ComUtilities.Release(ref cell);
+            }
+        }
+
+        private static BorderFormatSample CaptureBorder(
+            Excel.Borders borders,
+            Excel.XlBordersIndex index)
+        {
+            Excel.Border? border = null;
+            try
+            {
+                border = borders[index];
+                return new BorderFormatSample(
+                    FormatValue(border.LineStyle),
+                    FormatValue(border.Weight),
+                    FormatValue(border.Color));
+            }
+            finally
+            {
+                ComUtilities.Release(ref border);
+            }
+        }
+
+        private static string FormatValue(object? value)
+        {
+            if (value is null or DBNull)
+            {
+                return "<null>";
+            }
+
+            return Convert.ToString(value, CultureInfo.InvariantCulture) ?? "<null>";
+        }
+
+        private static HashSet<string> CollectTableNames(Excel.Workbook workbook, CancellationToken ct)
+        {
+            Excel.Sheets? sheets = null;
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                sheets = workbook.Worksheets;
+                for (int sheetIndex = 1; sheetIndex <= sheets.Count; sheetIndex++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    Excel.Worksheet? sheet = null;
+                    dynamic? tables = null;
+                    try
+                    {
+                        sheet = (Excel.Worksheet)sheets[sheetIndex];
+                        tables = sheet.ListObjects;
+                        for (int tableIndex = 1; tableIndex <= tables.Count; tableIndex++)
+                        {
+                            dynamic? table = null;
+                            try
+                            {
+                                table = tables.Item(tableIndex);
+                                names.Add(table.Name?.ToString() ?? string.Empty);
+                            }
+                            finally
+                            {
+                                ComUtilities.Release(ref table);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref tables);
+                        ComUtilities.Release(ref sheet);
+                    }
+                }
+
+                return names;
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheets);
+            }
+        }
+
+        private static string CreateUniqueRollbackSheetName(Excel.Workbook workbook)
+        {
+            for (int attempt = 0; attempt < 10; attempt++)
+            {
+                string candidate = RollbackSheetPrefix + Guid.NewGuid().ToString("N")[..12];
+                Excel.Worksheet? existing = null;
+                try
+                {
+                    existing = ComUtilities.FindSheet(workbook, candidate);
+                    if (existing == null)
+                    {
+                        return candidate;
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref existing);
+                }
+            }
+
+            throw new InvalidOperationException("Could not allocate a unique rollback worksheet name.");
+        }
+
+        private static void TryDeleteSheet(Excel.Worksheet sheet)
+        {
+            Excel.Application? application = null;
+            Excel.XlSheetVisibility originalVisibility = Excel.XlSheetVisibility.xlSheetVisible;
+            bool visibilityChanged = false;
+            try
+            {
+                application = sheet.Application;
+                bool originalAlerts = application.DisplayAlerts;
+                application.DisplayAlerts = false;
+                try
+                {
+                    originalVisibility = sheet.Visible;
+                    sheet.Visible = Excel.XlSheetVisibility.xlSheetVisible;
+                    visibilityChanged = true;
+                    sheet.Delete();
+                    visibilityChanged = false;
+                }
+                finally
+                {
+                    application.DisplayAlerts = originalAlerts;
+                }
+            }
+            catch
+            {
+                if (visibilityChanged)
+                {
+                    sheet.Visible = originalVisibility;
+                }
+
+                throw;
+            }
+            finally
+            {
+                ComUtilities.Release(ref application);
+            }
+        }
+
+        private static bool StateEquals(object? expected, object? actual)
+        {
+            if (expected is Array || actual is Array)
+            {
+                if (expected is not Array left || actual is not Array right
+                    || left.Rank != right.Rank
+                    || left.Length != right.Length)
+                {
+                    return false;
+                }
+
+                int rows = left.GetLength(0);
+                int columns = left.Rank == 1 ? 1 : left.GetLength(1);
+                for (int row = 0; row < rows; row++)
+                {
+                    for (int column = 0; column < columns; column++)
+                    {
+                        object? leftValue = left.Rank == 1
+                            ? left.GetValue(left.GetLowerBound(0) + row)
+                            : left.GetValue(left.GetLowerBound(0) + row, left.GetLowerBound(1) + column);
+                        object? rightValue = right.Rank == 1
+                            ? right.GetValue(right.GetLowerBound(0) + row)
+                            : right.GetValue(right.GetLowerBound(0) + row, right.GetLowerBound(1) + column);
+                        if (!ScalarEquals(leftValue, rightValue))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            return ScalarEquals(expected, actual);
+        }
+
+        private static bool ScalarEquals(object? expected, object? actual)
+        {
+            if (expected is null or DBNull && actual is null or DBNull)
+            {
+                return true;
+            }
+
+            if (expected is ErrorWrapper expectedError && actual is ErrorWrapper actualError)
+            {
+                return expectedError.ErrorCode == actualError.ErrorCode;
+            }
+
+            return Equals(expected, actual);
+        }
+
+        private sealed record CellFormatSample(
+            int Row,
+            int Column,
+            string NumberFormat,
+            string Style,
+            string HorizontalAlignment,
+            string VerticalAlignment,
+            string WrapText,
+            string FontName,
+            string FontSize,
+            string FontBold,
+            string FontItalic,
+            string FontColor,
+            string InteriorColor,
+            string InteriorPattern,
+            BorderFormatSample LeftBorder,
+            BorderFormatSample TopBorder,
+            BorderFormatSample RightBorder,
+            BorderFormatSample BottomBorder);
+
+        private sealed record BorderFormatSample(
+            string LineStyle,
+            string Weight,
+            string Color);
+    }
+}

--- a/src/ExcelMcp.Core/Models/TableConversionFailureStage.cs
+++ b/src/ExcelMcp.Core/Models/TableConversionFailureStage.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Stage at which range-to-table conversion failed.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<TableConversionFailureStage>))]
+public enum TableConversionFailureStage
+{
+    /// <summary>
+    /// The source range failed preflight policy checks.
+    /// </summary>
+    Preflight,
+
+    /// <summary>
+    /// The rollback snapshot could not be created.
+    /// </summary>
+    Snapshot,
+
+    /// <summary>
+    /// Explicit range normalization failed.
+    /// </summary>
+    Normalization,
+
+    /// <summary>
+    /// Excel could not create or name the table.
+    /// </summary>
+    Creation,
+
+    /// <summary>
+    /// Excel could not apply the requested table style.
+    /// </summary>
+    Styling,
+
+    /// <summary>
+    /// The created table failed post-creation validation.
+    /// </summary>
+    Validation,
+
+    /// <summary>
+    /// Rollback or rollback verification failed.
+    /// </summary>
+    Rollback
+}

--- a/src/ExcelMcp.Core/Models/TableConversionValidationFinding.cs
+++ b/src/ExcelMcp.Core/Models/TableConversionValidationFinding.cs
@@ -1,0 +1,22 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// One deterministic post-creation table validation failure.
+/// </summary>
+public sealed class TableConversionValidationFinding
+{
+    /// <summary>
+    /// Finding type.
+    /// </summary>
+    public TableConversionValidationFindingKind Kind { get; set; }
+
+    /// <summary>
+    /// Cells or ranges related to the finding.
+    /// </summary>
+    public List<string> Addresses { get; set; } = [];
+
+    /// <summary>
+    /// Plain-English explanation.
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/ExcelMcp.Core/Models/TableConversionValidationFindingKind.cs
+++ b/src/ExcelMcp.Core/Models/TableConversionValidationFindingKind.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Type of post-creation table validation failure.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<TableConversionValidationFindingKind>))]
+public enum TableConversionValidationFindingKind
+{
+    /// <summary>
+    /// A formula evaluated to an Excel error value.
+    /// </summary>
+    FormulaError,
+
+    /// <summary>
+    /// A formula-bearing data column is not a consistent calculated column.
+    /// </summary>
+    InconsistentCalculatedColumn,
+
+    /// <summary>
+    /// The created table does not match the requested identity or range.
+    /// </summary>
+    TableMismatch,
+
+    /// <summary>
+    /// The requested table style was not applied.
+    /// </summary>
+    StyleMismatch,
+
+    /// <summary>
+    /// Excel unexpectedly enabled a totals row.
+    /// </summary>
+    UnexpectedTotalsRow,
+
+    /// <summary>
+    /// Non-header source content changed during conversion.
+    /// </summary>
+    SourceContentChanged
+}

--- a/src/ExcelMcp.Core/Models/TableConversionValidationResult.cs
+++ b/src/ExcelMcp.Core/Models/TableConversionValidationResult.cs
@@ -1,0 +1,32 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Post-creation validation details for a converted table.
+/// </summary>
+public sealed class TableConversionValidationResult
+{
+    /// <summary>
+    /// Whether every deterministic validation passed.
+    /// </summary>
+    public bool IsValid { get; set; }
+
+    /// <summary>
+    /// Number of formula cells inspected.
+    /// </summary>
+    public int FormulaCellsChecked { get; set; }
+
+    /// <summary>
+    /// Names of consistent calculated columns.
+    /// </summary>
+    public List<string> CalculatedColumns { get; set; } = [];
+
+    /// <summary>
+    /// Whether the converted table shows an Excel totals row.
+    /// </summary>
+    public bool ShowTotals { get; set; }
+
+    /// <summary>
+    /// Deterministic validation failures.
+    /// </summary>
+    public List<TableConversionValidationFinding> Findings { get; set; } = [];
+}

--- a/src/ExcelMcp.Core/Models/TableHeaderChange.cs
+++ b/src/ExcelMcp.Core/Models/TableHeaderChange.cs
@@ -1,0 +1,27 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// One header normalization performed during table conversion.
+/// </summary>
+public sealed class TableHeaderChange
+{
+    /// <summary>
+    /// Absolute address of the changed header cell.
+    /// </summary>
+    public string Address { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Header value before normalization.
+    /// </summary>
+    public string? OriginalValue { get; set; }
+
+    /// <summary>
+    /// Header value after normalization.
+    /// </summary>
+    public string NewValue { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Why the header was changed.
+    /// </summary>
+    public TableHeaderChangeReason Reason { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/TableHeaderChangeReason.cs
+++ b/src/ExcelMcp.Core/Models/TableHeaderChangeReason.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Reason a table conversion changed a header.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<TableHeaderChangeReason>))]
+public enum TableHeaderChangeReason
+{
+    /// <summary>
+    /// The header cell was blank.
+    /// </summary>
+    Blank,
+
+    /// <summary>
+    /// The header duplicated an earlier header.
+    /// </summary>
+    Duplicate
+}

--- a/src/ExcelMcp.Core/Models/TableHeaderPolicy.cs
+++ b/src/ExcelMcp.Core/Models/TableHeaderPolicy.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Controls how range-to-table conversion handles blank and duplicate headers.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<TableHeaderPolicy>))]
+public enum TableHeaderPolicy
+{
+    /// <summary>
+    /// Report invalid headers as blockers without changing the range.
+    /// </summary>
+    Report,
+
+    /// <summary>
+    /// Generate deterministic names for blank and duplicate headers.
+    /// </summary>
+    Normalize
+}

--- a/src/ExcelMcp.Core/Models/TableMergedHeaderPolicy.cs
+++ b/src/ExcelMcp.Core/Models/TableMergedHeaderPolicy.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Controls how range-to-table conversion handles merged header cells.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<TableMergedHeaderPolicy>))]
+public enum TableMergedHeaderPolicy
+{
+    /// <summary>
+    /// Report merged headers as blockers without changing the range.
+    /// </summary>
+    Report,
+
+    /// <summary>
+    /// Unmerge header-only merged areas and repeat the top-left value.
+    /// </summary>
+    UnmergeAndFill
+}

--- a/src/ExcelMcp.Core/Models/TablePreflightFindingKind.cs
+++ b/src/ExcelMcp.Core/Models/TablePreflightFindingKind.cs
@@ -36,5 +36,15 @@ public enum TablePreflightFindingKind
     /// <summary>
     /// The requested table name already exists.
     /// </summary>
-    TableNameExists
+    TableNameExists,
+
+    /// <summary>
+    /// The effective range has only a header row, so Excel would insert a data row.
+    /// </summary>
+    HeaderOnlyRange,
+
+    /// <summary>
+    /// Header content would be silently converted or truncated by Excel.
+    /// </summary>
+    LossyHeaders
 }

--- a/src/ExcelMcp.Core/Models/TableRangeConversionException.cs
+++ b/src/ExcelMcp.Core/Models/TableRangeConversionException.cs
@@ -1,0 +1,24 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Failure from atomic range-to-table conversion with structured rollback details.
+/// </summary>
+public sealed class TableRangeConversionException : InvalidOperationException
+{
+    /// <summary>
+    /// Creates a conversion exception.
+    /// </summary>
+    public TableRangeConversionException(
+        string message,
+        TableRangeConversionFailureDetails details,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Details = details;
+    }
+
+    /// <summary>
+    /// Structured conversion and rollback details.
+    /// </summary>
+    public TableRangeConversionFailureDetails Details { get; }
+}

--- a/src/ExcelMcp.Core/Models/TableRangeConversionFailureDetails.cs
+++ b/src/ExcelMcp.Core/Models/TableRangeConversionFailureDetails.cs
@@ -1,0 +1,62 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Structured failure details for range-to-table conversion.
+/// </summary>
+public sealed class TableRangeConversionFailureDetails
+{
+    /// <summary>
+    /// Stage that failed.
+    /// </summary>
+    public TableConversionFailureStage FailureStage { get; set; }
+
+    /// <summary>
+    /// Whether caller cancellation initiated the failure and rollback.
+    /// </summary>
+    public bool WasCancelled { get; set; }
+
+    /// <summary>
+    /// Whether the session operation timeout initiated the failure and rollback.
+    /// </summary>
+    public bool WasTimedOut { get; set; }
+
+    /// <summary>
+    /// Worksheet containing the source range.
+    /// </summary>
+    public string SheetName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Requested table name.
+    /// </summary>
+    public string TableName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Caller-supplied range.
+    /// </summary>
+    public string RequestedRange { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Resolved effective range, when available.
+    /// </summary>
+    public string? EffectiveRange { get; set; }
+
+    /// <summary>
+    /// Preflight findings observed before the failure.
+    /// </summary>
+    public List<TablePreflightFinding> PreflightFindings { get; set; } = [];
+
+    /// <summary>
+    /// Header changes made before the failure.
+    /// </summary>
+    public List<TableHeaderChange> HeaderChanges { get; set; } = [];
+
+    /// <summary>
+    /// Post-creation validation details, when validation ran.
+    /// </summary>
+    public TableConversionValidationResult? Validation { get; set; }
+
+    /// <summary>
+    /// Rollback status.
+    /// </summary>
+    public TableRollbackResult Rollback { get; set; } = new();
+}

--- a/src/ExcelMcp.Core/Models/TableRangeConversionResult.cs
+++ b/src/ExcelMcp.Core/Models/TableRangeConversionResult.cs
@@ -1,0 +1,67 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result of converting a worksheet range to an Excel table.
+/// </summary>
+public sealed class TableRangeConversionResult : ResultBase
+{
+    /// <summary>
+    /// Worksheet containing the source range.
+    /// </summary>
+    public string SheetName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Requested table name.
+    /// </summary>
+    public string TableName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Caller-supplied range.
+    /// </summary>
+    public string RequestedRange { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Absolute range used after effective-range resolution.
+    /// </summary>
+    public string EffectiveRange { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Merged-header policy used.
+    /// </summary>
+    public TableMergedHeaderPolicy MergedHeaderPolicy { get; set; }
+
+    /// <summary>
+    /// Header policy used.
+    /// </summary>
+    public TableHeaderPolicy HeaderPolicy { get; set; }
+
+    /// <summary>
+    /// Preflight findings observed before policy handling.
+    /// </summary>
+    public List<TablePreflightFinding> PreflightFindings { get; set; } = [];
+
+    /// <summary>
+    /// Merged header ranges normalized by the operation.
+    /// </summary>
+    public List<string> NormalizedMergedRanges { get; set; } = [];
+
+    /// <summary>
+    /// Header changes made by the operation.
+    /// </summary>
+    public List<TableHeaderChange> HeaderChanges { get; set; } = [];
+
+    /// <summary>
+    /// Created table metadata.
+    /// </summary>
+    public TableInfo? Table { get; set; }
+
+    /// <summary>
+    /// Post-creation validation details.
+    /// </summary>
+    public TableConversionValidationResult Validation { get; set; } = new();
+
+    /// <summary>
+    /// Rollback status. Successful conversions do not require rollback.
+    /// </summary>
+    public TableRollbackResult Rollback { get; set; } = new();
+}

--- a/src/ExcelMcp.Core/Models/TableRollbackResult.cs
+++ b/src/ExcelMcp.Core/Models/TableRollbackResult.cs
@@ -1,0 +1,37 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Rollback state for a range-to-table conversion.
+/// </summary>
+public sealed class TableRollbackResult
+{
+    /// <summary>
+    /// Whether the operation changed workbook state and therefore required rollback.
+    /// </summary>
+    public bool Required { get; set; }
+
+    /// <summary>
+    /// Whether rollback was attempted.
+    /// </summary>
+    public bool Attempted { get; set; }
+
+    /// <summary>
+    /// Whether all rollback steps completed.
+    /// </summary>
+    public bool Completed { get; set; }
+
+    /// <summary>
+    /// Whether the restored state matched the captured rollback invariants.
+    /// </summary>
+    public bool Verified { get; set; }
+
+    /// <summary>
+    /// Rollback failure detail, when rollback did not complete or verify.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Very-hidden recovery worksheet retained when rollback could not be verified.
+    /// </summary>
+    public string? RecoverySheetName { get; set; }
+}

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -63,9 +63,9 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**31 specialized tools with 326 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
+**31 specialized tools with 327 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
 
-📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 326 operations, grouped by category
+📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 327 operations, grouped by category
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/src/ExcelMcp.McpServer/ServiceBridge/ServiceBridge.cs
+++ b/src/ExcelMcp.McpServer/ServiceBridge/ServiceBridge.cs
@@ -5,13 +5,18 @@ namespace Sbroenne.ExcelMcp.McpServer.ServiceBridge;
 
 internal interface IServiceBridgeBackend : IDisposable
 {
-    Task<ServiceResponse> ProcessAsync(ServiceRequest request);
+    Task<ServiceResponse> ProcessAsync(
+        ServiceRequest request,
+        CancellationToken cancellationToken = default);
     bool ForceCloseSession(string sessionId);
 }
 
-internal sealed class ExcelMcpServiceBackend(Service.ExcelMcpService service) : IServiceBridgeBackend
+internal sealed class ExcelMcpServiceBackend(ExcelMcpService service) : IServiceBridgeBackend
 {
-    public Task<ServiceResponse> ProcessAsync(ServiceRequest request) => service.ProcessAsync(request);
+    public Task<ServiceResponse> ProcessAsync(
+        ServiceRequest request,
+        CancellationToken cancellationToken = default) =>
+        service.ProcessAsync(request, cancellationToken);
 
     public bool ForceCloseSession(string sessionId) => service.SessionManager.CloseSession(sessionId, save: false, force: true);
 
@@ -26,7 +31,7 @@ public static class ServiceBridge
 {
     private static readonly SemaphoreSlim _initLock = new(1, 1);
     private static readonly Func<IServiceBridgeBackend> DefaultServiceFactory =
-        static () => new ExcelMcpServiceBackend(new Service.ExcelMcpService());
+        static () => new ExcelMcpServiceBackend(new ExcelMcpService());
 
     private static IServiceBridgeBackend? _service;
     private static Func<IServiceBridgeBackend> _serviceFactory = DefaultServiceFactory;
@@ -105,11 +110,9 @@ public static class ServiceBridge
         };
 
         var service = _service!;
-        var processTask = Task.Run(async () => await service.ProcessAsync(request), CancellationToken.None);
-
         if (!timeoutSeconds.HasValue && !cancellationToken.CanBeCanceled)
         {
-            return await processTask;
+            return await service.ProcessAsync(request);
         }
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -118,13 +121,25 @@ public static class ServiceBridge
             cts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds.Value));
         }
 
+        var processTask = Task.Run(
+            async () => await service.ProcessAsync(request, cts.Token),
+            CancellationToken.None);
+
         try
         {
             return await processTask.WaitAsync(cts.Token);
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
-            var completedResponse = await TryGetCompletedResponseAsync(processTask);
+            TimeSpan completionGrace = string.Equals(
+                command,
+                "table.convert-range",
+                StringComparison.OrdinalIgnoreCase)
+                ? TimeSpan.FromSeconds(35)
+                : TimeSpan.FromMilliseconds(50);
+            var completedResponse = await TryGetCompletedResponseAsync(
+                processTask,
+                completionGrace);
             if (completedResponse != null)
             {
                 return completedResponse;
@@ -179,7 +194,9 @@ public static class ServiceBridge
         Dispose();
     }
 
-    private static async Task<ServiceResponse?> TryGetCompletedResponseAsync(Task<ServiceResponse> processTask)
+    private static async Task<ServiceResponse?> TryGetCompletedResponseAsync(
+        Task<ServiceResponse> processTask,
+        TimeSpan completionGrace)
     {
         if (processTask.IsCompleted)
         {
@@ -188,7 +205,7 @@ public static class ServiceBridge
 
         var completedTask = await Task.WhenAny(
             processTask,
-            Task.Delay(TimeSpan.FromMilliseconds(50))).ConfigureAwait(false);
+            Task.Delay(completionGrace)).ConfigureAwait(false);
 
         if (completedTask == processTask)
         {

--- a/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelToolsBase.cs
@@ -119,6 +119,7 @@ public static class ExcelToolsBase
                 exceptionType = response.ExceptionType,
                 hresult = response.HResult,
                 innerError = response.InnerError,
+                details = DeserializeErrorDetails(response.ErrorDetails),
                 isError = true
             }, JsonOptions);
         }
@@ -159,6 +160,7 @@ public static class ExcelToolsBase
                 exceptionType = response.ExceptionType,
                 hresult = response.HResult,
                 innerError = response.InnerError,
+                details = DeserializeErrorDetails(response.ErrorDetails),
                 isError = true
             }, JsonOptions);
         }
@@ -167,6 +169,17 @@ public static class ExcelToolsBase
         {
             success = true
         }, JsonOptions);
+    }
+
+    private static JsonElement? DeserializeErrorDetails(string? errorDetails)
+    {
+        if (string.IsNullOrWhiteSpace(errorDetails))
+        {
+            return null;
+        }
+
+        using JsonDocument document = JsonDocument.Parse(errorDetails);
+        return document.RootElement.Clone();
     }
 
     /// <summary>

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -12,16 +12,17 @@ using Sbroenne.ExcelMcp.Core.Commands.Drawing;
 using Sbroenne.ExcelMcp.Core.Commands.PivotTable;
 using Sbroenne.ExcelMcp.Core.Commands.PythonInExcel;
 using Sbroenne.ExcelMcp.Core.Commands.Range;
-using Sbroenne.ExcelMcp.Service.Rpc;
-using StreamJsonRpc;
 using Sbroenne.ExcelMcp.Core.Commands.Screenshot;
 using Sbroenne.ExcelMcp.Core.Commands.Slicer;
 using Sbroenne.ExcelMcp.Core.Commands.Table;
 using Sbroenne.ExcelMcp.Core.Commands.Window;
 using Sbroenne.ExcelMcp.Core.Commands.Workbook;
 using Sbroenne.ExcelMcp.Core.Commands.XmlMap;
+using Sbroenne.ExcelMcp.Core.Models;
 using Sbroenne.ExcelMcp.Core.Utilities;
 using Sbroenne.ExcelMcp.Generated;
+using Sbroenne.ExcelMcp.Service.Rpc;
+using StreamJsonRpc;
 
 namespace Sbroenne.ExcelMcp.Service;
 
@@ -107,7 +108,7 @@ public sealed class ExcelMcpService : IDisposable
 
     /// <summary>
     /// Records client activity to keep the idle timeout monitor alive.
-    /// Called by <see cref="Rpc.DaemonRpcTarget"/> on each incoming RPC call.
+    /// Called by <see cref="DaemonRpcTarget"/> on each incoming RPC call.
     /// </summary>
     internal void RecordActivity() => _lastActivityTime = DateTime.UtcNow;
 
@@ -252,8 +253,16 @@ public sealed class ExcelMcpService : IDisposable
     /// Processes a service request directly (in-process, no pipe).
     /// Used by the MCP Server for direct in-process communication.
     /// </summary>
-    public async Task<ServiceResponse> ProcessAsync(ServiceRequest request)
+    public async Task<ServiceResponse> ProcessAsync(
+        ServiceRequest request,
+        CancellationToken cancellationToken = default)
     {
+        using var cancellationScope = BatchExecutionCancellation.Push(
+            cancellationToken,
+            string.Equals(
+                request.Command,
+                "table.convert-range",
+                StringComparison.OrdinalIgnoreCase));
         try
         {
             // Route command
@@ -959,48 +968,53 @@ public sealed class ExcelMcpService : IDisposable
         }
         catch (TimeoutException ex)
         {
-            // Operation timed out — Excel COM call is hung (IDispatch.Invoke stuck).
-            // Force-close the session to trigger the force-kill path in ExcelBatch.Dispose(),
-            // which will kill the hung Excel process and release the STA thread.
-            try
+            bool sessionClosed = false;
+            if (batch?.HasTimedOutOperation == true)
             {
-                _sessionManager.CloseSession(sessionId, save: false, force: true);
+                try
+                {
+                    _sessionManager.CloseSession(sessionId, save: false, force: true);
+                    sessionClosed = true;
+                }
+                catch (Exception cleanupEx)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+                }
             }
-            catch (Exception cleanupEx)
-            {
-                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
-            }
+
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
                 ErrorCategory = "Timeout",
-                ErrorMessage = $"Excel operation timed out and the session has been closed: {ex.Message} " +
-                               "Please reopen the file with a new session.",
+                ErrorMessage = sessionClosed
+                    ? $"Excel operation timed out and the session has been closed: {ex.Message} Please reopen the file with a new session."
+                    : $"Excel operation timed out after cooperative cleanup: {ex.Message} The session remains open.",
                 ExceptionType = ex.GetType().Name
             });
         }
         catch (OperationCanceledException)
         {
-            // Caller cancelled (e.g., VS Code cancelled the tool call) while a COM operation
-            // may still be running on the STA thread. ExcelBatch.Execute sets _operationTimedOut
-            // on cancellation, but nobody calls Dispose() — the session stays alive with a
-            // stuck STA thread, and all subsequent requests queue up and hang.
-            // Force-close the session to kill the hung Excel process and release the STA thread.
-            try
+            bool sessionClosed = false;
+            if (batch?.HasTimedOutOperation == true)
             {
-                _sessionManager.CloseSession(sessionId, save: false, force: true);
+                try
+                {
+                    _sessionManager.CloseSession(sessionId, save: false, force: true);
+                    sessionClosed = true;
+                }
+                catch (Exception cleanupEx)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
+                }
             }
-            catch (Exception cleanupEx)
-            {
-                System.Diagnostics.Debug.WriteLine($"Session cleanup failed for {sessionId}: {cleanupEx.Message}");
-            }
+
             return Task.FromResult(new ServiceResponse
             {
                 Success = false,
                 ErrorCategory = "Cancelled",
-                ErrorMessage = $"Operation was cancelled and the session has been closed. " +
-                               "The Excel COM thread may have been unresponsive. " +
-                               "Please reopen the file with a new session.",
+                ErrorMessage = sessionClosed
+                    ? "Operation was cancelled and the unresponsive session has been closed. Please reopen the file with a new session."
+                    : "Operation was cancelled before execution or after cooperative cleanup. The session remains open.",
                 ExceptionType = nameof(OperationCanceledException)
             });
         }
@@ -1020,6 +1034,10 @@ public sealed class ExcelMcpService : IDisposable
                 ExceptionType = ex.GetType().Name,
                 HResult = $"0x{ex.HResult:X8}"
             });
+        }
+        catch (TableRangeConversionException ex)
+        {
+            return Task.FromResult(CreateErrorResponse(ex));
         }
         catch (InvalidOperationException ex) when (
             ex.Message.Contains("no longer running", StringComparison.OrdinalIgnoreCase) ||
@@ -1147,6 +1165,7 @@ public sealed class ExcelMcpService : IDisposable
             ExceptionType = response.ExceptionType,
             HResult = response.HResult,
             InnerError = response.InnerError,
+            ErrorDetails = response.ErrorDetails,
             Result = response.Result
         };
     }
@@ -1154,11 +1173,17 @@ public sealed class ExcelMcpService : IDisposable
     private static ServiceResponse CreateErrorResponse(Exception ex, string? command = null, string? sessionId = null)
     {
         var exceptionType = ex.GetType().Name;
-        string? hresult = ex is COMException comEx ? $"0x{comEx.HResult:X8}" : null;
+        string? hresult = FindComException(ex) is { } comEx ? $"0x{comEx.HResult:X8}" : null;
         string? innerError = null;
         var errorCategory = ex switch
         {
             PowerQueryCommandException pqEx => pqEx.ErrorCategory,
+            TableRangeConversionException conversionEx =>
+                conversionEx.Details.WasCancelled
+                    ? "Cancelled"
+                    : conversionEx.Details.WasTimedOut
+                        ? "Timeout"
+                        : "TableConversion",
             TimeoutException => "Timeout",
             ArgumentException or JsonException => "InvalidInput",
             COMException => "ComInterop",
@@ -1187,6 +1212,24 @@ public sealed class ExcelMcpService : IDisposable
                 HResult = hresult,
                 InnerError = innerError
             },
+            TableRangeConversionException conversionEx => new ServiceResponse
+            {
+                Success = false,
+                Command = command,
+                SessionId = sessionId,
+                ErrorCategory = conversionEx.Details.WasCancelled
+                    ? "Cancelled"
+                    : conversionEx.Details.WasTimedOut
+                        ? "Timeout"
+                        : "TableConversion",
+                ErrorMessage = conversionEx.Message,
+                ExceptionType = exceptionType,
+                HResult = hresult,
+                InnerError = innerError,
+                ErrorDetails = JsonSerializer.Serialize(
+                    conversionEx.Details,
+                    ServiceProtocol.JsonOptions)
+            },
             _ => new ServiceResponse
             {
                 Success = false,
@@ -1199,6 +1242,19 @@ public sealed class ExcelMcpService : IDisposable
                 InnerError = innerError
             }
         };
+    }
+
+    private static COMException? FindComException(Exception exception)
+    {
+        for (Exception? current = exception; current != null; current = current.InnerException)
+        {
+            if (current is COMException comException)
+            {
+                return comException;
+            }
+        }
+
+        return null;
     }
 
     private ServiceResponse? TryBeginUsableSession(string sessionId, out IExcelBatch? batch)

--- a/src/ExcelMcp.Service/Rpc/DaemonRpcTarget.cs
+++ b/src/ExcelMcp.Service/Rpc/DaemonRpcTarget.cs
@@ -14,9 +14,11 @@ internal sealed class DaemonRpcTarget : IExcelDaemonRpc
     }
 
     /// <inheritdoc />
-    public async Task<ServiceResponse> ProcessCommandAsync(ServiceRequest request)
+    public async Task<ServiceResponse> ProcessCommandAsync(
+        ServiceRequest request,
+        CancellationToken cancellationToken = default)
     {
         _service.RecordActivity();
-        return await _service.ProcessAsync(request);
+        return await _service.ProcessAsync(request, cancellationToken);
     }
 }

--- a/src/ExcelMcp.Service/Rpc/IExcelDaemonRpc.cs
+++ b/src/ExcelMcp.Service/Rpc/IExcelDaemonRpc.cs
@@ -23,6 +23,9 @@ public partial interface IExcelDaemonRpc
     /// Wraps <see cref="ExcelMcpService.ProcessAsync"/> over the pipe transport.
     /// </summary>
     /// <param name="request">The service request with command, sessionId, and args.</param>
+    /// <param name="cancellationToken">Cancels the active Excel operation.</param>
     /// <returns>The service response indicating success/failure with optional result data.</returns>
-    Task<ServiceResponse> ProcessCommandAsync(ServiceRequest request);
+    Task<ServiceResponse> ProcessCommandAsync(
+        ServiceRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ExcelMcp.Service/ServiceClient.cs
+++ b/src/ExcelMcp.Service/ServiceClient.cs
@@ -76,7 +76,7 @@ public sealed class ServiceClient : IDisposable
                 using var disconnectMonitorCts = CancellationTokenSource.CreateLinkedTokenSource(requestCts.Token);
                 requestCts.CancelAfter(requestTimeout);
 
-                var callTask = proxy.ProcessCommandAsync(request);
+                var callTask = proxy.ProcessCommandAsync(request, requestCts.Token);
                 var disconnectTask = WaitForPipeDisconnectAsync(pipe, disconnectMonitorCts.Token);
                 var completed = await Task.WhenAny(callTask, disconnectTask);
                 if (completed == disconnectTask
@@ -88,7 +88,21 @@ public sealed class ServiceClient : IDisposable
                 }
 
                 await disconnectMonitorCts.CancelAsync();
-                return await callTask.WaitAsync(requestCts.Token);
+                try
+                {
+                    return await callTask.WaitAsync(requestCts.Token);
+                }
+                catch (OperationCanceledException) when (
+                    requestCts.IsCancellationRequested
+                    && string.Equals(
+                        request.Command,
+                        "table.convert-range",
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    using var cleanupGraceCts = new CancellationTokenSource(
+                        TimeSpan.FromSeconds(35));
+                    return await callTask.WaitAsync(cleanupGraceCts.Token);
+                }
             }
             finally
             {

--- a/src/ExcelMcp.Service/ServiceProtocol.cs
+++ b/src/ExcelMcp.Service/ServiceProtocol.cs
@@ -83,6 +83,9 @@ public sealed class ServiceResponse
     /// <summary>Inner exception details, when available.</summary>
     public string? InnerError { get; init; }
 
+    /// <summary>JSON-serialized structured failure details, when available.</summary>
+    public string? ErrorDetails { get; init; }
+
     /// <summary>JSON-serialized result data.</summary>
     public string? Result { get; init; }
 
@@ -99,6 +102,7 @@ public sealed class ServiceResponse
         ExceptionType = shared.ExceptionType,
         HResult = shared.HResult,
         InnerError = shared.InnerError,
+        ErrorDetails = shared.ErrorDetails,
         Result = shared.Result
     };
 }

--- a/tests/ExcelMcp.CLI.Tests/Integration/GeneratedActionContractCliTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/GeneratedActionContractCliTests.cs
@@ -72,6 +72,10 @@ public sealed class GeneratedActionContractCliTests : IDisposable
         "timeout",
         "2147483")]
     [InlineData(
+        "table convert-range --session missing-session --sheet-name Data --table-name Probe --range-address A1:B2 --merged-header-policy unsafe",
+        "mergedHeaderPolicy",
+        "unsafe")]
+    [InlineData(
         "chart create-from-range --session missing-session --sheet Model --source-range-address A1:B2 --chart-type 999",
         "chartType",
         "999")]

--- a/tests/ExcelMcp.CLI.Tests/Unit/ActionValidatorTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/ActionValidatorTests.cs
@@ -101,11 +101,12 @@ public sealed class ActionValidatorTests
     }
 
     [Fact]
-    public void TableActions_IncludePreflight()
+    public void TableActions_IncludeSafeCreationActions()
     {
         var actions = GetActualActions(typeof(ServiceRegistry.Table));
 
         Assert.Contains("preflight", actions);
+        Assert.Contains("convert-range", actions);
     }
 
     [Fact]

--- a/tests/ExcelMcp.CLI.Tests/Unit/ExcelMcpServiceErrorTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/ExcelMcpServiceErrorTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Models;
 using Sbroenne.ExcelMcp.Core.Utilities;
 using Sbroenne.ExcelMcp.Service;
 using Xunit;
@@ -24,6 +25,82 @@ namespace Sbroenne.ExcelMcp.CLI.Tests.Unit;
 [Trait("Speed", "Fast")]
 public sealed class ExcelMcpServiceErrorTests
 {
+    [Fact]
+    public void CreateErrorResponse_TableConversionFailure_PreservesRollbackDetailsAndComContext()
+    {
+        var details = new TableRangeConversionFailureDetails
+        {
+            FailureStage = TableConversionFailureStage.Styling,
+            TableName = "DataTable",
+            SheetName = "Data",
+            RequestedRange = "A1:B2",
+            EffectiveRange = "$A$1:$B$2",
+            Rollback = new TableRollbackResult
+            {
+                Required = true,
+                Attempted = true,
+                Completed = true,
+                Verified = true
+            }
+        };
+        var exception = new TableRangeConversionException(
+            "Conversion failed and rollback was verified.",
+            details,
+            Marshal.GetExceptionForHR(unchecked((int)0x800A03EC)));
+        MethodInfo method = typeof(ExcelMcpService).GetMethod(
+            "CreateErrorResponse",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var response = Assert.IsType<ServiceResponse>(
+            method.Invoke(null, [exception, "table.convert-range", "session-1"]));
+
+        Assert.False(response.Success);
+        Assert.Equal("TableConversion", response.ErrorCategory);
+        Assert.Equal("0x800A03EC", response.HResult);
+        Assert.NotNull(response.ErrorDetails);
+        using JsonDocument document = JsonDocument.Parse(response.ErrorDetails);
+        Assert.Equal(
+            "Styling",
+            document.RootElement.GetProperty("failureStage").GetString());
+        Assert.True(
+            document.RootElement.GetProperty("rollback").GetProperty("verified").GetBoolean());
+    }
+
+    [Fact]
+    public void CreateErrorResponse_CancelledTableConversion_PreservesTypedDetails()
+    {
+        var details = new TableRangeConversionFailureDetails
+        {
+            FailureStage = TableConversionFailureStage.Validation,
+            WasCancelled = true,
+            TableName = "DataTable",
+            Rollback = new TableRollbackResult
+            {
+                Required = true,
+                Attempted = true,
+                Completed = true,
+                Verified = true
+            }
+        };
+        var exception = new TableRangeConversionException(
+            "Conversion cancelled after verified rollback.",
+            details,
+            new OperationCanceledException());
+        MethodInfo method = typeof(ExcelMcpService).GetMethod(
+            "CreateErrorResponse",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var response = Assert.IsType<ServiceResponse>(
+            method.Invoke(null, [exception, "table.convert-range", "session-1"]));
+
+        Assert.Equal("Cancelled", response.ErrorCategory);
+        Assert.NotNull(response.ErrorDetails);
+        using JsonDocument document = JsonDocument.Parse(response.ErrorDetails);
+        Assert.True(document.RootElement.GetProperty("wasCancelled").GetBoolean());
+        Assert.True(
+            document.RootElement.GetProperty("rollback").GetProperty("verified").GetBoolean());
+    }
+
     /// <summary>
     /// REGRESSION TEST for Bug 5 (#482): When an unexpected exception escapes
     /// the ProcessAsync routing switch (e.g. NullReferenceException on null Command),

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTimeoutTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/ExcelBatchTimeoutTests.cs
@@ -210,6 +210,38 @@ public class ExcelBatchTimeoutTests : IAsyncLifetime
             "pre-emptive kill may not be working. Expected < 30s.");
     }
 
+    [Fact]
+    public void Execute_CooperativeCleanupScope_ObservesSessionTimeoutWithoutPoisoningBatch()
+    {
+        using var batch = ExcelSession.BeginBatch(
+            show: false,
+            operationTimeout: TimeSpan.FromSeconds(10),
+            _testFileCopy!);
+        using var cancellationScope = BatchExecutionCancellation.Push(
+            CancellationToken.None,
+            requiresCooperativeCleanup: true);
+        var cancellationObserved = false;
+
+        var exception = Assert.Throws<TimeoutException>(() =>
+            batch.Execute((_, ct) =>
+            {
+                while (true)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        cancellationObserved = true;
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    Thread.Sleep(20);
+                }
+            }));
+
+        Assert.True(cancellationObserved);
+        Assert.Contains("cooperative cleanup", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(batch.HasTimedOutOperation);
+    }
+
     /// <summary>
     /// REGRESSION TEST: After timeout, the Excel process must be killed and cleaned up.
     /// Before Bug 8 fix, the hung Excel process would remain alive permanently.

--- a/tests/ExcelMcp.ComInterop.Tests/Unit/BatchExecutionCancellationTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Unit/BatchExecutionCancellationTests.cs
@@ -1,0 +1,38 @@
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Unit;
+
+[Trait("Layer", "ComInterop")]
+[Trait("Category", "Unit")]
+[Trait("Feature", "Batch")]
+[Trait("Speed", "Fast")]
+public sealed class BatchExecutionCancellationTests
+{
+    [Fact]
+    public void Push_NestedScopes_RestorePreviousToken()
+    {
+        using var outerSource = new CancellationTokenSource();
+        using var innerSource = new CancellationTokenSource();
+
+        Assert.False(BatchExecutionCancellation.Current.CanBeCanceled);
+        using (BatchExecutionCancellation.Push(
+            outerSource.Token,
+            requiresCooperativeCleanup: true))
+        {
+            Assert.Equal(outerSource.Token, BatchExecutionCancellation.Current);
+            Assert.True(BatchExecutionCancellation.RequiresCooperativeCleanup);
+            using (BatchExecutionCancellation.Push(innerSource.Token))
+            {
+                Assert.Equal(innerSource.Token, BatchExecutionCancellation.Current);
+                Assert.False(BatchExecutionCancellation.RequiresCooperativeCleanup);
+            }
+
+            Assert.Equal(outerSource.Token, BatchExecutionCancellation.Current);
+            Assert.True(BatchExecutionCancellation.RequiresCooperativeCleanup);
+        }
+
+        Assert.False(BatchExecutionCancellation.Current.CanBeCanceled);
+        Assert.False(BatchExecutionCancellation.RequiresCooperativeCleanup);
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Table/TableCommandsTests.ConvertRange.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Table/TableCommandsTests.ConvertRange.cs
@@ -1,0 +1,482 @@
+using System.IO.Compression;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands.Range;
+using Sbroenne.ExcelMcp.Core.Commands.Table;
+using Sbroenne.ExcelMcp.Core.Models;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Table;
+
+[Trait("Layer", "Core")]
+[Trait("Category", "Integration")]
+[Trait("RequiresExcel", "true")]
+[Trait("Feature", "Tables")]
+[Trait("Speed", "Medium")]
+public sealed class TableRangeConversionTests : IClassFixture<TempDirectoryFixture>
+{
+    private readonly TempDirectoryFixture _fixture;
+    private readonly TableCommands _tableCommands = new();
+    private readonly RangeCommands _rangeCommands = new();
+
+    public TableRangeConversionTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void ConvertRange_WithExplicitNormalization_CreatesAndValidatesTable()
+    {
+        var testFile = CreateTestFile(nameof(ConvertRange_WithExplicitNormalization_CreatesAndValidatesTable));
+        using var batch = ExcelSession.BeginBatch(testFile);
+        InitializeSalesSheet(batch);
+        SetValues(batch, "F1:H3",
+        [
+            ["Region", null, null],
+            ["North", 10, null],
+            ["South", 20, null]
+        ]);
+        _rangeCommands.MergeCells(batch, "Sales", "F1:G1");
+        _rangeCommands.SetFormulas(batch, "Sales", "H2:H3", [["=G2*2"], ["=G3*2"]]);
+
+        var result = _tableCommands.ConvertRange(
+            batch,
+            "Sales",
+            "NormalizedTable",
+            "F1:H3",
+            tableStyle: "TableStyleLight1",
+            mergedHeaderPolicy: TableMergedHeaderPolicy.UnmergeAndFill,
+            headerPolicy: TableHeaderPolicy.Normalize);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal("$F$1:$H$3", result.EffectiveRange);
+        Assert.Equal(["$F$1:$G$1"], result.NormalizedMergedRanges);
+        Assert.Contains(
+            result.HeaderChanges,
+            change => change.Address == "$G$1"
+                && change.NewValue == "Region_2"
+                && change.Reason == TableHeaderChangeReason.Duplicate);
+        Assert.Contains(
+            result.HeaderChanges,
+            change => change.Address == "$H$1"
+                && change.NewValue == "Column3"
+                && change.Reason == TableHeaderChangeReason.Blank);
+        Assert.NotNull(result.Table);
+        Assert.Equal("TableStyleLight1", result.Table.TableStyle);
+        Assert.True(result.Validation.IsValid);
+        Assert.Contains("Column3", result.Validation.CalculatedColumns);
+        Assert.False(result.Validation.ShowTotals);
+        Assert.False(result.Rollback.Attempted);
+    }
+
+    [Fact]
+    public void ConvertRange_WithReportPolicies_RejectsBeforeMutation()
+    {
+        var testFile = CreateTestFile(nameof(ConvertRange_WithReportPolicies_RejectsBeforeMutation));
+        using var batch = ExcelSession.BeginBatch(testFile);
+        InitializeSalesSheet(batch);
+        SetValues(batch, "F1:G2", [[null, "Amount"], ["Widget", 10]]);
+
+        var exception = Assert.Throws<TableRangeConversionException>(
+            () => _tableCommands.ConvertRange(
+                batch,
+                "Sales",
+                "BlockedTable",
+                "F1:G2"));
+
+        Assert.Equal(TableConversionFailureStage.Preflight, exception.Details.FailureStage);
+        Assert.False(exception.Details.Rollback.Attempted);
+        Assert.False(exception.Details.Rollback.Required);
+        Assert.Contains(
+            exception.Details.PreflightFindings,
+            finding => finding.Kind == TablePreflightFindingKind.BlankHeaders);
+        Assert.DoesNotContain(_tableCommands.List(batch).Tables, table => table.Name == "BlockedTable");
+        Assert.Null(ReadCellValue(batch, "F1"));
+    }
+
+    [Fact]
+    public void ConvertRange_WhenStyleFailsAfterCreation_RestoresExactRangeState()
+    {
+        var testFile = CreateTestFile(nameof(ConvertRange_WhenStyleFailsAfterCreation_RestoresExactRangeState));
+        using var batch = ExcelSession.BeginBatch(testFile);
+        InitializeSalesSheet(batch);
+        SetValues(batch, "F1:H3",
+        [
+            ["Item", "Metrics", null],
+            ["One", 10, null],
+            ["Two", 20, null]
+        ]);
+        _rangeCommands.MergeCells(batch, "Sales", "G1:H1");
+        _rangeCommands.SetFormulas(batch, "Sales", "H2:H3", [["=G2*2"], ["=G3*2"]]);
+        SetRollbackSentinelFormatting(batch);
+
+        var exception = Assert.Throws<TableRangeConversionException>(
+            () => _tableCommands.ConvertRange(
+                batch,
+                "Sales",
+                "RollbackTable",
+                "F1:H3",
+                tableStyle: "NotARealTableStyle",
+                mergedHeaderPolicy: TableMergedHeaderPolicy.UnmergeAndFill,
+                headerPolicy: TableHeaderPolicy.Normalize));
+
+        Assert.Equal(TableConversionFailureStage.Styling, exception.Details.FailureStage);
+        Assert.True(exception.Details.Rollback.Required);
+        Assert.True(exception.Details.Rollback.Attempted);
+        Assert.True(exception.Details.Rollback.Completed, exception.Details.Rollback.ErrorMessage);
+        Assert.True(exception.Details.Rollback.Verified, exception.Details.Rollback.ErrorMessage);
+        Assert.NotNull(exception.InnerException);
+        Assert.DoesNotContain(_tableCommands.List(batch).Tables, table => table.Name == "RollbackTable");
+
+        var restored = ReadRollbackState(batch);
+        Assert.Equal("Item", restored.ItemHeader);
+        Assert.Equal("Metrics", restored.MetricsHeader);
+        Assert.Null(restored.MergedHeaderTail);
+        Assert.Equal("=G2*2", restored.FirstFormula);
+        Assert.Equal("=G3*2", restored.SecondFormula);
+        Assert.True(restored.IsMerged);
+        Assert.Equal("$G$1:$H$1", restored.MergeAddress);
+        Assert.Equal("0.00", restored.NumberFormat);
+        Assert.True(restored.Bold);
+        Assert.Equal(255, restored.FillColor);
+        Assert.Equal(
+            Convert.ToInt32(Excel.XlBorderWeight.xlMedium, System.Globalization.CultureInfo.InvariantCulture),
+            restored.BottomBorderWeight);
+        Assert.DoesNotContain(
+            restored.WorksheetNames,
+            name => name.StartsWith("__ExcelMcpTblRb_", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ConvertRange_WhenFormulaEvaluatesToError_RollsBackAndReportsValidation()
+    {
+        var testFile = CreateTestFile(nameof(ConvertRange_WhenFormulaEvaluatesToError_RollsBackAndReportsValidation));
+        using var batch = ExcelSession.BeginBatch(testFile);
+        InitializeSalesSheet(batch);
+        SetValues(batch, "A1:B2", [["Amount", "Ratio"], [10, null]]);
+        _rangeCommands.SetFormulas(batch, "Sales", "B2", [["=1/0"]]);
+
+        var exception = Assert.Throws<TableRangeConversionException>(
+            () => _tableCommands.ConvertRange(
+                batch,
+                "Sales",
+                "ErrorTable",
+                "A1:B2"));
+
+        Assert.Equal(TableConversionFailureStage.Validation, exception.Details.FailureStage);
+        Assert.NotNull(exception.Details.Validation);
+        Assert.Contains(
+            exception.Details.Validation.Findings,
+            finding => finding.Kind == TableConversionValidationFindingKind.FormulaError
+                && finding.Addresses.Contains("$B$2"));
+        Assert.True(exception.Details.Rollback.Completed);
+        Assert.True(exception.Details.Rollback.Verified);
+        Assert.DoesNotContain(_tableCommands.List(batch).Tables, table => table.Name == "ErrorTable");
+        Assert.Equal("=1/0", ReadCellFormula(batch, "B2"));
+    }
+
+    [Fact]
+    public void ConvertRange_WithBodyMergeAndUnmergePolicy_RejectsBeforeMutation()
+    {
+        var testFile = CreateTestFile(nameof(ConvertRange_WithBodyMergeAndUnmergePolicy_RejectsBeforeMutation));
+        using var batch = ExcelSession.BeginBatch(testFile);
+        InitializeSalesSheet(batch);
+        SetValues(batch, "A1:B2", [["Name", "Amount"], ["Widget", 10]]);
+        _rangeCommands.MergeCells(batch, "Sales", "A2:B2");
+
+        var exception = Assert.Throws<TableRangeConversionException>(
+            () => _tableCommands.ConvertRange(
+                batch,
+                "Sales",
+                "MergedBodyTable",
+                "A1:B2",
+                mergedHeaderPolicy: TableMergedHeaderPolicy.UnmergeAndFill));
+
+        Assert.Equal(TableConversionFailureStage.Preflight, exception.Details.FailureStage);
+        Assert.False(exception.Details.Rollback.Attempted);
+        Assert.True(_rangeCommands.GetMergeInfo(batch, "Sales", "A2:B2").IsMerged);
+    }
+
+    [Fact]
+    public void ConvertRange_WithHeaderOnlyRange_RejectsWithoutShiftingFollowingData()
+    {
+        var testFile = CreateTestFile(nameof(ConvertRange_WithHeaderOnlyRange_RejectsWithoutShiftingFollowingData));
+        using var batch = ExcelSession.BeginBatch(testFile);
+        InitializeSalesSheet(batch);
+        SetValues(batch, "A1:B2", [["Name", "Amount"], ["Widget", 10]]);
+
+        var exception = Assert.Throws<TableRangeConversionException>(
+            () => _tableCommands.ConvertRange(
+                batch,
+                "Sales",
+                "HeaderOnlyTable",
+                "A1:B1"));
+
+        Assert.Equal(TableConversionFailureStage.Preflight, exception.Details.FailureStage);
+        Assert.Contains(
+            exception.Details.PreflightFindings,
+            finding => finding.Kind == TablePreflightFindingKind.HeaderOnlyRange);
+        Assert.Equal("Widget", ReadCellValue(batch, "A2"));
+        Assert.Equal(10d, ReadCellValue(batch, "B2"));
+    }
+
+    [Fact]
+    public void ConvertRange_WithFormulaHeader_RejectsWithoutConvertingHeader()
+    {
+        var testFile = CreateTestFile(nameof(ConvertRange_WithFormulaHeader_RejectsWithoutConvertingHeader));
+        using var batch = ExcelSession.BeginBatch(testFile);
+        InitializeSalesSheet(batch);
+        SetValues(batch, "A1:B2", [["Name", "Amount"], ["Widget", 10]]);
+        _rangeCommands.SetFormulas(batch, "Sales", "A1", [["=\"Name\""]]);
+
+        var exception = Assert.Throws<TableRangeConversionException>(
+            () => _tableCommands.ConvertRange(
+                batch,
+                "Sales",
+                "FormulaHeaderTable",
+                "A1:B2"));
+
+        Assert.Equal(TableConversionFailureStage.Preflight, exception.Details.FailureStage);
+        Assert.Contains(
+            exception.Details.PreflightFindings,
+            finding => finding.Kind == TablePreflightFindingKind.LossyHeaders
+                && finding.Addresses.Contains("$A$1"));
+        Assert.Equal("=\"Name\"", ReadCellFormula(batch, "A1"));
+    }
+
+    private static object? ReadCellValue(IExcelBatch batch, string address)
+    {
+        return batch.Execute((ctx, _) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? cell = null;
+            try
+            {
+                sheet = ComUtilities.FindSheet(ctx.Book, "Sales");
+                cell = sheet!.Range[address];
+                return cell.Value2;
+            }
+            finally
+            {
+                ComUtilities.Release(ref cell);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+    }
+
+    private static string? ReadCellFormula(IExcelBatch batch, string address)
+    {
+        return batch.Execute((ctx, _) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? cell = null;
+            try
+            {
+                sheet = ComUtilities.FindSheet(ctx.Book, "Sales");
+                cell = sheet!.Range[address];
+                return Convert.ToString(cell.Formula2, System.Globalization.CultureInfo.InvariantCulture);
+            }
+            finally
+            {
+                ComUtilities.Release(ref cell);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+    }
+
+    private string CreateTestFile(string testName)
+    {
+        string path = Path.Join(
+            _fixture.TempDir,
+            $"{nameof(TableRangeConversionTests)}_{testName}_{Guid.NewGuid():N}.xlsx");
+        using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
+        WriteEntry(
+            archive,
+            "[Content_Types].xml",
+            """<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>""");
+        WriteEntry(
+            archive,
+            "_rels/.rels",
+            """<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>""");
+        WriteEntry(
+            archive,
+            "xl/workbook.xml",
+            """<?xml version="1.0" encoding="UTF-8"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>""");
+        WriteEntry(
+            archive,
+            "xl/_rels/workbook.xml.rels",
+            """<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>""");
+        WriteEntry(
+            archive,
+            "xl/worksheets/sheet1.xml",
+            """<?xml version="1.0" encoding="UTF-8"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>""");
+        return path;
+    }
+
+    private static void WriteEntry(ZipArchive archive, string name, string content)
+    {
+        ZipArchiveEntry entry = archive.CreateEntry(name);
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(content);
+    }
+
+    private static void InitializeSalesSheet(IExcelBatch batch)
+    {
+        batch.Execute((ctx, _) =>
+        {
+            Excel.Sheets? sheets = null;
+            Excel.Worksheet? sheet = null;
+            try
+            {
+                sheets = ctx.Book.Worksheets;
+                sheet = (Excel.Worksheet)sheets[1];
+                sheet.Name = "Sales";
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheet);
+                ComUtilities.Release(ref sheets);
+            }
+        });
+    }
+
+    private void SetValues(IExcelBatch batch, string address, List<List<object?>> values) =>
+        _rangeCommands.SetValues(batch, "Sales", address, values);
+
+    private static void SetRollbackSentinelFormatting(IExcelBatch batch)
+    {
+        batch.Execute((ctx, _) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? header = null;
+            Excel.Range? numeric = null;
+            Excel.Font? font = null;
+            Excel.Interior? interior = null;
+            Excel.Borders? borders = null;
+            Excel.Border? border = null;
+            try
+            {
+                sheet = ComUtilities.FindSheet(ctx.Book, "Sales");
+                header = sheet!.Range["F1"];
+                numeric = sheet.Range["G2:H3"];
+                font = header.Font;
+                interior = header.Interior;
+                borders = header.Borders;
+                font.Bold = true;
+                interior.Color = 255;
+                border = borders[Excel.XlBordersIndex.xlEdgeBottom];
+                border.Weight = Excel.XlBorderWeight.xlMedium;
+                numeric.NumberFormat = "0.00";
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref border);
+                ComUtilities.Release(ref borders);
+                ComUtilities.Release(ref interior);
+                ComUtilities.Release(ref font);
+                ComUtilities.Release(ref numeric);
+                ComUtilities.Release(ref header);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+    }
+
+    private static RollbackState ReadRollbackState(IExcelBatch batch)
+    {
+        return batch.Execute((ctx, _) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? itemHeader = null;
+            Excel.Range? metricsHeader = null;
+            Excel.Range? mergedHeaderTail = null;
+            Excel.Range? firstFormula = null;
+            Excel.Range? secondFormula = null;
+            Excel.Range? numeric = null;
+            Excel.Range? mergeArea = null;
+            Excel.Font? font = null;
+            Excel.Interior? interior = null;
+            Excel.Borders? borders = null;
+            Excel.Border? border = null;
+            Excel.Sheets? sheets = null;
+            try
+            {
+                sheet = ComUtilities.FindSheet(ctx.Book, "Sales");
+                itemHeader = sheet!.Range["F1"];
+                metricsHeader = sheet.Range["G1"];
+                mergedHeaderTail = sheet.Range["H1"];
+                firstFormula = sheet.Range["H2"];
+                secondFormula = sheet.Range["H3"];
+                numeric = sheet.Range["G2:H3"];
+                mergeArea = metricsHeader.MergeArea;
+                font = itemHeader.Font;
+                interior = itemHeader.Interior;
+                borders = itemHeader.Borders;
+                border = borders[Excel.XlBordersIndex.xlEdgeBottom];
+                sheets = ctx.Book.Worksheets;
+
+                var worksheetNames = new List<string>();
+                for (var index = 1; index <= sheets.Count; index++)
+                {
+                    Excel.Worksheet? current = null;
+                    try
+                    {
+                        current = (Excel.Worksheet)sheets[index];
+                        worksheetNames.Add(current.Name);
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref current);
+                    }
+                }
+
+                return new RollbackState(
+                    itemHeader.Value2,
+                    metricsHeader.Value2,
+                    mergedHeaderTail.Value2,
+                    firstFormula.Formula2,
+                    secondFormula.Formula2,
+                    Convert.ToBoolean(metricsHeader.MergeCells),
+                    mergeArea.Address,
+                    Convert.ToString(numeric.NumberFormat, System.Globalization.CultureInfo.InvariantCulture),
+                    Convert.ToBoolean(font.Bold),
+                    Convert.ToInt32(interior.Color, System.Globalization.CultureInfo.InvariantCulture),
+                    Convert.ToInt32(border.Weight, System.Globalization.CultureInfo.InvariantCulture),
+                    worksheetNames);
+            }
+            finally
+            {
+                ComUtilities.Release(ref sheets);
+                ComUtilities.Release(ref border);
+                ComUtilities.Release(ref borders);
+                ComUtilities.Release(ref interior);
+                ComUtilities.Release(ref font);
+                ComUtilities.Release(ref mergeArea);
+                ComUtilities.Release(ref numeric);
+                ComUtilities.Release(ref secondFormula);
+                ComUtilities.Release(ref firstFormula);
+                ComUtilities.Release(ref mergedHeaderTail);
+                ComUtilities.Release(ref metricsHeader);
+                ComUtilities.Release(ref itemHeader);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+    }
+
+    private sealed record RollbackState(
+        object? ItemHeader,
+        object? MetricsHeader,
+        object? MergedHeaderTail,
+        object? FirstFormula,
+        object? SecondFormula,
+        bool IsMerged,
+        string MergeAddress,
+        string? NumberFormat,
+        bool Bold,
+        int FillColor,
+        int BottomBorderWeight,
+        List<string> WorksheetNames);
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/McpToolSurfaceTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/McpToolSurfaceTests.cs
@@ -32,7 +32,7 @@ public class McpToolSurfaceTests(ITestOutputHelper output)
     private const int ExpectedToolCount = 31;
 
     /// <summary>Sum of the <c>action</c> enum values across all registered tools.</summary>
-    private const int ExpectedOperationCount = 325;
+    private const int ExpectedOperationCount = 327;
 
     [Fact]
     public void ToolSurface_MatchesDocumentedGroundTruth()

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
@@ -235,7 +235,7 @@ public class McpServerSmokeTests : IAsyncLifetime, IAsyncDisposable
 
         var createTableResult = await CallToolAsync("table", new Dictionary<string, object?>
         {
-            ["action"] = "create",
+            ["action"] = "convert-range",
             ["path"] = _testExcelFile,
             ["session_id"] = sessionId,
             ["table_name"] = "DataTable",
@@ -243,7 +243,14 @@ public class McpServerSmokeTests : IAsyncLifetime, IAsyncDisposable
             ["range_address"] = "A1:C3",
             ["has_headers"] = true
         });
-        AssertSuccess(createTableResult, "Create table");
+        AssertSuccess(createTableResult, "Convert range to table");
+        using (var conversionJson = JsonDocument.Parse(createTableResult))
+        {
+            Assert.Equal("$A$1:$C$3", conversionJson.RootElement.GetProperty("effectiveRange").GetString());
+            Assert.True(conversionJson.RootElement.GetProperty("validation").GetProperty("isValid").GetBoolean());
+            Assert.False(conversionJson.RootElement.GetProperty("rollback").GetProperty("attempted").GetBoolean());
+            Assert.Equal("DataTable", conversionJson.RootElement.GetProperty("table").GetProperty("name").GetString());
+        }
 
         var listTablesResult = await CallToolAsync("table", new Dictionary<string, object?>
         {
@@ -252,7 +259,7 @@ public class McpServerSmokeTests : IAsyncLifetime, IAsyncDisposable
             ["session_id"] = sessionId
         });
         AssertSuccess(listTablesResult, "List tables");
-        _output.WriteLine("  ✓ table: Preflight, Create, and List passed");
+        _output.WriteLine("  ✓ table: Preflight, ConvertRange, and List passed");
 
         // =====================================================================
         // STEP 6: NAMED RANGE OPERATIONS

--- a/tests/ExcelMcp.McpServer.Tests/Unit/ServiceBridgeCancellationTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Unit/ServiceBridgeCancellationTests.cs
@@ -103,6 +103,25 @@ public sealed class ServiceBridgeCancellationTests : IDisposable
     }
 
     [Fact]
+    public async Task SendAsync_TableConversionCancellation_ReturnsCooperativeRollbackDetails()
+    {
+        var backend = new CooperativeCancellationBackend();
+        Bridge.SetServiceFactoryForTests(() => backend);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var response = await Bridge.SendAsync(
+            "table.convert-range",
+            sessionId: "session-convert",
+            cancellationToken: cts.Token);
+
+        Assert.False(response.Success);
+        Assert.Equal("Cancelled", response.ErrorCategory);
+        Assert.Equal("""{"rollback":{"verified":true}}""", response.ErrorDetails);
+        Assert.Empty(backend.ClosedSessions);
+        Assert.False(backend.Disposed);
+    }
+
+    [Fact]
     public async Task SendAsync_WhenServiceFactoryThrows_IncludesStartupFailureDetails()
     {
         Bridge.SetServiceFactoryForTests(static () => throw new FileNotFoundException("office runtime missing"));
@@ -161,7 +180,9 @@ public sealed class ServiceBridgeCancellationTests : IDisposable
             _completeImmediately = completeImmediately;
         }
 
-        public Task<ServiceResponse> ProcessAsync(ServiceRequest request)
+        public Task<ServiceResponse> ProcessAsync(
+            ServiceRequest request,
+            CancellationToken cancellationToken = default)
         {
             if (_completeImmediately)
             {
@@ -207,7 +228,9 @@ public sealed class ServiceBridgeCancellationTests : IDisposable
 
         public bool Disposed { get; private set; }
 
-        public Task<ServiceResponse> ProcessAsync(ServiceRequest request)
+        public Task<ServiceResponse> ProcessAsync(
+            ServiceRequest request,
+            CancellationToken cancellationToken = default)
         {
             _requestStarted.TrySetResult(true);
             return _response.Task;
@@ -242,6 +265,43 @@ public sealed class ServiceBridgeCancellationTests : IDisposable
                 Success = false,
                 ErrorMessage = "disposed"
             });
+        }
+    }
+
+    private sealed class CooperativeCancellationBackend : IServiceBridgeBackend
+    {
+        public List<string> ClosedSessions { get; } = [];
+
+        public bool Disposed { get; private set; }
+
+        public async Task<ServiceResponse> ProcessAsync(
+            ServiceRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                .ContinueWith(
+                    _ => { },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorCategory = "Cancelled",
+                ErrorMessage = "Conversion cancelled after verified rollback.",
+                ErrorDetails = """{"rollback":{"verified":true}}"""
+            };
+        }
+
+        public bool ForceCloseSession(string sessionId)
+        {
+            ClosedSessions.Add(sessionId);
+            return true;
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
         }
     }
 }

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -19,7 +19,7 @@ Other tools (openpyxl-based MCP servers and Agent Skills, including Anthropic's 
 
 ## Key features
 
-The Excel MCP Server (excel-mcp) provides **31 specialized tools with 326 operations** for comprehensive Excel automation:
+The Excel MCP Server (excel-mcp) provides **31 specialized tools with 327 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query & M code** - Create, edit and optimize M code. Import from files, databases and APIs. Refresh queries and manage load destinations.
 - 🧮 **Power Pivot & DAX** - Build Data Models, create DAX measures and manage table relationships. Full Power Pivot automation.
@@ -31,7 +31,7 @@ The Excel MCP Server (excel-mcp) provides **31 specialized tools with 326 operat
 - 🐍 **Python in Excel** - Write and run `=PY()` formulas that execute in Excel's cloud Python engine — process worksheet data with pandas, NumPy and more, from your AI assistant.
 - 🧪 **LLM-tested quality** - Tool behavior validated with real LLM workflows using [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering), so AI assistants reliably understand and use every operation.
 
-📚 **[See all 31 tools and 326 operations →](https://excelmcpserver.dev/features/)**
+📚 **[See all 31 tools and 327 operations →](https://excelmcpserver.dev/features/)**
 
 ### Agent Skills (Bundled)
 


### PR DESCRIPTION
## Summary
- adds `table convert-range` across Core, generated Service, CLI, and MCP surfaces
- reuses PR #844 preflight findings, with explicit merged-header and header normalization policies
- creates/styles and validates the table, then restores the affected range and removes the table if a later step fails
- carries typed failure stage, cancellation/timeout, rollback verification, and retained recovery-sheet details through CLI and MCP errors

This is operation-level rollback for the effective source range and newly created table while Excel remains responsive. It does not claim workbook-wide transaction guarantees.

## Safety and validation
- rejects headerless, header-only, formula, non-text, and oversized headers before mutation
- snapshots at the original worksheet coordinates, preserving formulas, values, merges, validation, and formatting
- verifies exact formulas/constants/merges and all affected-cell formatting before deleting the rollback snapshot
- keeps a very-hidden recovery sheet with a collision-safe name when rollback cannot be verified
- waits for bounded cooperative rollback on cancellation or timeout before invalidating a stuck session

## Tests
- real-Excel conversion tests, including forced style failure after table creation and exact rollback-state assertions
- corrected table-preflight tests from the stacked base
- CLI, batch-error, MCP surface, cancellation, and service error-detail tests
- Release build and repository COM/coverage/MCP/success/count/dynamic audits
- full `scripts\Test-E2E.ps1`
- complete normal pre-commit hook, including CLI/MCP Excel E2E and all release deliverables

Stacked on #844.

Closes #839