### PR TITLE
Add verified table sorting

### DIFF
--- a/.changeset/verified-table-sorts.md
+++ b/.changeset/verified-table-sorts.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": minor
+---
+
+**Verified table sorting** (#840): Table sorts can now opt into typed pre-sort warnings and post-sort integrity checks for complete rows, calculated columns, composite keys, and control totals. Failed post-sort checks restore and verify the original table contents.

--- a/docs/features/DATA-ANALYTICS.md
+++ b/docs/features/DATA-ANALYTICS.md
@@ -128,6 +128,7 @@ Create and manage Excel Tables (ListObjects) — structured ranges with styling,
 **Sorting:**
 - **Sort (Single Column):** Sort by one column
 - **Sort (Multi-Column):** Sort by up to 3 columns/levels
+- **Optional integrity validation:** Snapshot and verify complete row movement, calculated-column formulas, optional composite row keys, and numeric control totals. Uncertain adjacent or row-aligned data is reported as a warning; deterministic post-sort failures restore and verify captured values and formulas. Row-specific formatting is outside the rollback scope.
 
 **Number Formatting:**
 - **Get Column Number Formats:** Read number formats applied to columns

--- a/skills/excel-mcp/references/table.md
+++ b/skills/excel-mcp/references/table.md
@@ -92,3 +92,10 @@ Example DAX queries for create-from-dax:
 - Use `rows` for inline 2D data or `rows_file` for JSON/CSV input when appending
 - `visible_only` only applies to the get-data action
 - Table names must be unique within workbook (Excel requirement)
+
+**Validated sorting**:
+
+- `table_column sort` and `sort-multi` preserve legacy behavior by default. Set `validate_integrity=true` to snapshot the table, report adjacency/formula warnings, and verify that complete rows and consistent calculated columns survive the sort.
+- `key_columns` is an optional JSON array of column names forming a unique composite row key. `control_totals` is an optional array of `{columnName, tolerance}` checks for numeric column sums. Supplying either also enables validation.
+- Invalid or duplicate requested row keys and invalid control totals block before sorting. Populated adjacent columns, sort-sensitive formulas, external row-aligned formulas, and mixed-formula columns are warnings because their relationship to the table is uncertain.
+- If a deterministic post-sort check fails, the server restores and verifies captured values and formulas. Check `sortCommitted`, `integrityPreserved`, `rollbackAttempted`, `rollbackSucceeded`, and `rollbackScope`. The rollback scope is `TableContent`; row-specific formatting is not restored, and a failed rollback means table state may have changed.

--- a/skills/shared/table.md
+++ b/skills/shared/table.md
@@ -92,3 +92,10 @@ Example DAX queries for create-from-dax:
 - Use `rows` for inline 2D data or `rows_file` for JSON/CSV input when appending
 - `visible_only` only applies to the get-data action
 - Table names must be unique within workbook (Excel requirement)
+
+**Validated sorting**:
+
+- `table_column sort` and `sort-multi` preserve legacy behavior by default. Set `validate_integrity=true` to snapshot the table, report adjacency/formula warnings, and verify that complete rows and consistent calculated columns survive the sort.
+- `key_columns` is an optional JSON array of column names forming a unique composite row key. `control_totals` is an optional array of `{columnName, tolerance}` checks for numeric column sums. Supplying either also enables validation.
+- Invalid or duplicate requested row keys and invalid control totals block before sorting. Populated adjacent columns, sort-sensitive formulas, external row-aligned formulas, and mixed-formula columns are warnings because their relationship to the table is uncertain.
+- If a deterministic post-sort check fails, the server restores and verifies captured values and formulas. Check `sortCommitted`, `integrityPreserved`, `rollbackAttempted`, `rollbackSucceeded`, and `rollbackScope`. The rollback scope is `TableContent`; row-specific formatting is not restored, and a failed rollback means table state may have changed.

--- a/src/ExcelMcp.Core/Attributes/ServiceIgnoreAttribute.cs
+++ b/src/ExcelMcp.Core/Attributes/ServiceIgnoreAttribute.cs
@@ -1,0 +1,7 @@
+namespace Sbroenne.ExcelMcp.Core.Attributes;
+
+/// <summary>
+/// Excludes a compatibility-only interface method from generated Service, CLI, and MCP surfaces.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class ServiceIgnoreAttribute : Attribute;

--- a/src/ExcelMcp.Core/Commands/Table/ITableColumnCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Table/ITableColumnCommands.cs
@@ -25,7 +25,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Table;
 /// </summary>
 [ServiceCategory("tablecolumn", "TableColumn")]
 [McpTool("table_column", Title = "Table Column Operations", Destructive = true, Category = "data",
-    Description = "Table column, filtering, and sorting operations. FILTERING: apply-filter (criteria like >100, =Active), apply-filter-values (JSON array of exact values), clear-filters, get-filters. SORTING: sort (single column), sort-multi (JSON array of {columnName, ascending}). COLUMNS: add-column, remove-column, rename-column. NUMBER FORMATS: US locale codes (#,##0.00, 0%, yyyy-mm-dd). Use table for lifecycle and data operations.")]
+    Description = "Table column, filtering, and sorting operations. FILTERING: apply-filter (criteria like >100, =Active), apply-filter-values (JSON array of exact values), clear-filters, get-filters. SORTING: sort (single column), sort-multi (JSON array of {columnName, ascending}); optional integrity validation reports warnings, verifies complete rows and calculated columns, and rolls back failed checks. COLUMNS: add-column, remove-column, rename-column. NUMBER FORMATS: US locale codes (#,##0.00, 0%, yyyy-mm-dd). Use table for lifecycle and data operations.")]
 public interface ITableColumnCommands
 {
     // === FILTER OPERATIONS ===
@@ -110,23 +110,96 @@ public interface ITableColumnCommands
     // === SORT OPERATIONS ===
 
     /// <summary>
+    /// Sorts a table by a single column without integrity validation.
+    /// Preserved for existing Core API consumers.
+    /// </summary>
+    [ServiceIgnore]
+    OperationResult Sort(IExcelBatch batch, string tableName, string columnName, bool ascending = true);
+
+    /// <summary>
     /// Sorts a table by a single column
     /// </summary>
     /// <param name="tableName">Name of the Excel table</param>
     /// <param name="columnName">Column to sort by</param>
     /// <param name="ascending">Sort order: true = ascending (A-Z, 0-9), false = descending (default: true)</param>
+    /// <param name="validateIntegrity">Capture and verify table integrity around the sort. Default false preserves legacy behavior.</param>
+    /// <param name="keyColumns">Optional unique composite row-key columns (JSON array in CLI/MCP). Supplying keys enables integrity validation.</param>
+    /// <param name="controlTotals">Optional numeric column sums and tolerances. Supplying totals enables integrity validation.</param>
     /// <exception cref="InvalidOperationException">Table or column not found</exception>
     [ServiceAction("sort")]
-    OperationResult Sort(IExcelBatch batch, string tableName, string columnName, bool ascending = true);
+    TableSortResult Sort(
+        IExcelBatch batch,
+        string tableName,
+        string columnName,
+        bool ascending = true,
+        bool validateIntegrity = false,
+        List<string>? keyColumns = null,
+        List<TableSortControlTotal>? controlTotals = null)
+    {
+        if (validateIntegrity || keyColumns is { Count: > 0 } || controlTotals is { Count: > 0 })
+        {
+            throw new NotSupportedException(
+                "This ITableColumnCommands implementation does not support validated sorting.");
+        }
+
+        OperationResult legacy = Sort(batch, tableName, columnName, ascending);
+        return new TableSortResult
+        {
+            Success = legacy.Success,
+            ErrorMessage = legacy.ErrorMessage,
+            FilePath = legacy.FilePath,
+            Action = legacy.Action,
+            Message = legacy.Message,
+            TableName = tableName,
+            SortAttempted = legacy.Success,
+            SortCommitted = legacy.Success
+        };
+    }
+
+    /// <summary>
+    /// Sorts a table by multiple columns without integrity validation.
+    /// Preserved for existing Core API consumers.
+    /// </summary>
+    [ServiceIgnore]
+    OperationResult SortMulti(IExcelBatch batch, string tableName, List<TableSortColumn> sortColumns);
 
     /// <summary>
     /// Sorts a table by multiple columns
     /// </summary>
     /// <param name="tableName">Name of the Excel table</param>
     /// <param name="sortColumns">List of sort specifications: [{columnName: 'Col1', ascending: true}, ...] - applied in order</param>
+    /// <param name="validateIntegrity">Capture and verify table integrity around the sort. Default false preserves legacy behavior.</param>
+    /// <param name="keyColumns">Optional unique composite row-key columns (JSON array in CLI/MCP). Supplying keys enables integrity validation.</param>
+    /// <param name="controlTotals">Optional numeric column sums and tolerances. Supplying totals enables integrity validation.</param>
     /// <exception cref="InvalidOperationException">Table or column not found</exception>
     [ServiceAction("sort-multi")]
-    OperationResult SortMulti(IExcelBatch batch, string tableName, List<TableSortColumn> sortColumns);
+    TableSortResult SortMulti(
+        IExcelBatch batch,
+        string tableName,
+        List<TableSortColumn> sortColumns,
+        bool validateIntegrity = false,
+        List<string>? keyColumns = null,
+        List<TableSortControlTotal>? controlTotals = null)
+    {
+        if (validateIntegrity || keyColumns is { Count: > 0 } || controlTotals is { Count: > 0 })
+        {
+            throw new NotSupportedException(
+                "This ITableColumnCommands implementation does not support validated sorting.");
+        }
+
+        OperationResult legacy = SortMulti(batch, tableName, sortColumns);
+        return new TableSortResult
+        {
+            Success = legacy.Success,
+            ErrorMessage = legacy.ErrorMessage,
+            FilePath = legacy.FilePath,
+            Action = legacy.Action,
+            Message = legacy.Message,
+            TableName = tableName,
+            SortAttempted = legacy.Success,
+            SortCommitted = legacy.Success
+        };
+    }
 
     // === NUMBER FORMATTING ===
 

--- a/src/ExcelMcp.Core/Commands/Table/TableCommands.Preflight.cs
+++ b/src/ExcelMcp.Core/Commands/Table/TableCommands.Preflight.cs
@@ -139,8 +139,8 @@ public partial class TableCommands
         }
 
         InspectHeaders(effectiveRange, hasHeaders, result);
-        InspectExcludedContiguousColumns(effectiveRange, result);
-        InspectSortSensitiveFormulas(effectiveRange, hasHeaders, result, cancellationToken);
+        InspectExcludedContiguousColumns(effectiveRange, result.Findings);
+        InspectSortSensitiveFormulas(effectiveRange, hasHeaders, result.Findings, cancellationToken);
 
         result.SafeToCreate = result.Findings.All(
             finding => finding.Severity != TablePreflightSeverity.Blocker);
@@ -233,7 +233,7 @@ public partial class TableCommands
 
     private static void InspectExcludedContiguousColumns(
         Excel.Range effectiveRange,
-        TablePreflightResult result)
+        List<TablePreflightFinding> findings)
     {
         Excel.Range? effectiveColumns = null;
         Excel.Range? currentRegion = null;
@@ -277,7 +277,7 @@ public partial class TableCommands
 
             if (excludedRanges.Count > 0)
             {
-                result.Findings.Add(new TablePreflightFinding
+                findings.Add(new TablePreflightFinding
                 {
                     Kind = TablePreflightFindingKind.ExcludedContiguousColumns,
                     Severity = TablePreflightSeverity.Warning,
@@ -300,7 +300,7 @@ public partial class TableCommands
     private static void InspectSortSensitiveFormulas(
         Excel.Range effectiveRange,
         bool hasHeaders,
-        TablePreflightResult result,
+        List<TablePreflightFinding> findings,
         CancellationToken cancellationToken)
     {
         Excel.Range? rows = null;
@@ -346,7 +346,7 @@ public partial class TableCommands
 
             if (warningAddresses.Count > 0)
             {
-                result.Findings.Add(new TablePreflightFinding
+                findings.Add(new TablePreflightFinding
                 {
                     Kind = TablePreflightFindingKind.SortSensitiveFormula,
                     Severity = TablePreflightSeverity.Warning,

--- a/src/ExcelMcp.Core/Commands/Table/TableCommands.Sort.cs
+++ b/src/ExcelMcp.Core/Commands/Table/TableCommands.Sort.cs
@@ -1,185 +1,367 @@
 using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Models;
+using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.Core.Commands.Table;
 
 /// <summary>
-/// TableCommands partial class - Sort operations
+/// Table sort operations.
 /// </summary>
 public partial class TableCommands
 {
-    // Excel constants for sorting
     private const int xlYes = 1;
-    private const int xlAscending = 1;
-    private const int xlDescending = 2;
 
-    /// <summary>
-    /// Sorts a table by a single column
-    /// </summary>
+    /// <inheritdoc />
     public OperationResult Sort(
         IExcelBatch batch,
         string tableName,
         string columnName,
-        bool ascending = true)
+        bool ascending = true) =>
+        Sort(batch, tableName, columnName, ascending, validateIntegrity: false);
+
+    /// <inheritdoc />
+    public TableSortResult Sort(
+        IExcelBatch batch,
+        string tableName,
+        string columnName,
+        bool ascending = true,
+        bool validateIntegrity = false,
+        List<string>? keyColumns = null,
+        List<TableSortControlTotal>? controlTotals = null)
     {
-        // Security: Validate table name
-        ValidateTableName(tableName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(columnName);
 
-        return batch.Execute((ctx, ct) =>
-        {
-            dynamic? table = null;
-            dynamic? columns = null;
-            dynamic? column = null;
-            dynamic? sortRange = null;
-            dynamic? columnRange = null;
-
-            try
-            {
-                table = FindTable(ctx.Book, tableName);
-
-                // Find column
-                columns = table.ListColumns;
-                column = columns.Item(columnName);
-                if (column == null)
-                {
-                    throw new InvalidOperationException($"Column '{columnName}' not found in table '{tableName}'");
-                }
-
-                // Get ranges for sorting
-                sortRange = table.Range;
-                columnRange = column.Range;
-
-                // Perform sort
-                sortRange.Sort(
-                    Key1: columnRange,
-                    Order1: ascending ? xlAscending : xlDescending,
-                    Header: xlYes
-                );
-
-                return new OperationResult { Success = true, FilePath = batch.WorkbookPath };
-            }
-            finally
-            {
-                ComUtilities.Release(ref columnRange);
-                ComUtilities.Release(ref sortRange);
-                ComUtilities.Release(ref column);
-                ComUtilities.Release(ref columns);
-                ComUtilities.Release(ref table);
-            }
-        });
+        return SortCore(
+            batch,
+            tableName,
+            [new TableSortColumn { ColumnName = columnName, Ascending = ascending }],
+            validateIntegrity,
+            keyColumns,
+            controlTotals);
     }
 
     /// <inheritdoc />
     public OperationResult SortMulti(
         IExcelBatch batch,
         string tableName,
-        List<TableSortColumn> sortColumns)
+        List<TableSortColumn> sortColumns) =>
+        SortMulti(batch, tableName, sortColumns, validateIntegrity: false);
+
+    /// <inheritdoc />
+    public TableSortResult SortMulti(
+        IExcelBatch batch,
+        string tableName,
+        List<TableSortColumn> sortColumns,
+        bool validateIntegrity = false,
+        List<string>? keyColumns = null,
+        List<TableSortControlTotal>? controlTotals = null)
     {
-        // Security: Validate table name
+        ArgumentNullException.ThrowIfNull(sortColumns);
+        if (sortColumns.Count == 0)
+        {
+            throw new ArgumentException("At least one sort column must be specified.", nameof(sortColumns));
+        }
+
+        if (sortColumns.Count > 3)
+        {
+            throw new ArgumentException("Excel supports a maximum of 3 sort levels.", nameof(sortColumns));
+        }
+
+        foreach (TableSortColumn sortColumn in sortColumns)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(sortColumn.ColumnName);
+        }
+
+        return SortCore(
+            batch,
+            tableName,
+            sortColumns,
+            validateIntegrity,
+            keyColumns,
+            controlTotals);
+    }
+
+    private static TableSortResult SortCore(
+        IExcelBatch batch,
+        string tableName,
+        IReadOnlyList<TableSortColumn> sortColumns,
+        bool validateIntegrity,
+        IReadOnlyList<string>? keyColumns,
+        IReadOnlyList<TableSortControlTotal>? controlTotals)
+    {
         ValidateTableName(tableName);
+        ValidateIntegrityArguments(keyColumns, controlTotals);
+
+        bool validationRequested = validateIntegrity
+            || keyColumns is { Count: > 0 }
+            || controlTotals is { Count: > 0 };
+        IReadOnlyList<string> requestedKeyColumns = keyColumns ?? [];
+        IReadOnlyList<TableSortControlTotal> requestedControlTotals = controlTotals ?? [];
 
         return batch.Execute((ctx, ct) =>
         {
-            if (sortColumns == null || sortColumns.Count == 0)
-            {
-                throw new ArgumentException("At least one sort column must be specified", nameof(sortColumns));
-            }
-
-            if (sortColumns.Count > 3)
-            {
-                throw new ArgumentException("Excel supports a maximum of 3 sort levels", nameof(sortColumns));
-            }
-
-            dynamic? table = null;
-            dynamic? sortRange = null;
-            dynamic? key1 = null, key2 = null, key3 = null;
-
+            Excel.ListObject? table = null;
+            Excel.Range? tableRange = null;
+            var keyRanges = new List<Excel.Range>();
             try
             {
-                table = FindTable(ctx.Book, tableName);
+                table = (Excel.ListObject)FindTable(ctx.Book, tableName);
+                tableRange = table.Range;
+                ResolveSortKeyRanges(table, sortColumns, keyRanges);
 
-                sortRange = table.Range;
-                dynamic? columns = null;
+                var result = new TableSortResult
+                {
+                    FilePath = batch.WorkbookPath,
+                    TableName = tableName,
+                    TableRange = Convert.ToString(tableRange.Address) ?? string.Empty,
+                    ValidationPerformed = validationRequested
+                };
+
+                if (!validationRequested)
+                {
+                    ApplySort(tableRange, keyRanges, sortColumns);
+                    result.Success = true;
+                    result.SortAttempted = true;
+                    result.SortCommitted = true;
+                    return result;
+                }
+
+                TableSortSnapshot snapshot = CaptureSortSnapshot(
+                    table,
+                    tableRange,
+                    requestedKeyColumns,
+                    requestedControlTotals,
+                    result,
+                    ct);
+                if (result.Findings.Any(finding => finding.Severity == TablePreflightSeverity.Blocker))
+                {
+                    result.Success = false;
+                    result.ErrorMessage = "The table was not sorted because an integrity check could not be evaluated safely.";
+                    return result;
+                }
+
+                Exception? postSortException = null;
                 try
                 {
-                    columns = table.ListColumns;
+                    ApplySort(tableRange, keyRanges, sortColumns);
+                    result.SortAttempted = true;
 
-                    // Get column ranges
-                    for (int i = 0; i < sortColumns.Count; i++)
+                    TableSortState postSortState = CaptureTableSortState(
+                        table,
+                        calculateValues: requestedControlTotals.Count > 0,
+                        ct);
+                    bool integrityPreserved = ValidatePostSortIntegrity(
+                        snapshot,
+                        postSortState,
+                        requestedControlTotals,
+                        result);
+                    result.IntegrityPreserved = integrityPreserved;
+
+                    if (integrityPreserved)
                     {
-                        dynamic? col = null;
-                        try
-                        {
-                            col = columns.Item(sortColumns[i].ColumnName);
-                            if (col == null)
-                            {
-                                throw new InvalidOperationException($"Column '{sortColumns[i].ColumnName}' not found in table '{tableName}'");
-                            }
-
-                            if (i == 0) key1 = col.Range;
-                            else if (i == 1) key2 = col.Range;
-                            else if (i == 2) key3 = col.Range;
-                        }
-                        finally
-                        {
-                            ComUtilities.Release(ref col);
-                        }
+                        result.Success = true;
+                        result.SortCommitted = true;
+                        return result;
                     }
                 }
-                finally
+#pragma warning disable CA1031 // Any failure after mutation must pass through rollback before preserving the original exception.
+                catch (Exception ex)
+#pragma warning restore CA1031
                 {
-                    ComUtilities.Release(ref columns);
+                    postSortException = ex;
+                    result.IntegrityPreserved = false;
                 }
 
-                // Perform sort based on number of columns
-                if (sortColumns.Count == 1)
+                result.RollbackAttempted = true;
+                string? rollbackError = null;
+                try
                 {
-                    sortRange.Sort(
-                        Key1: key1,
-                        Order1: sortColumns[0].Ascending ? xlAscending : xlDescending,
-                        Header: xlYes
-                    );
+                    RestoreSortSnapshot(table, snapshot);
+                    TableSortState restoredState = CaptureTableSortState(
+                        table,
+                        calculateValues: requestedControlTotals.Count > 0,
+                        CancellationToken.None);
+                    result.RollbackSucceeded = SnapshotWasRestored(snapshot, restoredState);
                 }
-                else if (sortColumns.Count == 2)
+#pragma warning disable CA1031 // Rollback must report an uncertain workbook state instead of hiding the original failed validation.
+                catch (Exception ex) when (ex is not OperationCanceledException)
+#pragma warning restore CA1031
                 {
-                    sortRange.Sort(
-                        Key1: key1,
-                        Order1: sortColumns[0].Ascending ? xlAscending : xlDescending,
-                        Key2: key2,
-                        Order2: sortColumns[1].Ascending ? xlAscending : xlDescending,
-                        Header: xlYes
-                    );
-                }
-                else if (sortColumns.Count == 3)
-                {
-                    sortRange.Sort(
-                        Key1: key1,
-                        Order1: sortColumns[0].Ascending ? xlAscending : xlDescending,
-                        Key2: key2,
-                        Order2: sortColumns[1].Ascending ? xlAscending : xlDescending,
-                        Key3: key3,
-                        Order3: sortColumns[2].Ascending ? xlAscending : xlDescending,
-                        Header: xlYes
-                    );
+                    result.RollbackSucceeded = false;
+                    rollbackError = ex.Message;
                 }
 
-                // Build description
-                var sortDesc = string.Join(", ", sortColumns.Select(sc => $"{sc.ColumnName} ({(sc.Ascending ? "asc" : "desc")})"));
+                result.Success = false;
+                result.SortCommitted = false;
+                if (postSortException is not null)
+                {
+                    if (result.RollbackSucceeded == true)
+                    {
+                        System.Runtime.ExceptionServices.ExceptionDispatchInfo
+                            .Capture(postSortException)
+                            .Throw();
+                    }
 
-                return new OperationResult { Success = true, FilePath = batch.WorkbookPath };
+                    throw new InvalidOperationException(
+                        "Table sorting failed after mutation, and the original table contents could not be restored and verified."
+                            + (string.IsNullOrWhiteSpace(rollbackError) ? string.Empty : $" Rollback error: {rollbackError}"),
+                        postSortException);
+                }
+
+                result.ErrorMessage = result.RollbackSucceeded == true
+                    ? "Post-sort integrity validation failed. The original table contents were restored and verified."
+                    : "Post-sort integrity validation failed, and the original table contents could not be restored and verified."
+                        + (string.IsNullOrWhiteSpace(rollbackError) ? string.Empty : $" Rollback error: {rollbackError}");
+                return result;
             }
             finally
             {
-                ComUtilities.Release(ref key3);
-                ComUtilities.Release(ref key2);
-                ComUtilities.Release(ref key1);
-                ComUtilities.Release(ref sortRange);
+                for (int index = keyRanges.Count - 1; index >= 0; index--)
+                {
+                    Excel.Range? keyRange = keyRanges[index];
+                    ComUtilities.Release(ref keyRange);
+                }
+
+                ComUtilities.Release(ref tableRange);
                 ComUtilities.Release(ref table);
             }
         });
     }
+
+    private static void ValidateIntegrityArguments(
+        IReadOnlyList<string>? keyColumns,
+        IReadOnlyList<TableSortControlTotal>? controlTotals)
+    {
+        if (keyColumns is not null)
+        {
+            foreach (string keyColumn in keyColumns)
+            {
+                ArgumentException.ThrowIfNullOrWhiteSpace(keyColumn);
+            }
+
+            if (keyColumns.Distinct(StringComparer.OrdinalIgnoreCase).Count() != keyColumns.Count)
+            {
+                throw new ArgumentException("Row-key column names must be unique.", nameof(keyColumns));
+            }
+        }
+
+        if (controlTotals is null)
+        {
+            return;
+        }
+
+        foreach (TableSortControlTotal controlTotal in controlTotals)
+        {
+            ArgumentNullException.ThrowIfNull(controlTotal);
+            ArgumentException.ThrowIfNullOrWhiteSpace(controlTotal.ColumnName);
+            if (controlTotal.Tolerance < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(controlTotals),
+                    "Control-total tolerance cannot be negative.");
+            }
+        }
+
+        if (controlTotals
+            .Select(total => total.ColumnName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count() != controlTotals.Count)
+        {
+            throw new ArgumentException("Control-total column names must be unique.", nameof(controlTotals));
+        }
+    }
+
+    private static void ResolveSortKeyRanges(
+        Excel.ListObject table,
+        IReadOnlyList<TableSortColumn> sortColumns,
+        List<Excel.Range> keyRanges)
+    {
+        Excel.ListColumns? columns = null;
+        try
+        {
+            columns = table.ListColumns;
+            foreach (TableSortColumn sortColumn in sortColumns)
+            {
+                Excel.ListColumn? matchedColumn = null;
+                try
+                {
+                    for (int index = 1; index <= columns.Count; index++)
+                    {
+                        Excel.ListColumn? candidate = null;
+                        try
+                        {
+                            candidate = columns.Item[index];
+                            if (string.Equals(
+                                candidate.Name,
+                                sortColumn.ColumnName,
+                                StringComparison.OrdinalIgnoreCase))
+                            {
+                                matchedColumn = candidate;
+                                candidate = null;
+                                break;
+                            }
+                        }
+                        finally
+                        {
+                            ComUtilities.Release(ref candidate);
+                        }
+                    }
+
+                    if (matchedColumn is null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Column '{sortColumn.ColumnName}' not found in table '{table.Name}'.");
+                    }
+
+                    keyRanges.Add(matchedColumn.Range);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref matchedColumn);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref columns);
+        }
+    }
+
+    private static void ApplySort(
+        Excel.Range sortRange,
+        List<Excel.Range> keyRanges,
+        IReadOnlyList<TableSortColumn> sortColumns)
+    {
+        // Reason: Excel's early-bound _Sort overload rejects valid ListObject range keys that the late-bound COM call accepts.
+        dynamic sortTarget = sortRange;
+        if (sortColumns.Count == 1)
+        {
+            sortTarget.Sort(
+                Key1: keyRanges[0],
+                Order1: sortColumns[0].Ascending ? 1 : 2,
+                Header: xlYes);
+            return;
+        }
+
+        if (sortColumns.Count == 2)
+        {
+            sortTarget.Sort(
+                Key1: keyRanges[0],
+                Order1: sortColumns[0].Ascending ? 1 : 2,
+                Key2: keyRanges[1],
+                Order2: sortColumns[1].Ascending ? 1 : 2,
+                Header: xlYes);
+            return;
+        }
+
+        sortTarget.Sort(
+            Key1: keyRanges[0],
+            Order1: sortColumns[0].Ascending ? 1 : 2,
+            Key2: keyRanges[1],
+            Order2: sortColumns[1].Ascending ? 1 : 2,
+            Key3: keyRanges[2],
+            Order3: sortColumns[2].Ascending ? 1 : 2,
+            Header: xlYes);
+    }
 }
-
-
-

--- a/src/ExcelMcp.Core/Commands/Table/TableCommands.SortIntegrity.cs
+++ b/src/ExcelMcp.Core/Commands/Table/TableCommands.SortIntegrity.cs
@@ -1,0 +1,1022 @@
+using System.Globalization;
+using System.Text;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.Core.Models;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Table;
+
+public partial class TableCommands
+{
+    private static TableSortSnapshot CaptureSortSnapshot(
+        Excel.ListObject table,
+        Excel.Range tableRange,
+        IReadOnlyList<string> keyColumns,
+        IReadOnlyList<TableSortControlTotal> controlTotals,
+        TableSortResult result,
+        CancellationToken cancellationToken)
+    {
+        TableSortState state = CaptureTableSortState(
+            table,
+            calculateValues: controlTotals.Count > 0,
+            cancellationToken);
+        var snapshot = new TableSortSnapshot { State = state };
+
+        Excel.Range? dataBodyRange = null;
+        try
+        {
+            dataBodyRange = table.DataBodyRange;
+            if (dataBodyRange is not null)
+            {
+                InspectSortSensitiveFormulas(
+                    dataBodyRange,
+                    hasHeaders: false,
+                    result.Findings,
+                    cancellationToken);
+            }
+
+            InspectAdjacentTableDataAndFormulas(
+                tableRange,
+                dataBodyRange,
+                result.Findings,
+                cancellationToken);
+        }
+        finally
+        {
+            ComUtilities.Release(ref dataBodyRange);
+        }
+
+        snapshot.CalculatedColumns = AnalyzeCalculatedColumns(state, result.Findings);
+
+        if (!TryResolveColumnIndexes(state.Headers, keyColumns, out int[] keyIndexes, out string? missingKey))
+        {
+            result.Findings.Add(new TablePreflightFinding
+            {
+                Kind = TablePreflightFindingKind.InvalidRowKey,
+                Severity = TablePreflightSeverity.Blocker,
+                Message = $"Row-key column '{missingKey}' was not found in the table.",
+                Remediation = "Choose existing table columns for the composite row key."
+            });
+        }
+        else if (keyIndexes.Length > 0)
+        {
+            if (!TryBuildKeyedRows(
+                state,
+                keyIndexes,
+                out Dictionary<string, KeyedRow> keyedRows,
+                out TablePreflightFindingKind failureKind,
+                out string failureMessage))
+            {
+                result.Findings.Add(new TablePreflightFinding
+                {
+                    Kind = failureKind,
+                    Severity = TablePreflightSeverity.Blocker,
+                    Message = failureMessage,
+                    Remediation = "Choose columns whose combined values are populated and unique for every table row."
+                });
+            }
+            else
+            {
+                snapshot.KeyColumnIndexes = keyIndexes;
+                snapshot.KeyedRows = keyedRows;
+            }
+        }
+
+        foreach (TableSortControlTotal controlTotal in controlTotals)
+        {
+            int columnIndex = FindColumnIndex(state.Headers, controlTotal.ColumnName);
+            if (columnIndex < 0)
+            {
+                result.Findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.InvalidControlTotal,
+                    Severity = TablePreflightSeverity.Blocker,
+                    Message = $"Control-total column '{controlTotal.ColumnName}' was not found in the table.",
+                    Remediation = "Choose an existing numeric table column for the control total."
+                });
+                continue;
+            }
+
+            if (!TryCalculateControlTotal(state, columnIndex, out decimal total, out string? error))
+            {
+                result.Findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.InvalidControlTotal,
+                    Severity = TablePreflightSeverity.Blocker,
+                    Message = $"Control-total column '{controlTotal.ColumnName}' cannot be summed: {error}",
+                    Remediation = "Remove nonnumeric or error values, or choose another numeric column."
+                });
+                continue;
+            }
+
+            snapshot.ControlTotals.Add(new ControlTotalSnapshot
+            {
+                ColumnIndex = columnIndex,
+                Request = controlTotal,
+                Before = total
+            });
+        }
+
+        return snapshot;
+    }
+
+    private static TableSortState CaptureTableSortState(
+        Excel.ListObject table,
+        bool calculateValues,
+        CancellationToken cancellationToken)
+    {
+        Excel.Range? tableRange = null;
+        Excel.Range? tableRows = null;
+        Excel.Range? tableColumns = null;
+        Excel.Range? dataBodyRange = null;
+        Excel.Range? dataRows = null;
+        Excel.Range? totalsRowRange = null;
+        Excel.ListColumns? listColumns = null;
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            tableRange = table.Range;
+            tableRows = tableRange.Rows;
+            tableColumns = tableRange.Columns;
+            dataBodyRange = table.DataBodyRange;
+            if (calculateValues && dataBodyRange is not null)
+            {
+                dataBodyRange.Calculate();
+            }
+
+            int tableRowCount = Convert.ToInt32(tableRows.Count, CultureInfo.InvariantCulture);
+            int columnCount = Convert.ToInt32(tableColumns.Count, CultureInfo.InvariantCulture);
+            int dataRowCount = 0;
+            int dataFirstRow = 0;
+            object? dataFormulas = null;
+            object? dataValues = null;
+            bool[,] dataFormulaFlags = new bool[0, columnCount];
+            if (dataBodyRange is not null)
+            {
+                dataRows = dataBodyRange.Rows;
+                dataRowCount = Convert.ToInt32(dataRows.Count, CultureInfo.InvariantCulture);
+                dataFirstRow = Convert.ToInt32(dataBodyRange.Row, CultureInfo.InvariantCulture);
+                dataFormulas = CloneMatrix(dataBodyRange.FormulaR1C1);
+                dataValues = CloneMatrix(dataBodyRange.Value2);
+                dataFormulaFlags = CaptureFormulaFlags(dataBodyRange, dataRowCount, columnCount);
+            }
+
+            bool showTotals = table.ShowTotals;
+            object? totalsContent = null;
+            object? totalsValues = null;
+            bool[,] totalsFormulaFlags = new bool[0, columnCount];
+            if (showTotals)
+            {
+                totalsRowRange = table.TotalsRowRange;
+                totalsContent = CloneMatrix(totalsRowRange.FormulaR1C1);
+                totalsValues = CloneMatrix(totalsRowRange.Value2);
+                totalsFormulaFlags = CaptureFormulaFlags(totalsRowRange, 1, columnCount);
+            }
+
+            listColumns = table.ListColumns;
+            var headers = new List<string>(columnCount);
+            for (int index = 1; index <= listColumns.Count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Excel.ListColumn? column = null;
+                try
+                {
+                    column = listColumns.Item[index];
+                    headers.Add(column.Name);
+                }
+                finally
+                {
+                    ComUtilities.Release(ref column);
+                }
+            }
+
+            return new TableSortState
+            {
+                RangeAddress = Convert.ToString(tableRange.Address) ?? string.Empty,
+                TableRowCount = tableRowCount,
+                ColumnCount = columnCount,
+                TableFirstColumn = Convert.ToInt32(tableRange.Column, CultureInfo.InvariantCulture),
+                DataFirstRow = dataFirstRow,
+                DataRowCount = dataRowCount,
+                Headers = headers,
+                ShowTotals = showTotals,
+                TotalsContentSignature = BuildContentSignature(
+                    totalsContent,
+                    totalsValues,
+                    totalsFormulaFlags,
+                    showTotals ? 1 : 0,
+                    columnCount),
+                TotalsFormulaMatrix = totalsContent,
+                TotalsValueMatrix = totalsValues,
+                TotalsFormulaFlags = totalsFormulaFlags,
+                DataFormulaMatrix = dataFormulas,
+                DataValueMatrix = dataValues,
+                DataFormulaFlags = dataFormulaFlags,
+                DataContentSignature = BuildContentSignature(
+                    dataFormulas,
+                    dataValues,
+                    dataFormulaFlags,
+                    dataRowCount,
+                    columnCount),
+                RowSignatures = BuildRowSignatures(
+                    dataFormulas,
+                    dataValues,
+                    dataFormulaFlags,
+                    dataRowCount,
+                    columnCount)
+            };
+        }
+        finally
+        {
+            ComUtilities.Release(ref listColumns);
+            ComUtilities.Release(ref totalsRowRange);
+            ComUtilities.Release(ref dataRows);
+            ComUtilities.Release(ref dataBodyRange);
+            ComUtilities.Release(ref tableColumns);
+            ComUtilities.Release(ref tableRows);
+            ComUtilities.Release(ref tableRange);
+        }
+    }
+
+    private static List<CalculatedColumnSnapshot> AnalyzeCalculatedColumns(
+        TableSortState state,
+        List<TablePreflightFinding> findings)
+    {
+        var calculatedColumns = new List<CalculatedColumnSnapshot>();
+        if (state.DataRowCount == 0)
+        {
+            return calculatedColumns;
+        }
+
+        for (int columnIndex = 0; columnIndex < state.ColumnCount; columnIndex++)
+        {
+            var formulas = new List<string>();
+            int formulaCount = 0;
+            for (int rowIndex = 0; rowIndex < state.DataRowCount; rowIndex++)
+            {
+                if (state.DataFormulaFlags[rowIndex, columnIndex])
+                {
+                    formulaCount++;
+                    formulas.Add(Convert.ToString(
+                        GetMatrixValue(state.DataFormulaMatrix ?? string.Empty, rowIndex, columnIndex),
+                        CultureInfo.InvariantCulture) ?? string.Empty);
+                }
+            }
+
+            if (formulaCount == 0)
+            {
+                continue;
+            }
+
+            string[] patterns = formulas.Distinct(StringComparer.Ordinal).ToArray();
+            if (formulaCount == state.DataRowCount && patterns.Length == 1)
+            {
+                calculatedColumns.Add(new CalculatedColumnSnapshot
+                {
+                    ColumnIndex = columnIndex,
+                    ColumnName = state.Headers[columnIndex],
+                    FormulaR1C1 = patterns[0]
+                });
+                continue;
+            }
+
+            findings.Add(new TablePreflightFinding
+            {
+                Kind = TablePreflightFindingKind.MixedFormulaColumn,
+                Severity = TablePreflightSeverity.Warning,
+                IsHeuristic = true,
+                Addresses =
+                [
+                    GetAbsoluteRangeAddress(
+                        state.TableFirstColumn + columnIndex,
+                        state.DataFirstRow,
+                        state.TableFirstColumn + columnIndex,
+                        state.DataFirstRow + state.DataRowCount - 1)
+                ],
+                Message = $"Column '{state.Headers[columnIndex]}' mixes formulas, formula patterns, or literal values and may contain intentional overrides.",
+                Remediation = "Confirm that the mixed cells are intentional before relying on calculated-column consistency."
+            });
+        }
+
+        return calculatedColumns;
+    }
+
+    private static bool ValidatePostSortIntegrity(
+        TableSortSnapshot snapshot,
+        TableSortState postSortState,
+        IReadOnlyList<TableSortControlTotal> requestedControlTotals,
+        TableSortResult result)
+    {
+        TableSortState before = snapshot.State;
+        TableSortIntegrityChecks checks = result.Checks;
+        checks.RangePreserved = string.Equals(
+            before.RangeAddress,
+            postSortState.RangeAddress,
+            StringComparison.Ordinal);
+        checks.ShapePreserved = before.TableRowCount == postSortState.TableRowCount
+            && before.DataRowCount == postSortState.DataRowCount
+            && before.ColumnCount == postSortState.ColumnCount;
+        checks.HeadersPreserved = before.Headers.SequenceEqual(
+            postSortState.Headers,
+            StringComparer.Ordinal);
+        checks.TotalsRowPreserved = before.ShowTotals == postSortState.ShowTotals
+            && string.Equals(
+                before.TotalsContentSignature,
+                postSortState.TotalsContentSignature,
+                StringComparison.Ordinal);
+        checks.RowSetPreserved = MultisetEquals(before.RowSignatures, postSortState.RowSignatures);
+
+        if (checks.RangePreserved != true
+            || checks.ShapePreserved != true
+            || checks.HeadersPreserved != true
+            || checks.TotalsRowPreserved != true)
+        {
+            result.Findings.Add(new TablePreflightFinding
+            {
+                Kind = TablePreflightFindingKind.TableStructureChanged,
+                Severity = TablePreflightSeverity.Blocker,
+                Addresses = [before.RangeAddress],
+                Message = "The table range, shape, headers, or totals row changed during sorting.",
+                Remediation = "Review the table structure after the operation; automatic rollback has been attempted."
+            });
+        }
+
+        if (checks.RowSetPreserved != true)
+        {
+            result.Findings.Add(new TablePreflightFinding
+            {
+                Kind = TablePreflightFindingKind.TableRowsChanged,
+                Severity = TablePreflightSeverity.Blocker,
+                Addresses = [before.RangeAddress],
+                Message = "Complete logical table rows were not preserved as a permutation.",
+                Remediation = "Review formulas and row data; automatic rollback has been attempted."
+            });
+        }
+
+        foreach (CalculatedColumnSnapshot calculatedColumn in snapshot.CalculatedColumns)
+        {
+            bool consistentAfter = ColumnMatchesFormula(postSortState, calculatedColumn);
+            checks.CalculatedColumns.Add(new TableCalculatedColumnCheckResult
+            {
+                ColumnName = calculatedColumn.ColumnName,
+                FormulaR1C1 = calculatedColumn.FormulaR1C1,
+                ConsistentBefore = true,
+                ConsistentAfter = consistentAfter,
+                Passed = consistentAfter
+            });
+            if (!consistentAfter)
+            {
+                result.Findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.CalculatedColumnChanged,
+                    Severity = TablePreflightSeverity.Blocker,
+                    Message = $"Calculated column '{calculatedColumn.ColumnName}' no longer has its original formula pattern.",
+                    Remediation = "Review the calculated-column formula; automatic rollback has been attempted."
+                });
+            }
+        }
+
+        if (snapshot.KeyColumnIndexes.Length > 0)
+        {
+            var keyCheck = new TableRowKeyCheckResult
+            {
+                KeyColumns = snapshot.KeyColumnIndexes.Select(index => before.Headers[index]).ToList(),
+                BeforeCount = snapshot.KeyedRows.Count
+            };
+            if (!TryBuildKeyedRows(
+                postSortState,
+                snapshot.KeyColumnIndexes,
+                out Dictionary<string, KeyedRow> afterRows,
+                out _,
+                out _))
+            {
+                keyCheck.Passed = false;
+            }
+            else
+            {
+                keyCheck.AfterCount = afterRows.Count;
+                foreach ((string key, KeyedRow originalRow) in snapshot.KeyedRows)
+                {
+                    if (!afterRows.TryGetValue(key, out KeyedRow? afterRow)
+                        || !string.Equals(originalRow.RowSignature, afterRow.RowSignature, StringComparison.Ordinal))
+                    {
+                        keyCheck.MismatchedKeys.Add(originalRow.DisplayKey);
+                    }
+                }
+
+                foreach ((string key, KeyedRow afterRow) in afterRows)
+                {
+                    if (!snapshot.KeyedRows.ContainsKey(key))
+                    {
+                        keyCheck.MismatchedKeys.Add(afterRow.DisplayKey);
+                    }
+                }
+
+                keyCheck.Passed = keyCheck.BeforeCount == keyCheck.AfterCount
+                    && keyCheck.MismatchedKeys.Count == 0;
+            }
+
+            checks.RowKeys = keyCheck;
+            if (!keyCheck.Passed)
+            {
+                result.Findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.RowKeyMismatch,
+                    Severity = TablePreflightSeverity.Blocker,
+                    Message = "Caller-supplied row identities or their complete row contents changed during sorting.",
+                    Remediation = "Review the reported key columns; automatic rollback has been attempted."
+                });
+            }
+        }
+
+        foreach (ControlTotalSnapshot controlTotal in snapshot.ControlTotals)
+        {
+            bool calculated = TryCalculateControlTotal(
+                postSortState,
+                controlTotal.ColumnIndex,
+                out decimal after,
+                out _);
+            decimal delta = calculated ? after - controlTotal.Before : decimal.MaxValue;
+            bool passed = calculated && Math.Abs(delta) <= controlTotal.Request.Tolerance;
+            checks.ControlTotals.Add(new TableControlTotalCheckResult
+            {
+                ColumnName = controlTotal.Request.ColumnName,
+                Before = controlTotal.Before,
+                After = calculated ? after : controlTotal.Before,
+                Delta = calculated ? delta : 0,
+                Tolerance = controlTotal.Request.Tolerance,
+                Passed = passed
+            });
+            if (!passed)
+            {
+                result.Findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.ControlTotalMismatch,
+                    Severity = TablePreflightSeverity.Blocker,
+                    Message = $"Control total for column '{controlTotal.Request.ColumnName}' changed beyond the requested tolerance.",
+                    Remediation = "Review row-dependent formulas or values; automatic rollback has been attempted."
+                });
+            }
+        }
+
+        return checks.RangePreserved == true
+            && checks.ShapePreserved == true
+            && checks.HeadersPreserved == true
+            && checks.TotalsRowPreserved == true
+            && checks.RowSetPreserved == true
+            && checks.CalculatedColumns.All(check => check.Passed)
+            && (checks.RowKeys?.Passed ?? true)
+            && checks.ControlTotals.All(check => check.Passed)
+            && requestedControlTotals.Count == checks.ControlTotals.Count;
+    }
+
+    private static void RestoreSortSnapshot(Excel.ListObject table, TableSortSnapshot snapshot)
+    {
+        Excel.ListColumns? listColumns = null;
+        Excel.Range? dataBodyRange = null;
+        Excel.Range? totalsRowRange = null;
+        try
+        {
+            listColumns = table.ListColumns;
+            if (listColumns.Count != snapshot.State.ColumnCount)
+            {
+                throw new InvalidOperationException("The table column count changed, so the captured contents cannot be restored.");
+            }
+
+            for (int index = 1; index <= listColumns.Count; index++)
+            {
+                Excel.ListColumn? column = null;
+                try
+                {
+                    column = listColumns.Item[index];
+                    column.Name = snapshot.State.Headers[index - 1];
+                }
+                finally
+                {
+                    ComUtilities.Release(ref column);
+                }
+            }
+
+            dataBodyRange = table.DataBodyRange;
+            if (snapshot.State.DataRowCount > 0)
+            {
+                if (dataBodyRange is null)
+                {
+                    throw new InvalidOperationException("The table data body is missing, so the captured contents cannot be restored.");
+                }
+
+                RestoreRangeContent(
+                    dataBodyRange,
+                    snapshot.State.DataFormulaMatrix,
+                    snapshot.State.DataValueMatrix,
+                    snapshot.State.DataFormulaFlags,
+                    snapshot.State.DataRowCount,
+                    snapshot.State.ColumnCount);
+            }
+
+            if (snapshot.State.ShowTotals)
+            {
+                if (!table.ShowTotals)
+                {
+                    table.ShowTotals = true;
+                }
+
+                totalsRowRange = table.TotalsRowRange;
+                RestoreRangeContent(
+                    totalsRowRange,
+                    snapshot.State.TotalsFormulaMatrix,
+                    snapshot.State.TotalsValueMatrix,
+                    snapshot.State.TotalsFormulaFlags,
+                    1,
+                    snapshot.State.ColumnCount);
+            }
+            else if (table.ShowTotals)
+            {
+                table.ShowTotals = false;
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref totalsRowRange);
+            ComUtilities.Release(ref dataBodyRange);
+            ComUtilities.Release(ref listColumns);
+        }
+    }
+
+    private static void RestoreRangeContent(
+        Excel.Range range,
+        object? formulaMatrix,
+        object? valueMatrix,
+        bool[,] formulaFlags,
+        int rowCount,
+        int columnCount)
+    {
+        range.Value2 = valueMatrix;
+        Excel.Range? cells = null;
+        try
+        {
+            cells = range.Cells;
+            for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
+            {
+                for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+                {
+                    object? value = GetMatrixValue(
+                        valueMatrix ?? string.Empty,
+                        rowIndex,
+                        columnIndex);
+                    bool restoreFormula = formulaFlags[rowIndex, columnIndex];
+                    bool forceLiteralText = !restoreFormula
+                        && value is string text
+                        && text.Length > 0
+                        && text[0] is '=' or '+' or '-' or '@';
+                    if (!restoreFormula && !forceLiteralText)
+                    {
+                        continue;
+                    }
+
+                    Excel.Range? cell = null;
+                    try
+                    {
+                        cell = cells[rowIndex + 1, columnIndex + 1];
+                        cell.FormulaR1C1 = restoreFormula
+                            ? Convert.ToString(
+                                GetMatrixValue(formulaMatrix ?? string.Empty, rowIndex, columnIndex),
+                                CultureInfo.InvariantCulture) ?? string.Empty
+                            : $"'{value}";
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref cell);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref cells);
+        }
+    }
+
+    private static bool SnapshotWasRestored(
+        TableSortSnapshot snapshot,
+        TableSortState restoredState) =>
+        string.Equals(snapshot.State.RangeAddress, restoredState.RangeAddress, StringComparison.Ordinal)
+        && snapshot.State.TableRowCount == restoredState.TableRowCount
+        && snapshot.State.ColumnCount == restoredState.ColumnCount
+        && snapshot.State.Headers.SequenceEqual(restoredState.Headers, StringComparer.Ordinal)
+        && snapshot.State.ShowTotals == restoredState.ShowTotals
+        && string.Equals(
+            snapshot.State.DataContentSignature,
+            restoredState.DataContentSignature,
+            StringComparison.Ordinal)
+        && string.Equals(
+            snapshot.State.TotalsContentSignature,
+            restoredState.TotalsContentSignature,
+            StringComparison.Ordinal);
+
+    private static bool ColumnMatchesFormula(
+        TableSortState state,
+        CalculatedColumnSnapshot calculatedColumn)
+    {
+        if (calculatedColumn.ColumnIndex >= state.ColumnCount)
+        {
+            return false;
+        }
+
+        for (int rowIndex = 0; rowIndex < state.DataRowCount; rowIndex++)
+        {
+            if (!state.DataFormulaFlags[rowIndex, calculatedColumn.ColumnIndex]
+                || !string.Equals(
+                    Convert.ToString(
+                        GetMatrixValue(
+                            state.DataFormulaMatrix ?? string.Empty,
+                            rowIndex,
+                            calculatedColumn.ColumnIndex),
+                        CultureInfo.InvariantCulture),
+                    calculatedColumn.FormulaR1C1,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveColumnIndexes(
+        IReadOnlyList<string> headers,
+        IReadOnlyList<string> requestedColumns,
+        out int[] indexes,
+        out string? missingColumn)
+    {
+        indexes = new int[requestedColumns.Count];
+        for (int index = 0; index < requestedColumns.Count; index++)
+        {
+            int columnIndex = FindColumnIndex(headers, requestedColumns[index]);
+            if (columnIndex < 0)
+            {
+                indexes = [];
+                missingColumn = requestedColumns[index];
+                return false;
+            }
+
+            indexes[index] = columnIndex;
+        }
+
+        missingColumn = null;
+        return true;
+    }
+
+    private static int FindColumnIndex(IReadOnlyList<string> headers, string columnName)
+    {
+        for (int index = 0; index < headers.Count; index++)
+        {
+            if (string.Equals(headers[index], columnName, StringComparison.OrdinalIgnoreCase))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool TryBuildKeyedRows(
+        TableSortState state,
+        IReadOnlyList<int> keyColumnIndexes,
+        out Dictionary<string, KeyedRow> keyedRows,
+        out TablePreflightFindingKind failureKind,
+        out string failureMessage)
+    {
+        keyedRows = new Dictionary<string, KeyedRow>(StringComparer.Ordinal);
+        for (int rowIndex = 0; rowIndex < state.DataRowCount; rowIndex++)
+        {
+            var canonicalKey = new StringBuilder();
+            var displayKey = new StringBuilder();
+            foreach (int columnIndex in keyColumnIndexes)
+            {
+                object? value = GetMatrixValue(
+                    state.DataValueMatrix ?? string.Empty,
+                    rowIndex,
+                    columnIndex);
+                if (value is null || value is string text && string.IsNullOrWhiteSpace(text))
+                {
+                    failureKind = TablePreflightFindingKind.InvalidRowKey;
+                    failureMessage = "One or more composite row keys are blank.";
+                    return false;
+                }
+
+                AppendLengthPrefixed(canonicalKey, CanonicalizeCell(value));
+                if (displayKey.Length > 0)
+                {
+                    displayKey.Append(" | ");
+                }
+
+                displayKey.Append(Convert.ToString(value, CultureInfo.InvariantCulture));
+            }
+
+            string key = canonicalKey.ToString();
+            if (!keyedRows.TryAdd(
+                key,
+                new KeyedRow
+                {
+                    DisplayKey = displayKey.ToString(),
+                    RowSignature = state.RowSignatures[rowIndex]
+                }))
+            {
+                failureKind = TablePreflightFindingKind.DuplicateRowKey;
+                failureMessage = $"Composite row key '{displayKey}' is not unique.";
+                return false;
+            }
+        }
+
+        failureKind = default;
+        failureMessage = string.Empty;
+        return true;
+    }
+
+    private static bool TryCalculateControlTotal(
+        TableSortState state,
+        int columnIndex,
+        out decimal total,
+        out string? error)
+    {
+        total = 0;
+        try
+        {
+            for (int rowIndex = 0; rowIndex < state.DataRowCount; rowIndex++)
+            {
+                object? value = GetMatrixValue(
+                    state.DataValueMatrix ?? string.Empty,
+                    rowIndex,
+                    columnIndex);
+                if (value is null || value is string text && string.IsNullOrWhiteSpace(text))
+                {
+                    continue;
+                }
+
+                if (!TryConvertNumericValue(value, out decimal number))
+                {
+                    error = $"row {rowIndex + 1} contains a nonnumeric or error value";
+                    return false;
+                }
+
+                total = checked(total + number);
+            }
+        }
+        catch (OverflowException)
+        {
+            error = "the numeric sum exceeds the supported decimal range";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool TryConvertNumericValue(object value, out decimal number)
+    {
+        switch (value)
+        {
+            case byte or sbyte or short or ushort or int or uint or long or ulong or decimal:
+                number = Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+                return true;
+            case float single when !float.IsNaN(single) && !float.IsInfinity(single):
+                number = Convert.ToDecimal(single, CultureInfo.InvariantCulture);
+                return true;
+            case double @double when !double.IsNaN(@double) && !double.IsInfinity(@double):
+                number = Convert.ToDecimal(@double, CultureInfo.InvariantCulture);
+                return true;
+            default:
+                number = 0;
+                return false;
+        }
+    }
+
+    private static List<string> BuildRowSignatures(
+        object? dataFormulaMatrix,
+        object? dataValueMatrix,
+        bool[,] formulaFlags,
+        int rowCount,
+        int columnCount)
+    {
+        var signatures = new List<string>(rowCount);
+        for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
+        {
+            var signature = new StringBuilder();
+            for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+            {
+                AppendLengthPrefixed(
+                    signature,
+                    CanonicalizeLogicalCell(
+                        GetMatrixValue(dataFormulaMatrix ?? string.Empty, rowIndex, columnIndex),
+                        GetMatrixValue(dataValueMatrix ?? string.Empty, rowIndex, columnIndex),
+                        formulaFlags[rowIndex, columnIndex]));
+            }
+
+            signatures.Add(signature.ToString());
+        }
+
+        return signatures;
+    }
+
+    private static bool MultisetEquals(List<string> before, List<string> after)
+    {
+        if (before.Count != after.Count)
+        {
+            return false;
+        }
+
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (string signature in before)
+        {
+            counts[signature] = counts.GetValueOrDefault(signature) + 1;
+        }
+
+        foreach (string signature in after)
+        {
+            if (!counts.TryGetValue(signature, out int count))
+            {
+                return false;
+            }
+
+            if (count == 1)
+            {
+                counts.Remove(signature);
+            }
+            else
+            {
+                counts[signature] = count - 1;
+            }
+        }
+
+        return counts.Count == 0;
+    }
+
+    private static string BuildContentSignature(
+        object? formulaMatrix,
+        object? valueMatrix,
+        bool[,] formulaFlags,
+        int rowCount,
+        int columnCount)
+    {
+        if (rowCount == 0 || columnCount == 0)
+        {
+            return string.Empty;
+        }
+
+        var signature = new StringBuilder();
+        for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
+        {
+            for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+            {
+                AppendLengthPrefixed(
+                    signature,
+                    CanonicalizeLogicalCell(
+                        GetMatrixValue(formulaMatrix ?? string.Empty, rowIndex, columnIndex),
+                        GetMatrixValue(valueMatrix ?? string.Empty, rowIndex, columnIndex),
+                        formulaFlags[rowIndex, columnIndex]));
+            }
+        }
+
+        return signature.ToString();
+    }
+
+    private static string CanonicalizeCell(object? value) =>
+        value switch
+        {
+            null => "null",
+            string text => $"string:{text}",
+            bool boolean => boolean ? "bool:true" : "bool:false",
+            double number => $"double:{number.ToString("R", CultureInfo.InvariantCulture)}",
+            float number => $"float:{number.ToString("R", CultureInfo.InvariantCulture)}",
+            decimal number => $"decimal:{number.ToString(CultureInfo.InvariantCulture)}",
+            DateTime dateTime => $"datetime:{dateTime.ToString("O", CultureInfo.InvariantCulture)}",
+            _ => $"{value.GetType().FullName}:{Convert.ToString(value, CultureInfo.InvariantCulture)}"
+        };
+
+    private static string CanonicalizeLogicalCell(
+        object? formula,
+        object? value,
+        bool hasFormula) =>
+        hasFormula
+            ? $"formula:{Convert.ToString(formula, CultureInfo.InvariantCulture)}"
+            : $"literal:{CanonicalizeCell(value)}";
+
+    private static bool[,] CaptureFormulaFlags(
+        Excel.Range range,
+        int rowCount,
+        int columnCount)
+    {
+        var flags = new bool[rowCount, columnCount];
+        Excel.Range? cells = null;
+        try
+        {
+            cells = range.Cells;
+            for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
+            {
+                for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+                {
+                    Excel.Range? cell = null;
+                    try
+                    {
+                        cell = cells[rowIndex + 1, columnIndex + 1];
+                        flags[rowIndex, columnIndex] = Convert.ToBoolean(
+                            cell.HasFormula,
+                            CultureInfo.InvariantCulture);
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref cell);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref cells);
+        }
+
+        return flags;
+    }
+
+    private static void AppendLengthPrefixed(StringBuilder builder, string value) =>
+        builder.Append(value.Length).Append(':').Append(value);
+
+    private static object? CloneMatrix(object? matrix) =>
+        matrix is Array array ? array.Clone() : matrix;
+
+    private sealed class TableSortSnapshot
+    {
+        public TableSortState State { get; set; } = new();
+
+        public List<CalculatedColumnSnapshot> CalculatedColumns { get; set; } = [];
+
+        public int[] KeyColumnIndexes { get; set; } = [];
+
+        public Dictionary<string, KeyedRow> KeyedRows { get; set; } = new(StringComparer.Ordinal);
+
+        public List<ControlTotalSnapshot> ControlTotals { get; } = [];
+    }
+
+    private sealed class TableSortState
+    {
+        public string RangeAddress { get; set; } = string.Empty;
+
+        public int TableRowCount { get; set; }
+
+        public int ColumnCount { get; set; }
+
+        public int TableFirstColumn { get; set; }
+
+        public int DataFirstRow { get; set; }
+
+        public int DataRowCount { get; set; }
+
+        public List<string> Headers { get; set; } = [];
+
+        public bool ShowTotals { get; set; }
+
+        public string TotalsContentSignature { get; set; } = string.Empty;
+
+        public object? TotalsFormulaMatrix { get; set; }
+
+        public object? TotalsValueMatrix { get; set; }
+
+        public bool[,] TotalsFormulaFlags { get; set; } = new bool[0, 0];
+
+        public object? DataFormulaMatrix { get; set; }
+
+        public object? DataValueMatrix { get; set; }
+
+        public bool[,] DataFormulaFlags { get; set; } = new bool[0, 0];
+
+        public string DataContentSignature { get; set; } = string.Empty;
+
+        public List<string> RowSignatures { get; set; } = [];
+    }
+
+    private sealed class CalculatedColumnSnapshot
+    {
+        public int ColumnIndex { get; set; }
+
+        public string ColumnName { get; set; } = string.Empty;
+
+        public string FormulaR1C1 { get; set; } = string.Empty;
+    }
+
+    private sealed class ControlTotalSnapshot
+    {
+        public int ColumnIndex { get; set; }
+
+        public TableSortControlTotal Request { get; set; } = new();
+
+        public decimal Before { get; set; }
+    }
+
+    private sealed class KeyedRow
+    {
+        public string DisplayKey { get; set; } = string.Empty;
+
+        public string RowSignature { get; set; } = string.Empty;
+    }
+}

--- a/src/ExcelMcp.Core/Commands/Table/TableCommands.SortIntegrityAnalysis.cs
+++ b/src/ExcelMcp.Core/Commands/Table/TableCommands.SortIntegrityAnalysis.cs
@@ -1,0 +1,236 @@
+using System.Globalization;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.Core.Models;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Table;
+
+public partial class TableCommands
+{
+    private static void InspectAdjacentTableDataAndFormulas(
+        Excel.Range tableRange,
+        Excel.Range? dataBodyRange,
+        List<TablePreflightFinding> findings,
+        CancellationToken cancellationToken)
+    {
+        Excel.Worksheet? worksheet = null;
+        Excel.Range? tableRows = null;
+        Excel.Range? tableColumns = null;
+        Excel.Range? dataRows = null;
+        Excel.Range? usedRange = null;
+        Excel.Range? usedColumns = null;
+        try
+        {
+            worksheet = tableRange.Worksheet;
+            tableRows = tableRange.Rows;
+            tableColumns = tableRange.Columns;
+            usedRange = worksheet.UsedRange;
+            usedColumns = usedRange.Columns;
+
+            int tableFirstRow = Convert.ToInt32(tableRange.Row, CultureInfo.InvariantCulture);
+            int tableLastRow = tableFirstRow
+                + Convert.ToInt32(tableRows.Count, CultureInfo.InvariantCulture) - 1;
+            int tableFirstColumn = Convert.ToInt32(tableRange.Column, CultureInfo.InvariantCulture);
+            int tableLastColumn = tableFirstColumn
+                + Convert.ToInt32(tableColumns.Count, CultureInfo.InvariantCulture) - 1;
+            int usedFirstColumn = Convert.ToInt32(usedRange.Column, CultureInfo.InvariantCulture);
+            int usedLastColumn = usedFirstColumn
+                + Convert.ToInt32(usedColumns.Count, CultureInfo.InvariantCulture) - 1;
+            int dataFirstRow = 0;
+            int dataLastRow = -1;
+            if (dataBodyRange is not null)
+            {
+                dataRows = dataBodyRange.Rows;
+                dataFirstRow = Convert.ToInt32(dataBodyRange.Row, CultureInfo.InvariantCulture);
+                dataLastRow = dataFirstRow
+                    + Convert.ToInt32(dataRows.Count, CultureInfo.InvariantCulture) - 1;
+            }
+
+            var formulaAddresses = new List<string>();
+            List<int> leftColumns = ScanAdjacentColumns(
+                worksheet,
+                tableFirstColumn - 1,
+                usedFirstColumn,
+                step: -1,
+                tableFirstRow,
+                tableLastRow,
+                cancellationToken);
+            List<int> rightColumns = ScanAdjacentColumns(
+                worksheet,
+                tableLastColumn + 1,
+                usedLastColumn,
+                step: 1,
+                tableFirstRow,
+                tableLastRow,
+                cancellationToken);
+            CollectExternalFormulaAddresses(
+                worksheet,
+                usedFirstColumn,
+                usedLastColumn,
+                tableFirstColumn,
+                tableLastColumn,
+                dataFirstRow,
+                dataLastRow,
+                formulaAddresses,
+                cancellationToken);
+
+            var excludedRanges = new List<string>();
+            if (leftColumns.Count > 0)
+            {
+                excludedRanges.Add(GetAbsoluteRangeAddress(
+                    leftColumns.Min(),
+                    tableFirstRow,
+                    leftColumns.Max(),
+                    tableLastRow));
+            }
+
+            if (rightColumns.Count > 0)
+            {
+                excludedRanges.Add(GetAbsoluteRangeAddress(
+                    rightColumns.Min(),
+                    tableFirstRow,
+                    rightColumns.Max(),
+                    tableLastRow));
+            }
+
+            if (excludedRanges.Count > 0)
+            {
+                findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.ExcludedContiguousColumns,
+                    Severity = TablePreflightSeverity.Warning,
+                    IsHeuristic = true,
+                    Addresses = excludedRanges,
+                    Message = "Populated worksheet columns directly beside the table will not move with its rows.",
+                    Remediation = "Confirm that these columns are separate data, or resize the table to include them before sorting."
+                });
+            }
+
+            if (formulaAddresses.Count > 0)
+            {
+                findings.Add(new TablePreflightFinding
+                {
+                    Kind = TablePreflightFindingKind.RowAssociatedFormulaOutsideTable,
+                    Severity = TablePreflightSeverity.Warning,
+                    IsHeuristic = true,
+                    Addresses = formulaAddresses,
+                    Message = "These formulas are outside the table but align with its data rows and may be row-associated.",
+                    Remediation = "Confirm that these formulas may remain fixed while table rows move, or include their data in the table."
+                });
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref usedColumns);
+            ComUtilities.Release(ref usedRange);
+            ComUtilities.Release(ref dataRows);
+            ComUtilities.Release(ref tableColumns);
+            ComUtilities.Release(ref tableRows);
+            ComUtilities.Release(ref worksheet);
+        }
+    }
+
+    private static List<int> ScanAdjacentColumns(
+        Excel.Worksheet worksheet,
+        int startColumn,
+        int boundaryColumn,
+        int step,
+        int tableFirstRow,
+        int tableLastRow,
+        CancellationToken cancellationToken)
+    {
+        var populatedColumns = new List<int>();
+        for (int column = startColumn;
+             step < 0 ? column >= boundaryColumn : column <= boundaryColumn;
+             column += step)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Excel.Range? columnRange = null;
+            try
+            {
+                columnRange = worksheet.Range[
+                    GetAbsoluteRangeAddress(column, tableFirstRow, column, tableLastRow)];
+                object formulas = columnRange.FormulaR1C1;
+                bool populated = false;
+                for (int rowOffset = 0; rowOffset <= tableLastRow - tableFirstRow; rowOffset++)
+                {
+                    string content = Convert.ToString(
+                        GetMatrixValue(formulas, rowOffset, 0),
+                        CultureInfo.InvariantCulture) ?? string.Empty;
+                    if (content.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    populated = true;
+                }
+
+                if (!populated)
+                {
+                    break;
+                }
+
+                populatedColumns.Add(column);
+            }
+            finally
+            {
+                ComUtilities.Release(ref columnRange);
+            }
+        }
+
+        return populatedColumns;
+    }
+
+    private static void CollectExternalFormulaAddresses(
+        Excel.Worksheet worksheet,
+        int usedFirstColumn,
+        int usedLastColumn,
+        int tableFirstColumn,
+        int tableLastColumn,
+        int dataFirstRow,
+        int dataLastRow,
+        List<string> formulaAddresses,
+        CancellationToken cancellationToken)
+    {
+        if (dataLastRow < dataFirstRow)
+        {
+            return;
+        }
+
+        Excel.Range? formulaRange = null;
+        try
+        {
+            formulaRange = worksheet.Range[
+                GetAbsoluteRangeAddress(usedFirstColumn, dataFirstRow, usedLastColumn, dataLastRow)];
+            object formulas = formulaRange.FormulaR1C1;
+            int rowCount = dataLastRow - dataFirstRow + 1;
+            int columnCount = usedLastColumn - usedFirstColumn + 1;
+            for (int rowOffset = 0; rowOffset < rowCount; rowOffset++)
+            {
+                for (int columnOffset = 0; columnOffset < columnCount; columnOffset++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    int worksheetColumn = usedFirstColumn + columnOffset;
+                    if (worksheetColumn >= tableFirstColumn && worksheetColumn <= tableLastColumn)
+                    {
+                        continue;
+                    }
+
+                    string content = Convert.ToString(
+                        GetMatrixValue(formulas, rowOffset, columnOffset),
+                        CultureInfo.InvariantCulture) ?? string.Empty;
+                    if (content.StartsWith('='))
+                    {
+                        formulaAddresses.Add(GetAbsoluteAddress(
+                            worksheetColumn,
+                            dataFirstRow + rowOffset));
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref formulaRange);
+        }
+    }
+}

--- a/src/ExcelMcp.Core/Models/TableCalculatedColumnCheckResult.cs
+++ b/src/ExcelMcp.Core/Models/TableCalculatedColumnCheckResult.cs
@@ -1,0 +1,32 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Formula consistency check for one table column.
+/// </summary>
+public sealed class TableCalculatedColumnCheckResult
+{
+    /// <summary>
+    /// Table column name.
+    /// </summary>
+    public string ColumnName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Uniform R1C1 formula pattern captured before sorting.
+    /// </summary>
+    public string FormulaR1C1 { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether the column had one formula pattern before sorting.
+    /// </summary>
+    public bool ConsistentBefore { get; set; }
+
+    /// <summary>
+    /// Whether the same formula pattern remained after sorting.
+    /// </summary>
+    public bool ConsistentAfter { get; set; }
+
+    /// <summary>
+    /// Whether the calculated-column check passed.
+    /// </summary>
+    public bool Passed { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/TableControlTotalCheckResult.cs
+++ b/src/ExcelMcp.Core/Models/TableControlTotalCheckResult.cs
@@ -1,0 +1,37 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Before/after numeric control-total comparison.
+/// </summary>
+public sealed class TableControlTotalCheckResult
+{
+    /// <summary>
+    /// Table column name.
+    /// </summary>
+    public string ColumnName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Numeric sum before sorting.
+    /// </summary>
+    public decimal Before { get; set; }
+
+    /// <summary>
+    /// Numeric sum after sorting.
+    /// </summary>
+    public decimal After { get; set; }
+
+    /// <summary>
+    /// Signed difference between the after and before sums.
+    /// </summary>
+    public decimal Delta { get; set; }
+
+    /// <summary>
+    /// Allowed absolute difference.
+    /// </summary>
+    public decimal Tolerance { get; set; }
+
+    /// <summary>
+    /// Whether the total stayed within tolerance.
+    /// </summary>
+    public bool Passed { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/TablePreflightFinding.cs
+++ b/src/ExcelMcp.Core/Models/TablePreflightFinding.cs
@@ -1,7 +1,7 @@
 namespace Sbroenne.ExcelMcp.Core.Models;
 
 /// <summary>
-/// One actionable result from a table-creation preflight.
+/// One actionable table-integrity finding.
 /// </summary>
 public sealed class TablePreflightFinding
 {
@@ -11,7 +11,7 @@ public sealed class TablePreflightFinding
     public TablePreflightFindingKind Kind { get; set; }
 
     /// <summary>
-    /// Whether the finding blocks creation or is advisory.
+    /// Whether the finding blocks the requested operation or is advisory.
     /// </summary>
     public TablePreflightSeverity Severity { get; set; }
 

--- a/src/ExcelMcp.Core/Models/TablePreflightFindingKind.cs
+++ b/src/ExcelMcp.Core/Models/TablePreflightFindingKind.cs
@@ -36,5 +36,55 @@ public enum TablePreflightFindingKind
     /// <summary>
     /// The requested table name already exists.
     /// </summary>
-    TableNameExists
+    TableNameExists,
+
+    /// <summary>
+    /// A formula outside the table appears aligned with table data rows.
+    /// </summary>
+    RowAssociatedFormulaOutsideTable,
+
+    /// <summary>
+    /// A table column mixes formulas, formula patterns, or literal values.
+    /// </summary>
+    MixedFormulaColumn,
+
+    /// <summary>
+    /// A requested row-key column does not exist or contains an invalid key.
+    /// </summary>
+    InvalidRowKey,
+
+    /// <summary>
+    /// A requested composite row key is not unique.
+    /// </summary>
+    DuplicateRowKey,
+
+    /// <summary>
+    /// A requested control total cannot be evaluated.
+    /// </summary>
+    InvalidControlTotal,
+
+    /// <summary>
+    /// The table range, shape, headers, or totals row changed during sorting.
+    /// </summary>
+    TableStructureChanged,
+
+    /// <summary>
+    /// Complete logical table rows were not preserved.
+    /// </summary>
+    TableRowsChanged,
+
+    /// <summary>
+    /// A previously consistent calculated-column formula pattern changed.
+    /// </summary>
+    CalculatedColumnChanged,
+
+    /// <summary>
+    /// Caller-supplied row identities or their complete row contents changed.
+    /// </summary>
+    RowKeyMismatch,
+
+    /// <summary>
+    /// A caller-supplied numeric control total changed beyond its tolerance.
+    /// </summary>
+    ControlTotalMismatch
 }

--- a/src/ExcelMcp.Core/Models/TablePreflightSeverity.cs
+++ b/src/ExcelMcp.Core/Models/TablePreflightSeverity.cs
@@ -3,13 +3,13 @@ using System.Text.Json.Serialization;
 namespace Sbroenne.ExcelMcp.Core.Models;
 
 /// <summary>
-/// Severity of a table-creation preflight finding.
+/// Severity of a table-integrity finding.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter<TablePreflightSeverity>))]
 public enum TablePreflightSeverity
 {
     /// <summary>
-    /// A deterministic problem that prevents safe table creation.
+    /// A deterministic problem that prevents a safe table operation.
     /// </summary>
     Blocker,
 

--- a/src/ExcelMcp.Core/Models/TableRowKeyCheckResult.cs
+++ b/src/ExcelMcp.Core/Models/TableRowKeyCheckResult.cs
@@ -1,0 +1,32 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Composite row-key preservation check.
+/// </summary>
+public sealed class TableRowKeyCheckResult
+{
+    /// <summary>
+    /// Columns used to form the composite key.
+    /// </summary>
+    public List<string> KeyColumns { get; set; } = [];
+
+    /// <summary>
+    /// Number of unique keys before sorting.
+    /// </summary>
+    public int BeforeCount { get; set; }
+
+    /// <summary>
+    /// Number of unique keys after sorting.
+    /// </summary>
+    public int AfterCount { get; set; }
+
+    /// <summary>
+    /// Keys whose row content was missing or changed.
+    /// </summary>
+    public List<string> MismatchedKeys { get; set; } = [];
+
+    /// <summary>
+    /// Whether all keyed rows were preserved.
+    /// </summary>
+    public bool Passed { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/TableSortControlTotal.cs
+++ b/src/ExcelMcp.Core/Models/TableSortControlTotal.cs
@@ -1,0 +1,17 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Optional numeric control total to compare before and after a table sort.
+/// </summary>
+public sealed class TableSortControlTotal
+{
+    /// <summary>
+    /// Table column whose numeric values should be summed.
+    /// </summary>
+    public string ColumnName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Allowed absolute difference between the before and after sums.
+    /// </summary>
+    public decimal Tolerance { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/TableSortIntegrityChecks.cs
+++ b/src/ExcelMcp.Core/Models/TableSortIntegrityChecks.cs
@@ -1,0 +1,47 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Deterministic checks performed around a validated table sort.
+/// </summary>
+public sealed class TableSortIntegrityChecks
+{
+    /// <summary>
+    /// Whether the table range address stayed unchanged.
+    /// </summary>
+    public bool? RangePreserved { get; set; }
+
+    /// <summary>
+    /// Whether the table row and column counts stayed unchanged.
+    /// </summary>
+    public bool? ShapePreserved { get; set; }
+
+    /// <summary>
+    /// Whether table headers stayed unchanged.
+    /// </summary>
+    public bool? HeadersPreserved { get; set; }
+
+    /// <summary>
+    /// Whether totals-row visibility and content stayed unchanged.
+    /// </summary>
+    public bool? TotalsRowPreserved { get; set; }
+
+    /// <summary>
+    /// Whether complete logical table rows were only permuted.
+    /// </summary>
+    public bool? RowSetPreserved { get; set; }
+
+    /// <summary>
+    /// Formula-pattern checks for calculated columns.
+    /// </summary>
+    public List<TableCalculatedColumnCheckResult> CalculatedColumns { get; set; } = [];
+
+    /// <summary>
+    /// Optional composite row-key check.
+    /// </summary>
+    public TableRowKeyCheckResult? RowKeys { get; set; }
+
+    /// <summary>
+    /// Optional numeric control-total checks.
+    /// </summary>
+    public List<TableControlTotalCheckResult> ControlTotals { get; set; } = [];
+}

--- a/src/ExcelMcp.Core/Models/TableSortResult.cs
+++ b/src/ExcelMcp.Core/Models/TableSortResult.cs
@@ -1,0 +1,62 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result of sorting an Excel table, including optional integrity evidence.
+/// </summary>
+public sealed class TableSortResult : OperationResult
+{
+    /// <summary>
+    /// Name of the sorted table.
+    /// </summary>
+    public string TableName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Absolute table range observed before sorting.
+    /// </summary>
+    public string TableRange { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether integrity validation was performed.
+    /// </summary>
+    public bool ValidationPerformed { get; set; }
+
+    /// <summary>
+    /// Whether Excel's sort operation was invoked.
+    /// </summary>
+    public bool SortAttempted { get; set; }
+
+    /// <summary>
+    /// Whether the sorted state was kept.
+    /// </summary>
+    public bool SortCommitted { get; set; }
+
+    /// <summary>
+    /// Whether all requested integrity checks passed, or null when validation was not performed.
+    /// </summary>
+    public bool? IntegrityPreserved { get; set; }
+
+    /// <summary>
+    /// Whether restoration of the pre-sort snapshot was attempted.
+    /// </summary>
+    public bool RollbackAttempted { get; set; }
+
+    /// <summary>
+    /// Whether restoration was verified, or null when rollback was not attempted.
+    /// </summary>
+    public bool? RollbackSucceeded { get; set; }
+
+    /// <summary>
+    /// State covered by rollback verification. TableContent excludes row-specific formatting.
+    /// </summary>
+    public string RollbackScope { get; set; } = "TableContent";
+
+    /// <summary>
+    /// Blocking and advisory integrity findings.
+    /// </summary>
+    public List<TablePreflightFinding> Findings { get; set; } = [];
+
+    /// <summary>
+    /// Typed post-sort integrity checks.
+    /// </summary>
+    public TableSortIntegrityChecks Checks { get; set; } = new();
+}

--- a/src/ExcelMcp.Generators.Shared/ServiceInfoExtractor.cs
+++ b/src/ExcelMcp.Generators.Shared/ServiceInfoExtractor.cs
@@ -82,7 +82,9 @@ public static class ServiceInfoExtractor
 
         foreach (var member in interfaceSymbol.GetMembers())
         {
-            if (member is IMethodSymbol method && method.MethodKind == MethodKind.Ordinary)
+            if (member is IMethodSymbol method
+                && method.MethodKind == MethodKind.Ordinary
+                && !HasServiceIgnoreAttribute(method))
             {
                 var actionName = GetActionName(method);
                 var methodMcpTool = GetMethodMcpTool(method) ?? mcpTool;
@@ -123,6 +125,10 @@ public static class ServiceInfoExtractor
             mcpToolDescription,
             hasMcpToolAttribute: mcpTool != null);
     }
+
+    private static bool HasServiceIgnoreAttribute(IMethodSymbol method) =>
+        method.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.Name == "ServiceIgnoreAttribute");
 
     private static string? ExtractInterfaceSummary(INamedTypeSymbol interfaceSymbol)
     {

--- a/tests/ExcelMcp.CLI.Tests/Integration/GeneratedActionContractCliTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/GeneratedActionContractCliTests.cs
@@ -252,6 +252,19 @@ public sealed class GeneratedActionContractCliTests : IDisposable
         Assert.DoesNotContain("Invalid value", combinedOutput, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task TableColumnSortHelp_ListsIntegrityOptions()
+    {
+        var result = await CliProcessHelper.RunAsync(
+            ["tablecolumn", "sort", "--help"],
+            timeoutMs: 30_000);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("--validate-integrity", result.Stdout, StringComparison.Ordinal);
+        Assert.Contains("--key-columns", result.Stdout, StringComparison.Ordinal);
+        Assert.Contains("--control-totals", result.Stdout, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("worksheet")]
     [InlineData("WORKSHEET")]

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Table/TableCommandsTests.SortIntegrity.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Table/TableCommandsTests.SortIntegrity.cs
@@ -1,0 +1,267 @@
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Models;
+using Xunit;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Table;
+
+public partial class TableCommandsTests
+{
+    [Fact]
+    public void Sort_DefaultBehavior_SortsWithoutIntegrityValidation()
+    {
+        var testFile = CopyTableFixture();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var result = _tableCommands.Sort(
+            batch,
+            "SalesTable",
+            "Amount",
+            ascending: true,
+            validateIntegrity: false);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.False(result.ValidationPerformed);
+        Assert.Null(result.IntegrityPreserved);
+        Assert.True(result.SortAttempted);
+        Assert.True(result.SortCommitted);
+        Assert.False(result.RollbackAttempted);
+        Assert.Null(result.RollbackSucceeded);
+
+        var data = _tableCommands.GetData(batch, "SalesTable", visibleOnly: false).Data;
+        Assert.Equal(["North", "East", "South", "West"], data.Select(row => row[0]?.ToString()));
+        Assert.Equal(["100", "150", "250", "300"], data.Select(row => row[2]?.ToString()));
+    }
+
+    [Fact]
+    public void Sort_WithIntegrityValidation_ProvesCompleteRowsWerePermuted()
+    {
+        var testFile = CopyTableFixture();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        List<string> beforeRows = GetCompleteRowSignatures(
+            _tableCommands.GetData(batch, "SalesTable", visibleOnly: false).Data);
+
+        var result = _tableCommands.Sort(
+            batch,
+            "SalesTable",
+            "Amount",
+            validateIntegrity: true);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.True(result.ValidationPerformed);
+        Assert.True(result.IntegrityPreserved);
+        Assert.True(result.SortCommitted);
+        Assert.True(result.Checks.RangePreserved);
+        Assert.True(result.Checks.ShapePreserved);
+        Assert.True(result.Checks.HeadersPreserved);
+        Assert.True(result.Checks.TotalsRowPreserved);
+        Assert.True(result.Checks.RowSetPreserved);
+        Assert.False(result.RollbackAttempted);
+        List<string> afterRows = GetCompleteRowSignatures(
+            _tableCommands.GetData(batch, "SalesTable", visibleOnly: false).Data);
+        Assert.Equal(beforeRows, afterRows);
+    }
+
+    [Fact]
+    public void SortMulti_WithIntegrityValidation_UsesSameValidationPipeline()
+    {
+        var testFile = CopyTableFixture();
+        using var batch = ExcelSession.BeginBatch(testFile);
+
+        var result = _tableCommands.SortMulti(
+            batch,
+            "SalesTable",
+            [
+                new TableSortColumn { ColumnName = "Product", Ascending = true },
+                new TableSortColumn { ColumnName = "Amount", Ascending = false }
+            ],
+            validateIntegrity: true);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.True(result.ValidationPerformed);
+        Assert.True(result.IntegrityPreserved);
+        Assert.True(result.SortCommitted);
+        Assert.True(result.Checks.RowSetPreserved);
+
+        var data = _tableCommands.GetData(batch, "SalesTable", visibleOnly: false).Data;
+        Assert.Equal(["Gadget", "Gadget", "Widget", "Widget"], data.Select(row => row[1]?.ToString()));
+        Assert.Equal(["300", "250", "150", "100"], data.Select(row => row[2]?.ToString()));
+    }
+
+    [Fact]
+    public void Sort_WithAdjacentDataAndExternalFormulas_ReturnsHeuristicWarnings()
+    {
+        var testFile = CopyTableFixture();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _tableCommands.Delete(batch, "SalesTable");
+        _rangeCommands.SetValues(
+            batch,
+            "Sales",
+            "E1",
+            [["Related"]]);
+        _rangeCommands.SetFormulas(
+            batch,
+            "Sales",
+            "E2:E5",
+            [["=C2*2"], ["=C3*2"], ["=C4*2"], ["=C5*2"]]);
+        _tableCommands.Create(batch, "Sales", "SalesTable", "A1:D5");
+
+        var result = _tableCommands.Sort(
+            batch,
+            "SalesTable",
+            "Amount",
+            validateIntegrity: true);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var adjacent = Assert.Single(
+            result.Findings,
+            finding => finding.Kind == TablePreflightFindingKind.ExcludedContiguousColumns);
+        Assert.Equal(TablePreflightSeverity.Warning, adjacent.Severity);
+        Assert.True(adjacent.IsHeuristic);
+
+        var external = Assert.Single(
+            result.Findings,
+            finding => finding.Kind == TablePreflightFindingKind.RowAssociatedFormulaOutsideTable);
+        Assert.Equal(TablePreflightSeverity.Warning, external.Severity);
+        Assert.True(external.IsHeuristic);
+        Assert.Equal(["$E$2", "$E$3", "$E$4", "$E$5"], external.Addresses);
+    }
+
+    [Fact]
+    public void Sort_WithDuplicateCompositeKeys_ReturnsBlockerWithoutMutation()
+    {
+        var testFile = CopyTableFixture();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        var before = _tableCommands.GetData(batch, "SalesTable", visibleOnly: false).Data;
+
+        var result = _tableCommands.Sort(
+            batch,
+            "SalesTable",
+            "Amount",
+            validateIntegrity: true,
+            keyColumns: ["Product"]);
+
+        Assert.False(result.Success);
+        Assert.False(result.SortAttempted);
+        Assert.False(result.SortCommitted);
+        Assert.Null(result.IntegrityPreserved);
+        var blocker = Assert.Single(
+            result.Findings,
+            finding => finding.Kind == TablePreflightFindingKind.DuplicateRowKey);
+        Assert.Equal(TablePreflightSeverity.Blocker, blocker.Severity);
+        Assert.False(blocker.IsHeuristic);
+        Assert.Equal(before, _tableCommands.GetData(batch, "SalesTable", visibleOnly: false).Data);
+    }
+
+    [Fact]
+    public void Sort_WithCalculatedColumn_VerifiesFormulaConsistency()
+    {
+        var testFile = CopyTableFixture();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _tableCommands.AddColumn(batch, "SalesTable", "DoubleAmount");
+        _rangeCommands.SetFormulas(
+            batch,
+            "Sales",
+            "E2:E5",
+            [
+                ["=[@Amount]*2"],
+                ["=[@Amount]*2"],
+                ["=[@Amount]*2"],
+                ["=[@Amount]*2"]
+            ]);
+
+        var result = _tableCommands.Sort(
+            batch,
+            "SalesTable",
+            "Amount",
+            validateIntegrity: true);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var calculated = Assert.Single(
+            result.Checks.CalculatedColumns,
+            check => check.ColumnName == "DoubleAmount");
+        Assert.True(calculated.ConsistentBefore);
+        Assert.True(calculated.ConsistentAfter);
+        Assert.True(calculated.Passed);
+    }
+
+    [Fact]
+    public void Sort_WhenControlTotalChanges_RestoresSnapshotAndReturnsTypedFailure()
+    {
+        var testFile = CopyTableFixture();
+        using var batch = ExcelSession.BeginBatch(testFile);
+        _tableCommands.AddColumn(batch, "SalesTable", "Weighted");
+        _tableCommands.AddColumn(batch, "SalesTable", "FormulaLikeText");
+        _rangeCommands.SetFormulas(
+            batch,
+            "Sales",
+            "E2:E5",
+            [
+                ["=[@Amount]*ROW()"],
+                ["=[@Amount]*ROW()"],
+                ["=[@Amount]*ROW()"],
+                ["=[@Amount]*ROW()"]
+            ]);
+        _rangeCommands.SetValues(
+            batch,
+            "Sales",
+            "F2:F5",
+            [["'=1+1"], ["'=2+2"], ["'=3+3"], ["'=4+4"]]);
+        var before = _tableCommands.GetData(batch, "SalesTable", visibleOnly: false).Data;
+
+        var result = _tableCommands.Sort(
+            batch,
+            "SalesTable",
+            "Amount",
+            validateIntegrity: true,
+            keyColumns: ["Region"],
+            controlTotals:
+            [
+                new TableSortControlTotal { ColumnName = "Weighted" }
+            ]);
+
+        Assert.False(result.Success);
+        Assert.True(result.SortAttempted);
+        Assert.False(result.SortCommitted);
+        Assert.False(result.IntegrityPreserved);
+        Assert.True(result.RollbackAttempted);
+        Assert.True(result.RollbackSucceeded);
+        var total = Assert.Single(result.Checks.ControlTotals);
+        Assert.False(total.Passed);
+        Assert.NotEqual(total.Before, total.After);
+        Assert.Contains(
+            result.Findings,
+            finding => finding.Kind == TablePreflightFindingKind.ControlTotalMismatch);
+        Assert.Equal(before, _tableCommands.GetData(batch, "SalesTable", visibleOnly: false).Data);
+        Assert.False(batch.Execute((ctx, ct) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? cell = null;
+            try
+            {
+                sheet = (Excel.Worksheet)ctx.Book.Worksheets["Sales"];
+                cell = sheet.Range["F2"];
+                return Convert.ToBoolean(cell.HasFormula);
+            }
+            finally
+            {
+                ComUtilities.Release(ref cell);
+                ComUtilities.Release(ref sheet);
+            }
+        }));
+    }
+
+    private string CopyTableFixture()
+    {
+        string path = Path.Join(_fixture.TempDir, $"SortIntegrity_{Guid.NewGuid():N}.xlsx");
+        System.IO.File.Copy(_tableFile, path);
+        return path;
+    }
+
+    private static List<string> GetCompleteRowSignatures(List<List<object?>> rows) =>
+        rows.Select(row => string.Join(
+                "\u001f",
+                row.Select(value => Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture))))
+            .OrderBy(signature => signature, StringComparer.Ordinal)
+            .ToList();
+}

--- a/tests/ExcelMcp.Core.Tests/Unit/GeneratedActionContractTests.cs
+++ b/tests/ExcelMcp.Core.Tests/Unit/GeneratedActionContractTests.cs
@@ -6,6 +6,7 @@ using Sbroenne.ExcelMcp.Core.Commands.Analysis;
 using Sbroenne.ExcelMcp.Core.Commands.Calculation;
 using Sbroenne.ExcelMcp.Core.Commands.Chart;
 using Sbroenne.ExcelMcp.Core.Commands.PivotTable;
+using Sbroenne.ExcelMcp.Core.Commands.Table;
 using Sbroenne.ExcelMcp.Core.Commands.XmlMap;
 using Sbroenne.ExcelMcp.Core.Models;
 using Sbroenne.ExcelMcp.Core.Utilities;
@@ -21,6 +22,29 @@ namespace Sbroenne.ExcelMcp.Core.Tests.Unit;
 [Trait("RequiresExcel", "false")]
 public sealed class GeneratedActionContractTests
 {
+    [Fact]
+    public void TableSort_PreservesLegacyCoreOverloadsAndGeneratesOneActionEach()
+    {
+        MethodInfo[] methods = typeof(ITableColumnCommands).GetMethods();
+
+        Assert.Contains(
+            methods,
+            method => method.Name == nameof(ITableColumnCommands.Sort)
+                && method.ReturnType == typeof(OperationResult)
+                && method.GetParameters().Length == 4);
+        Assert.Contains(
+            methods,
+            method => method.Name == nameof(ITableColumnCommands.Sort)
+                && method.ReturnType == typeof(TableSortResult)
+                && method.GetParameters().Length == 7);
+        Assert.Single(
+            ServiceRegistry.TableColumn.ValidActions,
+            action => action == "sort");
+        Assert.Single(
+            ServiceRegistry.TableColumn.ValidActions,
+            action => action == "sort-multi");
+    }
+
     [Theory]
     [InlineData("worksheet", PowerQueryLoadMode.LoadToTable)]
     [InlineData("TABLE", PowerQueryLoadMode.LoadToTable)]

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeneratedActionContractProtocolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeneratedActionContractProtocolTests.cs
@@ -229,6 +229,41 @@ public sealed class GeneratedActionContractProtocolTests : McpIntegrationTestBas
     }
 
     [Fact]
+    public async Task TableColumnSort_AcceptsIntegrityParametersBeforeSessionDispatch()
+    {
+        var result = await CallToolAsync(
+            "table_column",
+            new Dictionary<string, object?>
+            {
+                ["action"] = "sort",
+                ["session_id"] = "missing-session",
+                ["table_name"] = "Sales",
+                ["column_name"] = "Amount",
+                ["validate_integrity"] = true,
+                ["key_columns"] = """["Id"]""",
+                ["control_totals"] = new object[]
+                {
+                    new Dictionary<string, object?>
+                    {
+                        ["columnName"] = "Amount",
+                        ["tolerance"] = 0
+                    }
+                }
+            });
+
+        using var document = ParseJsonResult(result, "table_column.sort");
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains(
+            "session",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "controlTotals",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task PowerQueryLoadTo_RejectsTimeoutSecondsAsActionInapplicable()
     {
         var result = await CallToolAsync(

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/McpServerSmokeTests.cs
@@ -245,6 +245,46 @@ public class McpServerSmokeTests : IAsyncLifetime, IAsyncDisposable
         });
         AssertSuccess(createTableResult, "Create table");
 
+        var sortTableResult = await CallToolAsync("table_column", new Dictionary<string, object?>
+        {
+            ["action"] = "sort",
+            ["session_id"] = sessionId,
+            ["table_name"] = "DataTable",
+            ["column_name"] = "Value",
+            ["validate_integrity"] = true,
+            ["key_columns"] = """["Name"]""",
+            ["control_totals"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["columnName"] = "Value",
+                    ["tolerance"] = 0
+                }
+            }
+        });
+        AssertSuccess(sortTableResult, "Sort table with integrity validation");
+        using (var sortJson = JsonDocument.Parse(sortTableResult))
+        {
+            Assert.True(sortJson.RootElement.GetProperty("validationPerformed").GetBoolean());
+            Assert.True(sortJson.RootElement.GetProperty("integrityPreserved").GetBoolean());
+            Assert.True(sortJson.RootElement.GetProperty("sortCommitted").GetBoolean());
+            Assert.True(
+                sortJson.RootElement
+                    .GetProperty("checks")
+                    .GetProperty("rowKeys")
+                    .GetProperty("passed")
+                    .GetBoolean());
+            Assert.True(
+                Assert.Single(
+                        sortJson.RootElement
+                            .GetProperty("checks")
+                            .GetProperty("controlTotals")
+                            .EnumerateArray()
+                            .ToArray())
+                    .GetProperty("passed")
+                    .GetBoolean());
+        }
+
         var listTablesResult = await CallToolAsync("table", new Dictionary<string, object?>
         {
             ["action"] = "list",
@@ -252,7 +292,7 @@ public class McpServerSmokeTests : IAsyncLifetime, IAsyncDisposable
             ["session_id"] = sessionId
         });
         AssertSuccess(listTablesResult, "List tables");
-        _output.WriteLine("  ✓ table: Preflight, Create, and List passed");
+        _output.WriteLine("  ✓ table: Preflight, Create, validated Sort, and List passed");
 
         // =====================================================================
         // STEP 6: NAMED RANGE OPERATIONS


### PR DESCRIPTION
## Summary
- adds opt-in integrity validation to `table_column sort` and `sort-multi` while preserving legacy Core overloads and default behavior
- reuses PR #844 findings to warn about excluded adjacent data, sort-sensitive formulas, outside row-aligned formulas, and mixed formula columns without claiming heuristic associations are certain
- verifies table structure, complete row permutations, calculated-column formula consistency, optional composite row keys, and optional numeric control totals
- restores and verifies captured table values and formulas when deterministic post-sort checks fail; row-specific formatting is explicitly outside the rollback scope

## Stack
- Based on #844 / `sbroenne-table-creation-preflight`

## Validation
- focused real-Excel Core sort integrity tests: 7 passed
- CLI generated option contract: passed
- MCP generated parameter contract and real all-tools smoke test: passed
- Release solution build: zero warnings
- COM, generated coverage/naming, MCP-Core parity, success-flag, docs-count, and dynamic-cast audits: passed
- full `scripts\Test-E2E.ps1`: passed
- normal pre-commit hook, including CLI/MCP E2E and all release packaging: passed

Closes #840