### PR TITLE
feat: add workbook savepoints and rollback

### DIFF
--- a/.changeset/calm-savepoints-return.md
+++ b/.changeset/calm-savepoints-return.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Workbook savepoints add safer multi-step automation.** Create named session snapshots, roll back workbook changes without changing the session ID or path, list storage usage, and release snapshots from both the MCP `file` tool and `excelcli file`.

--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -68,7 +68,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## What You Can Do
 
-**31 feature command categories with 325 operations** for comprehensive Excel automation:
+**31 feature command categories with 329 operations** for comprehensive Excel automation:
 
 - **Power Query** (12 ops) — Create, update, refresh queries; M code management
 - **Data Model/DAX** (20 ops) — Measures, relationships, source metadata, EVALUATE queries

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -58,7 +58,7 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ## What You Can Do
 
-**31 specialized tools with 325 operations** for comprehensive Excel automation:
+**31 specialized tools with 329 operations** for comprehensive Excel automation:
 
 ### Core Operations
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # ExcelMcp - Complete Feature Reference
 
-**31 specialized tools with 325 operations for comprehensive Excel automation**
+**31 specialized tools with 329 operations for comprehensive Excel automation**
 
 Excel MCP Server automates the real Microsoft Excel application through four focused capability areas. Start with the category that matches your goal, or use the quick reference below.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ its official COM API. It can refresh Power Query, recalculate formulas, evaluate
 DAX, run VBA and Python `=PY()`, and preserve PivotTables, charts, macros, the
 Data Model, and workbook formatting.
 
-**31 tools with 325 operations** cover end-to-end Excel automation.
+**31 tools with 329 operations** cover end-to-end Excel automation.
 
 > [!IMPORTANT]
 > Requires **Windows**, **Microsoft Excel 2016 or later**, and an interactive
@@ -55,7 +55,7 @@ while automating them.
 - **[Automation & advanced](https://excelmcpserver.dev/features/automation-advanced/):**
   VBA, Python in Excel, Goal Seek, scenarios, data tables, windows, and XML Maps.
 
-Explore the [complete reference for all 325 operations](https://excelmcpserver.dev/features/).
+Explore the [complete reference for all 329 operations](https://excelmcpserver.dev/features/).
 
 ## See It in Action
 

--- a/docs/COPILOT-PLUGIN-DISTRIBUTION.md
+++ b/docs/COPILOT-PLUGIN-DISTRIBUTION.md
@@ -6,7 +6,7 @@ This document outlines how the Excel MCP Server and Excel CLI are distributed as
 
 ExcelMcp is published as **two complementary plugins** in the GitHub Copilot plugin marketplace:
 
-- **`excel-mcp`** — MCP Server with 31 tools (325 operations) for conversational AI (Claude Desktop, Copilot chat)
+- **`excel-mcp`** — MCP Server with 31 tools (329 operations) for conversational AI (Claude Desktop, Copilot chat)
 - **`excel-cli`** — CLI-only skill for coding agents (token-efficient, `--help` discoverable)
 
 Both plugins are maintained in a separate published repository and auto-synced from this source repo.
@@ -67,7 +67,7 @@ copilot plugin install excel-cli@mcp-server-excel-plugins
 
 ### Excel MCP Plugin
 
-Provides the full MCP Server with 31 tools (325 operations) for conversational AI:
+Provides the full MCP Server with 31 tools (329 operations) for conversational AI:
 
 ```powershell
 copilot plugin install excel-mcp@mcp-server-excel-plugins

--- a/docs/features/CELLS-WORKBOOKS.md
+++ b/docs/features/CELLS-WORKBOOKS.md
@@ -6,7 +6,7 @@ Read, write, calculate, and format cells while managing worksheets, workbooks, n
 
 ---
 
-## 📁 File Operations (5 operations)
+## 📁 File Operations (9 operations)
 
 Open, create, and close Excel workbooks. Every other tool works on a session opened here.
 
@@ -16,6 +16,19 @@ Open, create, and close Excel workbooks. Every other tool works on a session ope
 - **Close:** Close session with optional save
 - **Create Empty:** Create new .xlsx or .xlsm workbook
 - **Test:** Report existence, extension validity, openability, and IRM/AIP requirements through `canOpen`, `isIrmProtected`, `willOpenReadOnly`, and `requiresVisibleSession`.
+- **Create Savepoint:** Capture the current unsaved serializable workbook state under a session-owned name.
+- **Rollback Savepoint:** Persistently restore a named savepoint to the same workbook path while preserving the session ID.
+- **Release Savepoint:** Delete one named savepoint.
+- **List Savepoints:** List names, creation times, sizes, and enforced storage limits.
+
+Savepoints are local workbook snapshots, not general transactions. They restore state
+stored inside the workbook but cannot undo database writes, network calls, exported
+files, printing, or side effects from VBA. Save As releases all savepoints for the
+session. Read-only/IRM workbooks, active calculation or refresh, refresh-on-open
+connections, and connection types whose refresh state cannot be verified are
+rejected. Retained snapshots are limited to 8 and 1 GiB per session, and 4 GiB per
+service process. Rollback also requires temporary space for an emergency current-state
+copy and a same-volume replacement copy.
 
 ---
 

--- a/gh-pages/docs/faq.md
+++ b/gh-pages/docs/faq.md
@@ -31,7 +31,7 @@ possible - you don't need to memorize it.
 
 ### CLI or MCP Server - which should I install?
 
-Both expose the **same 325 operations**. Use the **MCP Server** for
+Both expose the **same 329 operations**. Use the **MCP Server** for
 conversational AI (Claude Desktop, VS Code Chat); use the **CLI** (`excelcli`)
 for coding agents and scripting, where it uses ~64% fewer tokens. You can
 install both. See [Installation](installation.md).

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,6 +1,6 @@
 ---
 title: Excel Automation Features
-description: Explore 31 Excel automation tools and 325 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
+description: Explore 31 Excel automation tools and 329 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
 keywords: "Excel automation features, Excel MCP tools, Power Query automation, DAX, PivotTables, VBA, Excel AI"
 ---
 
@@ -11,7 +11,7 @@ keywords: "Excel automation features, Excel MCP tools, Power Query automation, D
   <figcaption>A PivotTable — revenue by region and quarter with grand totals — created in the real Excel application from a plain-language request.</figcaption>
 </figure>
 
-Excel MCP Server provides **31 specialized tools and 325 operations** for
+Excel MCP Server provides **31 specialized tools and 329 operations** for
 automating the real Microsoft Excel application. You can ask your AI assistant
 in plain language—the reference pages below are for discovering what is
 possible and looking up individual operations.

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -132,7 +132,7 @@ hide:
 
 </div>
 
-[See all 31 tools and 325 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 31 tools and 329 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## Popular guides
 

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -1193,7 +1193,7 @@ def _write_llm_outputs(config) -> None:
         "# Excel MCP Server",
         "",
         "> Excel MCP Server (ExcelMcp) automates the real Microsoft Excel "
-        "application through its COM API, exposing 31 tools and 325 operations to AI assistants "
+        "application through its COM API, exposing 31 tools and 329 operations to AI assistants "
         "over the Model Context Protocol and to scripts through "
         "the `excelcli` command line. Unlike file-parser libraries it can refresh "
         "Power Query, evaluate DAX against the Data Model, refresh PivotTables, "

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -13,7 +13,7 @@ Excel MCP Server lets you automate Excel through conversation with Claude:
 - **Automate** - VBA macros, batch operations, data refresh
 - **Agent Mode** - Say "show me Excel" and watch AI work in real-time, side-by-side with Claude
 
-**31 tools with 325 operations** for comprehensive Excel automation.
+**31 tools with 329 operations** for comprehensive Excel automation.
 
 ## Requirements
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Excel (Windows)",
   "version": "2.0.5",
   "description": "Manage Sheets, Power Query, DAX, VBA, PowerPivot, Tables, Ranges, Charts, Formatting, Validation & more - requires Excel to be installed",
-  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 325 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
+  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 329 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/scripts/audit-core-coverage.ps1
+++ b/scripts/audit-core-coverage.ps1
@@ -472,7 +472,8 @@ if ($CheckNaming) {
                           "GetColumnNumberFormat", "SetColumnNumberFormat",
                           # Table slicer methods exposed via SlicerAction (cross-interface enum)
                           "CreateTableSlicer", "ListTableSlicers", "SetTableSlicerSelection", "DeleteTableSlicer")
-        "FileAction" = @("Open", "Close", "List", "Create")  # Adapter-specific session actions
+        "FileAction" = @("Open", "Close", "List", "Create",
+                         "CreateSavepoint", "RollbackSavepoint", "ReleaseSavepoint", "ListSavepoints")  # Adapter-specific session actions
         "RangeAction" = @("SetNumberFormatCustom", "InsertCells", "DeleteCells", "InsertRows", "DeleteRows",
                           "InsertColumns", "DeleteColumns", "Find", "Replace", "Sort",
                           "AddHyperlink", "RemoveHyperlink", "ListHyperlinks", "GetHyperlink",

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -12,7 +12,7 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
 
 # Excel MCP Server Skill
 
-Provides 325 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
+Provides 329 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
 
 ## Workflow Checklist
 

--- a/skills/excel-mcp/references/workbook.md
+++ b/skills/excel-mcp/references/workbook.md
@@ -1,6 +1,6 @@
 # Workbook Lifecycle
 
-Use the `workbook` tool or CLI command group for workbook-level metadata, file variants, publishing, and external links. Use `file` only for opening, creating, listing, and closing sessions.
+Use the `workbook` tool or CLI command group for workbook-level metadata, file variants, publishing, and external links. Use `file` for session lifecycle and session-owned savepoints.
 
 ## Metadata and document properties
 
@@ -18,6 +18,18 @@ Use the `workbook` tool or CLI command group for workbook-level metadata, file v
 - Output directories must already exist. Existing files require `overwrite=true`.
 
 Changing formats can remove unsupported workbook features. In particular, saving a macro-enabled workbook as `.xlsx` removes VBA content after Excel's format conversion.
+
+## Savepoints and rollback
+
+- `create-savepoint` captures the current unsaved serializable workbook state without changing the workbook path or saved flag.
+- `rollback-savepoint` persistently restores that snapshot to the same path while keeping the public session ID. The savepoint remains available until `release-savepoint`.
+- `list-savepoints` reports retained snapshot sizes and limits. Each session can retain 8 savepoints and 1 GiB; one service process can retain 4 GiB.
+- A successful `save-as` releases every savepoint for that session. Savepoints never move a session back to an earlier path.
+- Savepoints reject read-only/IRM workbooks, active calculation or refresh, refresh-on-open connections, and connection types whose refresh state ExcelMcp cannot verify safely.
+
+Savepoints cover workbook state that Excel serializes, including supported VBA, Power Query, Data Model, connection, table, chart, PivotTable, formula, and formatting state. They do not undo effects outside the workbook, such as database writes, exported files, network calls, printing, or VBA changes to other systems. Volatile formulas and external data can recalculate after rollback.
+
+The limits apply to retained savepoints. Rollback also needs temporary space for an emergency copy of the current workbook plus a same-volume replacement copy; ExcelMcp checks free space before closing the live workbook and removes those files after recovery stabilizes.
 
 ## External Excel links
 

--- a/skills/shared/workbook.md
+++ b/skills/shared/workbook.md
@@ -1,6 +1,6 @@
 # Workbook Lifecycle
 
-Use the `workbook` tool or CLI command group for workbook-level metadata, file variants, publishing, and external links. Use `file` only for opening, creating, listing, and closing sessions.
+Use the `workbook` tool or CLI command group for workbook-level metadata, file variants, publishing, and external links. Use `file` for session lifecycle and session-owned savepoints.
 
 ## Metadata and document properties
 
@@ -18,6 +18,18 @@ Use the `workbook` tool or CLI command group for workbook-level metadata, file v
 - Output directories must already exist. Existing files require `overwrite=true`.
 
 Changing formats can remove unsupported workbook features. In particular, saving a macro-enabled workbook as `.xlsx` removes VBA content after Excel's format conversion.
+
+## Savepoints and rollback
+
+- `create-savepoint` captures the current unsaved serializable workbook state without changing the workbook path or saved flag.
+- `rollback-savepoint` persistently restores that snapshot to the same path while keeping the public session ID. The savepoint remains available until `release-savepoint`.
+- `list-savepoints` reports retained snapshot sizes and limits. Each session can retain 8 savepoints and 1 GiB; one service process can retain 4 GiB.
+- A successful `save-as` releases every savepoint for that session. Savepoints never move a session back to an earlier path.
+- Savepoints reject read-only/IRM workbooks, active calculation or refresh, refresh-on-open connections, and connection types whose refresh state ExcelMcp cannot verify safely.
+
+Savepoints cover workbook state that Excel serializes, including supported VBA, Power Query, Data Model, connection, table, chart, PivotTable, formula, and formatting state. They do not undo effects outside the workbook, such as database writes, exported files, network calls, printing, or VBA changes to other systems. Volatile formulas and external data can recalculate after rollback.
+
+The limits apply to retained savepoints. Rollback also needs temporary space for an emergency copy of the current workbook plus a same-volume replacement copy; ExcelMcp checks free space before closing the live workbook and removes those files after recovery stabilizes.
 
 ## External Excel links
 

--- a/src/ExcelMcp.CLI/Commands/FileSavepointCommands.cs
+++ b/src/ExcelMcp.CLI/Commands/FileSavepointCommands.cs
@@ -1,0 +1,177 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Sbroenne.ExcelMcp.CLI.Infrastructure;
+using Sbroenne.ExcelMcp.Core.Utilities;
+using Sbroenne.ExcelMcp.Service;
+using Spectre.Console.Cli;
+
+namespace Sbroenne.ExcelMcp.CLI.Commands;
+
+internal sealed class FileCreateSavepointCommand
+    : AsyncCommand<FileCreateSavepointCommand.Settings>
+{
+    protected override Task<int> ExecuteAsync(
+        CommandContext context,
+        Settings settings,
+        CancellationToken cancellationToken) =>
+        FileSavepointCommandRunner.ExecuteAsync(
+            "create-savepoint",
+            settings.SessionId,
+            settings.Name,
+            settings.TimeoutSeconds,
+            cancellationToken);
+
+    internal sealed class Settings : FileSavepointTimeoutSettings
+    {
+    }
+}
+
+internal sealed class FileRollbackSavepointCommand
+    : AsyncCommand<FileRollbackSavepointCommand.Settings>
+{
+    protected override Task<int> ExecuteAsync(
+        CommandContext context,
+        Settings settings,
+        CancellationToken cancellationToken) =>
+        FileSavepointCommandRunner.ExecuteAsync(
+            "rollback-savepoint",
+            settings.SessionId,
+            settings.Name,
+            settings.TimeoutSeconds,
+            cancellationToken);
+
+    internal sealed class Settings : FileSavepointTimeoutSettings
+    {
+    }
+}
+
+internal sealed class FileReleaseSavepointCommand
+    : AsyncCommand<FileReleaseSavepointCommand.Settings>
+{
+    protected override Task<int> ExecuteAsync(
+        CommandContext context,
+        Settings settings,
+        CancellationToken cancellationToken) =>
+        FileSavepointCommandRunner.ExecuteAsync(
+            "release-savepoint",
+            settings.SessionId,
+            settings.Name,
+            timeoutSeconds: null,
+            cancellationToken);
+
+    internal sealed class Settings : FileSavepointSettings
+    {
+    }
+}
+
+internal sealed class FileListSavepointsCommand
+    : AsyncCommand<FileListSavepointsCommand.Settings>
+{
+    protected override Task<int> ExecuteAsync(
+        CommandContext context,
+        Settings settings,
+        CancellationToken cancellationToken) =>
+        FileSavepointCommandRunner.ExecuteAsync(
+            "list-savepoints",
+            settings.SessionId,
+            name: null,
+            timeoutSeconds: null,
+            cancellationToken);
+
+    internal sealed class Settings : CommandSettings
+    {
+        [CommandOption("-s|--session <SESSION>")]
+        [Description("Session ID that owns the savepoints")]
+        public string SessionId { get; init; } = string.Empty;
+    }
+}
+
+internal class FileSavepointSettings : CommandSettings
+{
+    [CommandOption("-s|--session <SESSION>")]
+    [Description("Session ID that owns the savepoint")]
+    public string SessionId { get; init; } = string.Empty;
+
+    [CommandOption("--name <NAME>")]
+    [Description("Savepoint name (1-128 ASCII letters, digits, '.', '_', or '-')")]
+    public string Name { get; init; } = string.Empty;
+}
+
+internal class FileSavepointTimeoutSettings : FileSavepointSettings
+{
+    [CommandOption("--timeout <SECONDS>")]
+    [Description("Savepoint operation timeout in whole seconds (default: 120; range: 10-3600)")]
+    public int TimeoutSeconds { get; init; } = 120;
+}
+
+internal static class FileSavepointCommandRunner
+{
+    internal static async Task<int> ExecuteAsync(
+        string action,
+        string sessionId,
+        string? name,
+        int? timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return CliErrorOutput.WriteError("Session ID is required.");
+        }
+
+        if (action is not "list-savepoints" && string.IsNullOrWhiteSpace(name))
+        {
+            return CliErrorOutput.WriteError("Savepoint name is required.");
+        }
+
+        try
+        {
+            ParameterTransforms.ValidateTimeoutSeconds(
+                timeoutSeconds,
+                "timeout",
+                minimumSeconds: 10,
+                maximumSeconds: 3600);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return CliErrorOutput.WriteError(ex.Message);
+        }
+
+        object? args = action switch
+        {
+            "create-savepoint" or "rollback-savepoint" => new
+            {
+                name,
+                timeoutSeconds
+            },
+            "release-savepoint" => new { name },
+            "list-savepoints" => null,
+            _ => throw new ArgumentException(
+                $"Unknown savepoint action: {action}",
+                nameof(action))
+        };
+
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = $"session.{action}",
+            SessionId = sessionId,
+            Args = args == null
+                ? null
+                : JsonSerializer.Serialize(args, ServiceProtocol.JsonOptions)
+        }, cancellationToken);
+
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceErrorWithResult(response);
+        }
+
+        if (string.IsNullOrWhiteSpace(response.Result))
+        {
+            return CliErrorOutput.WriteError(
+                $"Service returned an invalid {action} response.");
+        }
+
+        Console.WriteLine(response.Result);
+        return 0;
+    }
+}

--- a/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+++ b/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
@@ -24,7 +24,7 @@
     <!-- NuGet Package Configuration (secondary distribution — primary is standalone exe) -->
     <PackageId>Sbroenne.ExcelMcp.CLI</PackageId>
     <Title>ExcelMcp CLI</Title>
-    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 325 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
+    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 329 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
     <PackageTags>excel;cli;powerquery;dax;power-pivot;automation;com;rpa;ci-cd;scripting;github-copilot;mcp;windows;dotnet-tool;sbroenne;excel-automation;vba;pivottables;excel-tables;batch-processing;devops</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/sbroenne/mcp-server-excel/releases for release notes</PackageReleaseNotes>
@@ -144,7 +144,7 @@
       OutputPath="$(SkillOutputPath)"
       ManifestPath="$(SkillManifestPath)"
       ExcludeCommands="diag"
-      ExtraOperationCount="5"
+      ExtraOperationCount="9"
       ExtraToolCount="1" />
     <Message Text="Generated CLI Skill: $(SkillOutputPath)" Importance="high" />
   </Target>

--- a/src/ExcelMcp.CLI/Infrastructure/CliErrorOutput.cs
+++ b/src/ExcelMcp.CLI/Infrastructure/CliErrorOutput.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Nodes;
 using Sbroenne.ExcelMcp.Service;
 
 namespace Sbroenne.ExcelMcp.CLI.Infrastructure;
@@ -34,6 +35,40 @@ internal static class CliErrorOutput
             null,
             null));
         return 1;
+    }
+
+    public static int WriteServiceErrorWithResult(ServiceResponse response)
+    {
+        if (string.IsNullOrWhiteSpace(response.Result))
+        {
+            return WriteServiceError(response);
+        }
+
+        try
+        {
+            var result = JsonNode.Parse(response.Result) as JsonObject;
+            if (result == null)
+            {
+                return WriteServiceError(response);
+            }
+
+            result["success"] = false;
+            result["error"] = response.ErrorMessage ?? "Unknown error.";
+            result["errorMessage"] = response.ErrorMessage ?? "Unknown error.";
+            result["errorCategory"] = response.ErrorCategory;
+            result["command"] = response.Command;
+            result["sessionId"] ??= response.SessionId;
+            result["isError"] = true;
+            result["exceptionType"] = response.ExceptionType;
+            result["hresult"] = response.HResult;
+            result["innerError"] = response.InnerError;
+            Console.WriteLine(result.ToJsonString(ServiceProtocol.JsonOptions));
+            return 1;
+        }
+        catch (JsonException)
+        {
+            return WriteServiceError(response);
+        }
     }
 
     public static int WriteDaemonError(

--- a/src/ExcelMcp.CLI/Program.cs
+++ b/src/ExcelMcp.CLI/Program.cs
@@ -110,6 +110,20 @@ internal sealed class Program
                     .WithDescription("Test file existence, validity, openability, and IRM/AIP read-only requirements.");
             });
 
+            config.AddBranch("file", branch =>
+            {
+                branch.SetDescription(
+                    "Session-owned workbook savepoints. Rollback restores the same path and keeps the session ID.");
+                branch.AddCommand<FileCreateSavepointCommand>("create-savepoint")
+                    .WithDescription("Capture the current unsaved serializable workbook state.");
+                branch.AddCommand<FileRollbackSavepointCommand>("rollback-savepoint")
+                    .WithDescription("Persistently restore a savepoint to the same workbook path.");
+                branch.AddCommand<FileReleaseSavepointCommand>("release-savepoint")
+                    .WithDescription("Delete one retained savepoint.");
+                branch.AddCommand<FileListSavepointsCommand>("list-savepoints")
+                    .WithDescription("List retained savepoints and storage usage for a session.");
+            });
+
             // Sheet commands
             // =============================================
             // All service commands are auto-generated from

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides 31 feature command categories with 325 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
+The CLI provides 31 feature command categories with 329 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|
@@ -48,7 +48,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## 📋 What You Can Do
 
-ExcelMcp.CLI provides **325 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
+ExcelMcp.CLI provides **329 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
 
 Drives the **actual Excel application** via COM — not a file-format parser — so live operations (Power Query refresh, recalculation, DAX evaluation, VBA execution) run for real and existing workbooks stay intact.
 

--- a/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelBatch.cs
@@ -21,7 +21,7 @@ namespace Sbroenne.ExcelMcp.ComInterop.Session;
 /// </list>
 /// <para><b>Resource Cost:</b> Each ExcelBatch = one Excel.Application process (~50-100MB+ memory)</para>
 /// </remarks>
-internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState
+internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState, IWorkbookSavepointBatch
 {
     // P/Invoke for getting process ID from window handle
     [DllImport("user32.dll")]
@@ -61,6 +61,11 @@ internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState
 
     internal static Func<ExcelProcessIdentity, bool>? FailedStartupExitConfirmationHook { get; set; }
 
+    /// <summary>
+    /// Test-only seam invoked immediately before a workbook is reopened during rollback.
+    /// </summary>
+    internal static Action<string>? BeforeWorkbookRestoreOpenHook { get; set; }
+
     // COM state (STA thread only)
     private Excel.Application? _excel;
     private Excel.Workbook? _workbook; // Primary workbook
@@ -98,7 +103,13 @@ internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState
     /// <summary>
     /// Private constructor that handles both opening existing files and creating new ones.
     /// </summary>
-    private ExcelBatch(string[] workbookPaths, ILogger<ExcelBatch>? logger, bool show, bool createNewFile, bool isMacroEnabled, TimeSpan? operationTimeout = null)
+    private ExcelBatch(
+        string[] workbookPaths,
+        ILogger<ExcelBatch>? logger,
+        bool show,
+        bool createNewFile,
+        bool isMacroEnabled,
+        TimeSpan? operationTimeout = null)
     {
         if (workbookPaths == null || workbookPaths.Length == 0)
             throw new ArgumentException("At least one workbook path is required", nameof(workbookPaths));
@@ -411,8 +422,13 @@ internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState
                 // fields remain null and cleanup must fall back to the startup locals to avoid leaking
                 // a hidden Excel.exe process.
                 var cleanupExcel = _excel ?? startupExcel;
-                var cleanupWorkbook = _workbook ?? startupPrimaryWorkbook;
                 var cleanupWorkbooks = _workbooks ?? startupWorkbooks;
+                // After successful startup, a rollback can intentionally close and replace
+                // the primary workbook. Never fall back to the startup RCW in that state:
+                // it may already have been released during the replacement.
+                var cleanupWorkbook = _workbooks != null
+                    ? _workbook
+                    : startupPrimaryWorkbook;
 
                 // INSTRUMENTATION: Check if Excel process is alive BEFORE entering shutdown
                 if (_excelProcessId.HasValue)
@@ -862,6 +878,177 @@ internal sealed class ExcelBatch : IExcelBatch, IExcelBatchTeardownState
                 ct);
             return 0;
         }, cancellationToken);
+    }
+
+    public void RestoreWorkbookFromCopy(
+        string snapshotPath,
+        string recoveryPath,
+        TimeSpan timeout)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(snapshotPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(recoveryPath);
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeout),
+                "Rollback timeout must be greater than zero.");
+        }
+        var normalizedSnapshotPath = Path.GetFullPath(snapshotPath);
+        var normalizedRecoveryPath = Path.GetFullPath(recoveryPath);
+        if (!File.Exists(normalizedSnapshotPath))
+        {
+            throw new FileNotFoundException(
+                "Workbook savepoint snapshot was not found.",
+                normalizedSnapshotPath);
+        }
+
+        if (!File.Exists(normalizedRecoveryPath))
+        {
+            throw new FileNotFoundException(
+                "Workbook rollback recovery copy was not found.",
+                normalizedRecoveryPath);
+        }
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        try
+        {
+            Execute((_, token) =>
+            {
+                token.ThrowIfCancellationRequested();
+                if (_excel == null || _workbook == null || _workbooks == null)
+                {
+                    throw new InvalidOperationException("Workbook session is not initialized.");
+                }
+
+                var workbookPath = Path.GetFullPath(_workbookPath);
+                var commitStarted = false;
+                object? originalAutomationSecurity = null;
+                try
+                {
+                    // PIA gap: AutomationSecurity is typed with an Office.Core enum,
+                    // which this assembly intentionally does not reference. Use IDispatch
+                    // with integer value 3 to prevent auto-open macros during rollback.
+                    originalAutomationSecurity = ((dynamic)(object)_excel).AutomationSecurity;
+                    ((dynamic)(object)_excel).AutomationSecurity = 3;
+
+                    ClosePrimaryWorkbookForRestore(workbookPath);
+                    commitStarted = true;
+                    ReplaceWorkbookFile(normalizedSnapshotPath, workbookPath);
+                    OpenPrimaryWorkbookAfterRestore(workbookPath);
+                }
+                catch (Exception rollbackException) when (commitStarted)
+                {
+                    try
+                    {
+                        ReplaceWorkbookFile(normalizedRecoveryPath, workbookPath);
+                        OpenPrimaryWorkbookAfterRestore(workbookPath);
+                    }
+                    catch (Exception recoveryException)
+                    {
+                        throw new WorkbookRestoreException(
+                            sessionRecovered: false,
+                            rollbackException,
+                            recoveryException);
+                    }
+
+                    throw new WorkbookRestoreException(
+                        sessionRecovered: true,
+                        rollbackException);
+                }
+                finally
+                {
+                    if (originalAutomationSecurity != null && _excel != null)
+                    {
+                        try
+                        {
+                            ((dynamic)(object)_excel).AutomationSecurity =
+                                originalAutomationSecurity;
+                        }
+                        catch (COMException)
+                        {
+                        }
+                    }
+                }
+            }, timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Workbook rollback timed out after {timeout.TotalSeconds:F0} seconds.");
+        }
+    }
+
+    private void ClosePrimaryWorkbookForRestore(string workbookPath)
+    {
+        var workbook = _workbook
+            ?? throw new InvalidOperationException("Primary workbook is not initialized.");
+        workbook.Close(false);
+        _workbooks!.Remove(workbookPath);
+        _workbook = null;
+        _context = null;
+        ComUtilities.Release(ref workbook);
+    }
+
+    private void OpenPrimaryWorkbookAfterRestore(string workbookPath)
+    {
+        Excel.Workbooks? workbooks = null;
+        try
+        {
+            workbooks = _excel!.Workbooks;
+            BeforeWorkbookRestoreOpenHook?.Invoke(workbookPath);
+            var workbook = (Excel.Workbook)workbooks.Open(
+                workbookPath,
+                UpdateLinks: 0,
+                ReadOnly: false,
+                IgnoreReadOnlyRecommended: true,
+                Notify: false,
+                AddToMru: false);
+            _workbook = workbook;
+            _workbooks![workbookPath] = workbook;
+            _context = new ExcelContext(workbookPath, _excel, workbook);
+        }
+        finally
+        {
+            ComUtilities.Release(ref workbooks);
+        }
+    }
+
+    private static void ReplaceWorkbookFile(string sourcePath, string workbookPath)
+    {
+        var directory = Path.GetDirectoryName(workbookPath)
+            ?? throw new InvalidOperationException("Workbook directory is unavailable.");
+        var extension = Path.GetExtension(workbookPath);
+        var stagingPath = Path.Combine(
+            directory,
+            $".excelmcp-savepoint-{Guid.NewGuid():N}{extension}");
+        var backupPath = Path.Combine(
+            directory,
+            $".excelmcp-savepoint-backup-{Guid.NewGuid():N}{extension}");
+
+        try
+        {
+            File.Copy(sourcePath, stagingPath);
+            if (File.Exists(workbookPath))
+            {
+                File.Replace(stagingPath, workbookPath, backupPath, ignoreMetadataErrors: true);
+            }
+            else
+            {
+                File.Move(stagingPath, workbookPath);
+            }
+        }
+        finally
+        {
+            if (File.Exists(stagingPath))
+            {
+                File.Delete(stagingPath);
+            }
+
+            if (File.Exists(backupPath))
+            {
+                File.Delete(backupPath);
+            }
+        }
     }
 
     public void Dispose()

--- a/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
+++ b/src/ExcelMcp.ComInterop/Session/ExcelSession.cs
@@ -246,4 +246,3 @@ public static class ExcelSession
 }
 
 
-

--- a/src/ExcelMcp.ComInterop/Session/IExcelBatch.cs
+++ b/src/ExcelMcp.ComInterop/Session/IExcelBatch.cs
@@ -162,3 +162,11 @@ internal interface IExcelBatchTeardownState
 {
     bool TryConfirmOwnedProcessTeardown();
 }
+
+internal interface IWorkbookSavepointBatch
+{
+    void RestoreWorkbookFromCopy(
+        string snapshotPath,
+        string recoveryPath,
+        TimeSpan timeout);
+}

--- a/src/ExcelMcp.ComInterop/Session/SessionManager.cs
+++ b/src/ExcelMcp.ComInterop/Session/SessionManager.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Excel = Microsoft.Office.Interop.Excel;
 
 namespace Sbroenne.ExcelMcp.ComInterop.Session;
 
@@ -286,8 +287,11 @@ public sealed class SessionManager : IDisposable
     private readonly ConcurrentDictionary<string, SessionOrigin> _sessionOrigins = new();
     private readonly ConcurrentDictionary<string, DateTime> _sessionCreatedAt = new();
     private readonly ConcurrentDictionary<string, string> _sessionFilePathReservations = new();
+    private readonly ConcurrentDictionary<string, byte> _rollbackSessions = new();
+    private readonly ConcurrentDictionary<string, byte> _savepointCreationSessions = new();
     private readonly object _filePathReservationLock = new();
     private readonly Polly.ResiliencePipeline _sessionCreationPipeline = ResiliencePipelines.CreateSessionCreationPipeline();
+    private readonly WorkbookSavepointStore _savepointStore = new();
     private readonly ILogger<SessionManager> _logger;
     private bool _disposed;
 
@@ -587,10 +591,18 @@ public sealed class SessionManager : IDisposable
 
         _activeOperationCounts.TryRemove(sessionId, out _);
         _closingSessions.TryRemove(sessionId, out _);
+        _rollbackSessions.TryRemove(sessionId, out _);
+        _savepointCreationSessions.TryRemove(sessionId, out _);
         _showExcelFlags.TryRemove(sessionId, out _);
         _sessionOrigins.TryRemove(sessionId, out _);
         _sessionCreatedAt.TryRemove(sessionId, out _);
         _teardownFailures.TryRemove(sessionId, out _);
+        if (!_savepointStore.ReleaseAll(sessionId))
+        {
+            _logger.LogWarning(
+                "Savepoint cleanup for session {SessionId} was incomplete and will be retried by stale-store cleanup.",
+                sessionId);
+        }
 
         if (removeSessionLock)
         {
@@ -656,6 +668,20 @@ public sealed class SessionManager : IDisposable
             if (_closingSessions.ContainsKey(sessionId))
             {
                 errorMessage = $"Session '{sessionId}' is closing";
+                error = SessionOperationError.Closing;
+                return false;
+            }
+
+            if (_rollbackSessions.ContainsKey(sessionId))
+            {
+                errorMessage = $"Session '{sessionId}' is rolling back to a savepoint";
+                error = SessionOperationError.Closing;
+                return false;
+            }
+
+            if (_savepointCreationSessions.ContainsKey(sessionId))
+            {
+                errorMessage = $"Session '{sessionId}' is creating a savepoint";
                 error = SessionOperationError.Closing;
                 return false;
             }
@@ -784,6 +810,24 @@ public sealed class SessionManager : IDisposable
 
         var activeOps = GetActiveOperationCount(sessionId);
         var isVisible = IsExcelVisible(sessionId);
+
+        if (_rollbackSessions.ContainsKey(sessionId))
+        {
+            return new CloseValidationResult(
+                true,
+                isVisible,
+                activeOps,
+                $"Cannot close session '{sessionId}' while a savepoint rollback is in progress.");
+        }
+
+        if (_savepointCreationSessions.ContainsKey(sessionId))
+        {
+            return new CloseValidationResult(
+                true,
+                isVisible,
+                activeOps,
+                $"Cannot close session '{sessionId}' while a savepoint is being created.");
+        }
 
         if (activeOps > 0)
         {
@@ -1031,6 +1075,769 @@ public sealed class SessionManager : IDisposable
     }
 
     /// <summary>
+    /// Gets the savepoint storage limits enforced by this session manager.
+    /// </summary>
+    public static WorkbookSavepointLimits SavepointLimits => WorkbookSavepointStore.Limits;
+
+    /// <summary>
+    /// Creates an immutable snapshot of the current unsaved workbook state.
+    /// </summary>
+    public WorkbookSavepointDescriptor CreateSavepoint(
+        string sessionId,
+        string name,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        WorkbookSavepointStore.ValidateName(name);
+
+        if (_savepointStore.Contains(sessionId, name))
+        {
+            throw new InvalidOperationException(
+                $"Savepoint '{name}' already exists for session '{sessionId}'.");
+        }
+
+        IExcelBatch batch;
+        var sessionLock = GetSessionLock(sessionId);
+        lock (sessionLock)
+        {
+            if (_teardownFailures.TryGetValue(sessionId, out var teardownFailure))
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is quarantined after a failed close: " +
+                    teardownFailure.SourceException.Message);
+            }
+
+            if (_closingSessions.ContainsKey(sessionId))
+            {
+                throw new InvalidOperationException($"Session '{sessionId}' is closing.");
+            }
+
+            if (!_activeSessions.TryGetValue(sessionId, out batch!))
+            {
+                throw new KeyNotFoundException($"Session '{sessionId}' not found.");
+            }
+
+            if (_rollbackSessions.ContainsKey(sessionId) ||
+                _savepointCreationSessions.ContainsKey(sessionId) ||
+                (_activeOperationCounts.TryGetValue(sessionId, out var activeOperations) &&
+                 activeOperations != 0))
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is busy and cannot create a savepoint.");
+            }
+
+            if (batch.HasTimedOutOperation || !batch.IsExcelProcessAlive())
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is not usable and cannot create a savepoint.");
+            }
+
+            _savepointCreationSessions[sessionId] = 0;
+            _activeOperationCounts[sessionId] = 1;
+        }
+
+        string? snapshotPath = null;
+        var committed = false;
+        var reserved = false;
+        long snapshotEstimateBytes = 0;
+        try
+        {
+            var workbookPath = Path.GetFullPath(batch.WorkbookPath);
+            var extension = Path.GetExtension(workbookPath).ToLowerInvariant();
+            if (extension is not (".xlsx" or ".xlsm" or ".xls"))
+            {
+                throw new NotSupportedException(
+                    $"Savepoints support .xlsx, .xlsm, and .xls workbooks. '{extension}' cannot be reopened safely.");
+            }
+
+            snapshotEstimateBytes = new FileInfo(workbookPath).Length;
+            _savepointStore.Reserve(
+                sessionId,
+                name,
+                snapshotEstimateBytes);
+            reserved = true;
+            snapshotPath = _savepointStore.CreateSnapshotPath(sessionId, extension);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(timeout ?? batch.OperationTimeout);
+
+            try
+            {
+                batch.Execute((context, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    ValidateSavepointState(context);
+                    context.Book.SaveCopyAs(snapshotPath);
+                }, timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (
+                timeoutCts.IsCancellationRequested &&
+                !cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Creating savepoint '{name}' timed out after {(timeout ?? batch.OperationTimeout).TotalSeconds:F0} seconds.");
+            }
+
+            var entry = _savepointStore.Commit(
+                sessionId,
+                name,
+                workbookPath,
+                snapshotPath);
+            reserved = false;
+            committed = true;
+            return entry.ToDescriptor();
+        }
+        finally
+        {
+            if (!committed && snapshotPath != null)
+            {
+                _savepointStore.DeleteTransient(snapshotPath, snapshotEstimateBytes);
+            }
+
+            if (reserved)
+            {
+                _savepointStore.CancelReservation(sessionId, name);
+            }
+
+            if (_activeSessions.ContainsKey(sessionId))
+            {
+                _activeOperationCounts.AddOrUpdate(sessionId, 0, static (_, _) => 0);
+            }
+            _savepointCreationSessions.TryRemove(sessionId, out _);
+        }
+    }
+
+    /// <summary>
+    /// Lists immutable savepoints owned by an active session.
+    /// </summary>
+    public IReadOnlyList<WorkbookSavepointDescriptor> GetSavepoints(string sessionId)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var sessionLock = GetSessionLock(sessionId);
+        lock (sessionLock)
+        {
+            EnsureSessionAvailableForSavepointMetadata(sessionId);
+            return _savepointStore.List(sessionId)
+                .Select(entry => entry.ToDescriptor())
+                .ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Releases one savepoint. Missing names return false.
+    /// </summary>
+    public bool ReleaseSavepoint(string sessionId, string name)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        WorkbookSavepointStore.ValidateName(name);
+        var sessionLock = GetSessionLock(sessionId);
+        lock (sessionLock)
+        {
+            EnsureSessionAvailableForSavepointMetadata(sessionId);
+            return _savepointStore.Release(sessionId, name);
+        }
+    }
+
+    /// <summary>
+    /// Releases every savepoint owned by an active session.
+    /// </summary>
+    public void ReleaseSavepoints(string sessionId)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var sessionLock = GetSessionLock(sessionId);
+        lock (sessionLock)
+        {
+            EnsureSessionAvailableForSavepointMetadata(sessionId);
+            if (!_savepointStore.ReleaseAll(sessionId))
+            {
+                _logger.LogWarning(
+                    "Savepoint cleanup for session {SessionId} was incomplete and will be retried by stale-store cleanup.",
+                    sessionId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Restores a savepoint to the current workbook path and reopens the batch under
+    /// the same public session ID.
+    /// </summary>
+    public WorkbookSavepointRollback RollbackSavepoint(
+        string sessionId,
+        string name,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        WorkbookSavepointStore.ValidateName(name);
+
+        IExcelBatch batch;
+        string workbookPath;
+        TimeSpan operationTimeout;
+        var sessionLock = GetSessionLock(sessionId);
+        lock (sessionLock)
+        {
+            if (_teardownFailures.TryGetValue(sessionId, out var teardownFailure))
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is quarantined after a failed close: " +
+                    teardownFailure.SourceException.Message);
+            }
+
+            if (_closingSessions.ContainsKey(sessionId))
+            {
+                throw new InvalidOperationException($"Session '{sessionId}' is closing.");
+            }
+
+            if (!_activeSessions.TryGetValue(sessionId, out batch!))
+            {
+                throw new KeyNotFoundException($"Session '{sessionId}' not found.");
+            }
+
+            if (_activeOperationCounts.TryGetValue(sessionId, out var activeOperations) &&
+                activeOperations != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot roll back session '{sessionId}' while {activeOperations} operation(s) are active.");
+            }
+
+            if (_savepointCreationSessions.ContainsKey(sessionId))
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is creating a savepoint.");
+            }
+
+            if (batch.HasTimedOutOperation || !batch.IsExcelProcessAlive())
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is not usable and cannot roll back a savepoint.");
+            }
+
+            if (!_rollbackSessions.TryAdd(sessionId, 0))
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is already rolling back to a savepoint.");
+            }
+
+            _activeOperationCounts[sessionId] = 1;
+            workbookPath = Path.GetFullPath(batch.WorkbookPath);
+            operationTimeout = timeout ?? batch.OperationTimeout;
+        }
+
+        string? recoveryPath = null;
+        var rollbackTimer = Stopwatch.StartNew();
+        var recoveryCopyStarted = false;
+        try
+        {
+            var savepoint = _savepointStore.GetRequired(sessionId, name);
+            if (!string.Equals(
+                    savepoint.WorkbookPath,
+                    workbookPath,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Savepoint '{name}' belongs to a different workbook path and cannot be rolled back.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureRollbackFreeSpace(workbookPath, savepoint.SizeBytes);
+
+            recoveryPath = _savepointStore.CreateTransientPath(
+                sessionId,
+                Path.GetExtension(workbookPath),
+                new FileInfo(workbookPath).Length);
+            using (var copyTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                copyTimeout.CancelAfter(operationTimeout);
+                try
+                {
+                    recoveryCopyStarted = true;
+                    batch.Execute((context, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        ValidateSavepointState(context);
+                        context.Book.SaveCopyAs(recoveryPath);
+                    }, copyTimeout.Token);
+                }
+                catch (OperationCanceledException) when (
+                    copyTimeout.IsCancellationRequested &&
+                    !cancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"Rollback to savepoint '{name}' timed out while creating the emergency recovery copy.");
+                }
+            }
+            _savepointStore.UpdateTransientSize(
+                recoveryPath,
+                new FileInfo(recoveryPath).Length);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var remainingTimeout = operationTimeout - rollbackTimer.Elapsed;
+            if (remainingTimeout <= TimeSpan.Zero)
+            {
+                throw new TimeoutException(
+                    $"Rollback to savepoint '{name}' timed out before workbook replacement started.");
+            }
+
+            if (batch is not IWorkbookSavepointBatch savepointBatch)
+            {
+                throw new InvalidOperationException(
+                    "The active Excel batch does not support workbook savepoint rollback.");
+            }
+
+            savepointBatch.RestoreWorkbookFromCopy(
+                savepoint.SnapshotPath,
+                recoveryPath,
+                remainingTimeout);
+
+            return new WorkbookSavepointRollback(
+                sessionId,
+                name,
+                workbookPath,
+                DateTime.UtcNow);
+        }
+        catch (WorkbookRestoreException restoreException)
+        {
+            if (restoreException.SessionRecovered)
+            {
+                throw new WorkbookSavepointRollbackException(
+                    $"Rollback to savepoint '{name}' failed, but the pre-rollback workbook state was recovered under session '{sessionId}'.",
+                    sessionRecovered: true,
+                    sessionClosed: false,
+                    recoveryFilePath: null,
+                    restoreException.RollbackException);
+            }
+
+            string? promotedRecoveryPath = null;
+            Exception? promotionFailure = null;
+            if (recoveryPath != null && File.Exists(recoveryPath))
+            {
+                try
+                {
+                    promotedRecoveryPath = _savepointStore.PromoteRecoveryFile(
+                        recoveryPath,
+                        workbookPath);
+                    recoveryPath = null;
+                }
+                catch (IOException ex)
+                {
+                    promotionFailure = ex;
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    promotionFailure = ex;
+                }
+            }
+
+            if (promotedRecoveryPath == null &&
+                recoveryPath != null &&
+                File.Exists(recoveryPath))
+            {
+                try
+                {
+                    promotedRecoveryPath =
+                        _savepointStore.PreserveRecoveryFileInPlace(recoveryPath);
+                    recoveryPath = null;
+                }
+                catch (IOException ex)
+                {
+                    promotionFailure = CombineOptionalFailures(
+                        promotionFailure,
+                        ex);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    promotionFailure = CombineOptionalFailures(
+                        promotionFailure,
+                        ex);
+                }
+            }
+
+            Exception? closeFailure = null;
+            try
+            {
+                CloseSessionSync(sessionId, batch);
+            }
+            catch (InvalidOperationException ex)
+            {
+                closeFailure = ex;
+            }
+
+            throw new WorkbookSavepointRollbackException(
+                $"Rollback to savepoint '{name}' failed and session '{sessionId}' could not be recovered. " +
+                (closeFailure == null
+                    ? "The session was closed."
+                    : "The session is quarantined until its owned Excel process teardown can be confirmed."),
+                sessionRecovered: false,
+                sessionClosed: closeFailure == null,
+                recoveryFilePath: promotedRecoveryPath,
+                restoreException.RollbackException,
+                CombineRecoveryFailures(
+                    restoreException.RecoveryException!,
+                    promotionFailure,
+                    closeFailure));
+        }
+        catch (TimeoutException ex)
+        {
+            throw StabilizeInterruptedRollback(
+                    sessionId,
+                    name,
+                    batch,
+                    workbookPath,
+                    ref recoveryPath,
+                    ex);
+        }
+        catch (OperationCanceledException ex)
+        {
+            if (!recoveryCopyStarted)
+            {
+                throw;
+            }
+
+            throw StabilizeInterruptedRollback(
+                    sessionId,
+                    name,
+                    batch,
+                    workbookPath,
+                    ref recoveryPath,
+                    ex);
+        }
+        finally
+        {
+            if (recoveryPath != null)
+            {
+                _savepointStore.DeleteTransient(recoveryPath);
+            }
+
+            if (_activeSessions.ContainsKey(sessionId))
+            {
+                _activeOperationCounts.AddOrUpdate(sessionId, 0, static (_, _) => 0);
+            }
+            _rollbackSessions.TryRemove(sessionId, out _);
+        }
+    }
+
+    private WorkbookSavepointRollbackException StabilizeInterruptedRollback(
+        string sessionId,
+        string name,
+        IExcelBatch batch,
+        string workbookPath,
+        ref string? recoveryPath,
+        Exception interruption)
+    {
+        Exception? closeFailure = null;
+        try
+        {
+            batch.Dispose();
+        }
+        catch (InvalidOperationException ex)
+        {
+            closeFailure = new InvalidOperationException(
+                $"Failed to dispose interrupted rollback session '{sessionId}': {ex.Message}",
+                ex);
+            _teardownFailures[sessionId] = ExceptionDispatchInfo.Capture(closeFailure);
+        }
+
+        string? promotedRecoveryPath = null;
+        Exception? promotionFailure = null;
+        if (recoveryPath != null && File.Exists(recoveryPath))
+        {
+            try
+            {
+                promotedRecoveryPath = _savepointStore.PromoteRecoveryFile(
+                    recoveryPath,
+                    workbookPath);
+                recoveryPath = null;
+            }
+            catch (IOException ex)
+            {
+                promotionFailure = ex;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                promotionFailure = ex;
+            }
+
+            if (promotedRecoveryPath == null &&
+                recoveryPath != null &&
+                File.Exists(recoveryPath))
+            {
+                try
+                {
+                    promotedRecoveryPath =
+                        _savepointStore.PreserveRecoveryFileInPlace(recoveryPath);
+                    recoveryPath = null;
+                }
+                catch (IOException ex)
+                {
+                    promotionFailure = CombineOptionalFailures(
+                        promotionFailure,
+                        ex);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    promotionFailure = CombineOptionalFailures(
+                        promotionFailure,
+                        ex);
+                }
+            }
+        }
+
+        if (closeFailure == null)
+        {
+            var sessionLock = GetSessionLock(sessionId);
+            lock (sessionLock)
+            {
+                RemoveSessionTracking(sessionId, removeSessionLock: false);
+            }
+            _sessionLocks.TryRemove(sessionId, out _);
+        }
+
+        return new WorkbookSavepointRollbackException(
+            $"Rollback to savepoint '{name}' was interrupted. " +
+            (closeFailure == null
+                ? "The session was closed."
+                : "The session is quarantined until its owned Excel process teardown can be confirmed."),
+            sessionRecovered: false,
+            sessionClosed: closeFailure == null,
+            recoveryFilePath: promotedRecoveryPath,
+            rollbackException: interruption,
+            recoveryException: CombineOptionalFailures(
+                promotionFailure,
+                closeFailure));
+    }
+
+    private static Exception? CombineOptionalFailures(params Exception?[] failures)
+    {
+        var presentFailures = failures
+            .Where(failure => failure != null)
+            .Cast<Exception>()
+            .ToArray();
+        return presentFailures.Length switch
+        {
+            0 => null,
+            1 => presentFailures[0],
+            _ => new AggregateException(presentFailures)
+        };
+    }
+
+    private static Exception CombineRecoveryFailures(
+        Exception recoveryFailure,
+        Exception? promotionFailure,
+        Exception? closeFailure)
+    {
+        var failures = new List<Exception> { recoveryFailure };
+        if (promotionFailure != null)
+        {
+            failures.Add(promotionFailure);
+        }
+
+        if (closeFailure != null)
+        {
+            failures.Add(closeFailure);
+        }
+
+        return failures.Count == 1
+            ? recoveryFailure
+            : new AggregateException(failures);
+    }
+
+    private void EnsureSessionAvailableForSavepointMetadata(string sessionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        var sessionLock = GetSessionLock(sessionId);
+        lock (sessionLock)
+        {
+            if (_teardownFailures.TryGetValue(sessionId, out var teardownFailure))
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is quarantined after a failed close: " +
+                    teardownFailure.SourceException.Message);
+            }
+
+            if (_closingSessions.ContainsKey(sessionId))
+            {
+                throw new InvalidOperationException($"Session '{sessionId}' is closing.");
+            }
+
+            if (_rollbackSessions.ContainsKey(sessionId))
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is rolling back to a savepoint.");
+            }
+
+            if (_savepointCreationSessions.ContainsKey(sessionId))
+            {
+                throw new InvalidOperationException(
+                    $"Session '{sessionId}' is creating a savepoint.");
+            }
+
+            if (!_activeSessions.TryGetValue(sessionId, out var batch) ||
+                !batch.IsExcelProcessAlive())
+            {
+                throw new KeyNotFoundException($"Session '{sessionId}' not found.");
+            }
+        }
+    }
+
+    private static void ValidateSavepointState(ExcelContext context)
+    {
+        if (context.Book.ReadOnly)
+        {
+            throw new InvalidOperationException(
+                "Savepoints are not supported for read-only or IRM/AIP-protected workbooks.");
+        }
+
+        if (context.App.CalculationState != Excel.XlCalculationState.xlDone)
+        {
+            throw new InvalidOperationException(
+                "Cannot create or roll back a savepoint while Excel calculation is in progress.");
+        }
+
+        Excel.Connections? connections = null;
+        try
+        {
+            connections = context.Book.Connections;
+            for (var index = 1; index <= connections.Count; index++)
+            {
+                Excel.WorkbookConnection? connection = null;
+                Excel.OLEDBConnection? oledb = null;
+                Excel.ODBCConnection? odbc = null;
+                try
+                {
+                    connection = connections.Item(index);
+                    if (connection.Type == Excel.XlConnectionType.xlConnectionTypeOLEDB)
+                    {
+                        oledb = connection.OLEDBConnection;
+                        if (oledb.Refreshing)
+                        {
+                            throw new InvalidOperationException(
+                                $"Cannot create or roll back a savepoint while connection '{connection.Name}' is refreshing.");
+                        }
+
+                        if (oledb.RefreshOnFileOpen)
+                        {
+                            throw new InvalidOperationException(
+                                $"Connection '{connection.Name}' refreshes when the workbook opens. " +
+                                "Disable refresh-on-open before using savepoints.");
+                        }
+                    }
+                    else if (connection.Type == Excel.XlConnectionType.xlConnectionTypeODBC)
+                    {
+                        odbc = connection.ODBCConnection;
+                        if (odbc.Refreshing)
+                        {
+                            throw new InvalidOperationException(
+                                $"Cannot create or roll back a savepoint while connection '{connection.Name}' is refreshing.");
+                        }
+
+                        if (odbc.RefreshOnFileOpen)
+                        {
+                            throw new InvalidOperationException(
+                                $"Connection '{connection.Name}' refreshes when the workbook opens. " +
+                                "Disable refresh-on-open before using savepoints.");
+                        }
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(
+                            $"Connection '{connection.Name}' uses Excel connection type " +
+                            $"'{connection.Type}', whose refresh state cannot be verified safely. " +
+                            "Savepoints require all connections to expose deterministic refresh status.");
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref odbc);
+                    ComUtilities.Release(ref oledb);
+                    ComUtilities.Release(ref connection);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref connections);
+        }
+
+        ValidateQueryTableState(context.Book);
+    }
+
+    private static void ValidateQueryTableState(Excel.Workbook workbook)
+    {
+        Excel.Sheets? worksheets = null;
+        try
+        {
+            worksheets = workbook.Worksheets;
+            for (var sheetIndex = 1; sheetIndex <= worksheets.Count; sheetIndex++)
+            {
+                Excel.Worksheet? worksheet = null;
+                Excel.QueryTables? queryTables = null;
+                try
+                {
+                    worksheet = worksheets.Item[sheetIndex] as Excel.Worksheet;
+                    if (worksheet == null)
+                    {
+                        continue;
+                    }
+
+                    queryTables = worksheet.QueryTables;
+                    for (var queryIndex = 1; queryIndex <= queryTables.Count; queryIndex++)
+                    {
+                        Excel.QueryTable? queryTable = null;
+                        try
+                        {
+                            queryTable = queryTables.Item(queryIndex);
+                            if (queryTable.Refreshing)
+                            {
+                                throw new InvalidOperationException(
+                                    $"Cannot create or roll back a savepoint while query table " +
+                                    $"'{queryTable.Name}' is refreshing.");
+                            }
+
+                            if (queryTable.RefreshOnFileOpen)
+                            {
+                                throw new InvalidOperationException(
+                                    $"Query table '{queryTable.Name}' refreshes when the workbook opens. " +
+                                    "Disable refresh-on-open before using savepoints.");
+                            }
+                        }
+                        finally
+                        {
+                            ComUtilities.Release(ref queryTable);
+                        }
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref queryTables);
+                    ComUtilities.Release(ref worksheet);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref worksheets);
+        }
+    }
+
+    private static void EnsureRollbackFreeSpace(string workbookPath, long savepointSize)
+    {
+        var root = Path.GetPathRoot(workbookPath);
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            throw new InvalidOperationException("Workbook drive could not be determined.");
+        }
+
+        var existingSize = new FileInfo(workbookPath).Length;
+        const long safetyMargin = 64L * 1024L * 1024L;
+        var required = checked(existingSize + savepointSize + safetyMargin);
+        if (new DriveInfo(root).AvailableFreeSpace < required)
+        {
+            throw new IOException(
+                $"Rollback requires at least {required} bytes of free space on drive '{root}'.");
+        }
+    }
+
+    /// <summary>
     /// Atomically reserves a Save As target path for an active session.
     /// </summary>
     /// <param name="sessionId">Active session ID</param>
@@ -1197,6 +2004,8 @@ public sealed class SessionManager : IDisposable
                 // Best-effort cleanup — continue with remaining sessions
             }
         }
+
+        _savepointStore.Dispose();
     }
 }
 

--- a/src/ExcelMcp.ComInterop/Session/WorkbookRestoreException.cs
+++ b/src/ExcelMcp.ComInterop/Session/WorkbookRestoreException.cs
@@ -1,0 +1,27 @@
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+internal sealed class WorkbookRestoreException : InvalidOperationException
+{
+    internal WorkbookRestoreException(
+        bool sessionRecovered,
+        Exception rollbackException,
+        Exception? recoveryException = null)
+        : base(
+            sessionRecovered
+                ? "Workbook rollback failed, but the pre-rollback state was recovered."
+                : "Workbook rollback and emergency recovery both failed.",
+            recoveryException == null
+                ? rollbackException
+                : new AggregateException(rollbackException, recoveryException))
+    {
+        SessionRecovered = sessionRecovered;
+        RollbackException = rollbackException;
+        RecoveryException = recoveryException;
+    }
+
+    internal bool SessionRecovered { get; }
+
+    internal Exception RollbackException { get; }
+
+    internal Exception? RecoveryException { get; }
+}

--- a/src/ExcelMcp.ComInterop/Session/WorkbookSavepointDescriptor.cs
+++ b/src/ExcelMcp.ComInterop/Session/WorkbookSavepointDescriptor.cs
@@ -1,0 +1,38 @@
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+/// <summary>
+/// Describes one immutable workbook savepoint owned by an active session.
+/// </summary>
+/// <param name="Name">Caller-provided savepoint name.</param>
+/// <param name="CreatedAtUtc">UTC creation time.</param>
+/// <param name="SizeBytes">Snapshot size in bytes.</param>
+/// <param name="WorkbookPath">Workbook path captured by the savepoint.</param>
+public sealed record WorkbookSavepointDescriptor(
+    string Name,
+    DateTime CreatedAtUtc,
+    long SizeBytes,
+    string WorkbookPath);
+
+/// <summary>
+/// Describes a completed savepoint rollback.
+/// </summary>
+/// <param name="SessionId">Public session identifier retained after rollback.</param>
+/// <param name="Name">Rolled-back savepoint name.</param>
+/// <param name="WorkbookPath">Restored workbook path.</param>
+/// <param name="RestoredAtUtc">UTC completion time.</param>
+public sealed record WorkbookSavepointRollback(
+    string SessionId,
+    string Name,
+    string WorkbookPath,
+    DateTime RestoredAtUtc);
+
+/// <summary>
+/// Savepoint storage limits enforced by one service process.
+/// </summary>
+/// <param name="MaxSavepointsPerSession">Maximum retained savepoints per session.</param>
+/// <param name="MaxBytesPerSession">Maximum retained bytes per session.</param>
+/// <param name="MaxBytesPerProcess">Maximum retained bytes across the process.</param>
+public sealed record WorkbookSavepointLimits(
+    int MaxSavepointsPerSession,
+    long MaxBytesPerSession,
+    long MaxBytesPerProcess);

--- a/src/ExcelMcp.ComInterop/Session/WorkbookSavepointRollbackException.cs
+++ b/src/ExcelMcp.ComInterop/Session/WorkbookSavepointRollbackException.cs
@@ -1,0 +1,37 @@
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+/// <summary>
+/// Reports a rollback failure after the session manager attempted deterministic recovery.
+/// </summary>
+public sealed class WorkbookSavepointRollbackException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a rollback failure.
+    /// </summary>
+    public WorkbookSavepointRollbackException(
+        string message,
+        bool sessionRecovered,
+        bool sessionClosed,
+        string? recoveryFilePath,
+        Exception rollbackException,
+        Exception? recoveryException = null)
+        : base(
+            message,
+            recoveryException == null
+                ? rollbackException
+                : new AggregateException(rollbackException, recoveryException))
+    {
+        SessionRecovered = sessionRecovered;
+        SessionClosed = sessionClosed;
+        RecoveryFilePath = recoveryFilePath;
+    }
+
+    /// <summary>Whether the pre-rollback workbook state was reopened under the same session ID.</summary>
+    public bool SessionRecovered { get; }
+
+    /// <summary>Whether the session had to be closed because recovery failed.</summary>
+    public bool SessionClosed { get; }
+
+    /// <summary>Caller-owned recovery file retained only when automatic recovery failed.</summary>
+    public string? RecoveryFilePath { get; }
+}

--- a/src/ExcelMcp.ComInterop/Session/WorkbookSavepointStorageLimitException.cs
+++ b/src/ExcelMcp.ComInterop/Session/WorkbookSavepointStorageLimitException.cs
@@ -1,0 +1,13 @@
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+/// <summary>
+/// Indicates that retaining another workbook savepoint would exceed a configured limit.
+/// </summary>
+public sealed class WorkbookSavepointStorageLimitException : InvalidOperationException
+{
+    /// <summary>Initializes a savepoint storage limit failure.</summary>
+    public WorkbookSavepointStorageLimitException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/ExcelMcp.ComInterop/Session/WorkbookSavepointStore.cs
+++ b/src/ExcelMcp.ComInterop/Session/WorkbookSavepointStore.cs
@@ -1,0 +1,832 @@
+using System.Diagnostics;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Session;
+
+internal sealed class WorkbookSavepointStore : IDisposable
+{
+    internal const int MaxSavepointsPerSession = 8;
+    internal const long MaxBytesPerSession = 1024L * 1024L * 1024L;
+    internal const long MaxBytesPerProcess = 4L * 1024L * 1024L * 1024L;
+
+    private readonly object _sync = new();
+    private readonly Dictionary<string, Dictionary<string, SavepointEntry>> _entries =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<ReservationKey, long> _reservations = [];
+    private readonly Dictionary<string, TransientEntry> _transientFiles =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, long> _orphanedDirectories =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, long> _orphanedFiles =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _preservedRecoveryFiles =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly string _instanceDirectory;
+    private bool _disposed;
+
+    internal WorkbookSavepointStore()
+    {
+        var root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "ExcelMcp",
+            "savepoints");
+        TryDeleteStaleInstanceDirectories(root);
+
+        using var process = Process.GetCurrentProcess();
+        var identity = $"{process.Id}-{process.StartTime.ToUniversalTime().ToFileTimeUtc()}";
+        _instanceDirectory = Path.Combine(root, $"{identity}-{Guid.NewGuid():N}");
+    }
+
+    internal static WorkbookSavepointLimits Limits => new(
+        MaxSavepointsPerSession,
+        MaxBytesPerSession,
+        MaxBytesPerProcess);
+
+    internal static void ValidateName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (name.Length > 128 ||
+            !IsAsciiLetterOrDigit(name[0]) ||
+            name.Any(character =>
+                !IsAsciiLetterOrDigit(character) &&
+                character is not ('.' or '_' or '-')))
+        {
+            throw new ArgumentException(
+                "Savepoint name must be 1-128 characters, start with an ASCII letter or digit, " +
+                "and contain only ASCII letters, digits, '.', '_', or '-'.",
+                nameof(name));
+        }
+    }
+
+    internal string CreateSnapshotPath(string sessionId, string extension)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var sessionDirectory = GetSessionDirectory(sessionId);
+        Directory.CreateDirectory(sessionDirectory);
+        return Path.Combine(sessionDirectory, $"{Guid.NewGuid():N}{extension}");
+    }
+
+    internal string CreateTransientPath(
+        string sessionId,
+        string extension,
+        long estimatedSizeBytes)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (estimatedSizeBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(estimatedSizeBytes),
+                "Estimated transient size cannot be negative.");
+        }
+
+        var sessionDirectory = GetSessionDirectory(sessionId);
+        Directory.CreateDirectory(sessionDirectory);
+        var path = Path.Combine(
+            sessionDirectory,
+            $".transient-{Guid.NewGuid():N}{extension}");
+        lock (_sync)
+        {
+            var processBytes = _entries.Values
+                                   .SelectMany(entries => entries.Values)
+                                   .Sum(entry => entry.SizeBytes) +
+                               _reservations.Values.Sum() +
+                               _transientFiles.Values.Sum(entry => entry.SizeBytes) +
+                               _orphanedDirectories.Values.Sum() +
+                               _orphanedFiles.Values.Sum();
+            EnsureWithinLimit(
+                processBytes,
+                estimatedSizeBytes,
+                MaxBytesPerProcess,
+                "Savepoint and rollback storage for this service process");
+            _transientFiles.Add(
+                path,
+                new TransientEntry(sessionId, estimatedSizeBytes));
+        }
+        return path;
+    }
+
+    internal bool Contains(string sessionId, string name)
+    {
+        lock (_sync)
+        {
+            return _entries.TryGetValue(sessionId, out var sessionEntries) &&
+                   sessionEntries.ContainsKey(name);
+        }
+    }
+
+    internal void Reserve(string sessionId, string name, long estimatedSizeBytes)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        RetryOrphanedStorage();
+        if (estimatedSizeBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(estimatedSizeBytes),
+                "Estimated snapshot size cannot be negative.");
+        }
+
+        var key = new ReservationKey(sessionId, name);
+        lock (_sync)
+        {
+            var sessionEntries = GetOrCreateSessionEntries(sessionId);
+            if (sessionEntries.ContainsKey(name) || _reservations.ContainsKey(key))
+            {
+                throw new InvalidOperationException(
+                    $"Savepoint '{name}' already exists for session '{sessionId}'.");
+            }
+
+            var sessionReservations = _reservations
+                .Where(reservation => string.Equals(
+                    reservation.Key.SessionId,
+                    sessionId,
+                    StringComparison.Ordinal))
+                .ToArray();
+            if (sessionEntries.Count + sessionReservations.Length >= MaxSavepointsPerSession)
+            {
+                throw new WorkbookSavepointStorageLimitException(
+                    $"Session '{sessionId}' already has the maximum of {MaxSavepointsPerSession} savepoints.");
+            }
+
+            var sessionBytes = sessionEntries.Values.Sum(entry => entry.SizeBytes) +
+                               sessionReservations.Sum(reservation => reservation.Value);
+            EnsureWithinLimit(
+                sessionBytes,
+                estimatedSizeBytes,
+                MaxBytesPerSession,
+                $"Savepoint storage for session '{sessionId}'");
+
+            var processBytes = _entries.Values
+                                   .SelectMany(entries => entries.Values)
+                                   .Sum(entry => entry.SizeBytes) +
+                               _reservations.Values.Sum() +
+                               _transientFiles.Values.Sum(entry => entry.SizeBytes) +
+                               _orphanedDirectories.Values.Sum() +
+                               _orphanedFiles.Values.Sum();
+            EnsureWithinLimit(
+                processBytes,
+                estimatedSizeBytes,
+                MaxBytesPerProcess,
+                "Savepoint storage for this service process");
+
+            _reservations.Add(key, estimatedSizeBytes);
+        }
+    }
+
+    internal void CancelReservation(string sessionId, string name)
+    {
+        lock (_sync)
+        {
+            _reservations.Remove(new ReservationKey(sessionId, name));
+        }
+    }
+
+    internal SavepointEntry Commit(
+        string sessionId,
+        string name,
+        string workbookPath,
+        string snapshotPath)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureOwnedPath(snapshotPath);
+        var fileInfo = new FileInfo(snapshotPath);
+        if (!fileInfo.Exists)
+        {
+            throw new IOException("Excel did not create the savepoint snapshot.");
+        }
+
+        lock (_sync)
+        {
+            var sessionEntries = GetOrCreateSessionEntries(sessionId);
+            var reservationKey = new ReservationKey(sessionId, name);
+            if (!_reservations.ContainsKey(reservationKey))
+            {
+                throw new InvalidOperationException(
+                    $"Savepoint reservation '{name}' is no longer active for session '{sessionId}'.");
+            }
+
+            var sessionBytes = sessionEntries.Values.Sum(entry => entry.SizeBytes);
+            EnsureWithinLimit(
+                sessionBytes,
+                fileInfo.Length,
+                MaxBytesPerSession,
+                $"Savepoint storage for session '{sessionId}'");
+
+            var processBytes = _entries.Values
+                .SelectMany(entries => entries.Values)
+                .Sum(entry => entry.SizeBytes) +
+                _reservations
+                    .Where(reservation => reservation.Key != reservationKey)
+                    .Sum(reservation => reservation.Value) +
+                _transientFiles.Values.Sum(entry => entry.SizeBytes) +
+                _orphanedDirectories.Values.Sum() +
+                _orphanedFiles.Values.Sum();
+            EnsureWithinLimit(
+                processBytes,
+                fileInfo.Length,
+                MaxBytesPerProcess,
+                "Savepoint storage for this service process");
+
+            var entry = new SavepointEntry(
+                name,
+                DateTime.UtcNow,
+                fileInfo.Length,
+                Path.GetFullPath(workbookPath),
+                snapshotPath);
+            _reservations.Remove(reservationKey);
+            sessionEntries.Add(name, entry);
+            return entry;
+        }
+    }
+
+    internal SavepointEntry GetRequired(string sessionId, string name)
+    {
+        lock (_sync)
+        {
+            if (_entries.TryGetValue(sessionId, out var sessionEntries) &&
+                sessionEntries.TryGetValue(name, out var entry))
+            {
+                return entry;
+            }
+        }
+
+        throw new KeyNotFoundException(
+            $"Savepoint '{name}' was not found for session '{sessionId}'.");
+    }
+
+    internal IReadOnlyList<SavepointEntry> List(string sessionId)
+    {
+        lock (_sync)
+        {
+            return _entries.TryGetValue(sessionId, out var sessionEntries)
+                ? sessionEntries.Values
+                    .OrderBy(entry => entry.CreatedAtUtc)
+                    .ThenBy(entry => entry.Name, StringComparer.Ordinal)
+                    .ToArray()
+                : [];
+        }
+    }
+
+    internal bool Release(string sessionId, string name)
+    {
+        lock (_sync)
+        {
+            if (!_entries.TryGetValue(sessionId, out var sessionEntries) ||
+                !sessionEntries.TryGetValue(name, out var entry))
+            {
+                return false;
+            }
+
+            DeleteOwnedFile(entry.SnapshotPath);
+            sessionEntries.Remove(name);
+            if (sessionEntries.Count == 0)
+            {
+                _entries.Remove(sessionId);
+                TryDeleteDirectory(GetSessionDirectory(sessionId));
+            }
+
+            return true;
+        }
+    }
+
+    internal bool ReleaseAll(string sessionId)
+    {
+        var sessionDirectory = GetSessionDirectory(sessionId);
+        string[] preservedFiles;
+        lock (_sync)
+        {
+            long orphanedBytes = 0;
+            if (_entries.Remove(sessionId, out var sessionEntries))
+            {
+                orphanedBytes += sessionEntries.Values.Sum(entry => entry.SizeBytes);
+            }
+
+            foreach (var reservation in _reservations.Keys
+                         .Where(reservation => string.Equals(
+                             reservation.SessionId,
+                             sessionId,
+                             StringComparison.Ordinal))
+                         .ToArray())
+            {
+                orphanedBytes += _reservations[reservation];
+                _reservations.Remove(reservation);
+            }
+
+            foreach (var transientPath in _transientFiles
+                         .Where(transient => string.Equals(
+                             transient.Value.SessionId,
+                             sessionId,
+                             StringComparison.Ordinal))
+                         .Select(transient => transient.Key)
+                         .ToArray())
+            {
+                orphanedBytes += _transientFiles[transientPath].SizeBytes;
+                _transientFiles.Remove(transientPath);
+            }
+
+            var sessionPrefix = sessionDirectory + Path.DirectorySeparatorChar;
+            foreach (var orphanedFile in _orphanedFiles.Keys
+                         .Where(path => path.StartsWith(
+                             sessionPrefix,
+                             StringComparison.OrdinalIgnoreCase))
+                         .ToArray())
+            {
+                orphanedBytes += _orphanedFiles[orphanedFile];
+                _orphanedFiles.Remove(orphanedFile);
+            }
+
+            _orphanedDirectories[sessionDirectory] = orphanedBytes;
+            preservedFiles = _preservedRecoveryFiles
+                .Where(path => path.StartsWith(
+                    sessionPrefix,
+                    StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        if (preservedFiles.Length > 0)
+        {
+            var preserved = preservedFiles.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var cleanupComplete = true;
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(sessionDirectory))
+                {
+                    if (preserved.Contains(file))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch (IOException)
+                    {
+                        cleanupComplete = false;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        cleanupComplete = false;
+                    }
+                }
+            }
+            catch (IOException)
+            {
+                cleanupComplete = false;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                cleanupComplete = false;
+            }
+
+            lock (_sync)
+            {
+                _orphanedDirectories.Remove(sessionDirectory);
+            }
+            return cleanupComplete;
+        }
+
+        if (TryDeleteDirectory(sessionDirectory))
+        {
+            lock (_sync)
+            {
+                _orphanedDirectories.Remove(sessionDirectory);
+            }
+            return true;
+        }
+
+        lock (_sync)
+        {
+            _orphanedDirectories[sessionDirectory] =
+                Math.Max(
+                    _orphanedDirectories[sessionDirectory],
+                    GetDirectorySize(sessionDirectory));
+        }
+        return false;
+    }
+
+    internal void DeleteTransient(string path, long minimumSizeBytes = 0)
+    {
+        try
+        {
+            DeleteOwnedFile(path);
+            lock (_sync)
+            {
+                _transientFiles.Remove(path);
+                _orphanedFiles.Remove(path);
+            }
+        }
+        catch (IOException)
+        {
+            TrackOrphanedFile(path, minimumSizeBytes);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            TrackOrphanedFile(path, minimumSizeBytes);
+        }
+    }
+
+    internal void UpdateTransientSize(string path, long sizeBytes)
+    {
+        if (sizeBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(sizeBytes),
+                "Transient size cannot be negative.");
+        }
+
+        lock (_sync)
+        {
+            if (!_transientFiles.TryGetValue(path, out var transient))
+            {
+                throw new InvalidOperationException(
+                    "The rollback recovery file is no longer owned by this savepoint store.");
+            }
+
+            var processBytes = _entries.Values
+                                   .SelectMany(entries => entries.Values)
+                                   .Sum(entry => entry.SizeBytes) +
+                               _reservations.Values.Sum() +
+                               _transientFiles
+                                   .Where(entry => !string.Equals(
+                                       entry.Key,
+                                       path,
+                                       StringComparison.OrdinalIgnoreCase))
+                                   .Sum(entry => entry.Value.SizeBytes) +
+                               _orphanedDirectories.Values.Sum() +
+                               _orphanedFiles.Values.Sum();
+            EnsureWithinLimit(
+                processBytes,
+                sizeBytes,
+                MaxBytesPerProcess,
+                "Savepoint and rollback storage for this service process");
+            _transientFiles[path] = transient with { SizeBytes = sizeBytes };
+        }
+    }
+
+    internal string PromoteRecoveryFile(string recoveryPath, string workbookPath)
+    {
+        EnsureOwnedPath(recoveryPath);
+        var workbookDirectory = Path.GetDirectoryName(workbookPath)
+            ?? throw new InvalidOperationException("Workbook directory is unavailable.");
+        var fileName = Path.GetFileNameWithoutExtension(workbookPath);
+        var extension = Path.GetExtension(workbookPath);
+        var recoveryFileName =
+            $".{fileName}.excelmcp-recovery-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}{extension}";
+
+        Exception workbookDirectoryFailure;
+        try
+        {
+            var workbookRecoveryPath = Path.Combine(
+                workbookDirectory,
+                recoveryFileName);
+            File.Move(recoveryPath, workbookRecoveryPath);
+            UntrackTransient(recoveryPath);
+            return workbookRecoveryPath;
+        }
+        catch (IOException ex)
+        {
+            workbookDirectoryFailure = ex;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            workbookDirectoryFailure = ex;
+        }
+
+        var fallbackDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "ExcelMcp",
+            "recovery");
+        try
+        {
+            Directory.CreateDirectory(fallbackDirectory);
+            var fallbackPath = Path.Combine(fallbackDirectory, recoveryFileName);
+            File.Move(recoveryPath, fallbackPath);
+            UntrackTransient(recoveryPath);
+            return fallbackPath;
+        }
+        catch (IOException ex)
+        {
+            throw new IOException(
+                "The emergency recovery copy could not be moved to a durable location.",
+                new AggregateException(workbookDirectoryFailure, ex));
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new UnauthorizedAccessException(
+                "The emergency recovery copy could not be moved to a durable location.",
+                new AggregateException(workbookDirectoryFailure, ex));
+        }
+    }
+
+    internal string PreserveRecoveryFileInPlace(string recoveryPath)
+    {
+        EnsureOwnedPath(recoveryPath);
+        if (!File.Exists(recoveryPath))
+        {
+            throw new FileNotFoundException(
+                "The emergency recovery copy no longer exists.",
+                recoveryPath);
+        }
+
+        lock (_sync)
+        {
+            _transientFiles.Remove(recoveryPath);
+            _orphanedFiles.Remove(recoveryPath);
+            _preservedRecoveryFiles.Add(recoveryPath);
+        }
+
+        File.WriteAllText(
+            Path.Combine(_instanceDirectory, ".preserve-recovery"),
+            "This directory contains a caller-owned recovery workbook.");
+        return recoveryPath;
+    }
+
+    private void UntrackTransient(string path)
+    {
+        lock (_sync)
+        {
+            _transientFiles.Remove(path);
+            _orphanedFiles.Remove(path);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        lock (_sync)
+        {
+            _entries.Clear();
+            _reservations.Clear();
+            _transientFiles.Clear();
+            _orphanedDirectories.Clear();
+            _orphanedFiles.Clear();
+            if (_preservedRecoveryFiles.Count > 0)
+            {
+                return;
+            }
+        }
+
+        TryDeleteDirectory(_instanceDirectory);
+    }
+
+    private Dictionary<string, SavepointEntry> GetOrCreateSessionEntries(string sessionId)
+    {
+        if (!_entries.TryGetValue(sessionId, out var sessionEntries))
+        {
+            sessionEntries = new Dictionary<string, SavepointEntry>(StringComparer.Ordinal);
+            _entries.Add(sessionId, sessionEntries);
+        }
+
+        return sessionEntries;
+    }
+
+    private static void EnsureWithinLimit(
+        long existingBytes,
+        long candidateBytes,
+        long limitBytes,
+        string description)
+    {
+        if (candidateBytes > limitBytes || existingBytes > limitBytes - candidateBytes)
+        {
+            throw new WorkbookSavepointStorageLimitException(
+                $"{description} would exceed the {limitBytes} byte limit.");
+        }
+    }
+
+    private void RetryOrphanedStorage()
+    {
+        string[] directories;
+        string[] files;
+        lock (_sync)
+        {
+            directories = _orphanedDirectories.Keys.ToArray();
+            files = _orphanedFiles.Keys.ToArray();
+        }
+
+        foreach (var directory in directories)
+        {
+            if (!TryDeleteDirectory(directory))
+            {
+                lock (_sync)
+                {
+                    _orphanedDirectories[directory] =
+                        Math.Max(
+                            _orphanedDirectories[directory],
+                            GetDirectorySize(directory));
+                }
+                continue;
+            }
+
+            lock (_sync)
+            {
+                _orphanedDirectories.Remove(directory);
+            }
+        }
+
+        foreach (var file in files)
+        {
+            try
+            {
+                DeleteOwnedFile(file);
+                lock (_sync)
+                {
+                    _orphanedFiles.Remove(file);
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private void TrackOrphanedFile(string path, long minimumSizeBytes)
+    {
+        EnsureOwnedPath(path);
+        long sizeBytes = minimumSizeBytes;
+        lock (_sync)
+        {
+            if (_transientFiles.TryGetValue(path, out var transient))
+            {
+                sizeBytes = Math.Max(sizeBytes, transient.SizeBytes);
+            }
+        }
+
+        try
+        {
+            if (File.Exists(path))
+            {
+                sizeBytes = Math.Max(sizeBytes, new FileInfo(path).Length);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+
+        lock (_sync)
+        {
+            _transientFiles.Remove(path);
+            _orphanedFiles[path] = sizeBytes;
+        }
+    }
+
+    private static long GetDirectorySize(string directory)
+    {
+        try
+        {
+            return Directory.Exists(directory)
+                ? Directory.EnumerateFiles(
+                        directory,
+                        "*",
+                        SearchOption.AllDirectories)
+                    .Sum(path => new FileInfo(path).Length)
+                : 0;
+        }
+        catch (IOException)
+        {
+            return 0;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return 0;
+        }
+    }
+
+    private string GetSessionDirectory(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) ||
+            sessionId.Any(character => !IsAsciiLetterOrDigit(character)))
+        {
+            throw new ArgumentException("Session ID contains unsupported characters.", nameof(sessionId));
+        }
+
+        return Path.Combine(_instanceDirectory, sessionId);
+    }
+
+    private void DeleteOwnedFile(string path)
+    {
+        EnsureOwnedPath(path);
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private void EnsureOwnedPath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var root = Path.GetFullPath(_instanceDirectory) + Path.DirectorySeparatorChar;
+        if (!fullPath.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Refusing to access a file outside the savepoint store.");
+        }
+    }
+
+    private static bool IsAsciiLetterOrDigit(char character) =>
+        character is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9';
+
+    private static void TryDeleteStaleInstanceDirectories(string root)
+    {
+        if (!Directory.Exists(root))
+        {
+            return;
+        }
+
+        try
+        {
+            foreach (var directory in Directory.EnumerateDirectories(root))
+            {
+                if (File.Exists(Path.Combine(directory, ".preserve-recovery")))
+                {
+                    continue;
+                }
+
+                var name = Path.GetFileName(directory);
+                var parts = name.Split('-', 3);
+                if (parts.Length != 3 ||
+                    !int.TryParse(parts[0], out var processId) ||
+                    !long.TryParse(parts[1], out var startTimeFileTime))
+                {
+                    continue;
+                }
+
+                if (!IsExactProcessAlive(processId, startTimeFileTime))
+                {
+                    TryDeleteDirectory(directory);
+                }
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static bool IsExactProcessAlive(int processId, long startTimeFileTime)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return !process.HasExited &&
+                   process.StartTime.ToUniversalTime().ToFileTimeUtc() == startTimeFileTime;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return true;
+        }
+    }
+
+    private static bool TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    internal sealed record SavepointEntry(
+        string Name,
+        DateTime CreatedAtUtc,
+        long SizeBytes,
+        string WorkbookPath,
+        string SnapshotPath)
+    {
+        internal WorkbookSavepointDescriptor ToDescriptor() =>
+            new(Name, CreatedAtUtc, SizeBytes, WorkbookPath);
+    }
+
+    private readonly record struct ReservationKey(string SessionId, string Name);
+
+    private readonly record struct TransientEntry(string SessionId, long SizeBytes);
+}

--- a/src/ExcelMcp.Core/Models/Actions/ActionExtensions.cs
+++ b/src/ExcelMcp.Core/Models/Actions/ActionExtensions.cs
@@ -13,6 +13,10 @@ public static class ActionExtensions
         FileAction.Close => "close",
         FileAction.Create => "create",
         FileAction.Test => "test",
+        FileAction.CreateSavepoint => "create-savepoint",
+        FileAction.RollbackSavepoint => "rollback-savepoint",
+        FileAction.ReleaseSavepoint => "release-savepoint",
+        FileAction.ListSavepoints => "list-savepoints",
         _ => throw new ArgumentException($"Unknown FileAction: {action}")
     };
 
@@ -54,4 +58,3 @@ public static class ActionExtensions
     // CalculationModeAction.ToActionString() is now generated in ServiceRegistry.Calculation.ToActionString()
 }
 #pragma warning restore CS1591
-

--- a/src/ExcelMcp.Core/Models/Actions/ToolActions.cs
+++ b/src/ExcelMcp.Core/Models/Actions/ToolActions.cs
@@ -25,7 +25,19 @@ public enum FileAction
     Create,
 
     [System.Text.Json.Serialization.JsonStringEnumMemberName("test")]
-    Test
+    Test,
+
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("create-savepoint")]
+    CreateSavepoint,
+
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("rollback-savepoint")]
+    RollbackSavepoint,
+
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("release-savepoint")]
+    ReleaseSavepoint,
+
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("list-savepoints")]
+    ListSavepoints
 }
 
 // NOTE: PowerQueryAction is now generated from IPowerQueryCommands interface
@@ -78,4 +90,3 @@ public enum FileAction
 // CalculationModeAction is now generated from ICalculationModeCommands interface
 // See Sbroenne.ExcelMcp.Generated.CalculationAction in ServiceRegistry.Calculation.g.cs
 #pragma warning restore CS1591
-

--- a/src/ExcelMcp.Core/Models/WorkbookSavepointCreateResult.cs
+++ b/src/ExcelMcp.Core/Models/WorkbookSavepointCreateResult.cs
@@ -1,0 +1,13 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result returned after creating a workbook savepoint.
+/// </summary>
+public sealed class WorkbookSavepointCreateResult : ResultBase
+{
+    /// <summary>Session that owns the savepoint.</summary>
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>Created savepoint metadata.</summary>
+    public WorkbookSavepointInfo Savepoint { get; set; } = new();
+}

--- a/src/ExcelMcp.Core/Models/WorkbookSavepointInfo.cs
+++ b/src/ExcelMcp.Core/Models/WorkbookSavepointInfo.cs
@@ -1,0 +1,16 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Public metadata for one immutable workbook savepoint.
+/// </summary>
+public sealed class WorkbookSavepointInfo
+{
+    /// <summary>Caller-provided savepoint name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>UTC creation time.</summary>
+    public DateTime CreatedAtUtc { get; set; }
+
+    /// <summary>Snapshot size in bytes.</summary>
+    public long SizeBytes { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/WorkbookSavepointListResult.cs
+++ b/src/ExcelMcp.Core/Models/WorkbookSavepointListResult.cs
@@ -1,0 +1,28 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result returned when listing a session's workbook savepoints.
+/// </summary>
+public sealed class WorkbookSavepointListResult : ResultBase
+{
+    /// <summary>Session that owns the savepoints.</summary>
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>Savepoints ordered by creation time.</summary>
+    public List<WorkbookSavepointInfo> Savepoints { get; set; } = [];
+
+    /// <summary>Number of retained savepoints.</summary>
+    public int Count { get; set; }
+
+    /// <summary>Total retained snapshot bytes for this session.</summary>
+    public long TotalSizeBytes { get; set; }
+
+    /// <summary>Maximum retained savepoints per session.</summary>
+    public int MaxSavepointsPerSession { get; set; }
+
+    /// <summary>Maximum retained snapshot bytes per session.</summary>
+    public long MaxBytesPerSession { get; set; }
+
+    /// <summary>Maximum retained snapshot bytes across the service process.</summary>
+    public long MaxBytesPerProcess { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/WorkbookSavepointReleaseResult.cs
+++ b/src/ExcelMcp.Core/Models/WorkbookSavepointReleaseResult.cs
@@ -1,0 +1,16 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result returned after releasing a workbook savepoint.
+/// </summary>
+public sealed class WorkbookSavepointReleaseResult : ResultBase
+{
+    /// <summary>Session that owned the savepoint.</summary>
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>Requested savepoint name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Whether a savepoint was found and released.</summary>
+    public bool Released { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/WorkbookSavepointRollbackResult.cs
+++ b/src/ExcelMcp.Core/Models/WorkbookSavepointRollbackResult.cs
@@ -1,0 +1,22 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result returned after restoring a workbook savepoint.
+/// </summary>
+public sealed class WorkbookSavepointRollbackResult : ResultBase
+{
+    /// <summary>Session retained after rollback.</summary>
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>Rolled-back savepoint name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>UTC rollback completion time.</summary>
+    public DateTime RestoredAtUtc { get; set; }
+
+    /// <summary>Whether the savepoint remains available for another rollback.</summary>
+    public bool SavepointRetained { get; set; }
+
+    /// <summary>Whether the workbook was reopened under the same session ID.</summary>
+    public bool SessionReopened { get; set; }
+}

--- a/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
+++ b/src/ExcelMcp.McpServer/ExcelMcp.McpServer.csproj
@@ -336,7 +336,7 @@ internal static class TelemetryConfig
       <SkillManifestPath>$(MSBuildProjectDirectory)\..\ExcelMcp.Core\obj\GeneratedFiles\ExcelMcp.Generators\Sbroenne.ExcelMcp.Generators.ServiceRegistryGenerator\_SkillManifest.g.cs</SkillManifestPath>
     </PropertyGroup>
     <Message Text="Generating MCP Skill from template..." Importance="high" />
-    <GenerateSkillFile TemplatePath="$(SkillTemplatePath)" OutputPath="$(SkillOutputPath)" ManifestPath="$(SkillManifestPath)" ExcludeCommands="diag" ExtraOperationCount="5" ExtraToolCount="1" />
+    <GenerateSkillFile TemplatePath="$(SkillTemplatePath)" OutputPath="$(SkillOutputPath)" ManifestPath="$(SkillManifestPath)" ExcludeCommands="diag" ExtraOperationCount="9" ExtraToolCount="1" />
     <Message Text="Generated MCP Skill: $(SkillOutputPath)" Importance="high" />
   </Target>
 

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -63,9 +63,9 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**31 specialized tools with 325 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
+**31 specialized tools with 329 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
 
-📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 325 operations, grouped by category
+📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 329 operations, grouped by category
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/src/ExcelMcp.McpServer/ServiceBridge/ServiceBridge.cs
+++ b/src/ExcelMcp.McpServer/ServiceBridge/ServiceBridge.cs
@@ -130,6 +130,17 @@ public static class ServiceBridge
                 return completedResponse;
             }
 
+            // A rollback may already have crossed its file-replacement commit point.
+            // Let the service finish rollback or emergency recovery instead of force-closing
+            // the session while it is stabilizing the workbook path.
+            if (string.Equals(
+                    command,
+                    "session.rollback-savepoint",
+                    StringComparison.Ordinal))
+            {
+                return await processTask.ConfigureAwait(false);
+            }
+
             CleanupCancelledRequest(service, sessionId);
 
             if (timeoutSeconds.HasValue && !cancellationToken.IsCancellationRequested)
@@ -286,6 +297,52 @@ public static class ServiceBridge
     {
         return await SendAsync("session.test", null, new { filePath = excelPath }, cancellationToken: cancellationToken);
     }
+
+    /// <summary>Creates a named workbook savepoint for a session.</summary>
+    public static Task<ServiceResponse> CreateSavepointAsync(
+        string sessionId,
+        string name,
+        int timeoutSeconds = 120,
+        CancellationToken cancellationToken = default) =>
+        SendAsync(
+            "session.create-savepoint",
+            sessionId,
+            new { name, timeoutSeconds },
+            timeoutSeconds,
+            cancellationToken);
+
+    /// <summary>Restores a named workbook savepoint for a session.</summary>
+    public static Task<ServiceResponse> RollbackSavepointAsync(
+        string sessionId,
+        string name,
+        int timeoutSeconds = 120,
+        CancellationToken cancellationToken = default) =>
+        SendAsync(
+            "session.rollback-savepoint",
+            sessionId,
+            new { name, timeoutSeconds },
+            timeoutSeconds,
+            cancellationToken);
+
+    /// <summary>Releases a named workbook savepoint for a session.</summary>
+    public static Task<ServiceResponse> ReleaseSavepointAsync(
+        string sessionId,
+        string name,
+        CancellationToken cancellationToken = default) =>
+        SendAsync(
+            "session.release-savepoint",
+            sessionId,
+            new { name },
+            cancellationToken: cancellationToken);
+
+    /// <summary>Lists workbook savepoints owned by a session.</summary>
+    public static Task<ServiceResponse> ListSavepointsAsync(
+        string sessionId,
+        CancellationToken cancellationToken = default) =>
+        SendAsync(
+            "session.list-savepoints",
+            sessionId,
+            cancellationToken: cancellationToken);
 
     /// <summary>
     /// Disposes the in-process ExcelMCP Service, auto-saving all sessions before shutdown.

--- a/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
+++ b/src/ExcelMcp.McpServer/Tools/ExcelFileTool.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using ModelContextProtocol.Server;
+using Sbroenne.ExcelMcp.Service;
 
 namespace Sbroenne.ExcelMcp.McpServer.Tools;
 
@@ -22,9 +24,15 @@ public static partial class ExcelFileTool
     /// IMPORTANT: Before closing, check 'list' action - wait for canClose=true (no active operations).
     /// If show=true was used, confirm with user before closing visible Excel windows.
     ///
-    /// TIMEOUT: Open/create default to 120 seconds. Use timeout_seconds to customize
-    /// slow workbook startup or prompt-heavy files. Operations timing out trigger
-    /// aggressive cleanup and may leave Excel in inconsistent state.
+    /// SAVEPOINTS: create-savepoint captures the current unsaved serializable workbook
+    /// state. rollback-savepoint persistently restores that state to the same path while
+    /// preserving the public session ID. Save As releases all savepoints. External side
+    /// effects and volatile recalculation are not rolled back. Workbooks with active
+    /// refresh, refresh-on-open, or unverifiable connection refresh state are rejected.
+    ///
+    /// TIMEOUT: Open/create and savepoint create/rollback default to 120 seconds.
+    /// Use timeout_seconds to customize slow workbooks. Operations timing out trigger
+    /// aggressive cleanup.
     ///
     /// IRM/AIP FILES: Files protected with Azure Information Protection are detected automatically.
     /// They are opened as read-only with Excel forced visible for credential authentication.
@@ -37,7 +45,8 @@ public static partial class ExcelFileTool
     /// <param name="session_id">Session ID returned from 'open' or 'create'. Required for: close. Used by all other tools.</param>
     /// <param name="save">Whether to save changes when closing. Default: false (discard changes)</param>
     /// <param name="show">Whether to make Excel window visible. Default: false (hidden automation)</param>
-    /// <param name="timeout_seconds">Maximum time in seconds for opening/creating the session and for operations in this session. Default: 120. Range: 10-3600. Used for: open, create</param>
+    /// <param name="timeout_seconds">Maximum time in seconds. Default: 120. Range: 10-3600. Used for: open, create, create-savepoint, rollback-savepoint</param>
+    /// <param name="name">Savepoint name. Required for create-savepoint, rollback-savepoint, and release-savepoint.</param>
     [McpServerTool(Name = "file", Title = "File Operations", Destructive = true)]
     [McpMeta("category", "session")]
     [McpMeta("requiresSession", false)]
@@ -48,6 +57,7 @@ public static partial class ExcelFileTool
         [DefaultValue(false)] bool save,
         [DefaultValue(false)] bool show,
         [DefaultValue(120)] int timeout_seconds,
+        [DefaultValue(null)] string? name = null,
         CancellationToken cancellationToken = default)
     {
         using var cancellationScope = ExcelToolsBase.PushCancellationToken(cancellationToken);
@@ -80,6 +90,30 @@ public static partial class ExcelFileTool
                     FileAction.Close => CloseSessionAsync(session_id!, save),
                     FileAction.Create => CreateSessionAsync(path!, show, timeout),
                     FileAction.Test => TestFileAsync(path!),
+                    FileAction.CreateSavepoint => ExecuteSavepointAction(
+                        "create-savepoint",
+                        session_id,
+                        name,
+                        timeout_seconds,
+                        cancellationToken),
+                    FileAction.RollbackSavepoint => ExecuteSavepointAction(
+                        "rollback-savepoint",
+                        session_id,
+                        name,
+                        timeout_seconds,
+                        cancellationToken),
+                    FileAction.ReleaseSavepoint => ExecuteSavepointAction(
+                        "release-savepoint",
+                        session_id,
+                        name,
+                        timeoutSeconds: null,
+                        cancellationToken),
+                    FileAction.ListSavepoints => ExecuteSavepointAction(
+                        "list-savepoints",
+                        session_id,
+                        name: null,
+                        timeoutSeconds: null,
+                        cancellationToken),
                     _ => throw new ArgumentException($"Unknown action: {action} ({action.ToActionString()})", nameof(action))
                 };
             });
@@ -364,5 +398,88 @@ public static partial class ExcelFileTool
 
         return response.Result ?? throw new InvalidOperationException(
             "File test succeeded without returning validation metadata.");
+    }
+
+    private static string ExecuteSavepointAction(
+        string action,
+        string? sessionId,
+        string? name,
+        int? timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            throw new ArgumentException(
+                $"session_id is required for '{action}' action",
+                nameof(sessionId));
+        }
+
+        if (action is not "list-savepoints" && string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException(
+                $"name is required for '{action}' action",
+                nameof(name));
+        }
+
+        object? args = action switch
+        {
+            "create-savepoint" or "rollback-savepoint" => new
+            {
+                name,
+                timeoutSeconds
+            },
+            "release-savepoint" => new { name },
+            "list-savepoints" => null,
+            _ => throw new ArgumentException($"Unknown savepoint action: {action}", nameof(action))
+        };
+
+        var response = ServiceBridge.ServiceBridge.SendAsync(
+            $"session.{action}",
+            sessionId,
+            args,
+            timeoutSeconds,
+            cancellationToken).GetAwaiter().GetResult();
+
+        return TransformSavepointResponse(response, sessionId);
+    }
+
+    private static string TransformSavepointResponse(
+        ServiceResponse response,
+        string sessionId)
+    {
+        JsonObject result;
+        if (!string.IsNullOrWhiteSpace(response.Result))
+        {
+            result = JsonNode.Parse(response.Result) as JsonObject ?? new JsonObject();
+        }
+        else
+        {
+            result = new JsonObject
+            {
+                ["success"] = response.Success
+            };
+        }
+
+        if (result.Remove("sessionId", out var sessionIdNode))
+        {
+            result["session_id"] = sessionIdNode;
+        }
+        else
+        {
+            result["session_id"] = sessionId;
+        }
+
+        if (!response.Success)
+        {
+            result["success"] = false;
+            result["errorMessage"] = response.ErrorMessage ?? "Savepoint operation failed.";
+            result["errorCategory"] = response.ErrorCategory;
+            result["exceptionType"] = response.ExceptionType;
+            result["hresult"] = response.HResult;
+            result["innerError"] = response.InnerError;
+            result["isError"] = true;
+        }
+
+        return result.ToJsonString(ExcelToolsBase.JsonOptions);
     }
 }

--- a/src/ExcelMcp.Service/ExcelMcpService.cs
+++ b/src/ExcelMcp.Service/ExcelMcpService.cs
@@ -20,6 +20,7 @@ using Sbroenne.ExcelMcp.Core.Commands.Table;
 using Sbroenne.ExcelMcp.Core.Commands.Window;
 using Sbroenne.ExcelMcp.Core.Commands.Workbook;
 using Sbroenne.ExcelMcp.Core.Commands.XmlMap;
+using Sbroenne.ExcelMcp.Core.Models;
 using Sbroenne.ExcelMcp.Core.Utilities;
 using Sbroenne.ExcelMcp.Generated;
 
@@ -390,7 +391,16 @@ public sealed class ExcelMcpService : IDisposable
 
     private ServiceResponse HandleSessionCommand(string action, ServiceRequest request)
     {
-        if (action is not ("create" or "open" or "close" or "list" or "test"))
+        if (action is not (
+                "create" or
+                "open" or
+                "close" or
+                "list" or
+                "test" or
+                "create-savepoint" or
+                "rollback-savepoint" or
+                "release-savepoint" or
+                "list-savepoints"))
         {
             return new ServiceResponse
             {
@@ -408,6 +418,10 @@ public sealed class ExcelMcpService : IDisposable
             "close" => HandleSessionClose(request),
             "list" => HandleSessionList(),
             "test" => HandleSessionTest(request),
+            "create-savepoint" => HandleSessionCreateSavepoint(request),
+            "rollback-savepoint" => HandleSessionRollbackSavepoint(request),
+            "release-savepoint" => HandleSessionReleaseSavepoint(request),
+            "list-savepoints" => HandleSessionListSavepoints(request),
             _ => throw new InvalidOperationException($"Unhandled session action: {action}")
         };
     }
@@ -424,6 +438,13 @@ public sealed class ExcelMcpService : IDisposable
                 StringComparer.Ordinal),
             "close" => new HashSet<string>(["save"], StringComparer.Ordinal),
             "test" => new HashSet<string>(["filePath"], StringComparer.Ordinal),
+            "create-savepoint" => new HashSet<string>(
+                ["name", "timeoutSeconds"],
+                StringComparer.Ordinal),
+            "rollback-savepoint" => new HashSet<string>(
+                ["name", "timeoutSeconds"],
+                StringComparer.Ordinal),
+            "release-savepoint" => new HashSet<string>(["name"], StringComparer.Ordinal),
             _ => []
         };
         var unknownParameters = ServiceRegistry.GetJsonPropertyNames(argsJson, includeNullValues: true)
@@ -615,6 +636,255 @@ public sealed class ExcelMcpService : IDisposable
         {
             return CreateErrorResponse(ex);
         }
+    }
+
+    private ServiceResponse HandleSessionCreateSavepoint(ServiceRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+        {
+            return MissingSessionIdResponse();
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionSavepointArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.Name))
+        {
+            throw new ArgumentException("name is required.");
+        }
+
+        var timeout = ParameterTransforms.ParseTimeoutSeconds(
+            args.TimeoutSeconds,
+            "timeoutSeconds",
+            minimumSeconds: 10,
+            maximumSeconds: 3600);
+
+        try
+        {
+            var savepoint = _sessionManager.CreateSavepoint(
+                request.SessionId,
+                args.Name,
+                timeout);
+            var result = new WorkbookSavepointCreateResult
+            {
+                Success = true,
+                SessionId = request.SessionId,
+                FilePath = savepoint.WorkbookPath,
+                Savepoint = ToSavepointInfo(savepoint)
+            };
+            return SuccessResult(result);
+        }
+        catch (TimeoutException ex)
+        {
+            CleanupDeadSession(request.SessionId);
+            return CreateErrorResponse(ex);
+        }
+        catch (OperationCanceledException ex)
+        {
+            CleanupDeadSession(request.SessionId);
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorCategory = "Cancelled",
+                ErrorMessage = ex.Message,
+                ExceptionType = ex.GetType().Name
+            };
+        }
+        catch (Exception ex)
+        {
+            return CreateSavepointErrorResponse(ex);
+        }
+    }
+
+    private ServiceResponse HandleSessionRollbackSavepoint(ServiceRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+        {
+            return MissingSessionIdResponse();
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionSavepointArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.Name))
+        {
+            throw new ArgumentException("name is required.");
+        }
+
+        var timeout = ParameterTransforms.ParseTimeoutSeconds(
+            args.TimeoutSeconds,
+            "timeoutSeconds",
+            minimumSeconds: 10,
+            maximumSeconds: 3600);
+
+        try
+        {
+            var rollback = _sessionManager.RollbackSavepoint(
+                request.SessionId,
+                args.Name,
+                timeout);
+            return SuccessResult(new WorkbookSavepointRollbackResult
+            {
+                Success = true,
+                SessionId = rollback.SessionId,
+                FilePath = rollback.WorkbookPath,
+                Name = rollback.Name,
+                RestoredAtUtc = rollback.RestoredAtUtc,
+                SavepointRetained = true,
+                SessionReopened = true
+            });
+        }
+        catch (WorkbookSavepointRollbackException ex)
+        {
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorCategory = ex.SessionRecovered
+                    ? "RollbackFailed"
+                    : "RollbackRecoveryFailed",
+                ErrorMessage = ex.Message,
+                ExceptionType = ex.GetType().Name,
+                InnerError = ex.SessionRecovered
+                    ? "The requested snapshot could not be reopened; the pre-rollback workbook state was restored."
+                    : "Neither the requested snapshot nor the emergency current-state copy could be reopened.",
+                Result = JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    sessionId = request.SessionId,
+                    sessionRecovered = ex.SessionRecovered,
+                    sessionClosed = ex.SessionClosed,
+                    recoveryFilePath = ex.RecoveryFilePath
+                }, ServiceProtocol.JsonOptions)
+            };
+        }
+        catch (TimeoutException ex)
+        {
+            CleanupDeadSession(request.SessionId);
+            return CreateErrorResponse(ex);
+        }
+        catch (OperationCanceledException ex)
+        {
+            CleanupDeadSession(request.SessionId);
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorCategory = "Cancelled",
+                ErrorMessage = ex.Message,
+                ExceptionType = ex.GetType().Name
+            };
+        }
+        catch (Exception ex)
+        {
+            return CreateSavepointErrorResponse(ex);
+        }
+    }
+
+    private ServiceResponse HandleSessionReleaseSavepoint(ServiceRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+        {
+            return MissingSessionIdResponse();
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionSavepointArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.Name))
+        {
+            throw new ArgumentException("name is required.");
+        }
+
+        try
+        {
+            var released = _sessionManager.ReleaseSavepoint(request.SessionId, args.Name);
+            return SuccessResult(new WorkbookSavepointReleaseResult
+            {
+                Success = true,
+                SessionId = request.SessionId,
+                Name = args.Name,
+                Released = released
+            });
+        }
+        catch (Exception ex)
+        {
+            return CreateSavepointErrorResponse(ex);
+        }
+    }
+
+    private ServiceResponse HandleSessionListSavepoints(ServiceRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+        {
+            return MissingSessionIdResponse();
+        }
+
+        try
+        {
+            var savepoints = _sessionManager.GetSavepoints(request.SessionId);
+            var limits = SessionManager.SavepointLimits;
+            return SuccessResult(new WorkbookSavepointListResult
+            {
+                Success = true,
+                SessionId = request.SessionId,
+                FilePath = _sessionManager.TryGetFilePath(request.SessionId, out var filePath)
+                    ? filePath
+                    : null,
+                Savepoints = savepoints.Select(ToSavepointInfo).ToList(),
+                Count = savepoints.Count,
+                TotalSizeBytes = savepoints.Sum(savepoint => savepoint.SizeBytes),
+                MaxSavepointsPerSession = limits.MaxSavepointsPerSession,
+                MaxBytesPerSession = limits.MaxBytesPerSession,
+                MaxBytesPerProcess = limits.MaxBytesPerProcess
+            });
+        }
+        catch (Exception ex)
+        {
+            return CreateSavepointErrorResponse(ex);
+        }
+    }
+
+    private static WorkbookSavepointInfo ToSavepointInfo(
+        WorkbookSavepointDescriptor savepoint) =>
+        new()
+        {
+            Name = savepoint.Name,
+            CreatedAtUtc = savepoint.CreatedAtUtc,
+            SizeBytes = savepoint.SizeBytes
+        };
+
+    private static ServiceResponse SuccessResult<T>(T result) =>
+        new()
+        {
+            Success = true,
+            Result = JsonSerializer.Serialize(result, ServiceProtocol.JsonOptions)
+        };
+
+    private static ServiceResponse MissingSessionIdResponse() =>
+        new()
+        {
+            Success = false,
+            ErrorCategory = "InvalidInput",
+            ErrorMessage = "sessionId is required"
+        };
+
+    private static ServiceResponse CreateSavepointErrorResponse(Exception exception)
+    {
+        var response = CreateErrorResponse(exception);
+        var errorCategory = exception switch
+        {
+            WorkbookSavepointStorageLimitException => "StorageLimitExceeded",
+            KeyNotFoundException => "NotFound",
+            NotSupportedException => "Unsupported",
+            IOException => "FileIO",
+            InvalidOperationException => "Conflict",
+            _ => response.ErrorCategory
+        };
+        return new ServiceResponse
+        {
+            Success = false,
+            Command = response.Command,
+            SessionId = response.SessionId,
+            ErrorCategory = errorCategory,
+            ErrorMessage = response.ErrorMessage,
+            ExceptionType = response.ExceptionType,
+            HResult = response.HResult,
+            InnerError = response.InnerError,
+            Result = response.Result
+        };
     }
 
     private ServiceResponse HandleSessionList()
@@ -891,6 +1161,7 @@ public sealed class ExcelMcpService : IDisposable
                 if (result.Success && reservedPath != null)
                 {
                     _sessionManager.UpdateSessionFilePath(request.SessionId!, batch.WorkbookPath);
+                    _sessionManager.ReleaseSavepoints(request.SessionId!);
                 }
 
                 return result;
@@ -1252,3 +1523,8 @@ public sealed class SessionOpenArgs
 }
 public sealed class SessionCloseArgs { public bool Save { get; set; } }
 public sealed class SessionTestArgs { public string? FilePath { get; set; } }
+public sealed class SessionSavepointArgs
+{
+    public string? Name { get; set; }
+    public int? TimeoutSeconds { get; set; }
+}

--- a/tests/ExcelMcp.CLI.Tests/Integration/FileSavepointCliTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/FileSavepointCliTests.cs
@@ -1,0 +1,167 @@
+using System.Text.Json;
+using Sbroenne.ExcelMcp.CLI.Tests.Helpers;
+using Sbroenne.ExcelMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.CLI.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Trait("Feature", "WorkbookSavepoints")]
+[Trait("Layer", "CLI")]
+[Trait("RequiresExcel", "true")]
+[Trait("Speed", "Slow")]
+public sealed class FileSavepointCliTests : IAsyncLifetime, IClassFixture<TempDirectoryFixture>
+{
+    private readonly string _pipeName = $"excelmcp-savepoint-cli-{Guid.NewGuid():N}";
+    private readonly string _workbookPath;
+    private string? _sessionId;
+
+    public FileSavepointCliTests(TempDirectoryFixture fixture)
+    {
+        _workbookPath = Path.Combine(
+            fixture.TempDir,
+            $"FileSavepointCli_{Guid.NewGuid():N}.xlsx");
+    }
+
+    private Dictionary<string, string> EnvironmentVariables =>
+        new() { ["EXCELMCP_CLI_PIPE"] = _pipeName };
+
+    public async Task InitializeAsync()
+    {
+        await CliProcessHelper.RunAsync(
+            ["service", "stop"],
+            timeoutMs: 15_000,
+            environmentVariables: EnvironmentVariables,
+            diagnosticLabel: "savepoint-cli-initialize-stop");
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_sessionId != null)
+        {
+            await CliProcessHelper.RunAsync(
+                ["session", "close", "--session", _sessionId],
+                timeoutMs: 30_000,
+                environmentVariables: EnvironmentVariables,
+                diagnosticLabel: "savepoint-cli-cleanup-close");
+        }
+
+        await CliProcessHelper.RunAsync(
+            ["service", "stop"],
+            timeoutMs: 30_000,
+            environmentVariables: EnvironmentVariables,
+            diagnosticLabel: "savepoint-cli-cleanup-stop");
+    }
+
+    [Fact(Timeout = 180_000)]
+    public async Task FileSavepointCommands_RestoreStateAndKeepSessionId()
+    {
+        using (var create = await RunSuccessAsync(
+                   ["session", "create", _workbookPath],
+                   "savepoint-cli-create"))
+        {
+            _sessionId = create.RootElement.GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(_sessionId));
+        }
+
+        await SetCellAsync("before", "savepoint-cli-set-before");
+
+        using (var savepoint = await RunSuccessAsync(
+                   [
+                       "file", "create-savepoint",
+                       "--session", _sessionId!,
+                       "--name", "before-change"
+                   ],
+                   "savepoint-cli-create-savepoint"))
+        {
+            Assert.Equal(
+                _sessionId,
+                savepoint.RootElement.GetProperty("sessionId").GetString());
+        }
+
+        await SetCellAsync("after", "savepoint-cli-set-after");
+
+        using (var rollback = await RunSuccessAsync(
+                   [
+                       "file", "rollback-savepoint",
+                       "--session", _sessionId!,
+                       "--name", "before-change"
+                   ],
+                   "savepoint-cli-rollback"))
+        {
+            Assert.Equal(
+                _sessionId,
+                rollback.RootElement.GetProperty("sessionId").GetString());
+            Assert.True(rollback.RootElement.GetProperty("sessionReopened").GetBoolean());
+        }
+
+        using (var value = await RunSuccessAsync(
+                   [
+                       "range", "get-values",
+                       "--session", _sessionId!,
+                       "--sheet-name", "Sheet1",
+                       "--range-address", "A1"
+                   ],
+                   "savepoint-cli-get-value"))
+        {
+            Assert.Equal(
+                "before",
+                value.RootElement.GetProperty("values")[0][0].GetString());
+        }
+
+        using (var release = await RunSuccessAsync(
+                   [
+                       "file", "release-savepoint",
+                       "--session", _sessionId!,
+                       "--name", "before-change"
+                   ],
+                   "savepoint-cli-release"))
+        {
+            Assert.True(release.RootElement.GetProperty("released").GetBoolean());
+        }
+
+        using (var list = await RunSuccessAsync(
+                   ["file", "list-savepoints", "--session", _sessionId!],
+                   "savepoint-cli-list"))
+        {
+            Assert.Equal(0, list.RootElement.GetProperty("count").GetInt32());
+        }
+
+        using var close = await RunSuccessAsync(
+            ["session", "close", "--session", _sessionId!],
+            "savepoint-cli-close");
+        _sessionId = null;
+    }
+
+    private async Task SetCellAsync(string value, string label)
+    {
+        var values = JsonSerializer.Serialize(new[] { new[] { value } });
+        using var _ = await RunSuccessAsync(
+            [
+                "range", "set-values",
+                "--session", _sessionId!,
+                "--sheet-name", "Sheet1",
+                "--range-address", "A1",
+                "--values", values
+            ],
+            label);
+    }
+
+    private async Task<JsonDocument> RunSuccessAsync(
+        IReadOnlyList<string> arguments,
+        string label)
+    {
+        var (result, json) = await CliProcessHelper.RunJsonAsync(
+            arguments,
+            timeoutMs: 60_000,
+            environmentVariables: EnvironmentVariables,
+            diagnosticLabel: label);
+        Assert.True(
+            result.ExitCode == 0,
+            $"{label} exited with {result.ExitCode}: {result.Stdout}{Environment.NewLine}{result.Stderr}");
+        Assert.True(
+            json.RootElement.GetProperty("success").GetBoolean(),
+            $"{label} failed: {result.Stdout}{Environment.NewLine}{result.Stderr}");
+        return json;
+    }
+}

--- a/tests/ExcelMcp.CLI.Tests/Integration/SessionLifecycleContractTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/SessionLifecycleContractTests.cs
@@ -42,6 +42,33 @@ public sealed class SessionLifecycleContractTests : IDisposable
     }
 
     [Fact]
+    public async Task FileHelp_AdvertisesCanonicalSavepointActions()
+    {
+        var result = await CliProcessHelper.RunAsync(["file", "--help"], timeoutMs: 10_000);
+        var output = result.Stdout + result.Stderr;
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("create-savepoint", output, StringComparison.Ordinal);
+        Assert.Contains("rollback-savepoint", output, StringComparison.Ordinal);
+        Assert.Contains("release-savepoint", output, StringComparison.Ordinal);
+        Assert.Contains("list-savepoints", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FileCreateSavepoint_MissingSessionIsRejected()
+    {
+        var result = await CliProcessHelper.RunAsync(
+            ["file", "create-savepoint", "--name", "before-change"],
+            timeoutMs: 10_000);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(
+            "Session ID is required",
+            result.Stdout + result.Stderr,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ServiceStatus_ResponsiveServiceWithoutDaemonMutex_ReportsRunning()
     {
         var (result, json) = await CliProcessHelper.RunJsonAsync(

--- a/tests/ExcelMcp.CLI.Tests/Unit/CliErrorOutputTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Unit/CliErrorOutputTests.cs
@@ -43,4 +43,40 @@ public sealed class CliErrorOutputTests
             "Open the workbook again",
             json.RootElement.GetProperty("errorMessage").GetString());
     }
+
+    [Fact]
+    public void WriteServiceErrorWithResult_PreservesRollbackRecoveryMetadata()
+    {
+        using var stdout = new StringWriter();
+        var originalOut = Console.Out;
+
+        try
+        {
+            Console.SetOut(stdout);
+            var exitCode = CliErrorOutput.WriteServiceErrorWithResult(new ServiceResponse
+            {
+                Success = false,
+                SessionId = "session-1",
+                ErrorCategory = "RollbackRecoveryFailed",
+                ErrorMessage = "Rollback failed and the session was closed.",
+                Result =
+                    """{"success":false,"sessionId":"session-1","sessionRecovered":false,"sessionClosed":true,"recoveryFilePath":"C:\\safe\\recovery.xlsx"}"""
+            });
+
+            Assert.Equal(1, exitCode);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        using var json = JsonDocument.Parse(stdout.ToString());
+        Assert.Equal(
+            "RollbackRecoveryFailed",
+            json.RootElement.GetProperty("errorCategory").GetString());
+        Assert.True(json.RootElement.GetProperty("sessionClosed").GetBoolean());
+        Assert.Equal(
+            @"C:\safe\recovery.xlsx",
+            json.RootElement.GetProperty("recoveryFilePath").GetString());
+    }
 }

--- a/tests/ExcelMcp.ComInterop.Tests/Integration/Session/SessionManagerSavepointTests.cs
+++ b/tests/ExcelMcp.ComInterop.Tests/Integration/Session/SessionManagerSavepointTests.cs
@@ -1,0 +1,315 @@
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Xunit;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.ComInterop.Tests.Integration.Session;
+
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "ComInterop")]
+[Trait("Feature", "WorkbookSavepoints")]
+[Trait("RequiresExcel", "true")]
+[Trait("RunType", "OnDemand")]
+[Collection("Sequential")]
+public sealed class SessionManagerSavepointTests : IDisposable
+{
+    private static readonly string TemplateFilePath = Path.Combine(
+        Path.GetDirectoryName(typeof(SessionManagerSavepointTests).Assembly.Location)!,
+        "Integration", "Session", "TestFiles", "batch-test-static.xlsx");
+
+    private readonly string _tempDirectory = Path.Combine(
+        Path.GetTempPath(),
+        $"SessionManagerSavepointTests_{Guid.NewGuid():N}");
+
+    public SessionManagerSavepointTests()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public void RollbackSavepoint_RestoresUnsavedStateAndPreservesSessionIdentity()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+        var originalBatch = manager.GetSession(sessionId)!;
+
+        SetCell(originalBatch, "before");
+        var savepoint = manager.CreateSavepoint(sessionId, "before-change");
+        SetCell(originalBatch, "after");
+
+        var rollback = manager.RollbackSavepoint(sessionId, savepoint.Name);
+        var restoredBatch = manager.GetSession(sessionId);
+
+        Assert.NotNull(restoredBatch);
+        Assert.Same(originalBatch, restoredBatch);
+        Assert.Equal(sessionId, rollback.SessionId);
+        Assert.Equal(Path.GetFullPath(workbookPath), rollback.WorkbookPath, ignoreCase: true);
+        Assert.Equal("before", GetCell(restoredBatch));
+        Assert.Single(manager.GetSavepoints(sessionId));
+
+        manager.CloseSession(sessionId, save: false);
+        using var persistedBatch = ExcelSession.BeginBatch(workbookPath);
+        Assert.Equal("before", GetCell(persistedBatch));
+    }
+
+    [Fact]
+    public void ReleaseSavepoint_RemovesOnlyTheRequestedSnapshot()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+
+        manager.CreateSavepoint(sessionId, "first");
+        manager.CreateSavepoint(sessionId, "second");
+
+        Assert.True(manager.ReleaseSavepoint(sessionId, "first"));
+        var remaining = Assert.Single(manager.GetSavepoints(sessionId));
+        Assert.Equal("second", remaining.Name);
+        Assert.False(manager.ReleaseSavepoint(sessionId, "missing"));
+
+        manager.CloseSession(sessionId);
+    }
+
+    [Fact]
+    public void CreateSavepoint_DuplicateNameIsRejectedWithoutReplacingSnapshot()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+
+        SetCell(manager.GetSession(sessionId)!, "original");
+        manager.CreateSavepoint(sessionId, "stable");
+        SetCell(manager.GetSession(sessionId)!, "changed");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => manager.CreateSavepoint(sessionId, "stable"));
+        Assert.Contains("already exists", exception.Message, StringComparison.Ordinal);
+
+        manager.RollbackSavepoint(sessionId, "stable");
+        Assert.Equal("original", GetCell(manager.GetSession(sessionId)!));
+        manager.CloseSession(sessionId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("contains space")]
+    [InlineData("../escape")]
+    [InlineData("slash/name")]
+    public void CreateSavepoint_InvalidNameIsRejected(string name)
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+
+        Assert.Throws<ArgumentException>(() => manager.CreateSavepoint(sessionId, name));
+        Assert.Empty(manager.GetSavepoints(sessionId));
+        manager.CloseSession(sessionId);
+    }
+
+    [Fact]
+    public void CreateSavepoint_NinthSnapshotIsRejectedBySessionLimit()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+
+        for (var index = 0; index < SessionManager.SavepointLimits.MaxSavepointsPerSession; index++)
+        {
+            manager.CreateSavepoint(sessionId, $"point-{index}");
+        }
+
+        var exception = Assert.Throws<WorkbookSavepointStorageLimitException>(
+            () => manager.CreateSavepoint(sessionId, "over-limit"));
+        Assert.Contains("maximum", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(
+            SessionManager.SavepointLimits.MaxSavepointsPerSession,
+            manager.GetSavepoints(sessionId).Count);
+        manager.CloseSession(sessionId);
+    }
+
+    [Fact]
+    public void CreateSavepoint_ReadOnlyWorkbookIsRejected()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+        manager.GetSession(sessionId)!.Execute((context, _) =>
+            context.Book.ChangeFileAccess(Excel.XlFileAccess.xlReadOnly));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => manager.CreateSavepoint(sessionId, "read-only"));
+        Assert.Contains("read-only", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(manager.GetSavepoints(sessionId));
+        manager.CloseSession(sessionId);
+    }
+
+    [Fact]
+    public void RollbackSavepoint_ReopenFailureRecoversPreRollbackState()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+        var batch = manager.GetSession(sessionId)!;
+        SetCell(batch, "checkpoint");
+        manager.CreateSavepoint(sessionId, "stable");
+        SetCell(batch, "current");
+
+        var reopenAttempts = 0;
+        ExcelBatch.BeforeWorkbookRestoreOpenHook = _ =>
+        {
+            if (Interlocked.Increment(ref reopenAttempts) == 1)
+            {
+                throw new IOException("Injected rollback reopen failure.");
+            }
+        };
+
+        try
+        {
+            var exception = Assert.Throws<WorkbookSavepointRollbackException>(
+                () => manager.RollbackSavepoint(sessionId, "stable"));
+            Assert.True(exception.SessionRecovered);
+            Assert.False(exception.SessionClosed);
+            Assert.Same(batch, manager.GetSession(sessionId));
+            Assert.Equal("current", GetCell(batch));
+            Assert.Single(manager.GetSavepoints(sessionId));
+        }
+        finally
+        {
+            ExcelBatch.BeforeWorkbookRestoreOpenHook = null;
+            manager.CloseSession(sessionId);
+        }
+    }
+
+    [Fact]
+    public void RollbackSavepoint_RecoveryFailureClosesSessionAndPreservesRecoveryFile()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+        var batch = manager.GetSession(sessionId)!;
+        SetCell(batch, "checkpoint");
+        manager.CreateSavepoint(sessionId, "stable");
+        SetCell(batch, "current");
+        ExcelBatch.BeforeWorkbookRestoreOpenHook = _ =>
+            throw new IOException("Injected reopen failure.");
+
+        string? recoveryFilePath = null;
+        try
+        {
+            var exception = Assert.Throws<WorkbookSavepointRollbackException>(
+                () => manager.RollbackSavepoint(sessionId, "stable"));
+            recoveryFilePath = exception.RecoveryFilePath;
+
+            Assert.False(exception.SessionRecovered);
+            Assert.True(exception.SessionClosed);
+            Assert.Null(manager.GetSession(sessionId));
+            Assert.False(string.IsNullOrWhiteSpace(recoveryFilePath));
+            Assert.True(File.Exists(recoveryFilePath));
+        }
+        finally
+        {
+            ExcelBatch.BeforeWorkbookRestoreOpenHook = null;
+            if (recoveryFilePath != null && File.Exists(recoveryFilePath))
+            {
+                File.Delete(recoveryFilePath);
+            }
+        }
+    }
+
+    [Fact]
+    public void EndOperation_DoesNotDisposeSavepointsOwnedByOtherSessions()
+    {
+        var firstWorkbook = CreateWorkbook();
+        var secondWorkbook = CreateWorkbook();
+        using var manager = new SessionManager();
+        var firstSession = manager.CreateSession(firstWorkbook);
+        var secondSession = manager.CreateSession(secondWorkbook);
+
+        manager.CreateSavepoint(secondSession, "second-session");
+        manager.BeginOperation(firstSession);
+        manager.EndOperation(firstSession);
+
+        var savepoint = Assert.Single(manager.GetSavepoints(secondSession));
+        Assert.Equal("second-session", savepoint.Name);
+        manager.CloseSession(firstSession);
+        manager.CloseSession(secondSession);
+    }
+
+    [Fact]
+    public void SavepointMutation_IsRejectedWhileAnotherOperationIsActive()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+        manager.CreateSavepoint(sessionId, "stable");
+        manager.BeginOperation(sessionId);
+
+        try
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => manager.CreateSavepoint(sessionId, "concurrent"));
+            Assert.Throws<InvalidOperationException>(
+                () => manager.RollbackSavepoint(sessionId, "stable"));
+        }
+        finally
+        {
+            manager.EndOperation(sessionId);
+            manager.CloseSession(sessionId);
+        }
+    }
+
+    [Fact]
+    public void RollbackSavepoint_PreCancelledRequestLeavesSessionAndUnsavedStateIntact()
+    {
+        var workbookPath = CreateWorkbook();
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(workbookPath);
+        var batch = manager.GetSession(sessionId)!;
+        SetCell(batch, "checkpoint");
+        manager.CreateSavepoint(sessionId, "stable");
+        SetCell(batch, "current");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            manager.RollbackSavepoint(
+                sessionId,
+                "stable",
+                cancellationToken: cancellation.Token));
+
+        Assert.Same(batch, manager.GetSession(sessionId));
+        Assert.Equal("current", GetCell(batch));
+        Assert.Single(manager.GetSavepoints(sessionId));
+        manager.CloseSession(sessionId);
+    }
+
+    private string CreateWorkbook()
+    {
+        var path = Path.Combine(_tempDirectory, $"{Guid.NewGuid():N}.xlsx");
+        File.Copy(TemplateFilePath, path);
+        return path;
+    }
+
+    private static void SetCell(IExcelBatch batch, string value)
+    {
+        batch.Execute((context, _) =>
+        {
+            context.Book.Worksheets[1].Cells[1, 1].Value2 = value;
+        });
+    }
+
+    private static string? GetCell(IExcelBatch batch)
+    {
+        return batch.Execute((context, _) =>
+            Convert.ToString(context.Book.Worksheets[1].Cells[1, 1].Value2));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolProtocolRegressionTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/ExcelFileToolProtocolRegressionTests.cs
@@ -91,6 +91,94 @@ public sealed class ExcelFileToolProtocolRegressionTests : McpIntegrationTestBas
         await Task.Delay(TimeSpan.FromSeconds(2));
     }
 
+    [Fact]
+    public async Task FileSavepoint_RollbackPreservesSessionAndRestoresUnsavedValue()
+    {
+        var workbookPath = Path.Join(_tempDir, $"Savepoint_{Guid.NewGuid():N}.xlsx");
+
+        var openResult = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "create",
+            ["path"] = workbookPath
+        });
+        AssertSuccess(openResult, "Create savepoint workbook");
+        var sessionId = GetJsonProperty(openResult, "session_id")!;
+        TrackSession(sessionId);
+
+        await SetCellAsync(sessionId, "before");
+        var createResult = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "create-savepoint",
+            ["session_id"] = sessionId,
+            ["name"] = "before-change"
+        });
+        AssertSuccess(createResult, "Create savepoint");
+
+        await SetCellAsync(sessionId, "after");
+        var rollbackResult = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "rollback-savepoint",
+            ["session_id"] = sessionId,
+            ["name"] = "before-change"
+        });
+        AssertSuccess(rollbackResult, "Rollback savepoint");
+        using (var rollbackJson = JsonDocument.Parse(rollbackResult))
+        {
+            Assert.Equal(
+                sessionId,
+                rollbackJson.RootElement.GetProperty("session_id").GetString());
+            Assert.True(rollbackJson.RootElement.GetProperty("sessionReopened").GetBoolean());
+            Assert.True(rollbackJson.RootElement.GetProperty("savepointRetained").GetBoolean());
+        }
+
+        var valueResult = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "get-values",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "A1"
+        });
+        AssertSuccess(valueResult, "Read rolled-back value");
+        using var valueJson = JsonDocument.Parse(valueResult);
+        Assert.Equal(
+            "before",
+            valueJson.RootElement.GetProperty("values")[0][0].GetString());
+
+        var listBeforeSaveAs = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "list-savepoints",
+            ["session_id"] = sessionId
+        });
+        AssertSuccess(listBeforeSaveAs, "List savepoints before Save As");
+        using (var listJson = JsonDocument.Parse(listBeforeSaveAs))
+        {
+            Assert.Equal(1, listJson.RootElement.GetProperty("count").GetInt32());
+        }
+
+        var saveAsPath = Path.Join(_tempDir, $"SavepointMoved_{Guid.NewGuid():N}.xlsx");
+        var saveAsResult = await CallToolAsync("workbook", new Dictionary<string, object?>
+        {
+            ["action"] = "save-as",
+            ["session_id"] = sessionId,
+            ["target_path"] = saveAsPath,
+            ["format"] = "xlsx"
+        });
+        AssertSuccess(saveAsResult, "Save As after savepoint");
+
+        var listAfterSaveAs = await CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "list-savepoints",
+            ["session_id"] = sessionId
+        });
+        AssertSuccess(listAfterSaveAs, "List savepoints after Save As");
+        using (var listJson = JsonDocument.Parse(listAfterSaveAs))
+        {
+            Assert.Equal(0, listJson.RootElement.GetProperty("count").GetInt32());
+        }
+
+        await CloseSessionAsync(sessionId, save: false);
+    }
+
     [ConfiguredIrmFact]
     [Trait("RunType", "OnDemand")]
     public async Task FileOpen_RealIrmWorkbook_ReturnsWithinTimeoutBudget_WhenConfigured()
@@ -154,6 +242,19 @@ public sealed class ExcelFileToolProtocolRegressionTests : McpIntegrationTestBas
             TrackSession(sessionId);
             await CloseSessionAsync(sessionId, save: false);
         }
+    }
+
+    private async Task SetCellAsync(string sessionId, string value)
+    {
+        var result = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-values",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "A1",
+            ["values"] = new List<List<object?>> { new() { value } }
+        });
+        AssertSuccess(result, $"Set A1 to {value}");
     }
 
 }

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/FileLifecycleContractProtocolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/FileLifecycleContractProtocolTests.cs
@@ -34,8 +34,25 @@ public sealed class FileLifecycleContractProtocolTests : McpIntegrationTestBase
             .Select(value => value.GetString()!)
             .ToArray();
 
-        Assert.Equal(["list", "open", "close", "create", "test"], actions);
+        Assert.Equal(
+            [
+                "list",
+                "open",
+                "close",
+                "create",
+                "test",
+                "create-savepoint",
+                "rollback-savepoint",
+                "release-savepoint",
+                "list-savepoints"
+            ],
+            actions);
         Assert.DoesNotContain("close-workbook", actions);
+
+        var properties = fileTool.JsonSchema.GetProperty("properties");
+        Assert.True(properties.TryGetProperty("name", out _));
+        Assert.True(properties.TryGetProperty("session_id", out _));
+        Assert.True(properties.TryGetProperty("timeout_seconds", out _));
     }
 
     [Fact]
@@ -51,6 +68,25 @@ public sealed class FileLifecycleContractProtocolTests : McpIntegrationTestBase
         var response = Assert.Single(result.Content.OfType<TextContentBlock>()).Text;
         Output.WriteLine(response);
         Assert.False(string.IsNullOrWhiteSpace(response));
+    }
+
+    [Fact]
+    public async Task FileCreateSavepoint_MissingNameReturnsStructuredError()
+    {
+        var result = await Client!.CallToolAsync("file", new Dictionary<string, object?>
+        {
+            ["action"] = "create-savepoint",
+            ["session_id"] = "missing-session"
+        }, cancellationToken: TestCancellationToken);
+
+        var response = Assert.Single(result.Content.OfType<TextContentBlock>()).Text;
+        using var json = JsonDocument.Parse(response);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(json.RootElement.GetProperty("isError").GetBoolean());
+        Assert.Contains(
+            "name is required",
+            json.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -19,7 +19,7 @@ Other tools (openpyxl-based MCP servers and Agent Skills, including Anthropic's 
 
 ## Key features
 
-The Excel MCP Server (excel-mcp) provides **31 specialized tools with 325 operations** for comprehensive Excel automation:
+The Excel MCP Server (excel-mcp) provides **31 specialized tools with 329 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query & M code** - Create, edit and optimize M code. Import from files, databases and APIs. Refresh queries and manage load destinations.
 - 🧮 **Power Pivot & DAX** - Build Data Models, create DAX measures and manage table relationships. Full Power Pivot automation.
@@ -31,7 +31,7 @@ The Excel MCP Server (excel-mcp) provides **31 specialized tools with 325 operat
 - 🐍 **Python in Excel** - Write and run `=PY()` formulas that execute in Excel's cloud Python engine — process worksheet data with pandas, NumPy and more, from your AI assistant.
 - 🧪 **LLM-tested quality** - Tool behavior validated with real LLM workflows using [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering), so AI assistants reliably understand and use every operation.
 
-📚 **[See all 31 tools and 325 operations →](https://excelmcpserver.dev/features/)**
+📚 **[See all 31 tools and 329 operations →](https://excelmcpserver.dev/features/)**
 
 ### Agent Skills (Bundled)
 


### PR DESCRIPTION
## Summary
- add named workbook savepoints with create, rollback, release, and list actions
- preserve the public session ID and workbook path during rollback with bounded emergency recovery
- expose identical CLI and MCP behavior, storage limits, documentation, and generated guidance

## Guarantees
- savepoints capture unsaved workbook state that Excel can serialize
- rollback persists the selected snapshot to the same workbook path and retains the savepoint
- Save As, session close, forced cleanup, and dead-session cleanup release session-owned savepoints
- read-only/IRM workbooks, active calculation or refresh, refresh-on-open, and unverifiable connection refresh state are rejected
- external effects such as database writes, network calls, exported files, printing, and VBA effects outside the workbook are not rolled back
- retained storage is limited to 8 savepoints and 1 GiB per session, and 4 GiB per service process

## Validation
- Release build with zero warnings
- focused ComInterop, CLI, MCP, VBA, and connection tests
- COM, coverage/naming, MCP/Core, success-flag, docs-count, and dynamic-cast audits
- strict MkDocs build
- full Excel E2E suite
- unchanged normal pre-commit hook, including CLI/MCP packages, VSIX, MCPB, skills, and plugin validation

Closes #836