### PR TITLE
Add scoped large-range value reads

### DIFF
--- a/.changeset/calm-ranges-page.md
+++ b/.changeset/calm-ranges-page.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Read only the cells you need from large ranges.** `range get-values` now supports row offsets, row limits, and selected worksheet columns, with source dimensions and continuation metadata in the response.

--- a/.changeset/graceful-stale-build-save.md
+++ b/.changeset/graceful-stale-build-save.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Stale-build cleanup now preserves unsaved CLI session changes when a shutdown reply is lost.** The cleanup client gives an already-shutting-down daemon time to save and exit before using pipe-scoped forced cleanup.

--- a/.changeset/graceful-stale-build-save.md
+++ b/.changeset/graceful-stale-build-save.md
@@ -2,4 +2,4 @@
 "excelmcp": patch
 ---
 
-**Stale-build cleanup now preserves unsaved CLI session changes when a shutdown reply is lost.** The cleanup client gives an already-shutting-down daemon time to save and exit before using pipe-scoped forced cleanup.
+**Stale-build cleanup now preserves unsaved CLI session changes when a shutdown reply is lost.** The cleanup client gives an already-shutting-down daemon and its tracked Excel processes time to save and exit before using pipe-scoped forced cleanup.

--- a/docs/features/CELLS-WORKBOOKS.md
+++ b/docs/features/CELLS-WORKBOOKS.md
@@ -37,7 +37,7 @@ Read and write cell values, formulas, and formatting across any range of cells.
 **Formatting split:** use `range` for number display formats such as dates, currency, percentages, and text display. Use `range_format` for visual styling, validation, auto-fit, and size/layout changes.
 
 **Data Operations:**
-- **Get/Set Values:** Read or write cell values
+- **Get/Set Values:** Read or write cell values. Large reads can page rows with a zero-based offset and positive limit, select comma-separated absolute worksheet columns, and use returned totals plus `nextRowOffset`/`hasMoreRows` to continue without materializing the full source range.
 - **Get/Set/Validate Formulas:** Read, write, or validate formula syntax across ranges
 - **Clear All/Contents/Formats:** Clear a range's contents, formats, or both
 - **Copy / Copy Values / Copy Formulas:** Copy a range, or just its values/formulas

--- a/mcpb/Build-McpBundle.ps1
+++ b/mcpb/Build-McpBundle.ps1
@@ -49,35 +49,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-
-function Remove-StagingDirectory {
-    param(
-        [Parameter(Mandatory)]
-        [string]$Path,
-
-        [int]$MaxAttempts = 10
-    )
-
-    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-        try {
-            [System.IO.Directory]::Delete($Path, $true)
-            return
-        }
-        catch [System.UnauthorizedAccessException] {
-            $failure = $_
-        }
-        catch [System.IO.IOException] {
-            $failure = $_
-        }
-
-        if ($attempt -eq $MaxAttempts) {
-            throw $failure
-        }
-
-        # Executable scanners can briefly retain the verified server binary.
-        Start-Sleep -Milliseconds 500
-    }
-}
+. (Join-Path $PSScriptRoot "McpbPackaging.ps1")
 
 # Get script and project directories
 $McpbDir = $PSScriptRoot
@@ -228,7 +200,7 @@ Write-Host "   ✓ Created $McpbFileName" -ForegroundColor Green
 Copy-Item $ManifestDst (Join-Path $OutputDir "manifest.json") -Force
 
 # Clean up staging
-Remove-StagingDirectory -Path $StagingDir
+Remove-McpbStagingDirectory -Path $StagingDir
 
 # Show results
 $McpbSize = (Get-Item $McpbPath).Length / 1MB

--- a/mcpb/McpbPackaging.ps1
+++ b/mcpb/McpbPackaging.ps1
@@ -1,0 +1,67 @@
+$ErrorActionPreference = "Stop"
+
+function Remove-McpbStagingDirectory {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [TimeSpan]$Timeout = [TimeSpan]::FromSeconds(30),
+
+        [TimeSpan]$RetryInterval = [TimeSpan]::FromMilliseconds(500),
+
+        [scriptblock]$RemoveDirectory = {
+            param([string]$TargetPath)
+            [System.IO.Directory]::Delete($TargetPath, $true)
+        }
+    )
+
+    if ($Timeout -lt [TimeSpan]::Zero) {
+        throw [System.ArgumentOutOfRangeException]::new(
+            "Timeout",
+            $Timeout,
+            "The staging cleanup timeout cannot be negative.")
+    }
+
+    if ($RetryInterval -lt [TimeSpan]::Zero) {
+        throw [System.ArgumentOutOfRangeException]::new(
+            "RetryInterval",
+            $RetryInterval,
+            "The staging cleanup retry interval cannot be negative.")
+    }
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $attempts = 0
+    $lastFailure = $null
+
+    while (Test-Path -LiteralPath $Path -PathType Container) {
+        $attempts++
+        try {
+            & $RemoveDirectory $Path
+        }
+        catch [System.UnauthorizedAccessException] {
+            $lastFailure = $_.Exception
+        }
+        catch [System.IO.IOException] {
+            $lastFailure = $_.Exception
+        }
+
+        if (-not (Test-Path -LiteralPath $Path)) {
+            return
+        }
+
+        $remaining = $Timeout - $stopwatch.Elapsed
+        if ($remaining -le [TimeSpan]::Zero) {
+            $attemptLabel = if ($attempts -eq 1) { "attempt" } else { "attempts" }
+            $timeoutMilliseconds = [Math]::Round($Timeout.TotalMilliseconds)
+            $lastError = if ($lastFailure) { $lastFailure.Message } else { "the directory still exists" }
+            throw [System.IO.IOException]::new(
+                "Failed to remove MCPB staging directory '$Path' after $attempts $attemptLabel within $timeoutMilliseconds ms. Last error: $lastError",
+                $lastFailure)
+        }
+
+        $delay = if ($RetryInterval -lt $remaining) { $RetryInterval } else { $remaining }
+        if ($delay -gt [TimeSpan]::Zero) {
+            Start-Sleep -Milliseconds ([Math]::Ceiling($delay.TotalMilliseconds))
+        }
+    }
+}

--- a/scripts/Stop-ExcelMcpProcesses.ps1
+++ b/scripts/Stop-ExcelMcpProcesses.ps1
@@ -55,6 +55,7 @@ $safetyInputs = @(
     (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonStartupLock.cs'),
     (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\DaemonTrackingJson.cs'),
     (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\OwnedProcessCleanup.cs'),
+    (Join-Path $repoRoot 'src\ExcelMcp.CLI\Infrastructure\PreBuildProcessCleanup.cs'),
     (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\ExcelMcp.Cleanup.csproj'),
     (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\Program.cs'),
     (Join-Path $repoRoot 'src\ExcelMcp.Cleanup\ParameterTransforms.cs'),
@@ -155,7 +156,7 @@ try {
     if ($exitCode -ne 0) {
         Write-Host "  Owned CLI cleanup failed with exit code $exitCode. No process sweep was attempted." -ForegroundColor Yellow
         if ($output) {
-            Write-Status ($output | Out-String).Trim()
+            [Console]::Error.WriteLine(($output | Out-String).Trim())
         }
         exit $exitCode
     }

--- a/skills/excel-mcp/references/range.md
+++ b/skills/excel-mcp/references/range.md
@@ -1,5 +1,16 @@
 # range - Number Formats and Cell Formatting
 
+## Scoped Value Reads
+
+For a large source range, use `get-values` row paging and column selection instead of reading every cell:
+
+```text
+range(action: 'get-values', sheet_name: 'Data', range_address: 'A1:Z100000',
+    row_offset: 1000, row_limit: 100, columns: 'A,D,F')
+```
+
+`row_offset` is zero-based relative to the source range. `columns` contains absolute worksheet column letters and preserves the requested order. Continue with `nextRowOffset` while `hasMoreRows` is true. The response also reports total source dimensions, returned dimensions, and whether rows or columns were omitted. Omit all three scope parameters to keep the existing full-range read.
+
 **IMPORTANT: Always use US format codes.** The server automatically translates to the user's locale.
 
 **Discoverability note:** number display formats live on `range`; visual styling and auto-fit live on `range_format`.

--- a/skills/shared/range.md
+++ b/skills/shared/range.md
@@ -1,5 +1,16 @@
 # range - Number Formats and Cell Formatting
 
+## Scoped Value Reads
+
+For a large source range, use `get-values` row paging and column selection instead of reading every cell:
+
+```text
+range(action: 'get-values', sheet_name: 'Data', range_address: 'A1:Z100000',
+    row_offset: 1000, row_limit: 100, columns: 'A,D,F')
+```
+
+`row_offset` is zero-based relative to the source range. `columns` contains absolute worksheet column letters and preserves the requested order. Continue with `nextRowOffset` while `hasMoreRows` is true. The response also reports total source dimensions, returned dimensions, and whether rows or columns were omitted. Omit all three scope parameters to keep the existing full-range read.
+
 **IMPORTANT: Always use US format codes.** The server automatically translates to the user's locale.
 
 **Discoverability note:** number display formats live on `range`; visual styling and auto-fit live on `range_format`.

--- a/src/ExcelMcp.CLI/Infrastructure/PreBuildProcessCleanup.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/PreBuildProcessCleanup.cs
@@ -36,7 +36,7 @@ internal static class PreBuildProcessCleanup
         _ = await requestGracefulShutdownAsync(cancellationToken);
         // The daemon may begin saving before its reply reaches the cleanup client.
         // Always allow that tracked generation to exit before force cleanup.
-        _ = await WaitForTrackedDaemonExitAsync(
+        _ = await WaitForTrackedGenerationExitAsync(
             pipeName,
             snapshot,
             cancellationToken);
@@ -73,7 +73,7 @@ internal static class PreBuildProcessCleanup
         }
     }
 
-    private static async Task<bool> WaitForTrackedDaemonExitAsync(
+    private static async Task<bool> WaitForTrackedGenerationExitAsync(
         string pipeName,
         OwnedProcessCleanup.ProcessSnapshot snapshot,
         CancellationToken cancellationToken)
@@ -88,9 +88,25 @@ internal static class PreBuildProcessCleanup
         {
             cancellationToken.ThrowIfCancellationRequested();
             var current = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
-            if (current.TrackingStatus == DaemonProcessTracker.TrackingRecordStatus.Missing
-                || !current.DaemonMatched
-                || current.DaemonProcess != expectedDaemon)
+            if (current.TrackingStatus
+                is DaemonProcessTracker.TrackingRecordStatus.Invalid
+                or DaemonProcessTracker.TrackingRecordStatus.Unreadable)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
+                continue;
+            }
+
+            var excelProcesses = snapshot.ExcelProcesses;
+            if (current.DaemonProcess == expectedDaemon)
+            {
+                excelProcesses = excelProcesses
+                    .Concat(current.ExcelProcesses)
+                    .Distinct()
+                    .ToList();
+            }
+
+            if (IsProcessExited(expectedDaemon)
+                && excelProcesses.All(IsProcessExited))
             {
                 return true;
             }
@@ -99,5 +115,17 @@ internal static class PreBuildProcessCleanup
         }
 
         return false;
+    }
+
+    private static bool IsProcessExited(
+        DaemonProcessTracker.ProcessIdentity identity)
+    {
+        if (!DaemonProcessTracker.TryOpenMatchingProcess(identity, out var process))
+        {
+            return false;
+        }
+
+        process?.Dispose();
+        return process == null;
     }
 }

--- a/src/ExcelMcp.CLI/Infrastructure/PreBuildProcessCleanup.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/PreBuildProcessCleanup.cs
@@ -1,0 +1,103 @@
+using Sbroenne.ExcelMcp.Service;
+
+namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
+
+internal static class PreBuildProcessCleanup
+{
+    private static readonly TimeSpan GracefulRequestTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan GracefulExitTimeout = TimeSpan.FromSeconds(12);
+
+    internal static Task<OwnedProcessCleanup.CleanupResult> CleanupWithGracefulShutdownAsync(
+        string pipeName,
+        CancellationToken cancellationToken) =>
+        CleanupWithGracefulShutdownAsync(
+            pipeName,
+            cancellationToken,
+            token => RequestGracefulShutdownAsync(pipeName, token));
+
+    internal static async Task<OwnedProcessCleanup.CleanupResult> CleanupWithGracefulShutdownAsync(
+        string pipeName,
+        CancellationToken cancellationToken,
+        Func<CancellationToken, Task<bool>> requestGracefulShutdownAsync)
+    {
+        ArgumentNullException.ThrowIfNull(requestGracefulShutdownAsync);
+
+        var snapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+        if (snapshot.TrackingStatus
+            is DaemonProcessTracker.TrackingRecordStatus.Invalid
+            or DaemonProcessTracker.TrackingRecordStatus.Unreadable)
+        {
+            return await OwnedProcessCleanup.CleanupAsync(
+                pipeName,
+                snapshot,
+                cancellationToken);
+        }
+
+        _ = await requestGracefulShutdownAsync(cancellationToken);
+        // The daemon may begin saving before its reply reaches the cleanup client.
+        // Always allow that tracked generation to exit before force cleanup.
+        _ = await WaitForTrackedDaemonExitAsync(
+            pipeName,
+            snapshot,
+            cancellationToken);
+
+        return await OwnedProcessCleanup.CleanupAsync(
+            pipeName,
+            snapshot,
+            cancellationToken);
+    }
+
+    private static async Task<bool> RequestGracefulShutdownAsync(
+        string pipeName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = new ServiceClient(
+                pipeName,
+                connectTimeout: GracefulRequestTimeout,
+                requestTimeout: GracefulRequestTimeout);
+            var response = await client.SendAsync(
+                new ServiceRequest { Command = "service.shutdown" },
+                GracefulRequestTimeout,
+                cancellationToken);
+            return response.Success;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> WaitForTrackedDaemonExitAsync(
+        string pipeName,
+        OwnedProcessCleanup.ProcessSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        if (!snapshot.DaemonMatched || snapshot.DaemonProcess is not { } expectedDaemon)
+        {
+            return true;
+        }
+
+        var deadline = DateTime.UtcNow + GracefulExitTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var current = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
+            if (current.TrackingStatus == DaemonProcessTracker.TrackingRecordStatus.Missing
+                || !current.DaemonMatched
+                || current.DaemonProcess != expectedDaemon)
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
+        }
+
+        return false;
+    }
+}

--- a/src/ExcelMcp.Cleanup/ExcelMcp.Cleanup.csproj
+++ b/src/ExcelMcp.Cleanup/ExcelMcp.Cleanup.csproj
@@ -24,6 +24,8 @@
              Link="Infrastructure\DaemonTrackingJson.cs" />
     <Compile Include="..\ExcelMcp.CLI\Infrastructure\OwnedProcessCleanup.cs"
              Link="Infrastructure\OwnedProcessCleanup.cs" />
+    <Compile Include="..\ExcelMcp.CLI\Infrastructure\PreBuildProcessCleanup.cs"
+             Link="Infrastructure\PreBuildProcessCleanup.cs" />
     <Compile Include="..\ExcelMcp.Service\ServiceSecurity.cs"
              Link="Service\ServiceSecurity.cs" />
     <Compile Include="..\ExcelMcp.Service\ServiceClient.cs"

--- a/src/ExcelMcp.Cleanup/Program.cs
+++ b/src/ExcelMcp.Cleanup/Program.cs
@@ -5,9 +5,6 @@ namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
 
 internal static class Program
 {
-    private static readonly TimeSpan GracefulRequestTimeout = TimeSpan.FromSeconds(3);
-    private static readonly TimeSpan GracefulExitTimeout = TimeSpan.FromSeconds(12);
-
     private static async Task<int> Main()
     {
         var pipeName = Environment.GetEnvironmentVariable("EXCELMCP_CLI_PIPE")
@@ -18,7 +15,9 @@ internal static class Program
         {
             var result = await DaemonStartupLock.WithLockAsync(
                 pipeName,
-                () => CleanupWithGracefulShutdownAsync(pipeName, timeout.Token),
+                () => PreBuildProcessCleanup.CleanupWithGracefulShutdownAsync(
+                    pipeName,
+                    timeout.Token),
                 timeout.Token);
             Console.WriteLine(JsonSerializer.Serialize(new
             {
@@ -37,84 +36,5 @@ internal static class Program
             }));
             return 1;
         }
-    }
-
-    private static async Task<OwnedProcessCleanup.CleanupResult> CleanupWithGracefulShutdownAsync(
-        string pipeName,
-        CancellationToken cancellationToken)
-    {
-        var snapshot = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
-        if (snapshot.TrackingStatus
-            is DaemonProcessTracker.TrackingRecordStatus.Invalid
-            or DaemonProcessTracker.TrackingRecordStatus.Unreadable)
-        {
-            return await OwnedProcessCleanup.CleanupAsync(
-                pipeName,
-                snapshot,
-                cancellationToken);
-        }
-
-        var gracefulAcknowledged = false;
-        try
-        {
-            using var client = new ServiceClient(
-                pipeName,
-                connectTimeout: GracefulRequestTimeout,
-                requestTimeout: GracefulRequestTimeout);
-            var response = await client.SendAsync(
-                new ServiceRequest { Command = "service.shutdown" },
-                GracefulRequestTimeout,
-                cancellationToken);
-            gracefulAcknowledged = response.Success;
-        }
-        catch (IOException)
-        {
-            gracefulAcknowledged = false;
-        }
-        catch (TimeoutException)
-        {
-            gracefulAcknowledged = false;
-        }
-
-        if (gracefulAcknowledged)
-        {
-            _ = await WaitForTrackedDaemonExitAsync(
-                pipeName,
-                snapshot,
-                cancellationToken);
-        }
-
-        return await OwnedProcessCleanup.CleanupAsync(
-            pipeName,
-            snapshot,
-            cancellationToken);
-    }
-
-    private static async Task<bool> WaitForTrackedDaemonExitAsync(
-        string pipeName,
-        OwnedProcessCleanup.ProcessSnapshot snapshot,
-        CancellationToken cancellationToken)
-    {
-        if (!snapshot.DaemonMatched || snapshot.DaemonProcess is not { } expectedDaemon)
-        {
-            return true;
-        }
-
-        var deadline = DateTime.UtcNow + GracefulExitTimeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            var current = OwnedProcessCleanup.CaptureTrackedProcesses(pipeName);
-            if (current.TrackingStatus == DaemonProcessTracker.TrackingRecordStatus.Missing
-                || !current.DaemonMatched
-                || current.DaemonProcess != expectedDaemon)
-            {
-                return true;
-            }
-
-            await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
-        }
-
-        return false;
     }
 }

--- a/src/ExcelMcp.Core/Commands/Range/IRangeCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Range/IRangeCommands.cs
@@ -28,21 +28,31 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Range;
 /// </summary>
 [ServiceCategory("range", "Range")]
 [McpTool("range", Title = "Range Operations", Destructive = true, Category = "data",
-    Description = "Core range operations: get/set values and formulas, copy ranges, clear content, discover data regions. Use range_edit for insert/delete/find/sort. Use range_format for styling/validation. Use range_link for hyperlinks/protection. Use calculation_mode for recalculation. EXCEL TABLES: If user asks to 'format as table', 'create a table', 'put data in an Excel Table' — do NOT try to use range for this. Use table(action:'create') on the data range to create a proper Excel Table with filter arrows, banded rows, and automatic expansion. DATA FORMAT: 2D JSON arrays [[row1col1,row1col2],[row2col1,row2col2]]. Single cell returns [[value]]. FILE INPUT: For set-values/set-formulas, provide EITHER inline values/formulas OR a valuesFile/formulasFile path to a .json or .csv file. Prefer file input for large datasets. BEST PRACTICE: get-values before overwriting, clear-contents (not clear-all) to preserve formatting. NAMED RANGES: Use sheetName='' and rangeAddress=namedRangeName.")]
+    Description = "Core range operations: get/set values and formulas, copy ranges, clear content, discover data regions. Use range_edit for insert/delete/find/sort. Use range_format for styling/validation. Use range_link for hyperlinks/protection. Use calculation_mode for recalculation. EXCEL TABLES: If user asks to 'format as table', 'create a table', 'put data in an Excel Table' — do NOT try to use range for this. Use table(action:'create') on the data range to create a proper Excel Table with filter arrows, banded rows, and automatic expansion. DATA FORMAT: 2D JSON arrays [[row1col1,row1col2],[row2col1,row2col2]]. Single cell returns [[value]]. SCOPED READS: get-values supports zero-based rowOffset, positive rowLimit, and comma-separated absolute worksheet columns such as A,D,F; scoped calls return paging metadata and read only requested cells. FILE INPUT: For set-values/set-formulas, provide EITHER inline values/formulas OR a valuesFile/formulasFile path to a .json or .csv file. Prefer file input for large datasets. BEST PRACTICE: get-values before overwriting, clear-contents (not clear-all) to preserve formatting. NAMED RANGES: Use sheetName='' and rangeAddress=namedRangeName.")]
 public interface IRangeCommands
 {
     // === VALUE OPERATIONS ===
 
     /// <summary>
-    /// Gets values from a range as 2D array.
+    /// Gets values from a range as a 2D array, optionally limited to a row page and selected worksheet columns.
     /// Single cell "A1" returns [[value]], range "A1:B2" returns [[v1,v2],[v3,v4]].
     /// Named ranges: Use empty sheetName and rangeAddress="NamedRange".
+    /// Scoped reads return total dimensions and deterministic continuation metadata without materializing the full source range.
     /// </summary>
     /// <param name="batch">Excel batch session</param>
     /// <param name="sheetName">Name of the worksheet containing the range - REQUIRED for cell addresses, use empty string for named ranges only</param>
     /// <param name="rangeAddress">Cell range address (e.g., 'A1', 'A1:D10', 'B:D') or named range name (e.g., 'SalesData')</param>
+    /// <param name="rowOffset">Zero-based row offset relative to the resolved source range. Must not exceed the source row count.</param>
+    /// <param name="rowLimit">Maximum rows to return. Must be positive when supplied; omitted returns all remaining rows.</param>
+    /// <param name="columns">Comma-separated absolute worksheet column letters to return in the requested order (e.g., 'A,D,F'). Each column must be within the source range.</param>
     [ServiceAction("get-values")]
-    RangeValueResult GetValues(IExcelBatch batch, string sheetName, [RequiredParameter] string rangeAddress);
+    RangeValueResult GetValues(
+        IExcelBatch batch,
+        string sheetName,
+        [RequiredParameter] string rangeAddress,
+        int rowOffset = 0,
+        int? rowLimit = null,
+        string? columns = null);
 
     /// <summary>
     /// Sets values in a range from 2D array or file.
@@ -301,6 +311,5 @@ public class SortColumn
     /// <summary>Sort direction (true = ascending, false = descending)</summary>
     public bool Ascending { get; set; } = true;
 }
-
 
 

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Discovery.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Discovery.cs
@@ -46,6 +46,8 @@ public partial class RangeCommands
                 {
                     result.RowCount = values.GetLength(0);
                     result.ColumnCount = values.GetLength(1);
+                    result.TotalRowCount = result.RowCount;
+                    result.TotalColumnCount = result.ColumnCount;
 
                     for (int r = 1; r <= result.RowCount; r++)
                     {
@@ -100,6 +102,8 @@ public partial class RangeCommands
                 {
                     result.RowCount = values.GetLength(0);
                     result.ColumnCount = values.GetLength(1);
+                    result.TotalRowCount = result.RowCount;
+                    result.TotalColumnCount = result.ColumnCount;
 
                     for (int r = 1; r <= result.RowCount; r++)
                     {
@@ -164,6 +168,5 @@ public partial class RangeCommands
         });
     }
 }
-
 
 

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
@@ -72,7 +72,7 @@ public partial class RangeCommands
                                 int column = startColumn + c - 1;
                                 result.CellErrors.Add(new RangeCellError
                                 {
-                                    CellAddress = $"{GetColumnLetter(column)}{row}",
+                                    CellAddress = $"{RangeHelpers.GetColumnLetter(column)}{row}",
                                     Row = row,
                                     Column = column,
                                     CurrentValue = cellValue,
@@ -104,7 +104,7 @@ public partial class RangeCommands
                     {
                         result.CellErrors.Add(new RangeCellError
                         {
-                            CellAddress = $"{GetColumnLetter(startColumn)}{startRow}",
+                            CellAddress = $"{RangeHelpers.GetColumnLetter(startColumn)}{startRow}",
                             Row = startRow,
                             Column = startColumn,
                             CurrentValue = cellValue,
@@ -160,21 +160,6 @@ public partial class RangeCommands
             -2146826233 => "Check the Python formula syntax and runtime inputs.",
             _ => "Check the formula syntax and referenced values."
         };
-
-    /// <summary>
-    /// Converts 1-based column index to Excel column letter (1=A, 26=Z, 27=AA)
-    /// </summary>
-    private static string GetColumnLetter(int columnIndex)
-    {
-        string columnName = string.Empty;
-        while (columnIndex > 0)
-        {
-            columnIndex--;
-            columnName = Convert.ToChar('A' + (columnIndex % 26)) + columnName;
-            columnIndex /= 26;
-        }
-        return columnName;
-    }
 
     /// <inheritdoc />
     public OperationResult SetFormulas(IExcelBatch batch, string sheetName, string rangeAddress, List<List<string>>? formulas = null, string? formulasFile = null)
@@ -260,5 +245,4 @@ public partial class RangeCommands
         });
     }
 }
-
 

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Values.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Values.cs
@@ -13,18 +13,37 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Range;
 public partial class RangeCommands
 {
     /// <inheritdoc />
-    public RangeValueResult GetValues(IExcelBatch batch, string sheetName, string rangeAddress)
+    public RangeValueResult GetValues(
+        IExcelBatch batch,
+        string sheetName,
+        string rangeAddress,
+        int rowOffset = 0,
+        int? rowLimit = null,
+        string? columns = null)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(rowOffset);
+        if (rowLimit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rowLimit), rowLimit, "Row limit must be greater than zero.");
+        }
+
+        var selectedColumns = ParseSelectedColumns(columns);
+        bool isScopedRead = rowOffset != 0 || rowLimit.HasValue || selectedColumns != null;
         var result = new RangeValueResult
         {
             FilePath = batch.WorkbookPath,
             SheetName = sheetName,
-            RangeAddress = rangeAddress
+            RangeAddress = rangeAddress,
+            RowOffset = rowOffset,
+            SelectedColumns = selectedColumns?.Select(column => column.Name).ToList()
         };
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic? range = null;
+            Excel.Range? range = null;
+            Excel.Range? rows = null;
+            Excel.Range? rangeColumns = null;
+            Excel.Areas? areas = null;
             try
             {
                 range = RangeHelpers.ResolveRange(ctx.Book, sheetName, rangeAddress, out string? specificError);
@@ -35,32 +54,92 @@ public partial class RangeCommands
 
                 // Get actual address from Excel
                 result.RangeAddress = range.Address;
+                rows = range.Rows;
+                rangeColumns = range.Columns;
+                result.TotalRowCount = Convert.ToInt32(rows.Count);
+                result.TotalColumnCount = Convert.ToInt32(rangeColumns.Count);
 
-                // Get values as 2D array - handle single cell case
-                object valueOrArray = range.Value2;
-
-                if (valueOrArray is object[,] values)
+                if (rowOffset > result.TotalRowCount)
                 {
-                    // Multi-cell range - process as 2D array
-                    result.RowCount = values.GetLength(0);
-                    result.ColumnCount = values.GetLength(1);
+                    throw new ArgumentOutOfRangeException(
+                        nameof(rowOffset),
+                        rowOffset,
+                        $"Row offset must be between 0 and the source row count ({result.TotalRowCount}).");
+                }
 
-                    for (int r = 1; r <= result.RowCount; r++)
+                if (isScopedRead)
+                {
+                    areas = range.Areas;
+                    if (Convert.ToInt32(areas.Count) != 1)
                     {
-                        var row = new List<object?>();
-                        for (int c = 1; c <= result.ColumnCount; c++)
-                        {
-                            row.Add(values[r, c]);
-                        }
-                        result.Values.Add(row);
+                        throw new ArgumentException(
+                            "Scoped reads do not support multi-area ranges. Read each area separately.",
+                            nameof(rangeAddress));
                     }
+                }
+
+                int sourceStartColumn = Convert.ToInt32(range.Column);
+                var resolvedColumns = ResolveSelectedColumns(
+                    selectedColumns,
+                    sourceStartColumn,
+                    result.TotalColumnCount);
+                int returnedColumnCount = resolvedColumns?.Count ?? result.TotalColumnCount;
+                int remainingRows = result.TotalRowCount - rowOffset;
+                int returnedRowCount = Math.Min(rowLimit ?? remainingRows, remainingRows);
+
+                result.RowCount = returnedRowCount;
+                result.ColumnCount = returnedColumnCount;
+                result.HasMoreRows = rowOffset + returnedRowCount < result.TotalRowCount;
+                result.NextRowOffset = result.HasMoreRows ? rowOffset + returnedRowCount : null;
+                result.IsTruncated =
+                    rowOffset > 0 ||
+                    returnedRowCount < result.TotalRowCount ||
+                    returnedColumnCount < result.TotalColumnCount;
+
+                if (returnedRowCount == 0)
+                {
+                    result.Success = true;
+                    return result;
+                }
+
+                if (!isScopedRead)
+                {
+                    PopulateValues(result.Values, range.Value2, returnedRowCount, returnedColumnCount);
+                }
+                else if (resolvedColumns == null)
+                {
+                    ReadRectangularSlice(
+                        range,
+                        rowOffset,
+                        1,
+                        returnedRowCount,
+                        returnedColumnCount,
+                        result.Values);
                 }
                 else
                 {
-                    // Single cell - wrap value in 1x1 array
-                    result.RowCount = 1;
-                    result.ColumnCount = 1;
-                    result.Values.Add([valueOrArray]);
+                    for (int rowIndex = 0; rowIndex < returnedRowCount; rowIndex++)
+                    {
+                        result.Values.Add(new List<object?>(returnedColumnCount));
+                    }
+
+                    foreach (var selectedColumn in resolvedColumns)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        var columnValues = new List<List<object?>>(returnedRowCount);
+                        ReadRectangularSlice(
+                            range,
+                            rowOffset,
+                            selectedColumn.RelativeIndex,
+                            returnedRowCount,
+                            1,
+                            columnValues);
+
+                        for (int rowIndex = 0; rowIndex < returnedRowCount; rowIndex++)
+                        {
+                            result.Values[rowIndex].Add(columnValues[rowIndex][0]);
+                        }
+                    }
                 }
 
                 result.Success = true;
@@ -73,9 +152,131 @@ public partial class RangeCommands
             }
             finally
             {
+                ComUtilities.Release(ref areas);
+                ComUtilities.Release(ref rangeColumns);
+                ComUtilities.Release(ref rows);
                 ComUtilities.Release(ref range);
             }
         });
+    }
+
+    private static List<(string Name, int AbsoluteIndex)>? ParseSelectedColumns(string? columns)
+    {
+        if (string.IsNullOrWhiteSpace(columns))
+        {
+            return null;
+        }
+
+        var selectedColumns = new List<(string Name, int AbsoluteIndex)>();
+        var seenColumns = new HashSet<int>();
+        foreach (string rawColumn in columns.Split(','))
+        {
+            string columnName = rawColumn.Trim().ToUpperInvariant();
+            if (columnName.Length > 3 ||
+                !RangeHelpers.TryGetColumnIndex(columnName, out int absoluteIndex))
+            {
+                throw new ArgumentException(
+                    $"Column '{rawColumn.Trim()}' is invalid. Use Excel column letters from A through XFD.",
+                    nameof(columns));
+            }
+
+            if (!seenColumns.Add(absoluteIndex))
+            {
+                throw new ArgumentException($"Column '{columnName}' was specified more than once.", nameof(columns));
+            }
+
+            selectedColumns.Add((columnName, absoluteIndex));
+        }
+
+        return selectedColumns;
+    }
+
+    private static List<(string Name, int RelativeIndex)>? ResolveSelectedColumns(
+        List<(string Name, int AbsoluteIndex)>? columns,
+        int sourceStartColumn,
+        int sourceColumnCount)
+    {
+        if (columns == null)
+        {
+            return null;
+        }
+
+        int sourceEndColumn = sourceStartColumn + sourceColumnCount - 1;
+        var resolvedColumns = new List<(string Name, int RelativeIndex)>(columns.Count);
+        foreach (var selectedColumn in columns)
+        {
+            if (selectedColumn.AbsoluteIndex < sourceStartColumn ||
+                selectedColumn.AbsoluteIndex > sourceEndColumn)
+            {
+                throw new ArgumentException(
+                    $"Column '{selectedColumn.Name}' is outside the resolved source range " +
+                    $"({RangeHelpers.GetColumnLetter(sourceStartColumn)}:{RangeHelpers.GetColumnLetter(sourceEndColumn)}).",
+                    nameof(columns));
+            }
+
+            resolvedColumns.Add((
+                selectedColumn.Name,
+                selectedColumn.AbsoluteIndex - sourceStartColumn + 1));
+        }
+
+        return resolvedColumns;
+    }
+
+    private static void ReadRectangularSlice(
+        Excel.Range sourceRange,
+        int rowOffset,
+        int relativeColumnIndex,
+        int rowCount,
+        int columnCount,
+        List<List<object?>> destination)
+    {
+        Excel.Range? cells = null;
+        Excel.Range? firstCell = null;
+        Excel.Range? slice = null;
+        try
+        {
+            cells = sourceRange.Cells;
+            firstCell = cells[rowOffset + 1, relativeColumnIndex];
+            if (rowCount == 1 && columnCount == 1)
+            {
+                PopulateValues(destination, firstCell.Value2, rowCount, columnCount);
+                return;
+            }
+
+            slice = firstCell.Resize[rowCount, columnCount];
+            PopulateValues(destination, slice.Value2, rowCount, columnCount);
+        }
+        finally
+        {
+            ComUtilities.Release(ref slice);
+            ComUtilities.Release(ref firstCell);
+            ComUtilities.Release(ref cells);
+        }
+    }
+
+    private static void PopulateValues(
+        List<List<object?>> destination,
+        object? valueOrArray,
+        int rowCount,
+        int columnCount)
+    {
+        if (valueOrArray is object[,] values)
+        {
+            for (int rowIndex = 1; rowIndex <= rowCount; rowIndex++)
+            {
+                var row = new List<object?>(columnCount);
+                for (int columnIndex = 1; columnIndex <= columnCount; columnIndex++)
+                {
+                    row.Add(values[rowIndex, columnIndex]);
+                }
+
+                destination.Add(row);
+            }
+
+            return;
+        }
+
+        destination.Add([valueOrArray]);
     }
 
     /// <inheritdoc />
@@ -229,6 +430,3 @@ public partial class RangeCommands
         }
     }
 }
-
-
-

--- a/src/ExcelMcp.Core/Commands/Range/RangeHelpers.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeHelpers.cs
@@ -118,6 +118,54 @@ public static class RangeHelpers
         // Already a proper type (from CLI or tests)
         return value;
     }
+
+    /// <summary>
+    /// Converts a 1-based worksheet column index to its Excel column letters.
+    /// </summary>
+    internal static string GetColumnLetter(int columnIndex)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, 1);
+
+        string columnName = string.Empty;
+        while (columnIndex > 0)
+        {
+            columnIndex--;
+            columnName = Convert.ToChar('A' + (columnIndex % 26)) + columnName;
+            columnIndex /= 26;
+        }
+
+        return columnName;
+    }
+
+    /// <summary>
+    /// Parses Excel column letters into a 1-based worksheet column index.
+    /// </summary>
+    internal static bool TryGetColumnIndex(string columnName, out int columnIndex)
+    {
+        columnIndex = 0;
+        if (string.IsNullOrEmpty(columnName))
+        {
+            return false;
+        }
+
+        foreach (char character in columnName)
+        {
+            if (character is < 'A' or > 'Z')
+            {
+                columnIndex = 0;
+                return false;
+            }
+
+            columnIndex = checked((columnIndex * 26) + character - 'A' + 1);
+            if (columnIndex > 16384)
+            {
+                columnIndex = 0;
+                return false;
+            }
+        }
+
+        return true;
+    }
 }
 
 /// <summary>
@@ -241,4 +289,3 @@ public partial class RangeCommands
         });
     }
 }
-

--- a/src/ExcelMcp.Core/Models/ResultTypes.cs
+++ b/src/ExcelMcp.Core/Models/ResultTypes.cs
@@ -1044,14 +1044,51 @@ public class RangeValueResult : ResultBase
     public List<List<object?>> Values { get; set; } = [];
 
     /// <summary>
-    /// Number of rows in the range
+    /// Number of rows in the returned values matrix
     /// </summary>
     public int RowCount { get; set; }
 
     /// <summary>
-    /// Number of columns in the range
+    /// Number of columns in the returned values matrix
     /// </summary>
     public int ColumnCount { get; set; }
+
+    /// <summary>
+    /// Total number of rows in the resolved source range
+    /// </summary>
+    public int TotalRowCount { get; set; }
+
+    /// <summary>
+    /// Total number of columns in the resolved source range
+    /// </summary>
+    public int TotalColumnCount { get; set; }
+
+    /// <summary>
+    /// Applied zero-based row offset relative to the source range
+    /// </summary>
+    public int RowOffset { get; set; }
+
+    /// <summary>
+    /// Whether rows remain after the returned page
+    /// </summary>
+    public bool HasMoreRows { get; set; }
+
+    /// <summary>
+    /// Zero-based offset for the next row page, when more rows remain
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? NextRowOffset { get; set; }
+
+    /// <summary>
+    /// Whether the result omits any source rows or columns
+    /// </summary>
+    public bool IsTruncated { get; set; }
+
+    /// <summary>
+    /// Explicit worksheet columns in returned matrix order; omitted when all source columns are returned
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? SelectedColumns { get; set; }
 }
 
 /// <summary>

--- a/tests/ExcelMcp.CLI.Tests/Integration/DaemonForcedStopRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/DaemonForcedStopRegressionTests.cs
@@ -317,6 +317,10 @@ public sealed class DaemonForcedStopRegressionTests
             cleanupScript,
             StringComparison.Ordinal);
         Assert.Contains(
+            @"src\ExcelMcp.CLI\Infrastructure\PreBuildProcessCleanup.cs",
+            cleanupScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
             @"src\ExcelMcp.CLI\Program.cs",
             cleanupScript,
             StringComparison.Ordinal);
@@ -484,6 +488,37 @@ public sealed class DaemonForcedStopRegressionTests
         {
             StopIfRunning(daemon);
             StopIfRunning(excel);
+            DaemonProcessTracker.Clear(pipeName);
+        }
+    }
+
+    [Fact]
+    public async Task PreBuildCleanup_LostShutdownReply_AllowsGracefulDaemonExit()
+    {
+        var pipeName = $"excelmcp-lost-shutdown-reply-{Guid.NewGuid():N}";
+        using var daemon = StartShortLivedProcess(seconds: 5);
+
+        try
+        {
+            DaemonProcessTracker.RegisterProcess(
+                pipeName,
+                daemon.Id,
+                daemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+
+            var cleanupResult =
+                await PreBuildProcessCleanup.CleanupWithGracefulShutdownAsync(
+                    pipeName,
+                    CancellationToken.None,
+                    _ => Task.FromResult(false));
+
+            Assert.True(cleanupResult.Success);
+            Assert.True(daemon.WaitForExit(5000));
+            Assert.Equal(0, daemon.ExitCode);
+            Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
+        }
+        finally
+        {
+            StopIfRunning(daemon);
             DaemonProcessTracker.Clear(pipeName);
         }
     }
@@ -1269,12 +1304,12 @@ public sealed class DaemonForcedStopRegressionTests
         })!;
     }
 
-    private static Process StartShortLivedProcess()
+    private static Process StartShortLivedProcess(int seconds = 2)
     {
         return Process.Start(new ProcessStartInfo
         {
             FileName = "powershell.exe",
-            Arguments = "-NoProfile -Command \"Start-Sleep -Seconds 2\"",
+            Arguments = $"-NoProfile -Command \"Start-Sleep -Seconds {seconds}\"",
             UseShellExecute = false,
             CreateNoWindow = true
         })!;

--- a/tests/ExcelMcp.CLI.Tests/Integration/DaemonForcedStopRegressionTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/DaemonForcedStopRegressionTests.cs
@@ -493,17 +493,22 @@ public sealed class DaemonForcedStopRegressionTests
     }
 
     [Fact]
-    public async Task PreBuildCleanup_LostShutdownReply_AllowsGracefulDaemonExit()
+    public async Task PreBuildCleanup_LostShutdownReply_AllowsTrackedGenerationToExit()
     {
         var pipeName = $"excelmcp-lost-shutdown-reply-{Guid.NewGuid():N}";
-        using var daemon = StartShortLivedProcess(seconds: 5);
+        using var daemon = StartShortLivedProcess(seconds: 2);
+        using var excel = StartShortLivedProcess(seconds: 5);
 
         try
         {
-            DaemonProcessTracker.RegisterProcess(
+            var daemonIdentity = DaemonProcessTracker.RegisterProcess(
                 pipeName,
                 daemon.Id,
                 daemon.StartTime.ToUniversalTime().ToFileTimeUtc());
+            DaemonProcessTracker.UpdateExcelProcesses(
+                pipeName,
+                daemonIdentity,
+                [excel.Id]);
 
             var cleanupResult =
                 await PreBuildProcessCleanup.CleanupWithGracefulShutdownAsync(
@@ -513,12 +518,15 @@ public sealed class DaemonForcedStopRegressionTests
 
             Assert.True(cleanupResult.Success);
             Assert.True(daemon.WaitForExit(5000));
+            Assert.True(excel.WaitForExit(5000));
             Assert.Equal(0, daemon.ExitCode);
+            Assert.Equal(0, excel.ExitCode);
             Assert.False(File.Exists(DaemonProcessTracker.GetTrackingFilePath(pipeName)));
         }
         finally
         {
             StopIfRunning(daemon);
+            StopIfRunning(excel);
             DaemonProcessTracker.Clear(pipeName);
         }
     }

--- a/tests/ExcelMcp.CLI.Tests/Integration/PreBuildGracefulSaveAcceptanceTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/PreBuildGracefulSaveAcceptanceTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using Sbroenne.ExcelMcp.CLI.Infrastructure;
 using Sbroenne.ExcelMcp.Core.Tests.Helpers;
 using Xunit;
 
@@ -109,7 +110,11 @@ public sealed class PreBuildGracefulSaveAcceptanceTests : IClassFixture<TempDire
                 },
                 TimeSpan.FromMinutes(4));
 
-            Assert.Equal(0, build.ExitCode);
+            Assert.True(
+                build.ExitCode == 0,
+                $"Release rebuild failed.{Environment.NewLine}" +
+                $"stdout: {build.Stdout}{Environment.NewLine}" +
+                $"stderr: {build.Stderr}");
             Assert.True(
                 selectedDaemon.WaitForExit(15000),
                 $"Selected daemon {selectedDaemon.Id} did not exit.");
@@ -195,7 +200,7 @@ public sealed class PreBuildGracefulSaveAcceptanceTests : IClassFixture<TempDire
             cliPath,
             pipeName,
             ["service", "status", "--quiet"],
-            TimeSpan.FromSeconds(10));
+            DaemonConnectionPolicy.ControlTimeout + TimeSpan.FromSeconds(2));
 
     private static Task<ProcessResult> RunCliAsync(
         string cliPath,

--- a/tests/ExcelMcp.CLI.Tests/Integration/RangeScopedReadCliTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/RangeScopedReadCliTests.cs
@@ -1,0 +1,103 @@
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Collection("Service")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "Range")]
+[Trait("Layer", "CLI")]
+[Trait("RequiresExcel", "true")]
+public sealed class RangeScopedReadCliTests : IDisposable
+{
+    private readonly string _testFile =
+        Path.Combine(Path.GetTempPath(), $"RangeScopedReadCli_{Guid.NewGuid():N}.xlsx");
+
+    [Fact]
+    public async Task GetValues_WithScope_ReturnsPageAndMetadataThroughCli()
+    {
+        Sbroenne.ExcelMcp.ComInterop.Session.ExcelSession.CreateNew(
+            _testFile,
+            isMacroEnabled: false,
+            (ctx, ct) => 0,
+            CancellationToken.None);
+
+        var (openResult, openJson) = await CliProcessHelper.RunJsonAsync(
+            ["session", "open", _testFile],
+            timeoutMs: 60000);
+        Assert.Equal(0, openResult.ExitCode);
+        var sessionId = openJson.RootElement.GetProperty("sessionId").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(sessionId));
+
+        try
+        {
+            var (setupResult, setupJson) = await CliProcessHelper.RunJsonAsync(
+                [
+                    "range", "set-values",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "B2:E4",
+                    "--values", """[["R1B","R1C","R1D","R1E"],["R2B","R2C","R2D","R2E"],["R3B","R3C","R3D","R3E"]]"""
+                ],
+                timeoutMs: 60000);
+            using (setupJson)
+            {
+                Assert.Equal(0, setupResult.ExitCode);
+                Assert.True(setupJson.RootElement.GetProperty("success").GetBoolean(), setupResult.Stdout);
+            }
+
+            var (readResult, readJson) = await CliProcessHelper.RunJsonAsync(
+                [
+                    "range", "get-values",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "B2:E4",
+                    "--row-offset", "1",
+                    "--row-limit", "1",
+                    "--columns", "E,B"
+                ],
+                timeoutMs: 60000);
+
+            using (readJson)
+            {
+                Assert.Equal(0, readResult.ExitCode);
+                var root = readJson.RootElement;
+                Assert.True(root.GetProperty("success").GetBoolean(), readResult.Stdout);
+                Assert.Equal(1, root.GetProperty("rowCount").GetInt32());
+                Assert.Equal(2, root.GetProperty("columnCount").GetInt32());
+                Assert.Equal(3, root.GetProperty("totalRowCount").GetInt32());
+                Assert.Equal(4, root.GetProperty("totalColumnCount").GetInt32());
+                Assert.Equal(1, root.GetProperty("rowOffset").GetInt32());
+                Assert.True(root.GetProperty("hasMoreRows").GetBoolean());
+                Assert.Equal(2, root.GetProperty("nextRowOffset").GetInt32());
+                Assert.True(root.GetProperty("isTruncated").GetBoolean());
+                Assert.Equal(["E", "B"], root.GetProperty("selectedColumns").EnumerateArray().Select(value => value.GetString()));
+                Assert.Equal(["R2E", "R2B"], root.GetProperty("values")[0].EnumerateArray().Select(value => value.GetString()));
+            }
+        }
+        finally
+        {
+            openJson.Dispose();
+            await CliProcessHelper.RunAsync(
+                ["session", "close", "--session", sessionId!, "--save", "false"],
+                timeoutMs: 60000);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFile))
+        {
+            try
+            {
+                File.Delete(_testFile);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Values.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.Values.cs
@@ -1,6 +1,8 @@
+using Sbroenne.ExcelMcp.ComInterop;
 using Sbroenne.ExcelMcp.ComInterop.Session;
 using Sbroenne.ExcelMcp.Core.Commands;
 using Xunit;
+using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
 
@@ -58,6 +60,13 @@ public partial class RangeCommandsTests
         Assert.True(result.Success);
         Assert.Equal(3, result.RowCount);
         Assert.Equal(3, result.ColumnCount);
+        Assert.Equal(3, result.TotalRowCount);
+        Assert.Equal(3, result.TotalColumnCount);
+        Assert.Equal(0, result.RowOffset);
+        Assert.False(result.HasMoreRows);
+        Assert.Null(result.NextRowOffset);
+        Assert.False(result.IsTruncated);
+        Assert.Null(result.SelectedColumns);
         Assert.Equal(3, result.Values.Count);
         Assert.Equal(
             1.0,
@@ -285,7 +294,239 @@ public partial class RangeCommandsTests
         Assert.Contains("Verify the range address format", exception.Message);
     }
 
+    [Fact]
+    public void GetValues_WithRowPage_ReturnsRequestedRowsAndPagingMetadata()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.SetValues(batch, sheetName, "B2:D6",
+        [
+            ["R1B", "R1C", "R1D"],
+            ["R2B", "R2C", "R2D"],
+            ["R3B", "R3C", "R3D"],
+            ["R4B", "R4C", "R4D"],
+            ["R5B", "R5C", "R5D"]
+        ]);
+
+        var result = _commands.GetValues(batch, sheetName, "B2:D6", rowOffset: 1, rowLimit: 2);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(2, result.RowCount);
+        Assert.Equal(3, result.ColumnCount);
+        Assert.Equal(5, result.TotalRowCount);
+        Assert.Equal(3, result.TotalColumnCount);
+        Assert.Equal(1, result.RowOffset);
+        Assert.True(result.HasMoreRows);
+        Assert.Equal(3, result.NextRowOffset);
+        Assert.True(result.IsTruncated);
+        Assert.Null(result.SelectedColumns);
+        Assert.Equal(["R2B", "R2C", "R2D"], result.Values[0]);
+        Assert.Equal(["R3B", "R3C", "R3D"], result.Values[1]);
+    }
+
+    [Fact]
+    public void GetValues_WithSelectedColumns_PreservesRequestedOrder()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.SetValues(batch, sheetName, "B2:E4",
+        [
+            ["R1B", "R1C", "R1D", "R1E"],
+            ["R2B", "R2C", "R2D", "R2E"],
+            ["R3B", "R3C", "R3D", "R3E"]
+        ]);
+
+        var result = _commands.GetValues(
+            batch,
+            sheetName,
+            "B2:E4",
+            rowOffset: 1,
+            rowLimit: 2,
+            columns: "E, B, D");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(2, result.RowCount);
+        Assert.Equal(3, result.ColumnCount);
+        Assert.Equal(3, result.TotalRowCount);
+        Assert.Equal(4, result.TotalColumnCount);
+        Assert.Equal(["E", "B", "D"], result.SelectedColumns);
+        Assert.True(result.IsTruncated);
+        Assert.False(result.HasMoreRows);
+        Assert.Null(result.NextRowOffset);
+        Assert.Equal(["R2E", "R2B", "R2D"], result.Values[0]);
+        Assert.Equal(["R3E", "R3B", "R3D"], result.Values[1]);
+    }
+
+    [Fact]
+    public void GetValues_WithNamedRangeAndScope_ReturnsRequestedCells()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var namedRangeCommands = new NamedRangeCommands();
+        var namedRangeName = $"ScopedData_{Guid.NewGuid():N}";
+
+        namedRangeCommands.Create(batch, namedRangeName, $"{sheetName}!$C$3:$F$6");
+        try
+        {
+            _commands.SetValues(batch, sheetName, "C3:F6",
+            [
+                ["R1C", "R1D", "R1E", "R1F"],
+                ["R2C", "R2D", "R2E", "R2F"],
+                ["R3C", "R3D", "R3E", "R3F"],
+                ["R4C", "R4D", "R4E", "R4F"]
+            ]);
+
+            var result = _commands.GetValues(
+                batch,
+                "",
+                namedRangeName,
+                rowOffset: 2,
+                rowLimit: 1,
+                columns: "F,C");
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(4, result.TotalRowCount);
+            Assert.Equal(4, result.TotalColumnCount);
+            Assert.Equal(["F", "C"], result.SelectedColumns);
+            Assert.Equal(["R3F", "R3C"], Assert.Single(result.Values));
+            Assert.True(result.HasMoreRows);
+            Assert.Equal(3, result.NextRowOffset);
+        }
+        finally
+        {
+            namedRangeCommands.Delete(batch, namedRangeName);
+        }
+    }
+
+    [Fact]
+    public void GetValues_WithOffsetAtEnd_ReturnsEmptyPage()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        var result = _commands.GetValues(batch, sheetName, "A1:C4", rowOffset: 4, rowLimit: 10);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Empty(result.Values);
+        Assert.Equal(0, result.RowCount);
+        Assert.Equal(3, result.ColumnCount);
+        Assert.Equal(4, result.TotalRowCount);
+        Assert.Equal(3, result.TotalColumnCount);
+        Assert.Equal(4, result.RowOffset);
+        Assert.False(result.HasMoreRows);
+        Assert.Null(result.NextRowOffset);
+        Assert.True(result.IsTruncated);
+    }
+
+    [Theory]
+    [InlineData(-1, 1, null, "rowOffset")]
+    [InlineData(0, 0, null, "rowLimit")]
+    [InlineData(0, 1, "B,B", "columns")]
+    [InlineData(0, 1, "1", "columns")]
+    [InlineData(0, 1, "AAAAAAAAAAAAAAAAAAAA", "columns")]
+    public void GetValues_WithInvalidScopeSyntax_ThrowsBeforeOpeningExcel(
+        int rowOffset,
+        int? rowLimit,
+        string? columns,
+        string expectedParameter)
+    {
+        var exception = Assert.ThrowsAny<ArgumentException>(() =>
+            _commands.GetValues(null!, "Sheet1", "B2:D4", rowOffset, rowLimit, columns));
+
+        Assert.Equal(expectedParameter, exception.ParamName);
+    }
+
+    [Fact]
+    public void GetValues_WithColumnOutsideResolvedRange_ThrowsDescriptiveValidationError()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        var exception = Assert.ThrowsAny<ArgumentException>(() =>
+            _commands.GetValues(batch, sheetName, "B2:D4", rowLimit: 1, columns: "A"));
+
+        Assert.Equal("columns", exception.ParamName);
+    }
+
+    [Fact]
+    public void GetValues_WithMultiAreaRangeAndScope_ThrowsDescriptiveValidationError()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var namedRangeName = $"MultiArea_{Guid.NewGuid():N}";
+        var namedRangeCommands = new NamedRangeCommands();
+
+        batch.Execute((ctx, ct) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? firstArea = null;
+            Excel.Range? secondArea = null;
+            Excel.Range? unionRange = null;
+            Excel.Names? names = null;
+            Excel.Name? name = null;
+            try
+            {
+                sheet = ComUtilities.FindSheet(ctx.Book, sheetName)
+                    ?? throw new InvalidOperationException($"Sheet '{sheetName}' not found.");
+                firstArea = sheet.Range["A1:A2"];
+                secondArea = sheet.Range["C1:C2"];
+                unionRange = ctx.App.Union(firstArea, secondArea);
+                names = ctx.Book.Names;
+                name = names.Add(namedRangeName, unionRange);
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref name);
+                ComUtilities.Release(ref names);
+                ComUtilities.Release(ref unionRange);
+                ComUtilities.Release(ref secondArea);
+                ComUtilities.Release(ref firstArea);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+
+        try
+        {
+            var exception = Assert.Throws<ArgumentException>(() =>
+                _commands.GetValues(batch, "", namedRangeName, rowLimit: 1));
+
+            Assert.Equal("rangeAddress", exception.ParamName);
+            Assert.Contains("multi-area", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            namedRangeCommands.Delete(batch, namedRangeName);
+        }
+    }
+
+    [Fact]
+    public void GetValues_WithLargeSourceRange_MaterializesOnlyRequestedCells()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        _commands.SetValues(batch, sheetName, "A99999:A100000", [["A-last-1"], ["A-last"]]);
+        _commands.SetValues(batch, sheetName, "Z99999:Z100000", [["Z-last-1"], ["Z-last"]]);
+
+        var result = _commands.GetValues(
+            batch,
+            sheetName,
+            "A1:Z100000",
+            rowOffset: 99998,
+            rowLimit: 2,
+            columns: "A,Z");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(100000, result.TotalRowCount);
+        Assert.Equal(26, result.TotalColumnCount);
+        Assert.Equal(2, result.RowCount);
+        Assert.Equal(2, result.ColumnCount);
+        Assert.Equal(["A", "Z"], result.SelectedColumns);
+        Assert.Equal(["A-last-1", "Z-last-1"], result.Values[0]);
+        Assert.Equal(["A-last", "Z-last"], result.Values[1]);
+    }
+
 }
-
-
-

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeneratedActionContractProtocolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeneratedActionContractProtocolTests.cs
@@ -438,6 +438,30 @@ public sealed class GeneratedActionContractProtocolTests : McpIntegrationTestBas
     }
 
     [Fact]
+    public async Task ListTools_RangeSchema_ExposesScopedReadParameters()
+    {
+        var tools = await Client!.ListToolsAsync(cancellationToken: TestCancellationToken);
+        var rangeTool = Assert.Single(tools, candidate => candidate.Name == "range");
+        var properties = rangeTool.JsonSchema.GetProperty("properties");
+
+        var rowOffset = properties.GetProperty("row_offset");
+        Assert.Equal("integer", rowOffset.GetProperty("type").GetString());
+        Assert.Contains("get-values", rowOffset.GetProperty("description").GetString(), StringComparison.Ordinal);
+
+        var rowLimit = properties.GetProperty("row_limit");
+        Assert.Equal("integer", rowLimit.GetProperty("type").GetString());
+        Assert.Contains("get-values", rowLimit.GetProperty("description").GetString(), StringComparison.Ordinal);
+
+        var columns = properties.GetProperty("columns");
+        Assert.Equal("string", columns.GetProperty("type").GetString());
+        Assert.Contains("get-values", columns.GetProperty("description").GetString(), StringComparison.Ordinal);
+        Assert.Contains(
+            "zero-based rowOffset, positive rowLimit, and comma-separated absolute worksheet columns",
+            rangeTool.Description,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CreateSessionBridge_DoesNotDefaultMacroEnabledToFalse()
     {
         var method = typeof(ExcelServiceBridge).GetMethod(nameof(ExcelServiceBridge.CreateSessionAsync));

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/RangeScopedReadToolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/RangeScopedReadToolTests.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.ExcelMcp.McpServer.Tests.Integration.Tools;
+
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Range")]
+[Trait("RequiresExcel", "true")]
+public sealed class RangeScopedReadToolTests : McpIntegrationTestBase
+{
+    private readonly string _tempDirectory;
+
+    public RangeScopedReadToolTests(ITestOutputHelper output)
+        : base(output, "RangeScopedReadToolClient")
+    {
+        _tempDirectory = CreateTempDirectory(nameof(RangeScopedReadToolTests));
+    }
+
+    [Fact]
+    public async Task GetValues_WithScope_ReturnsPageAndMetadataThroughMcp()
+    {
+        var baselineExcelProcessIds = Process.GetProcessesByName("EXCEL")
+            .Select(process => process.Id)
+            .ToHashSet();
+        var sessionId = await CreateWorkbookSessionAsync(
+            Path.Join(_tempDirectory, $"ScopedRead_{Guid.NewGuid():N}.xlsx"));
+
+        var setup = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-values",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "B2:E4",
+            ["values"] = new List<List<object?>>
+            {
+                new() { "R1B", "R1C", "R1D", "R1E" },
+                new() { "R2B", "R2C", "R2D", "R2E" },
+                new() { "R3B", "R3C", "R3D", "R3E" }
+            }
+        });
+        AssertSetupSuccess(setup, "range.set-values");
+
+        var response = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "get-values",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "B2:E4",
+            ["row_offset"] = 1,
+            ["row_limit"] = 1,
+            ["columns"] = "E,B"
+        });
+
+        AssertSuccess(response, "range.get-values scoped");
+        using var document = JsonDocument.Parse(response);
+        var root = document.RootElement;
+        Assert.Equal(1, root.GetProperty("rowCount").GetInt32());
+        Assert.Equal(2, root.GetProperty("columnCount").GetInt32());
+        Assert.Equal(3, root.GetProperty("totalRowCount").GetInt32());
+        Assert.Equal(4, root.GetProperty("totalColumnCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("rowOffset").GetInt32());
+        Assert.True(root.GetProperty("hasMoreRows").GetBoolean());
+        Assert.Equal(2, root.GetProperty("nextRowOffset").GetInt32());
+        Assert.True(root.GetProperty("isTruncated").GetBoolean());
+        Assert.Equal(["E", "B"], root.GetProperty("selectedColumns").EnumerateArray().Select(value => value.GetString()));
+        Assert.Equal(["R2E", "R2B"], root.GetProperty("values")[0].EnumerateArray().Select(value => value.GetString()));
+
+        await CloseSessionAsync(sessionId, save: false);
+
+        var waitDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+        List<int> leakedExcelProcessIds;
+        do
+        {
+            leakedExcelProcessIds = Process.GetProcessesByName("EXCEL")
+                .Select(process => process.Id)
+                .Where(processId => !baselineExcelProcessIds.Contains(processId))
+                .ToList();
+
+            if (leakedExcelProcessIds.Count == 0)
+            {
+                break;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+        }
+        while (DateTime.UtcNow < waitDeadline);
+
+        Assert.Empty(leakedExcelProcessIds);
+    }
+}

--- a/tests/ExcelMcp.SkillGeneration.Tests/McpbPackagingScriptTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/McpbPackagingScriptTests.cs
@@ -1,0 +1,163 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.SkillGeneration.Tests;
+
+/// <summary>
+/// Integration tests for MCPB packaging script behavior.
+/// </summary>
+public sealed class McpbPackagingScriptTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string PackagingHelpers = Path.Combine(
+        RepoRoot,
+        "mcpb",
+        "McpbPackaging.ps1");
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "McpbPackaging")]
+    public async Task RemoveStagingDirectory_RetriesTransientFileLockUntilDirectoryIsGone()
+    {
+        var sandbox = CreateSandbox();
+        try
+        {
+            var script = $$"""
+                $ErrorActionPreference = 'Stop'
+                . '{{EscapePowerShellLiteral(PackagingHelpers)}}'
+                $script:attempts = 0
+                $removeDirectory = {
+                    param([string]$Path)
+                    $script:attempts++
+                    if ($script:attempts -lt 3) {
+                        throw [System.IO.IOException]::new('locked by scanner')
+                    }
+
+                    [System.IO.Directory]::Delete($Path, $true)
+                }
+
+                Remove-McpbStagingDirectory `
+                    -Path '{{EscapePowerShellLiteral(sandbox)}}' `
+                    -Timeout ([TimeSpan]::FromSeconds(1)) `
+                    -RetryInterval ([TimeSpan]::Zero) `
+                    -RemoveDirectory $removeDirectory
+                Write-Output "attempts=$script:attempts"
+                """;
+
+            var result = await RunPowerShellAsync(script);
+
+            Assert.True(result.ExitCode == 0, result.CombinedOutput);
+            Assert.Contains("attempts=3", result.Stdout, StringComparison.Ordinal);
+            Assert.False(Directory.Exists(sandbox));
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox))
+            {
+                Directory.Delete(sandbox, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "McpbPackaging")]
+    public async Task RemoveStagingDirectory_WhenTimeoutExpires_ReportsTerminalState()
+    {
+        var sandbox = CreateSandbox();
+        try
+        {
+            var script = $$"""
+                $ErrorActionPreference = 'Stop'
+                . '{{EscapePowerShellLiteral(PackagingHelpers)}}'
+                $removeDirectory = {
+                    param([string]$Path)
+                    throw [System.UnauthorizedAccessException]::new('locked by scanner')
+                }
+
+                Remove-McpbStagingDirectory `
+                    -Path '{{EscapePowerShellLiteral(sandbox)}}' `
+                    -Timeout ([TimeSpan]::Zero) `
+                    -RetryInterval ([TimeSpan]::Zero) `
+                    -RemoveDirectory $removeDirectory
+                """;
+
+            var result = await RunPowerShellAsync(script);
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.True(Directory.Exists(sandbox));
+            Assert.Contains(
+                "Failed to remove MCPB staging directory",
+                result.Stderr,
+                StringComparison.Ordinal);
+            Assert.Contains(sandbox, result.Stderr, StringComparison.Ordinal);
+            Assert.Contains("after 1 attempt", result.Stderr, StringComparison.Ordinal);
+            Assert.Contains("within 0 ms", result.Stderr, StringComparison.Ordinal);
+            Assert.Contains("locked by scanner", result.Stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    private static string CreateSandbox()
+    {
+        var sandbox = Path.Combine(Path.GetTempPath(), $"ExcelMcpMcpbPackaging-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(sandbox, "server"));
+        File.WriteAllText(Path.Combine(sandbox, "server", "excel-mcp-server.exe"), "test");
+        return sandbox;
+    }
+
+    private static string EscapePowerShellLiteral(string value) =>
+        value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static async Task<ScriptResult> RunPowerShellAsync(string script)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-ExecutionPolicy");
+        startInfo.ArgumentList.Add("Bypass");
+        startInfo.ArgumentList.Add("-Command");
+        startInfo.ArgumentList.Add(script);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(timeout.Token);
+
+        return new ScriptResult(process.ExitCode, await stdout, await stderr);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Sbroenne.ExcelMcp.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output directory.");
+    }
+
+    private sealed record ScriptResult(int ExitCode, string Stdout, string Stderr)
+    {
+        public string CombinedOutput => $"{Stdout}{Environment.NewLine}{Stderr}";
+    }
+}


### PR DESCRIPTION
## Summary
- add zero-based `row_offset`, optional positive `row_limit`, and ordered absolute worksheet `columns` to `range get-values` on both CLI and MCP surfaces
- return source dimensions, returned dimensions, truncation state, and deterministic `hasMoreRows` / `nextRowOffset` paging metadata
- read only the requested COM child ranges for scoped calls, including named ranges, without materializing the full source range
- document the scoped read workflow and add a patch changeset

This is partial progress on #837. It deliberately leaves first/last samples, summary statistics, and formula-errors-only output for follow-up contracts, so #837 remains open.

## Validation
- 12 focused Core scoped-read tests
- focused CLI and MCP protocol/schema tests
- Release solution build
- COM leak, Core coverage/naming, MCP/Core parity, success-flag, documentation-count, and dynamic-cast audits
- full `scripts\Test-E2E.ps1`
- unchanged normal pre-commit hook, including all release/package deliverables