### PR TITLE
Complete scoped large-range reads

### DIFF
--- a/.changeset/scoped-range-insights.md
+++ b/.changeset/scoped-range-insights.md
@@ -1,0 +1,5 @@
+---
+"excelmcp": patch
+---
+
+**Inspect large ranges without transferring every cell.** New range actions return first/last row samples, per-column summary statistics, or bounded sparse formula-error diagnostics through both MCP and `excelcli`.

--- a/.github/plugins/excel-cli/README.md
+++ b/.github/plugins/excel-cli/README.md
@@ -68,7 +68,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## What You Can Do
 
-**31 feature command categories with 325 operations** for comprehensive Excel automation:
+**31 feature command categories with 328 operations** for comprehensive Excel automation:
 
 - **Power Query** (12 ops) — Create, update, refresh queries; M code management
 - **Data Model/DAX** (20 ops) — Measures, relationships, source metadata, EVALUATE queries

--- a/.github/plugins/excel-mcp/README.md
+++ b/.github/plugins/excel-mcp/README.md
@@ -58,7 +58,7 @@ pwsh -ExecutionPolicy Bypass -File `
 
 ## What You Can Do
 
-**31 specialized tools with 325 operations** for comprehensive Excel automation:
+**31 specialized tools with 328 operations** for comprehensive Excel automation:
 
 ### Core Operations
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # ExcelMcp - Complete Feature Reference
 
-**31 specialized tools with 325 operations for comprehensive Excel automation**
+**31 specialized tools with 328 operations for comprehensive Excel automation**
 
 Excel MCP Server automates the real Microsoft Excel application through four focused capability areas. Start with the category that matches your goal, or use the quick reference below.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ its official COM API. It can refresh Power Query, recalculate formulas, evaluate
 DAX, run VBA and Python `=PY()`, and preserve PivotTables, charts, macros, the
 Data Model, and workbook formatting.
 
-**31 tools with 325 operations** cover end-to-end Excel automation.
+**31 tools with 328 operations** cover end-to-end Excel automation.
 
 > [!IMPORTANT]
 > Requires **Windows**, **Microsoft Excel 2016 or later**, and an interactive
@@ -55,7 +55,7 @@ while automating them.
 - **[Automation & advanced](https://excelmcpserver.dev/features/automation-advanced/):**
   VBA, Python in Excel, Goal Seek, scenarios, data tables, windows, and XML Maps.
 
-Explore the [complete reference for all 325 operations](https://excelmcpserver.dev/features/).
+Explore the [complete reference for all 328 operations](https://excelmcpserver.dev/features/).
 
 ## See It in Action
 

--- a/docs/features/CELLS-WORKBOOKS.md
+++ b/docs/features/CELLS-WORKBOOKS.md
@@ -30,7 +30,7 @@ Control when and how Excel recalculates formulas — useful for speeding up bulk
 
 ---
 
-## 📋 Ranges (51 operations)
+## 📋 Ranges (54 operations)
 
 Read and write cell values, formulas, and formatting across any range of cells.
 
@@ -38,6 +38,9 @@ Read and write cell values, formulas, and formatting across any range of cells.
 
 **Data Operations:**
 - **Get/Set Values:** Read or write cell values. Large reads can page rows with a zero-based offset and positive limit, select comma-separated absolute worksheet columns, and use returned totals plus `nextRowOffset`/`hasMoreRows` to continue without materializing the full source range.
+- **Sample Values:** Return bounded first/last row samples with source row coordinates and optional ordered columns.
+- **Summarize Values:** Return per-column type counts and numeric sum, average, minimum, and maximum without a values matrix.
+- **Get Formula Errors:** Return bounded sparse diagnostics only for formulas whose calculated result is an Excel error.
 - **Get/Set/Validate Formulas:** Read, write, or validate formula syntax across ranges
 - **Clear All/Contents/Formats:** Clear a range's contents, formats, or both
 - **Copy / Copy Values / Copy Formulas:** Copy a range, or just its values/formulas

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,6 +1,6 @@
 ---
 title: Excel Automation Features
-description: Explore 31 Excel automation tools and 325 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
+description: Explore 31 Excel automation tools and 328 operations for Power Query, DAX, PivotTables, charts, formulas, VBA, and more.
 keywords: "Excel automation features, Excel MCP tools, Power Query automation, DAX, PivotTables, VBA, Excel AI"
 ---
 
@@ -11,7 +11,7 @@ keywords: "Excel automation features, Excel MCP tools, Power Query automation, D
   <figcaption>A PivotTable — revenue by region and quarter with grand totals — created in the real Excel application from a plain-language request.</figcaption>
 </figure>
 
-Excel MCP Server provides **31 specialized tools and 325 operations** for
+Excel MCP Server provides **31 specialized tools and 328 operations** for
 automating the real Microsoft Excel application. You can ask your AI assistant
 in plain language—the reference pages below are for discovering what is
 possible and looking up individual operations.

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -132,7 +132,7 @@ hide:
 
 </div>
 
-[See all 31 tools and 325 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 31 tools and 328 operations :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## Popular guides
 

--- a/mcpb/Build-McpBundle.ps1
+++ b/mcpb/Build-McpBundle.ps1
@@ -49,35 +49,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-
-function Remove-StagingDirectory {
-    param(
-        [Parameter(Mandatory)]
-        [string]$Path,
-
-        [int]$MaxAttempts = 10
-    )
-
-    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-        try {
-            [System.IO.Directory]::Delete($Path, $true)
-            return
-        }
-        catch [System.UnauthorizedAccessException] {
-            $failure = $_
-        }
-        catch [System.IO.IOException] {
-            $failure = $_
-        }
-
-        if ($attempt -eq $MaxAttempts) {
-            throw $failure
-        }
-
-        # Executable scanners can briefly retain the verified server binary.
-        Start-Sleep -Milliseconds 500
-    }
-}
+. (Join-Path $PSScriptRoot "McpbPackaging.ps1")
 
 # Get script and project directories
 $McpbDir = $PSScriptRoot
@@ -228,7 +200,7 @@ Write-Host "   ✓ Created $McpbFileName" -ForegroundColor Green
 Copy-Item $ManifestDst (Join-Path $OutputDir "manifest.json") -Force
 
 # Clean up staging
-Remove-StagingDirectory -Path $StagingDir
+Remove-McpbStagingDirectory -Path $StagingDir
 
 # Show results
 $McpbSize = (Get-Item $McpbPath).Length / 1MB

--- a/mcpb/McpbPackaging.ps1
+++ b/mcpb/McpbPackaging.ps1
@@ -1,0 +1,67 @@
+$ErrorActionPreference = "Stop"
+
+function Remove-McpbStagingDirectory {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [TimeSpan]$Timeout = [TimeSpan]::FromSeconds(30),
+
+        [TimeSpan]$RetryInterval = [TimeSpan]::FromMilliseconds(500),
+
+        [scriptblock]$RemoveDirectory = {
+            param([string]$TargetPath)
+            [System.IO.Directory]::Delete($TargetPath, $true)
+        }
+    )
+
+    if ($Timeout -lt [TimeSpan]::Zero) {
+        throw [System.ArgumentOutOfRangeException]::new(
+            "Timeout",
+            $Timeout,
+            "The staging cleanup timeout cannot be negative.")
+    }
+
+    if ($RetryInterval -lt [TimeSpan]::Zero) {
+        throw [System.ArgumentOutOfRangeException]::new(
+            "RetryInterval",
+            $RetryInterval,
+            "The staging cleanup retry interval cannot be negative.")
+    }
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $attempts = 0
+    $lastFailure = $null
+
+    while (Test-Path -LiteralPath $Path -PathType Container) {
+        $attempts++
+        try {
+            & $RemoveDirectory $Path
+        }
+        catch [System.UnauthorizedAccessException] {
+            $lastFailure = $_.Exception
+        }
+        catch [System.IO.IOException] {
+            $lastFailure = $_.Exception
+        }
+
+        if (-not (Test-Path -LiteralPath $Path)) {
+            return
+        }
+
+        $remaining = $Timeout - $stopwatch.Elapsed
+        if ($remaining -le [TimeSpan]::Zero) {
+            $attemptLabel = if ($attempts -eq 1) { "attempt" } else { "attempts" }
+            $timeoutMilliseconds = [Math]::Round($Timeout.TotalMilliseconds)
+            $lastError = if ($lastFailure) { $lastFailure.Message } else { "the directory still exists" }
+            throw [System.IO.IOException]::new(
+                "Failed to remove MCPB staging directory '$Path' after $attempts $attemptLabel within $timeoutMilliseconds ms. Last error: $lastError",
+                $lastFailure)
+        }
+
+        $delay = if ($RetryInterval -lt $remaining) { $RetryInterval } else { $remaining }
+        if ($delay -gt [TimeSpan]::Zero) {
+            Start-Sleep -Milliseconds ([Math]::Ceiling($delay.TotalMilliseconds))
+        }
+    }
+}

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -13,7 +13,7 @@ Excel MCP Server lets you automate Excel through conversation with Claude:
 - **Automate** - VBA macros, batch operations, data refresh
 - **Agent Mode** - Say "show me Excel" and watch AI work in real-time, side-by-side with Claude
 
-**31 tools with 325 operations** for comprehensive Excel automation.
+**31 tools with 328 operations** for comprehensive Excel automation.
 
 ## Requirements
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Excel (Windows)",
   "version": "2.0.5",
   "description": "Manage Sheets, Power Query, DAX, VBA, PowerPivot, Tables, Ranges, Charts, Formatting, Validation & more - requires Excel to be installed",
-  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 325 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
+  "long_description": "Automate the real Microsoft Excel application from Claude. 31 specialized tools with 328 operations for Power Query, DAX and the Data Model, VBA, PivotTables, Charts, Conditional Formatting, and more. Unlike file-parser libraries, it drives Excel through its official COM API, so PivotTables, macros, charts, the Data Model and workbook formatting are preserved. Windows-only, requires Microsoft Excel desktop application (2016 or later).",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/skills/excel-mcp/SKILL.md
+++ b/skills/excel-mcp/SKILL.md
@@ -12,7 +12,7 @@ compatibility: Requires Windows, Microsoft Excel 2016 or later, and network acce
 
 # Excel MCP Server Skill
 
-Provides 325 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
+Provides 328 Excel operations via Model Context Protocol. The MCP Server hosts the ExcelMCP Service in-process and calls it directly for low-latency Excel automation. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
 
 ## Workflow Checklist
 

--- a/skills/excel-mcp/references/range.md
+++ b/skills/excel-mcp/references/range.md
@@ -11,6 +11,21 @@ range(action: 'get-values', sheet_name: 'Data', range_address: 'A1:Z100000',
 
 `row_offset` is zero-based relative to the source range. `columns` contains absolute worksheet column letters and preserves the requested order. Continue with `nextRowOffset` while `hasMoreRows` is true. The response also reports total source dimensions, returned dimensions, and whether rows or columns were omitted. Omit all three scope parameters to keep the existing full-range read.
 
+Use the typed large-range read actions when a values matrix is not needed:
+
+```text
+range(action: 'sample-values', sheet_name: 'Data', range_address: 'A1:Z100000',
+    first_row_count: 5, last_row_count: 5, columns: 'A,D,F')
+range(action: 'summarize-values', sheet_name: 'Data', range_address: 'A1:Z100000',
+    columns: 'D,F')
+range(action: 'get-formula-errors', sheet_name: 'Data', range_address: 'A1:Z100000',
+    max_errors: 100)
+```
+
+`sample-values` returns up to 100 leading and 100 trailing rows, removes overlap, includes absolute row coordinates, and rejects results over 1,000 cells. `summarize-values` returns per-column blank, number, text, logical, and error counts plus numeric sum, average, minimum, and maximum; dates are numeric serials, nonnumeric cells and errors are excluded from numeric statistics, and statistics are omitted when no numbers exist. Select at most 256 columns. Both actions require a single-area source.
+
+`get-formula-errors` uses Excel's formula-error selection and returns at most 1,000 sparse diagnostics with source areas ordered by their top-left cell and then by Excel cell order. Each diagnostic includes the cell address, formula, error code, message, and truncation metadata. Constant errors are excluded; multi-area and named ranges are supported. None of these actions returns a full values matrix.
+
 **IMPORTANT: Always use US format codes.** The server automatically translates to the user's locale.
 
 **Discoverability note:** number display formats live on `range`; visual styling and auto-fit live on `range_format`.

--- a/skills/shared/range.md
+++ b/skills/shared/range.md
@@ -11,6 +11,21 @@ range(action: 'get-values', sheet_name: 'Data', range_address: 'A1:Z100000',
 
 `row_offset` is zero-based relative to the source range. `columns` contains absolute worksheet column letters and preserves the requested order. Continue with `nextRowOffset` while `hasMoreRows` is true. The response also reports total source dimensions, returned dimensions, and whether rows or columns were omitted. Omit all three scope parameters to keep the existing full-range read.
 
+Use the typed large-range read actions when a values matrix is not needed:
+
+```text
+range(action: 'sample-values', sheet_name: 'Data', range_address: 'A1:Z100000',
+    first_row_count: 5, last_row_count: 5, columns: 'A,D,F')
+range(action: 'summarize-values', sheet_name: 'Data', range_address: 'A1:Z100000',
+    columns: 'D,F')
+range(action: 'get-formula-errors', sheet_name: 'Data', range_address: 'A1:Z100000',
+    max_errors: 100)
+```
+
+`sample-values` returns up to 100 leading and 100 trailing rows, removes overlap, includes absolute row coordinates, and rejects results over 1,000 cells. `summarize-values` returns per-column blank, number, text, logical, and error counts plus numeric sum, average, minimum, and maximum; dates are numeric serials, nonnumeric cells and errors are excluded from numeric statistics, and statistics are omitted when no numbers exist. Select at most 256 columns. Both actions require a single-area source.
+
+`get-formula-errors` uses Excel's formula-error selection and returns at most 1,000 sparse diagnostics with source areas ordered by their top-left cell and then by Excel cell order. Each diagnostic includes the cell address, formula, error code, message, and truncation metadata. Constant errors are excluded; multi-area and named ranges are supported. None of these actions returns a full values matrix.
+
 **IMPORTANT: Always use US format codes.** The server automatically translates to the user's locale.
 
 **Discoverability note:** number display formats live on `range`; visual styling and auto-fit live on `range_format`.

--- a/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
+++ b/src/ExcelMcp.CLI/ExcelMcp.CLI.csproj
@@ -24,7 +24,7 @@
     <!-- NuGet Package Configuration (secondary distribution — primary is standalone exe) -->
     <PackageId>Sbroenne.ExcelMcp.CLI</PackageId>
     <Title>ExcelMcp CLI</Title>
-    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 325 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
+    <Description>Command-line interface tool for automating Microsoft Excel operations using COM interop by Sbroenne. 328 operations across Power Query M code, Power Pivot DAX measures, VBA macros, PivotTables, Excel Tables, ranges, formatting, data validation, and connections. Perfect for RPA, CI/CD pipelines, scripting (PowerShell/Bash), and batch processing. Windows x64 and ARM64 support.</Description>
     <PackageTags>excel;cli;powerquery;dax;power-pivot;automation;com;rpa;ci-cd;scripting;github-copilot;mcp;windows;dotnet-tool;sbroenne;excel-automation;vba;pivottables;excel-tables;batch-processing;devops</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/sbroenne/mcp-server-excel/releases for release notes</PackageReleaseNotes>

--- a/src/ExcelMcp.CLI/README.md
+++ b/src/ExcelMcp.CLI/README.md
@@ -10,7 +10,7 @@
 > **Primary distribution: Standalone executable** — Download `excelcli.exe` from the [latest release](https://github.com/sbroenne/mcp-server-excel/releases/latest). No .NET runtime required.
 > **Secondary distribution: NuGet .NET tool** — `dotnet tool install --global Sbroenne.ExcelMcp.CLI` (requires .NET 10 runtime).
 
-The CLI provides 31 feature command categories with 325 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
+The CLI provides 31 feature command categories with 328 operations matching the MCP Server, plus `session`, `service`, and `batch` commands — the same capabilities without loading 31 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|
@@ -48,7 +48,7 @@ dotnet tool install --global Sbroenne.ExcelMcp.CLI
 
 ## 📋 What You Can Do
 
-ExcelMcp.CLI provides **325 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
+ExcelMcp.CLI provides **328 operations** across 31 feature command categories including Power Query, Python in Excel, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, and Window Management.
 
 Drives the **actual Excel application** via COM — not a file-format parser — so live operations (Power Query refresh, recalculation, DAX evaluation, VBA execution) run for real and existing workbooks stay intact.
 

--- a/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
+++ b/src/ExcelMcp.Core/Commands/PythonInExcel/PythonInExcelCommands.cs
@@ -166,7 +166,7 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                 const int RequiredNonBusyReads = 3;
 
                 // Well-known Excel error code for #PYTHON! (Python code raised an error), used only to
-                // look up the canonical human-readable message via MapErrorCodeToMessage. Detection of
+                // look up the canonical human-readable message via ExcelErrorMapper. Detection of
                 // "this is a Python error" is NOT done by matching this exact code (the actual negative
                 // int Value2 returns for a Python-side error/object has been observed to vary and is not
                 // a reliable discriminator on its own) - see the returnType-based classification below.
@@ -258,13 +258,28 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                 {
                     // Standard Excel error codes are well-known/fixed and mean the *formula itself*
                     // failed to evaluate (e.g. bad range reference) - these are never Python results.
-                    bool isStandardExcelError = errorCode is -2146826288 or -2147483648 or -2146826259
-                        or -2146826246 or -2146826252 or -2142019887;
+                    bool isStandardExcelError = errorCode is
+                        -2146826288 or // #NULL!
+                        -2146826281 or -2147483648 or // #DIV/0!
+                        -2146826273 or // #VALUE!
+                        -2146826265 or // #REF!
+                        -2146826259 or // #NAME?
+                        -2146826252 or // #NUM!
+                        -2146826246 or -2142019887 or // #N/A
+                        -2146826245 or // #GETTING_DATA
+                        -2146826243 or // #SPILL!
+                        -2146826242 or // #CONNECT!
+                        -2146826241 or // #BLOCKED!
+                        -2146826240 or // #UNKNOWN!
+                        -2146826239 or // #FIELD!
+                        -2146826238 or // #CALC!
+                        -2146826237 or // #BUSY!
+                        -2146826236; // #DATA!
 
                     if (isStandardExcelError)
                     {
                         result.Success = false;
-                        result.ErrorMessage = RangeCommands.MapErrorCodeToMessage(errorCode);
+                        result.ErrorMessage = ExcelErrorMapper.GetMessage(errorCode);
                     }
                     else if (formulaReturnType == 1)
                     {
@@ -285,7 +300,7 @@ public sealed class PythonInExcelCommands : IPythonInExcelCommands
                         // this is the Python code itself raising an error (syntax or runtime exception).
                         result.Success = false;
                         result.IsPythonError = true;
-                        result.ErrorMessage = RangeCommands.MapErrorCodeToMessage(PythonErrorCode);
+                        result.ErrorMessage = ExcelErrorMapper.GetMessage(PythonErrorCode);
                     }
                 }
                 else

--- a/src/ExcelMcp.Core/Commands/Range/ExcelErrorMapper.cs
+++ b/src/ExcelMcp.Core/Commands/Range/ExcelErrorMapper.cs
@@ -1,0 +1,68 @@
+using System.Runtime.InteropServices;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Range;
+
+internal static class ExcelErrorMapper
+{
+    internal static bool TryGetErrorCode(object? value, out int errorCode)
+    {
+        errorCode = value switch
+        {
+            int intValue => intValue,
+            ErrorWrapper wrapper => wrapper.ErrorCode,
+            _ => 0
+        };
+
+        return errorCode < 0;
+    }
+
+    internal static string GetMessage(int errorCode) =>
+        errorCode switch
+        {
+            -2146826288 => "#NULL! - Invalid intersection of ranges",
+            -2146826281 => "#DIV/0! - Division by zero",
+            -2147483648 => "#DIV/0! - Division by zero",
+            -2146826273 => "#VALUE! - Wrong type of argument",
+            -2146826265 => "#REF! - Invalid cell reference",
+            -2146826259 => "#NAME? - Unknown function or name",
+            -2146826252 => "#NUM! - Invalid numeric value",
+            -2146826246 => "#N/A - Value not available",
+            -2146826245 => "#GETTING_DATA - Data is still loading",
+            -2146826243 => "#SPILL! - Dynamic array result cannot spill",
+            -2146826242 => "#CONNECT! - External data connection is not ready",
+            -2146826241 => "#BLOCKED! - Required resource is blocked",
+            -2146826240 => "#UNKNOWN! - Excel cannot determine the data type",
+            -2146826239 => "#FIELD! - Referenced data field is unavailable",
+            -2146826238 => "#CALC! - Calculation failed",
+            -2146826237 => "#BUSY! - Calculation is still running",
+            -2146826236 => "#DATA! - Linked data returned an error",
+            -2142019887 => "#N/A - Value not available",
+            -2146826233 => "#PYTHON! - Python code raised an error (syntax or runtime exception)",
+            _ => $"#ERROR! - Unknown error code {errorCode}"
+        };
+
+    internal static string GetSuggestion(int errorCode) =>
+        errorCode switch
+        {
+            -2146826288 => "Check the intersection operator and referenced ranges.",
+            -2146826281 => "Ensure the formula does not divide by zero.",
+            -2147483648 => "Ensure the formula does not divide by zero.",
+            -2146826273 => "Check function names and argument types.",
+            -2146826265 => "Check that referenced cells and ranges still exist.",
+            -2146826259 => "Check function and named-range spelling.",
+            -2146826252 => "Check numeric inputs and supported value ranges.",
+            -2146826246 => "Check that the lookup value and source data are available.",
+            -2146826245 => "Wait for the external data operation to finish.",
+            -2146826243 => "Clear cells that block the dynamic array result.",
+            -2146826242 => "Check the external data connection and try again.",
+            -2146826241 => "Allow the required resource or review workbook security settings.",
+            -2146826240 => "Check the linked data type and its source.",
+            -2146826239 => "Check that the referenced data field still exists.",
+            -2146826238 => "Check the formula inputs and array dimensions.",
+            -2146826237 => "Wait for calculation to finish and read the cell again.",
+            -2146826236 => "Refresh or repair the linked data source.",
+            -2142019887 => "Check that the lookup value and source data are available.",
+            -2146826233 => "Check the Python formula syntax and runtime inputs.",
+            _ => "Check the formula syntax and referenced values."
+        };
+}

--- a/src/ExcelMcp.Core/Commands/Range/IRangeCommands.cs
+++ b/src/ExcelMcp.Core/Commands/Range/IRangeCommands.cs
@@ -28,7 +28,7 @@ namespace Sbroenne.ExcelMcp.Core.Commands.Range;
 /// </summary>
 [ServiceCategory("range", "Range")]
 [McpTool("range", Title = "Range Operations", Destructive = true, Category = "data",
-    Description = "Core range operations: get/set values and formulas, copy ranges, clear content, discover data regions. Use range_edit for insert/delete/find/sort. Use range_format for styling/validation. Use range_link for hyperlinks/protection. Use calculation_mode for recalculation. EXCEL TABLES: If user asks to 'format as table', 'create a table', 'put data in an Excel Table' — do NOT try to use range for this. Use table(action:'create') on the data range to create a proper Excel Table with filter arrows, banded rows, and automatic expansion. DATA FORMAT: 2D JSON arrays [[row1col1,row1col2],[row2col1,row2col2]]. Single cell returns [[value]]. SCOPED READS: get-values supports zero-based rowOffset, positive rowLimit, and comma-separated absolute worksheet columns such as A,D,F; scoped calls return paging metadata and read only requested cells. FILE INPUT: For set-values/set-formulas, provide EITHER inline values/formulas OR a valuesFile/formulasFile path to a .json or .csv file. Prefer file input for large datasets. BEST PRACTICE: get-values before overwriting, clear-contents (not clear-all) to preserve formatting. NAMED RANGES: Use sheetName='' and rangeAddress=namedRangeName.")]
+    Description = "Core range operations: get/set values and formulas, copy ranges, clear content, discover data regions. Use range_edit for insert/delete/find/sort. Use range_format for styling/validation. Use range_link for hyperlinks/protection. Use calculation_mode for recalculation. EXCEL TABLES: If user asks to 'format as table', 'create a table', 'put data in an Excel Table' — do NOT try to use range for this. Use table(action:'create') on the data range to create a proper Excel Table with filter arrows, banded rows, and automatic expansion. DATA FORMAT: 2D JSON arrays [[row1col1,row1col2],[row2col1,row2col2]]. Single cell returns [[value]]. SCOPED READS: get-values pages rows and selects columns; sample-values returns bounded boundary rows with source coordinates; summarize-values returns type counts and numeric statistics; get-formula-errors returns bounded sparse diagnostics without a values matrix. FILE INPUT: For set-values/set-formulas, provide EITHER inline values/formulas OR a valuesFile/formulasFile path to a .json or .csv file. Prefer file input for large datasets. BEST PRACTICE: get-values before overwriting, clear-contents (not clear-all) to preserve formatting. NAMED RANGES: Use sheetName='' and rangeAddress=namedRangeName.")]
 public interface IRangeCommands
 {
     // === VALUE OPERATIONS ===
@@ -53,6 +53,59 @@ public interface IRangeCommands
         int rowOffset = 0,
         int? rowLimit = null,
         string? columns = null);
+
+    /// <summary>
+    /// Returns a bounded sample of the first and last source rows in worksheet order.
+    /// Overlapping boundary rows are returned once. Each row includes its zero-based source offset,
+    /// absolute worksheet row number, address, and values.
+    /// </summary>
+    /// <param name="batch">Excel batch session</param>
+    /// <param name="sheetName">Name of the worksheet, or empty string for a named range</param>
+    /// <param name="rangeAddress">Cell range address or named range name</param>
+    /// <param name="firstRowCount">Number of rows to sample from the start, from 0 through 100</param>
+    /// <param name="lastRowCount">Number of rows to sample from the end, from 0 through 100</param>
+    /// <param name="columns">Optional comma-separated absolute worksheet columns in return order</param>
+    [ServiceAction("sample-values")]
+    RangeSampleResult SampleValues(
+        IExcelBatch batch,
+        string sheetName,
+        [RequiredParameter] string rangeAddress,
+        int firstRowCount = 5,
+        int lastRowCount = 5,
+        string? columns = null);
+
+    /// <summary>
+    /// Returns per-column type counts and numeric statistics without returning cell values.
+    /// Blank means no constant or formula. Numeric statistics include Excel numbers and dates,
+    /// ignore blanks, text, logical values, and errors, and are null when no numeric cells exist.
+    /// </summary>
+    /// <param name="batch">Excel batch session</param>
+    /// <param name="sheetName">Name of the worksheet, or empty string for a named range</param>
+    /// <param name="rangeAddress">Cell range address or named range name</param>
+    /// <param name="columns">Optional comma-separated absolute worksheet columns in return order. At most 256 columns are summarized.</param>
+    [ServiceAction("summarize-values")]
+    RangeSummaryResult SummarizeValues(
+        IExcelBatch batch,
+        string sheetName,
+        [RequiredParameter] string rangeAddress,
+        string? columns = null);
+
+    /// <summary>
+    /// Returns sparse diagnostics only for formula cells whose calculated result is an Excel error.
+    /// Constant error values are excluded. Source areas are ordered by their top-left cell, then each area
+    /// follows Excel cell order. Results are bounded by maxErrors.
+    /// Multi-area and named ranges are supported.
+    /// </summary>
+    /// <param name="batch">Excel batch session</param>
+    /// <param name="sheetName">Name of the worksheet, or empty string for a named range</param>
+    /// <param name="rangeAddress">Cell range address or named range name</param>
+    /// <param name="maxErrors">Maximum diagnostics to return, from 1 through 1000</param>
+    [ServiceAction("get-formula-errors")]
+    RangeFormulaErrorResult GetFormulaErrors(
+        IExcelBatch batch,
+        string sheetName,
+        [RequiredParameter] string rangeAddress,
+        int maxErrors = 100);
 
     /// <summary>
     /// Sets values in a range from 2D array or file.
@@ -311,5 +364,3 @@ public class SortColumn
     /// <summary>Sort direction (true = ascending, false = descending)</summary>
     public bool Ascending { get; set; } = true;
 }
-
-

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.Formulas.cs
@@ -66,7 +66,7 @@ public partial class RangeCommands
                             valueRow.Add(cellValue);
 
                             // ERROR CODE DETECTION: Map Excel error codes to human-readable messages
-                            if (cellValue is int errorCode && errorCode < 0)
+                            if (ExcelErrorMapper.TryGetErrorCode(cellValue, out int errorCode))
                             {
                                 int row = startRow + r - 1;
                                 int column = startColumn + c - 1;
@@ -75,10 +75,11 @@ public partial class RangeCommands
                                     CellAddress = $"{RangeHelpers.GetColumnLetter(column)}{row}",
                                     Row = row,
                                     Column = column,
+                                    Formula = formula.StartsWith('=') ? formula : null,
                                     CurrentValue = cellValue,
                                     ErrorCode = errorCode,
-                                    ErrorMessage = MapErrorCodeToMessage(errorCode),
-                                    Suggestion = MapErrorCodeToSuggestion(errorCode)
+                                    ErrorMessage = ExcelErrorMapper.GetMessage(errorCode),
+                                    Suggestion = ExcelErrorMapper.GetSuggestion(errorCode)
                                 });
                             }
                         }
@@ -100,17 +101,18 @@ public partial class RangeCommands
                     result.Values.Add([cellValue]);
 
                     // ERROR CODE DETECTION: Single cell error
-                    if (cellValue is int errorCode && errorCode < 0)
+                    if (ExcelErrorMapper.TryGetErrorCode(cellValue, out int errorCode))
                     {
                         result.CellErrors.Add(new RangeCellError
                         {
                             CellAddress = $"{RangeHelpers.GetColumnLetter(startColumn)}{startRow}",
                             Row = startRow,
                             Column = startColumn,
+                            Formula = formula.StartsWith('=') ? formula : null,
                             CurrentValue = cellValue,
                             ErrorCode = errorCode,
-                            ErrorMessage = MapErrorCodeToMessage(errorCode),
-                            Suggestion = MapErrorCodeToSuggestion(errorCode)
+                            ErrorMessage = ExcelErrorMapper.GetMessage(errorCode),
+                            Suggestion = ExcelErrorMapper.GetSuggestion(errorCode)
                         });
                     }
                 }
@@ -135,32 +137,6 @@ public partial class RangeCommands
     /// Internal (not private) so sibling feature areas (e.g. PythonInExcel) can reuse the same
     /// mapping table instead of duplicating it - see Bug Fix Pattern Search rule.
     /// </summary>
-    internal static string MapErrorCodeToMessage(int errorCode) =>
-        errorCode switch
-        {
-            -2146826288 => "#NULL! - Invalid intersection of ranges",
-            -2147483648 => "#DIV/0! - Division by zero",
-            -2146826259 => "#VALUE! - Wrong type of argument",
-            -2146826246 => "#REF! - Invalid cell reference",
-            -2146826252 => "#NUM! - Invalid numeric value",
-            -2142019887 => "#N/A - Value not available",
-            -2146826233 => "#PYTHON! - Python code raised an error (syntax or runtime exception)",
-            _ => $"#ERROR! - Unknown error code {errorCode}"
-        };
-
-    private static string MapErrorCodeToSuggestion(int errorCode) =>
-        errorCode switch
-        {
-            -2146826288 => "Check the intersection operator and referenced ranges.",
-            -2147483648 => "Ensure the formula does not divide by zero.",
-            -2146826259 => "Check function names and argument types.",
-            -2146826246 => "Check that referenced cells and ranges still exist.",
-            -2146826252 => "Check numeric inputs and supported value ranges.",
-            -2142019887 => "Check that the lookup value and source data are available.",
-            -2146826233 => "Check the Python formula syntax and runtime inputs.",
-            _ => "Check the formula syntax and referenced values."
-        };
-
     /// <inheritdoc />
     public OperationResult SetFormulas(IExcelBatch batch, string sheetName, string rangeAddress, List<List<string>>? formulas = null, string? formulasFile = null)
     {
@@ -245,4 +221,3 @@ public partial class RangeCommands
         });
     }
 }
-

--- a/src/ExcelMcp.Core/Commands/Range/RangeCommands.ScopedAnalytics.cs
+++ b/src/ExcelMcp.Core/Commands/Range/RangeCommands.ScopedAnalytics.cs
@@ -1,0 +1,804 @@
+using System.Runtime.InteropServices;
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Models;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Commands.Range;
+
+/// <summary>
+/// Bounded range sampling, summaries, and sparse formula error diagnostics.
+/// </summary>
+public partial class RangeCommands
+{
+    private const int MaxSampleRowsPerBoundary = 100;
+    private const int MaxSampleCells = 1000;
+    private const int MaxSummaryColumns = 256;
+    private const int MaxFormulaErrors = 1000;
+    private const int MaxSpecialCellsChunkSize = 4096;
+    private const int NoCellsFoundHResult = unchecked((int)0x800A03EC);
+
+    /// <inheritdoc />
+    public RangeSampleResult SampleValues(
+        IExcelBatch batch,
+        string sheetName,
+        string rangeAddress,
+        int firstRowCount = 5,
+        int lastRowCount = 5,
+        string? columns = null)
+    {
+        ValidateSampleCount(firstRowCount, nameof(firstRowCount));
+        ValidateSampleCount(lastRowCount, nameof(lastRowCount));
+        if (firstRowCount == 0 && lastRowCount == 0)
+        {
+            throw new ArgumentException(
+                "At least one of firstRowCount or lastRowCount must be greater than zero.",
+                nameof(firstRowCount));
+        }
+
+        var selectedColumns = ParseSelectedColumns(columns);
+        var result = new RangeSampleResult
+        {
+            FilePath = batch.WorkbookPath,
+            SheetName = sheetName,
+            RangeAddress = rangeAddress,
+            FirstRowCount = firstRowCount,
+            LastRowCount = lastRowCount,
+            SelectedColumns = selectedColumns?.Select(column => column.Name).ToList()
+        };
+
+        return batch.Execute((ctx, ct) =>
+        {
+            Excel.Range? range = null;
+            Excel.Range? rows = null;
+            Excel.Range? rangeColumns = null;
+            Excel.Areas? areas = null;
+            try
+            {
+                range = ResolveSingleAreaRange(ctx.Book, sheetName, rangeAddress, "Sampling", out areas);
+                result.RangeAddress = range.Address;
+                rows = range.Rows;
+                rangeColumns = range.Columns;
+                result.TotalRowCount = Convert.ToInt32(rows.Count);
+                result.TotalColumnCount = Convert.ToInt32(rangeColumns.Count);
+
+                int sourceStartColumn = Convert.ToInt32(range.Column);
+                int sourceStartRow = Convert.ToInt32(range.Row);
+                var resolvedColumns = ResolveSelectedColumns(
+                    selectedColumns,
+                    sourceStartColumn,
+                    result.TotalColumnCount);
+                result.ColumnCount = resolvedColumns?.Count ?? result.TotalColumnCount;
+
+                int firstCount = Math.Min(firstRowCount, result.TotalRowCount);
+                int lastStart = Math.Max(firstCount, result.TotalRowCount - lastRowCount);
+                int returnedRowCount = firstCount + result.TotalRowCount - lastStart;
+                if ((long)returnedRowCount * result.ColumnCount > MaxSampleCells)
+                {
+                    throw new ArgumentException(
+                        $"The sample would return more than {MaxSampleCells} cells. Reduce the row counts or select fewer columns.",
+                        nameof(columns));
+                }
+
+                var rowOffsets = Enumerable.Range(0, firstCount)
+                    .Concat(Enumerable.Range(lastStart, result.TotalRowCount - lastStart));
+                foreach (int rowOffset in rowOffsets)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var values = ReadSampleRow(
+                        range,
+                        rowOffset,
+                        resolvedColumns,
+                        result.TotalColumnCount);
+                    int rowNumber = sourceStartRow + rowOffset;
+                    result.Rows.Add(new RangeSampleRow
+                    {
+                        RowOffset = rowOffset,
+                        RowNumber = rowNumber,
+                        RangeAddress = BuildSampleRowAddress(
+                            rowNumber,
+                            sourceStartColumn,
+                            result.TotalColumnCount,
+                            resolvedColumns),
+                        Values = values
+                    });
+                }
+
+                result.Success = true;
+                return result;
+            }
+            finally
+            {
+                ComUtilities.Release(ref areas);
+                ComUtilities.Release(ref rangeColumns);
+                ComUtilities.Release(ref rows);
+                ComUtilities.Release(ref range);
+            }
+        });
+    }
+
+    /// <inheritdoc />
+    public RangeSummaryResult SummarizeValues(
+        IExcelBatch batch,
+        string sheetName,
+        string rangeAddress,
+        string? columns = null)
+    {
+        var selectedColumns = ParseSelectedColumns(columns);
+        if (selectedColumns?.Count > MaxSummaryColumns)
+        {
+            throw new ArgumentException(
+                $"At most {MaxSummaryColumns} columns can be summarized.",
+                nameof(columns));
+        }
+
+        var result = new RangeSummaryResult
+        {
+            FilePath = batch.WorkbookPath,
+            SheetName = sheetName,
+            RangeAddress = rangeAddress,
+            SelectedColumns = selectedColumns?.Select(column => column.Name).ToList()
+        };
+
+        return batch.Execute((ctx, ct) =>
+        {
+            Excel.Range? range = null;
+            Excel.Range? rows = null;
+            Excel.Range? rangeColumns = null;
+            Excel.Areas? areas = null;
+            Excel.WorksheetFunction? worksheetFunction = null;
+            try
+            {
+                range = ResolveSingleAreaRange(ctx.Book, sheetName, rangeAddress, "Summaries", out areas);
+                result.RangeAddress = range.Address;
+                rows = range.Rows;
+                rangeColumns = range.Columns;
+                result.TotalRowCount = Convert.ToInt32(rows.Count);
+                result.TotalColumnCount = Convert.ToInt32(rangeColumns.Count);
+
+                int sourceStartColumn = Convert.ToInt32(range.Column);
+                var resolvedColumns = ResolveSelectedColumns(
+                    selectedColumns,
+                    sourceStartColumn,
+                    result.TotalColumnCount);
+                int returnedColumnCount = resolvedColumns?.Count ?? result.TotalColumnCount;
+                if (returnedColumnCount > MaxSummaryColumns)
+                {
+                    throw new ArgumentException(
+                        $"The source has {returnedColumnCount} columns. Select at most {MaxSummaryColumns} columns.",
+                        nameof(columns));
+                }
+
+                worksheetFunction = ctx.App.WorksheetFunction;
+                for (int index = 0; index < returnedColumnCount; index++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    int relativeColumn = resolvedColumns?[index].RelativeIndex ?? index + 1;
+                    int absoluteColumn = sourceStartColumn + relativeColumn - 1;
+                    Excel.Range? cells = null;
+                    Excel.Range? firstCell = null;
+                    Excel.Range? columnRange = null;
+                    try
+                    {
+                        cells = range.Cells;
+                        firstCell = cells[1, relativeColumn];
+                        columnRange = firstCell.Resize[result.TotalRowCount, 1];
+                        result.Columns.Add(SummarizeColumn(
+                            columnRange,
+                            worksheetFunction,
+                            absoluteColumn,
+                            ct));
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref columnRange);
+                        ComUtilities.Release(ref firstCell);
+                        ComUtilities.Release(ref cells);
+                    }
+                }
+
+                result.Success = true;
+                return result;
+            }
+            finally
+            {
+                ComUtilities.Release(ref worksheetFunction);
+                ComUtilities.Release(ref areas);
+                ComUtilities.Release(ref rangeColumns);
+                ComUtilities.Release(ref rows);
+                ComUtilities.Release(ref range);
+            }
+        });
+    }
+
+    /// <inheritdoc />
+    public RangeFormulaErrorResult GetFormulaErrors(
+        IExcelBatch batch,
+        string sheetName,
+        string rangeAddress,
+        int maxErrors = 100)
+    {
+        if (maxErrors is < 1 or > MaxFormulaErrors)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxErrors),
+                maxErrors,
+                $"Maximum errors must be between 1 and {MaxFormulaErrors}.");
+        }
+
+        var result = new RangeFormulaErrorResult
+        {
+            FilePath = batch.WorkbookPath,
+            SheetName = sheetName,
+            RangeAddress = rangeAddress,
+            MaxErrors = maxErrors
+        };
+
+        return batch.Execute((ctx, ct) =>
+        {
+            Excel.Range? range = null;
+            Excel.Areas? sourceAreas = null;
+            var orderedSourceAreas = new List<(int Index, int Row, int Column)>();
+            try
+            {
+                range = RangeHelpers.ResolveRange(ctx.Book, sheetName, rangeAddress, out string? specificError);
+                if (range == null)
+                {
+                    throw new InvalidOperationException(
+                        specificError ?? RangeHelpers.GetResolveError(sheetName, rangeAddress));
+                }
+
+                result.RangeAddress = range.Address;
+                sourceAreas = range.Areas;
+                int sourceAreaCount = Convert.ToInt32(sourceAreas.Count);
+                for (int sourceAreaIndex = 1; sourceAreaIndex <= sourceAreaCount; sourceAreaIndex++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    Excel.Range? sourceArea = null;
+                    try
+                    {
+                        sourceArea = sourceAreas[sourceAreaIndex];
+                        orderedSourceAreas.Add((
+                            sourceAreaIndex,
+                            Convert.ToInt32(sourceArea.Row),
+                            Convert.ToInt32(sourceArea.Column)));
+                        result.TotalErrorCount += CountFormulaErrors(sourceArea, ct);
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref sourceArea);
+                    }
+                }
+
+                foreach (var sourceAreaOrder in orderedSourceAreas
+                             .OrderBy(area => area.Row)
+                             .ThenBy(area => area.Column))
+                {
+                    if (result.Errors.Count >= maxErrors)
+                    {
+                        break;
+                    }
+
+                    ct.ThrowIfCancellationRequested();
+                    Excel.Range? sourceArea = null;
+                    try
+                    {
+                        sourceArea = sourceAreas[sourceAreaOrder.Index];
+                        AppendFormulaErrors(sourceArea, result.Errors, maxErrors, ct);
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref sourceArea);
+                    }
+                }
+
+                result.ReturnedErrorCount = result.Errors.Count;
+                result.IsTruncated = result.ReturnedErrorCount < result.TotalErrorCount;
+                result.Success = true;
+                return result;
+            }
+            finally
+            {
+                ComUtilities.Release(ref sourceAreas);
+                ComUtilities.Release(ref range);
+            }
+        });
+    }
+
+    private static void ValidateSampleCount(int count, string parameterName)
+    {
+        if (count is < 0 or > MaxSampleRowsPerBoundary)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                count,
+                $"Sample row counts must be between 0 and {MaxSampleRowsPerBoundary}.");
+        }
+    }
+
+    private static Excel.Range ResolveSingleAreaRange(
+        Excel.Workbook workbook,
+        string sheetName,
+        string rangeAddress,
+        string operation,
+        out Excel.Areas areas)
+    {
+        Excel.Range? range = RangeHelpers.ResolveRange(
+            workbook,
+            sheetName,
+            rangeAddress,
+            out string? specificError);
+        if (range == null)
+        {
+            throw new InvalidOperationException(
+                specificError ?? RangeHelpers.GetResolveError(sheetName, rangeAddress));
+        }
+
+        try
+        {
+            areas = range.Areas;
+            if (Convert.ToInt32(areas.Count) != 1)
+            {
+                throw new ArgumentException(
+                    $"{operation} do not support multi-area ranges. Read each area separately.",
+                    nameof(rangeAddress));
+            }
+
+            return range;
+        }
+        catch
+        {
+            ComUtilities.Release(ref range);
+            throw;
+        }
+    }
+
+    private static List<object?> ReadSampleRow(
+        Excel.Range range,
+        int rowOffset,
+        List<(string Name, int RelativeIndex)>? resolvedColumns,
+        int totalColumnCount)
+    {
+        if (resolvedColumns == null)
+        {
+            var values = new List<List<object?>>(1);
+            ReadRectangularSlice(range, rowOffset, 1, 1, totalColumnCount, values);
+            return values[0];
+        }
+
+        var selectedValues = new List<object?>(resolvedColumns.Count);
+        foreach (var selectedColumn in resolvedColumns)
+        {
+            var values = new List<List<object?>>(1);
+            ReadRectangularSlice(range, rowOffset, selectedColumn.RelativeIndex, 1, 1, values);
+            selectedValues.Add(values[0][0]);
+        }
+
+        return selectedValues;
+    }
+
+    private static string BuildSampleRowAddress(
+        int rowNumber,
+        int sourceStartColumn,
+        int totalColumnCount,
+        List<(string Name, int RelativeIndex)>? resolvedColumns)
+    {
+        if (resolvedColumns != null)
+        {
+            return string.Join(",", resolvedColumns.Select(column => $"${column.Name}${rowNumber}"));
+        }
+
+        string firstColumn = RangeHelpers.GetColumnLetter(sourceStartColumn);
+        string lastColumn = RangeHelpers.GetColumnLetter(sourceStartColumn + totalColumnCount - 1);
+        return totalColumnCount == 1
+            ? $"${firstColumn}${rowNumber}"
+            : $"${firstColumn}${rowNumber}:${lastColumn}${rowNumber}";
+    }
+
+    private static RangeColumnSummary SummarizeColumn(
+        Excel.Range columnRange,
+        Excel.WorksheetFunction worksheetFunction,
+        int absoluteColumn,
+        CancellationToken cancellationToken)
+    {
+        long cellCount = Convert.ToInt64(columnRange.CountLarge);
+        var summary = new RangeColumnSummary
+        {
+            Column = RangeHelpers.GetColumnLetter(absoluteColumn),
+            ColumnNumber = absoluteColumn,
+            RangeAddress = columnRange.Address,
+            CellCount = cellCount
+        };
+
+        var numeric = new NumericSummaryAccumulator();
+        ForEachRangeChunk(columnRange, cancellationToken, chunk =>
+        {
+            if (Convert.ToInt64(chunk.CountLarge) == 1)
+            {
+                AccumulateSingleCellSummary(chunk.Value2, summary, numeric);
+            }
+            else
+            {
+                summary.NumericCount += AccumulateSpecialCells(
+                    chunk,
+                    Excel.XlSpecialCellsValue.xlNumbers,
+                    worksheetFunction,
+                    numeric);
+                summary.TextCount += CountSpecialCells(
+                    chunk,
+                    Excel.XlSpecialCellsValue.xlTextValues);
+                summary.LogicalCount += CountSpecialCells(
+                    chunk,
+                    Excel.XlSpecialCellsValue.xlLogical);
+                summary.ErrorCount += CountSpecialCells(
+                    chunk,
+                    Excel.XlSpecialCellsValue.xlErrors);
+            }
+
+            return true;
+        });
+        summary.BlankCount = cellCount -
+            summary.NumericCount -
+            summary.TextCount -
+            summary.LogicalCount -
+            summary.ErrorCount;
+
+        if (summary.NumericCount > 0)
+        {
+            summary.Sum = numeric.Sum;
+            summary.Average = numeric.Sum / summary.NumericCount;
+            summary.Minimum = numeric.Minimum;
+            summary.Maximum = numeric.Maximum;
+        }
+
+        return summary;
+    }
+
+    private static void AccumulateSingleCellSummary(
+        object? value,
+        RangeColumnSummary summary,
+        NumericSummaryAccumulator numeric)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        if (ExcelErrorMapper.TryGetErrorCode(value, out _))
+        {
+            summary.ErrorCount++;
+        }
+        else if (value is bool)
+        {
+            summary.LogicalCount++;
+        }
+        else if (value is string)
+        {
+            summary.TextCount++;
+        }
+        else if (value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal)
+        {
+            double number = Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture);
+            summary.NumericCount++;
+            numeric.Add(number, number, number);
+        }
+        else
+        {
+            summary.TextCount++;
+        }
+    }
+
+    private static long CountSpecialCells(
+        Excel.Range source,
+        Excel.XlSpecialCellsValue valueType)
+    {
+        long count = 0;
+        foreach (Excel.XlCellType cellType in new[]
+                 {
+                     Excel.XlCellType.xlCellTypeConstants,
+                     Excel.XlCellType.xlCellTypeFormulas
+                 })
+        {
+            Excel.Range? cells = null;
+            try
+            {
+                cells = TryGetSpecialCells(source, cellType, valueType);
+                if (cells != null)
+                {
+                    count += Convert.ToInt64(cells.CountLarge);
+                }
+            }
+            finally
+            {
+                ComUtilities.Release(ref cells);
+            }
+        }
+
+        return count;
+    }
+
+    private static long AccumulateSpecialCells(
+        Excel.Range source,
+        Excel.XlSpecialCellsValue valueType,
+        Excel.WorksheetFunction worksheetFunction,
+        NumericSummaryAccumulator accumulator)
+    {
+        long count = 0;
+        foreach (Excel.XlCellType cellType in new[]
+                 {
+                     Excel.XlCellType.xlCellTypeConstants,
+                     Excel.XlCellType.xlCellTypeFormulas
+                 })
+        {
+            Excel.Range? cells = null;
+            try
+            {
+                cells = TryGetSpecialCells(source, cellType, valueType);
+                if (cells == null)
+                {
+                    continue;
+                }
+
+                long subsetCount = Convert.ToInt64(cells.CountLarge);
+                count += subsetCount;
+                accumulator.Add(
+                    Convert.ToDouble(worksheetFunction.Sum(cells)),
+                    Convert.ToDouble(worksheetFunction.Min(cells)),
+                    Convert.ToDouble(worksheetFunction.Max(cells)));
+            }
+            finally
+            {
+                ComUtilities.Release(ref cells);
+            }
+        }
+
+        return count;
+    }
+
+    private static Excel.Range? TryGetSpecialCells(
+        Excel.Range source,
+        Excel.XlCellType cellType,
+        Excel.XlSpecialCellsValue valueType)
+    {
+        try
+        {
+            return source.SpecialCells(cellType, valueType);
+        }
+        catch (COMException exception) when (exception.HResult == NoCellsFoundHResult)
+        {
+            return null;
+        }
+    }
+
+    private static long CountFormulaErrors(
+        Excel.Range sourceArea,
+        CancellationToken cancellationToken)
+    {
+        long count = 0;
+        ForEachRangeChunk(sourceArea, cancellationToken, chunk =>
+        {
+            if (Convert.ToInt64(chunk.CountLarge) == 1)
+            {
+                object? value = chunk.Value2;
+                string formula = chunk.Formula2?.ToString() ?? string.Empty;
+                if (formula.StartsWith('=') &&
+                    ExcelErrorMapper.TryGetErrorCode(value, out _))
+                {
+                    count++;
+                }
+            }
+            else
+            {
+                Excel.Range? formulaErrors = null;
+                try
+                {
+                    formulaErrors = TryGetSpecialCells(
+                        chunk,
+                        Excel.XlCellType.xlCellTypeFormulas,
+                        Excel.XlSpecialCellsValue.xlErrors);
+                    if (formulaErrors != null)
+                    {
+                        count += Convert.ToInt64(formulaErrors.CountLarge);
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref formulaErrors);
+                }
+            }
+
+            return true;
+        });
+        return count;
+    }
+
+    private static void AppendFormulaErrors(
+        Excel.Range sourceArea,
+        List<RangeCellError> destination,
+        int maxErrors,
+        CancellationToken cancellationToken)
+    {
+        ForEachRangeChunk(sourceArea, cancellationToken, chunk =>
+        {
+            if (Convert.ToInt64(chunk.CountLarge) == 1)
+            {
+                if (TryCreateFormulaError(chunk, out var error))
+                {
+                    destination.Add(error);
+                }
+            }
+            else
+            {
+                Excel.Range? formulaErrors = null;
+                Excel.Areas? errorAreas = null;
+                try
+                {
+                    formulaErrors = TryGetSpecialCells(
+                        chunk,
+                        Excel.XlCellType.xlCellTypeFormulas,
+                        Excel.XlSpecialCellsValue.xlErrors);
+                    if (formulaErrors == null)
+                    {
+                        return destination.Count < maxErrors;
+                    }
+
+                    errorAreas = formulaErrors.Areas;
+                    int errorAreaCount = Convert.ToInt32(errorAreas.Count);
+                    for (int areaIndex = 1;
+                         areaIndex <= errorAreaCount && destination.Count < maxErrors;
+                         areaIndex++)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        Excel.Range? errorArea = null;
+                        Excel.Range? cells = null;
+                        try
+                        {
+                            errorArea = errorAreas[areaIndex];
+                            cells = errorArea.Cells;
+                            long cellCount = Convert.ToInt64(cells.CountLarge);
+                            long cellsToRead = Math.Min(cellCount, maxErrors - destination.Count);
+                            for (long cellIndex = 1; cellIndex <= cellsToRead; cellIndex++)
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                Excel.Range? cell = null;
+                                try
+                                {
+                                    cell = cells[cellIndex];
+                                    if (TryCreateFormulaError(cell, out var error))
+                                    {
+                                        destination.Add(error);
+                                    }
+                                }
+                                finally
+                                {
+                                    ComUtilities.Release(ref cell);
+                                }
+                            }
+                        }
+                        finally
+                        {
+                            ComUtilities.Release(ref cells);
+                            ComUtilities.Release(ref errorArea);
+                        }
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref errorAreas);
+                    ComUtilities.Release(ref formulaErrors);
+                }
+            }
+
+            return destination.Count < maxErrors;
+        });
+    }
+
+    private static bool TryCreateFormulaError(
+        Excel.Range cell,
+        out RangeCellError error)
+    {
+        object? value = cell.Value2;
+        string formula = cell.Formula2?.ToString() ?? string.Empty;
+        if (!formula.StartsWith('=') ||
+            !ExcelErrorMapper.TryGetErrorCode(value, out int errorCode))
+        {
+            error = null!;
+            return false;
+        }
+
+        error = new RangeCellError
+        {
+            CellAddress = cell.Address[RowAbsolute: false, ColumnAbsolute: false],
+            Row = Convert.ToInt32(cell.Row),
+            Column = Convert.ToInt32(cell.Column),
+            Formula = formula,
+            CurrentValue = value,
+            ErrorCode = errorCode,
+            ErrorMessage = ExcelErrorMapper.GetMessage(errorCode),
+            Suggestion = ExcelErrorMapper.GetSuggestion(errorCode)
+        };
+        return true;
+    }
+
+    private static void ForEachRangeChunk(
+        Excel.Range source,
+        CancellationToken cancellationToken,
+        Func<Excel.Range, bool> visitor)
+    {
+        Excel.Range? rows = null;
+        Excel.Range? columns = null;
+        Excel.Range? cells = null;
+        try
+        {
+            rows = source.Rows;
+            columns = source.Columns;
+            cells = source.Cells;
+            int totalRows = Convert.ToInt32(rows.Count);
+            int totalColumns = Convert.ToInt32(columns.Count);
+            int columnChunkSize = Math.Min(totalColumns, MaxSpecialCellsChunkSize);
+            int rowChunkSize = Math.Max(1, MaxSpecialCellsChunkSize / columnChunkSize);
+
+            for (int rowStart = 1; rowStart <= totalRows; rowStart += rowChunkSize)
+            {
+                int rowsInChunk = Math.Min(rowChunkSize, totalRows - rowStart + 1);
+                for (int columnStart = 1;
+                     columnStart <= totalColumns;
+                     columnStart += columnChunkSize)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    int columnsInChunk = Math.Min(
+                        columnChunkSize,
+                        totalColumns - columnStart + 1);
+                    Excel.Range? firstCell = null;
+                    Excel.Range? chunk = null;
+                    try
+                    {
+                        firstCell = cells[rowStart, columnStart];
+                        if (rowsInChunk == 1 && columnsInChunk == 1)
+                        {
+                            chunk = firstCell;
+                            firstCell = null;
+                        }
+                        else
+                        {
+                            chunk = firstCell.Resize[rowsInChunk, columnsInChunk];
+                        }
+
+                        if (!visitor(chunk))
+                        {
+                            return;
+                        }
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref chunk);
+                        ComUtilities.Release(ref firstCell);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref cells);
+            ComUtilities.Release(ref columns);
+            ComUtilities.Release(ref rows);
+        }
+    }
+
+    private sealed class NumericSummaryAccumulator
+    {
+        internal double Sum { get; private set; }
+
+        internal double? Minimum { get; private set; }
+
+        internal double? Maximum { get; private set; }
+
+        internal void Add(double sum, double minimum, double maximum)
+        {
+            Sum += sum;
+            Minimum = Minimum.HasValue ? Math.Min(Minimum.Value, minimum) : minimum;
+            Maximum = Maximum.HasValue ? Math.Max(Maximum.Value, maximum) : maximum;
+        }
+    }
+
+}

--- a/src/ExcelMcp.Core/Models/RangeColumnSummary.cs
+++ b/src/ExcelMcp.Core/Models/RangeColumnSummary.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Type counts and numeric statistics for one worksheet column.
+/// </summary>
+public sealed class RangeColumnSummary
+{
+    /// <summary>Absolute worksheet column letters.</summary>
+    public string Column { get; set; } = string.Empty;
+
+    /// <summary>One-based absolute worksheet column number.</summary>
+    public int ColumnNumber { get; set; }
+
+    /// <summary>Resolved source address summarized for this column.</summary>
+    public string RangeAddress { get; set; } = string.Empty;
+
+    /// <summary>Total cells in the summarized column range.</summary>
+    public long CellCount { get; set; }
+
+    /// <summary>Cells with neither a constant nor a formula.</summary>
+    public long BlankCount { get; set; }
+
+    /// <summary>Numeric cells, including Excel date serial values.</summary>
+    public long NumericCount { get; set; }
+
+    /// <summary>Text cells, including formulas returning text.</summary>
+    public long TextCount { get; set; }
+
+    /// <summary>Boolean cells.</summary>
+    public long LogicalCount { get; set; }
+
+    /// <summary>Constant or formula cells containing Excel errors.</summary>
+    public long ErrorCount { get; set; }
+
+    /// <summary>Sum of numeric cells, or null when no numeric cells exist.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Sum { get; set; }
+
+    /// <summary>Average of numeric cells, or null when no numeric cells exist.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Average { get; set; }
+
+    /// <summary>Minimum numeric value, or null when no numeric cells exist.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Minimum { get; set; }
+
+    /// <summary>Maximum numeric value, or null when no numeric cells exist.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Maximum { get; set; }
+}

--- a/src/ExcelMcp.Core/Models/RangeFormulaErrorResult.cs
+++ b/src/ExcelMcp.Core/Models/RangeFormulaErrorResult.cs
@@ -1,0 +1,28 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Sparse diagnostics for formula cells whose calculated values are Excel errors.
+/// </summary>
+public sealed class RangeFormulaErrorResult : ResultBase
+{
+    /// <summary>Worksheet containing the source range.</summary>
+    public string SheetName { get; set; } = string.Empty;
+
+    /// <summary>Resolved source range address.</summary>
+    public string RangeAddress { get; set; } = string.Empty;
+
+    /// <summary>Total formula error cells found in the source range.</summary>
+    public long TotalErrorCount { get; set; }
+
+    /// <summary>Number of diagnostics returned.</summary>
+    public int ReturnedErrorCount { get; set; }
+
+    /// <summary>Maximum diagnostics requested by the caller.</summary>
+    public int MaxErrors { get; set; }
+
+    /// <summary>Whether additional formula errors were omitted.</summary>
+    public bool IsTruncated { get; set; }
+
+    /// <summary>Sparse formula error diagnostics in deterministic worksheet order.</summary>
+    public List<RangeCellError> Errors { get; set; } = [];
+}

--- a/src/ExcelMcp.Core/Models/RangeSampleResult.cs
+++ b/src/ExcelMcp.Core/Models/RangeSampleResult.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result for deterministic first/last row sampling.
+/// </summary>
+public sealed class RangeSampleResult : ResultBase
+{
+    /// <summary>Worksheet containing the source range.</summary>
+    public string SheetName { get; set; } = string.Empty;
+
+    /// <summary>Resolved source range address.</summary>
+    public string RangeAddress { get; set; } = string.Empty;
+
+    /// <summary>Total rows in the source range.</summary>
+    public int TotalRowCount { get; set; }
+
+    /// <summary>Total columns in the source range.</summary>
+    public int TotalColumnCount { get; set; }
+
+    /// <summary>Requested number of leading rows.</summary>
+    public int FirstRowCount { get; set; }
+
+    /// <summary>Requested number of trailing rows.</summary>
+    public int LastRowCount { get; set; }
+
+    /// <summary>Number of values returned for each sampled row.</summary>
+    public int ColumnCount { get; set; }
+
+    /// <summary>Selected worksheet columns in return order, or null when all columns are returned.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? SelectedColumns { get; set; }
+
+    /// <summary>Sampled rows in ascending source order without overlap duplicates.</summary>
+    public List<RangeSampleRow> Rows { get; set; } = [];
+}

--- a/src/ExcelMcp.Core/Models/RangeSampleRow.cs
+++ b/src/ExcelMcp.Core/Models/RangeSampleRow.cs
@@ -1,0 +1,19 @@
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// A sampled source row with relative and absolute coordinates.
+/// </summary>
+public sealed class RangeSampleRow
+{
+    /// <summary>Zero-based row offset within the source range.</summary>
+    public int RowOffset { get; set; }
+
+    /// <summary>One-based absolute worksheet row number.</summary>
+    public int RowNumber { get; set; }
+
+    /// <summary>Absolute address of the returned cells in this row.</summary>
+    public string RangeAddress { get; set; } = string.Empty;
+
+    /// <summary>Cell values in selected column order.</summary>
+    public List<object?> Values { get; set; } = [];
+}

--- a/src/ExcelMcp.Core/Models/RangeSummaryResult.cs
+++ b/src/ExcelMcp.Core/Models/RangeSummaryResult.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.ExcelMcp.Core.Models;
+
+/// <summary>
+/// Result for per-column range summary statistics.
+/// </summary>
+public sealed class RangeSummaryResult : ResultBase
+{
+    /// <summary>Worksheet containing the source range.</summary>
+    public string SheetName { get; set; } = string.Empty;
+
+    /// <summary>Resolved source range address.</summary>
+    public string RangeAddress { get; set; } = string.Empty;
+
+    /// <summary>Total rows in the source range.</summary>
+    public int TotalRowCount { get; set; }
+
+    /// <summary>Total columns in the source range.</summary>
+    public int TotalColumnCount { get; set; }
+
+    /// <summary>Selected worksheet columns in return order, or null when all columns are summarized.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? SelectedColumns { get; set; }
+
+    /// <summary>Per-column statistics in requested order.</summary>
+    public List<RangeColumnSummary> Columns { get; set; } = [];
+}

--- a/src/ExcelMcp.Core/Models/ResultTypes.cs
+++ b/src/ExcelMcp.Core/Models/ResultTypes.cs
@@ -1155,6 +1155,12 @@ public class RangeCellError
     public int Column { get; set; }
 
     /// <summary>
+    /// Formula text that produced the error
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Formula { get; set; }
+
+    /// <summary>
     /// Current cell value displayed (often the error code like #NAME?)
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/ExcelMcp.McpServer/README.md
+++ b/src/ExcelMcp.McpServer/README.md
@@ -63,9 +63,9 @@ dotnet tool install --global Sbroenne.ExcelMcp.McpServer
 
 ## 🛠️ What You Can Do
 
-**31 specialized tools with 325 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
+**31 specialized tools with 328 operations** covering Power Query, Data Model/DAX, What-If Analysis, PivotTables, Excel Tables, Charts, Drawings, VBA, Ranges, Worksheets, Workbooks, QueryTables, XML Maps, Connections, Named Ranges, File/Session management, Calculation Mode, Slicers, Conditional Formatting, Screenshots, and Window Management.
 
-📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 325 operations, grouped by category
+📚 **[Complete Feature Reference →](https://github.com/sbroenne/mcp-server-excel/blob/main/FEATURES.md)** - Detailed documentation of all 328 operations, grouped by category
 
 **AI-Powered Workflows:**
 - 💬 Natural language Excel commands through GitHub Copilot, Claude, or ChatGPT

--- a/tests/ExcelMcp.CLI.Tests/Integration/RangeScopedReadCliTests.cs
+++ b/tests/ExcelMcp.CLI.Tests/Integration/RangeScopedReadCliTests.cs
@@ -84,6 +84,124 @@ public sealed class RangeScopedReadCliTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task ScopedAnalytics_ReturnTypedBoundedResultsThroughCli()
+    {
+        Sbroenne.ExcelMcp.ComInterop.Session.ExcelSession.CreateNew(
+            _testFile,
+            isMacroEnabled: false,
+            (ctx, ct) => 0,
+            CancellationToken.None);
+
+        var (openResult, openJson) = await CliProcessHelper.RunJsonAsync(
+            ["session", "open", _testFile],
+            timeoutMs: 60000);
+        Assert.Equal(0, openResult.ExitCode);
+        var sessionId = openJson.RootElement.GetProperty("sessionId").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(sessionId));
+
+        try
+        {
+            var (valuesResult, valuesJson) = await CliProcessHelper.RunJsonAsync(
+                [
+                    "range", "set-values",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "B2:C4",
+                    "--values", """[[1,10],[2,20],[3,30]]"""
+                ],
+                timeoutMs: 60000);
+            using (valuesJson)
+            {
+                Assert.Equal(0, valuesResult.ExitCode);
+                Assert.True(valuesJson.RootElement.GetProperty("success").GetBoolean(), valuesResult.Stdout);
+            }
+
+            var (formulaResult, formulaJson) = await CliProcessHelper.RunJsonAsync(
+                [
+                    "range", "set-formulas",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "D2:D3",
+                    "--formulas", """[["=1/0"],["=NA()"]]"""
+                ],
+                timeoutMs: 60000);
+            using (formulaJson)
+            {
+                Assert.Equal(0, formulaResult.ExitCode);
+                Assert.True(formulaJson.RootElement.GetProperty("success").GetBoolean(), formulaResult.Stdout);
+            }
+
+            var (sampleResult, sampleJson) = await CliProcessHelper.RunJsonAsync(
+                [
+                    "range", "sample-values",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "B2:C4",
+                    "--first-row-count", "1",
+                    "--last-row-count", "1",
+                    "--columns", "C"
+                ],
+                timeoutMs: 60000);
+            using (sampleJson)
+            {
+                Assert.Equal(0, sampleResult.ExitCode);
+                var root = sampleJson.RootElement;
+                Assert.True(root.GetProperty("success").GetBoolean(), sampleResult.Stdout);
+                Assert.Equal([0, 2], root.GetProperty("rows").EnumerateArray()
+                    .Select(row => row.GetProperty("rowOffset").GetInt32()));
+                Assert.Equal(10, root.GetProperty("rows")[0].GetProperty("values")[0].GetDouble());
+                Assert.Equal("$C$4", root.GetProperty("rows")[1].GetProperty("rangeAddress").GetString());
+            }
+
+            var (summaryResult, summaryJson) = await CliProcessHelper.RunJsonAsync(
+                [
+                    "range", "summarize-values",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "B2:C4",
+                    "--columns", "B"
+                ],
+                timeoutMs: 60000);
+            using (summaryJson)
+            {
+                Assert.Equal(0, summaryResult.ExitCode);
+                var root = summaryJson.RootElement;
+                Assert.True(root.GetProperty("success").GetBoolean(), summaryResult.Stdout);
+                Assert.Equal(3, root.GetProperty("columns")[0].GetProperty("numericCount").GetInt64());
+                Assert.Equal(6, root.GetProperty("columns")[0].GetProperty("sum").GetDouble());
+            }
+
+            var (errorsResult, errorsJson) = await CliProcessHelper.RunJsonAsync(
+                [
+                    "range", "get-formula-errors",
+                    "--session", sessionId!,
+                    "--sheet-name", "Sheet1",
+                    "--range-address", "B2:D4",
+                    "--max-errors", "1"
+                ],
+                timeoutMs: 60000);
+            using (errorsJson)
+            {
+                Assert.Equal(0, errorsResult.ExitCode);
+                var root = errorsJson.RootElement;
+                Assert.True(root.GetProperty("success").GetBoolean(), errorsResult.Stdout);
+                Assert.Equal(2, root.GetProperty("totalErrorCount").GetInt64());
+                Assert.Equal(1, root.GetProperty("returnedErrorCount").GetInt32());
+                Assert.True(root.GetProperty("isTruncated").GetBoolean());
+                Assert.Equal("D2", root.GetProperty("errors")[0].GetProperty("cellAddress").GetString());
+                Assert.False(root.TryGetProperty("values", out _));
+            }
+        }
+        finally
+        {
+            openJson.Dispose();
+            await CliProcessHelper.RunAsync(
+                ["session", "close", "--session", sessionId!, "--save", "false"],
+                timeoutMs: 60000);
+        }
+    }
+
     public void Dispose()
     {
         if (File.Exists(_testFile))

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.FormulaValidation.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.FormulaValidation.cs
@@ -178,7 +178,7 @@ public partial class RangeCommandsTests
         using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
         var sheetName = _fixture.CreateTestSheet(batch);
 
-        // Current Excel versions report an unsupported function as #VALUE!.
+        // Current Excel versions report an unsupported function as #NAME?.
         _commands.SetFormulas(batch, sheetName, "A1", [
             ["=UNDEFINEDFUNCTION()"]
         ]);
@@ -192,8 +192,8 @@ public partial class RangeCommandsTests
 
         var error = result.CellErrors[0];
         Assert.Equal("A1", error.CellAddress);
-        Assert.Equal(-2146826259, error.ErrorCode);  // #VALUE! error code
-        Assert.Contains("argument", error.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(-2146826259, error.ErrorCode);
+        Assert.Contains("#NAME?", error.ErrorMessage, StringComparison.Ordinal);
         Assert.NotNull(error.Suggestion);
     }
 

--- a/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.ScopedAnalytics.cs
+++ b/tests/ExcelMcp.Core.Tests/Integration/Commands/Range/RangeCommandsTests.ScopedAnalytics.cs
@@ -1,0 +1,387 @@
+using Sbroenne.ExcelMcp.ComInterop;
+using Sbroenne.ExcelMcp.ComInterop.Session;
+using Sbroenne.ExcelMcp.Core.Commands;
+using Xunit;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace Sbroenne.ExcelMcp.Core.Tests.Commands.Range;
+
+public partial class RangeCommandsTests
+{
+    [Fact]
+    public void SampleValues_ReturnsBoundaryRowsWithSourceCoordinates()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetValues(batch, sheetName, "B2:C6",
+        [
+            ["R1B", "R1C"],
+            ["R2B", "R2C"],
+            ["R3B", "R3C"],
+            ["R4B", "R4C"],
+            ["R5B", "R5C"]
+        ]);
+
+        var result = _commands.SampleValues(batch, sheetName, "B2:C6", 2, 1);
+
+        Assert.True(result.Success);
+        Assert.Equal(3, result.Rows.Count);
+        Assert.Equal(0, result.Rows[0].RowOffset);
+        Assert.Equal(2, result.Rows[0].RowNumber);
+        Assert.Equal(4, result.Rows[2].RowOffset);
+        Assert.Equal(6, result.Rows[2].RowNumber);
+        Assert.Equal("R5C", result.Rows[2].Values[1]);
+    }
+
+    [Fact]
+    public void SummarizeValues_ReturnsTypedCountsAndNumericStatistics()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetValues(batch, sheetName, "A1:A4", [[1], [3], ["text"], [true]]);
+        _commands.SetFormulas(batch, sheetName, "A6", [["=1/0"]]);
+
+        var result = _commands.SummarizeValues(batch, sheetName, "A1:A6");
+        var summary = result.Columns[0];
+
+        Assert.True(result.Success);
+        Assert.Equal(6L, summary.CellCount);
+        Assert.Equal(1L, summary.BlankCount);
+        Assert.Equal(2L, summary.NumericCount);
+        Assert.Equal(1L, summary.TextCount);
+        Assert.Equal(1L, summary.LogicalCount);
+        Assert.Equal(1L, summary.ErrorCount);
+        Assert.Equal(4d, summary.Sum);
+        Assert.Equal(2d, summary.Average);
+        Assert.Equal(1d, summary.Minimum);
+        Assert.Equal(3d, summary.Maximum);
+    }
+
+    [Fact]
+    public void GetFormulaErrors_ReturnsSparseBoundedDiagnostics()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetFormulas(batch, sheetName, "B2:B4", [["=1+1"], ["=1/0"], ["=NA()"]]);
+
+        var result = _commands.GetFormulaErrors(batch, sheetName, "B2:B4", 1);
+        var error = result.Errors[0];
+
+        Assert.True(result.Success);
+        Assert.Equal(2L, result.TotalErrorCount);
+        Assert.Equal(1, result.ReturnedErrorCount);
+        Assert.True(result.IsTruncated);
+        Assert.Equal("B3", error.CellAddress);
+        Assert.Equal("=1/0", error.Formula);
+        Assert.Contains("#DIV/0!", error.ErrorMessage, StringComparison.Ordinal);
+
+        var allErrors = _commands.GetFormulaErrors(batch, sheetName, "B2:B4");
+        Assert.Contains(allErrors.Errors, candidate =>
+            candidate.Formula == "=NA()" &&
+            candidate.ErrorMessage.Contains("#N/A", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GetFormulaErrors_WithSingleCell_DoesNotEscapeRequestedRange()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetFormulas(batch, sheetName, "A1", [["=1/0"]]);
+        _commands.SetFormulas(batch, sheetName, "B2", [["=1+1"]]);
+
+        var result = _commands.GetFormulaErrors(batch, sheetName, "B2");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(0, result.TotalErrorCount);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void GetFormulaErrors_ExcludesConstantErrorValues()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetFormulas(batch, sheetName, "C1", [["=1/0"]]);
+        _commands.CopyValues(batch, sheetName, "C1", sheetName, "D1");
+
+        var result = _commands.GetFormulaErrors(batch, sheetName, "C1:D1");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("C1", error.CellAddress);
+        Assert.Equal("=1/0", error.Formula);
+    }
+
+    [Fact]
+    public void SampleValues_WithNamedRangeAndSelectedColumns_DeduplicatesOverlap()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var name = $"Sample_{Guid.NewGuid():N}";
+        var namedRanges = new NamedRangeCommands();
+        namedRanges.Create(batch, name, $"{sheetName}!$C$3:$E$5");
+        try
+        {
+            _commands.SetValues(batch, sheetName, "C3:E5",
+            [
+                ["R1C", "R1D", "R1E"],
+                ["R2C", "R2D", "R2E"],
+                ["R3C", "R3D", "R3E"]
+            ]);
+
+            var result = _commands.SampleValues(batch, "", name, 2, 2, "E,C");
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(3, result.Rows.Count);
+            Assert.Equal(["E", "C"], result.SelectedColumns);
+            Assert.Equal([0, 1, 2], result.Rows.Select(row => row.RowOffset));
+            Assert.Equal(["R3E", "R3C"], result.Rows[2].Values);
+            Assert.Equal("$E$5,$C$5", result.Rows[2].RangeAddress);
+        }
+        finally
+        {
+            namedRanges.Delete(batch, name);
+        }
+    }
+
+    [Fact]
+    public void SummarizeValues_WithSelectedColumns_PreservesOrderAndNullNumericStatistics()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var name = $"Summary_{Guid.NewGuid():N}";
+        var namedRanges = new NamedRangeCommands();
+        _commands.SetValues(batch, sheetName, "B2:D4",
+        [
+            ["b1", 10, true],
+            ["b2", 20, false],
+            ["b3", 30, true]
+        ]);
+        namedRanges.Create(batch, name, $"{sheetName}!$B$2:$D$4");
+
+        try
+        {
+            var result = _commands.SummarizeValues(batch, "", name, "D,B");
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(["D", "B"], result.SelectedColumns);
+            Assert.Equal(["D", "B"], result.Columns.Select(column => column.Column));
+            Assert.Equal(3, result.Columns[0].LogicalCount);
+            Assert.Null(result.Columns[0].Sum);
+            Assert.Equal(3, result.Columns[1].TextCount);
+            Assert.Null(result.Columns[1].Average);
+        }
+        finally
+        {
+            namedRanges.Delete(batch, name);
+        }
+    }
+
+    [Fact]
+    public void SummarizeValues_WithLargeSourceRange_AggregatesWithoutReturningValues()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        _commands.SetValues(batch, sheetName, "A99999:A100000", [[2], [4]]);
+
+        var result = _commands.SummarizeValues(batch, sheetName, "A1:A100000");
+        var summary = Assert.Single(result.Columns);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(100000, summary.CellCount);
+        Assert.Equal(99998, summary.BlankCount);
+        Assert.Equal(2, summary.NumericCount);
+        Assert.Equal(6, summary.Sum);
+    }
+
+    [Fact]
+    public void SummarizeValues_WithFragmentedTypes_ReturnsCompleteCounts()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var values = Enumerable.Range(0, 17000)
+            .Select(index => new List<object?> { index % 2 == 0 ? 1 : "text" })
+            .ToList();
+        _commands.SetValues(batch, sheetName, "A1:A17000", values);
+
+        var result = _commands.SummarizeValues(batch, sheetName, "A1:A17000");
+        var summary = Assert.Single(result.Columns);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(8500, summary.NumericCount);
+        Assert.Equal(8500, summary.TextCount);
+        Assert.Equal(8500, summary.Sum);
+    }
+
+    [Fact]
+    public void GetFormulaErrors_WithFragmentedResults_ReturnsCompleteCount()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var formulas = Enumerable.Range(0, 17000)
+            .Select(index => new List<string> { index % 2 == 0 ? "=1/0" : "=1+1" })
+            .ToList();
+        _commands.SetFormulas(batch, sheetName, "A1:A17000", formulas);
+
+        var result = _commands.GetFormulaErrors(batch, sheetName, "A1:A17000", 1);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(8500, result.TotalErrorCount);
+        Assert.Single(result.Errors);
+        Assert.True(result.IsTruncated);
+    }
+
+    [Fact]
+    public void GetFormulaErrors_WithMultiAreaNamedRange_ReturnsWorksheetOrderedDiagnostics()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var name = $"FormulaErrors_{Guid.NewGuid():N}";
+        var namedRanges = new NamedRangeCommands();
+        _commands.SetFormulas(batch, sheetName, "A1", [["=1/0"]]);
+        _commands.SetFormulas(batch, sheetName, "C2", [["=NA()"]]);
+
+        batch.Execute((ctx, ct) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? firstArea = null;
+            Excel.Range? secondArea = null;
+            Excel.Range? unionRange = null;
+            Excel.Names? names = null;
+            Excel.Name? namedRange = null;
+            try
+            {
+                sheet = ComUtilities.FindSheet(ctx.Book, sheetName)
+                    ?? throw new InvalidOperationException($"Sheet '{sheetName}' not found.");
+                firstArea = sheet.Range["C1:C2"];
+                secondArea = sheet.Range["A1:A2"];
+                unionRange = ctx.App.Union(firstArea, secondArea);
+                names = ctx.Book.Names;
+                namedRange = names.Add(name, unionRange);
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref namedRange);
+                ComUtilities.Release(ref names);
+                ComUtilities.Release(ref unionRange);
+                ComUtilities.Release(ref secondArea);
+                ComUtilities.Release(ref firstArea);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+
+        try
+        {
+            var result = _commands.GetFormulaErrors(batch, "", name);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(2, result.TotalErrorCount);
+            Assert.Equal(["A1", "C2"], result.Errors.Select(error => error.CellAddress));
+            Assert.Equal(["=1/0", "=NA()"], result.Errors.Select(error => error.Formula));
+        }
+        finally
+        {
+            namedRanges.Delete(batch, name);
+        }
+    }
+
+    [Theory]
+    [InlineData(-1, 1, "firstRowCount")]
+    [InlineData(1, -1, "lastRowCount")]
+    [InlineData(101, 1, "firstRowCount")]
+    [InlineData(1, 101, "lastRowCount")]
+    [InlineData(0, 0, "firstRowCount")]
+    public void SampleValues_WithInvalidCounts_ThrowsBeforeOpeningExcel(
+        int firstRowCount,
+        int lastRowCount,
+        string parameterName)
+    {
+        var exception = Assert.ThrowsAny<ArgumentException>(() =>
+            _commands.SampleValues(
+                null!,
+                "Sheet1",
+                "A1",
+                firstRowCount,
+                lastRowCount));
+
+        Assert.Equal(parameterName, exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1001)]
+    public void GetFormulaErrors_WithInvalidLimit_ThrowsBeforeOpeningExcel(int maxErrors)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            _commands.GetFormulaErrors(null!, "Sheet1", "A1", maxErrors));
+
+        Assert.Equal("maxErrors", exception.ParamName);
+    }
+
+    [Fact]
+    public void SampleValues_WhenResponseWouldExceedCellLimit_Throws()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            _commands.SampleValues(batch, sheetName, "A1:Z100", 50, 50));
+
+        Assert.Contains("1000 cells", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SamplingAndSummaries_WithMultiAreaRange_RejectClearly()
+    {
+        using var batch = ExcelSession.BeginBatch(_fixture.TestFilePath);
+        var sheetName = _fixture.CreateTestSheet(batch);
+        var name = $"ScopedModes_{Guid.NewGuid():N}";
+        var namedRanges = new NamedRangeCommands();
+
+        batch.Execute((ctx, ct) =>
+        {
+            Excel.Worksheet? sheet = null;
+            Excel.Range? firstArea = null;
+            Excel.Range? secondArea = null;
+            Excel.Range? unionRange = null;
+            Excel.Names? names = null;
+            Excel.Name? namedRange = null;
+            try
+            {
+                sheet = ComUtilities.FindSheet(ctx.Book, sheetName)
+                    ?? throw new InvalidOperationException($"Sheet '{sheetName}' not found.");
+                firstArea = sheet.Range["A1:A2"];
+                secondArea = sheet.Range["C1:C2"];
+                unionRange = ctx.App.Union(firstArea, secondArea);
+                names = ctx.Book.Names;
+                namedRange = names.Add(name, unionRange);
+                return 0;
+            }
+            finally
+            {
+                ComUtilities.Release(ref namedRange);
+                ComUtilities.Release(ref names);
+                ComUtilities.Release(ref unionRange);
+                ComUtilities.Release(ref secondArea);
+                ComUtilities.Release(ref firstArea);
+                ComUtilities.Release(ref sheet);
+            }
+        });
+
+        try
+        {
+            var sampleException = Assert.Throws<ArgumentException>(() =>
+                _commands.SampleValues(batch, "", name));
+            var summaryException = Assert.Throws<ArgumentException>(() =>
+                _commands.SummarizeValues(batch, "", name));
+
+            Assert.Contains("multi-area", sampleException.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("multi-area", summaryException.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            namedRanges.Delete(batch, name);
+        }
+    }
+}

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeneratedActionContractProtocolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/GeneratedActionContractProtocolTests.cs
@@ -456,9 +456,21 @@ public sealed class GeneratedActionContractProtocolTests : McpIntegrationTestBas
         Assert.Equal("string", columns.GetProperty("type").GetString());
         Assert.Contains("get-values", columns.GetProperty("description").GetString(), StringComparison.Ordinal);
         Assert.Contains(
-            "zero-based rowOffset, positive rowLimit, and comma-separated absolute worksheet columns",
+            "sample-values returns bounded boundary rows with source coordinates",
             rangeTool.Description,
             StringComparison.Ordinal);
+
+        var firstRowCount = properties.GetProperty("first_row_count");
+        Assert.Equal("integer", firstRowCount.GetProperty("type").GetString());
+        Assert.Contains("sample-values", firstRowCount.GetProperty("description").GetString(), StringComparison.Ordinal);
+
+        var lastRowCount = properties.GetProperty("last_row_count");
+        Assert.Equal("integer", lastRowCount.GetProperty("type").GetString());
+        Assert.Contains("sample-values", lastRowCount.GetProperty("description").GetString(), StringComparison.Ordinal);
+
+        var maxErrors = properties.GetProperty("max_errors");
+        Assert.Equal("integer", maxErrors.GetProperty("type").GetString());
+        Assert.Contains("get-formula-errors", maxErrors.GetProperty("description").GetString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/ExcelMcp.McpServer.Tests/Integration/Tools/RangeScopedReadToolTests.cs
+++ b/tests/ExcelMcp.McpServer.Tests/Integration/Tools/RangeScopedReadToolTests.cs
@@ -92,4 +92,96 @@ public sealed class RangeScopedReadToolTests : McpIntegrationTestBase
 
         Assert.Empty(leakedExcelProcessIds);
     }
+
+    [Fact]
+    public async Task ScopedAnalytics_ReturnTypedBoundedResultsThroughMcp()
+    {
+        var sessionId = await CreateWorkbookSessionAsync(
+            Path.Join(_tempDirectory, $"ScopedAnalytics_{Guid.NewGuid():N}.xlsx"));
+
+        var values = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-values",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "B2:C4",
+            ["values"] = new List<List<object?>>
+            {
+                new() { 1, 10 },
+                new() { 2, 20 },
+                new() { 3, 30 }
+            }
+        });
+        AssertSetupSuccess(values, "range.set-values");
+
+        var formulas = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "set-formulas",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "D2:D3",
+            ["formulas"] = new List<List<string>>
+            {
+                new() { "=1/0" },
+                new() { "=NA()" }
+            }
+        });
+        AssertSetupSuccess(formulas, "range.set-formulas");
+
+        var sample = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "sample-values",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "B2:C4",
+            ["first_row_count"] = 1,
+            ["last_row_count"] = 1,
+            ["columns"] = "C"
+        });
+        AssertSuccess(sample, "range.sample-values");
+        using (var document = JsonDocument.Parse(sample))
+        {
+            var root = document.RootElement;
+            Assert.Equal([0, 2], root.GetProperty("rows").EnumerateArray()
+                .Select(row => row.GetProperty("rowOffset").GetInt32()));
+            Assert.Equal("$C$4", root.GetProperty("rows")[1].GetProperty("rangeAddress").GetString());
+        }
+
+        var summary = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "summarize-values",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "B2:C4",
+            ["columns"] = "B"
+        });
+        AssertSuccess(summary, "range.summarize-values");
+        using (var document = JsonDocument.Parse(summary))
+        {
+            var column = document.RootElement.GetProperty("columns")[0];
+            Assert.Equal(3, column.GetProperty("numericCount").GetInt64());
+            Assert.Equal(6, column.GetProperty("sum").GetDouble());
+        }
+
+        var errors = await CallToolAsync("range", new Dictionary<string, object?>
+        {
+            ["action"] = "get-formula-errors",
+            ["session_id"] = sessionId,
+            ["sheet_name"] = "Sheet1",
+            ["range_address"] = "B2:D4",
+            ["max_errors"] = 1
+        });
+        AssertSuccess(errors, "range.get-formula-errors");
+        using (var document = JsonDocument.Parse(errors))
+        {
+            var root = document.RootElement;
+            Assert.Equal(2, root.GetProperty("totalErrorCount").GetInt64());
+            Assert.Equal(1, root.GetProperty("returnedErrorCount").GetInt32());
+            Assert.True(root.GetProperty("isTruncated").GetBoolean());
+            Assert.Equal("D2", root.GetProperty("errors")[0].GetProperty("cellAddress").GetString());
+            Assert.False(root.TryGetProperty("values", out _));
+        }
+
+        await CloseSessionAsync(sessionId, save: false);
+    }
 }

--- a/tests/ExcelMcp.SkillGeneration.Tests/McpbPackagingScriptTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/McpbPackagingScriptTests.cs
@@ -1,0 +1,163 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace Sbroenne.ExcelMcp.SkillGeneration.Tests;
+
+/// <summary>
+/// Integration tests for MCPB packaging script behavior.
+/// </summary>
+public sealed class McpbPackagingScriptTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string PackagingHelpers = Path.Combine(
+        RepoRoot,
+        "mcpb",
+        "McpbPackaging.ps1");
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "McpbPackaging")]
+    public async Task RemoveStagingDirectory_RetriesTransientFileLockUntilDirectoryIsGone()
+    {
+        var sandbox = CreateSandbox();
+        try
+        {
+            var script = $$"""
+                $ErrorActionPreference = 'Stop'
+                . '{{EscapePowerShellLiteral(PackagingHelpers)}}'
+                $script:attempts = 0
+                $removeDirectory = {
+                    param([string]$Path)
+                    $script:attempts++
+                    if ($script:attempts -lt 3) {
+                        throw [System.IO.IOException]::new('locked by scanner')
+                    }
+
+                    [System.IO.Directory]::Delete($Path, $true)
+                }
+
+                Remove-McpbStagingDirectory `
+                    -Path '{{EscapePowerShellLiteral(sandbox)}}' `
+                    -Timeout ([TimeSpan]::FromSeconds(1)) `
+                    -RetryInterval ([TimeSpan]::Zero) `
+                    -RemoveDirectory $removeDirectory
+                Write-Output "attempts=$script:attempts"
+                """;
+
+            var result = await RunPowerShellAsync(script);
+
+            Assert.True(result.ExitCode == 0, result.CombinedOutput);
+            Assert.Contains("attempts=3", result.Stdout, StringComparison.Ordinal);
+            Assert.False(Directory.Exists(sandbox));
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox))
+            {
+                Directory.Delete(sandbox, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "McpbPackaging")]
+    public async Task RemoveStagingDirectory_WhenTimeoutExpires_ReportsTerminalState()
+    {
+        var sandbox = CreateSandbox();
+        try
+        {
+            var script = $$"""
+                $ErrorActionPreference = 'Stop'
+                . '{{EscapePowerShellLiteral(PackagingHelpers)}}'
+                $removeDirectory = {
+                    param([string]$Path)
+                    throw [System.UnauthorizedAccessException]::new('locked by scanner')
+                }
+
+                Remove-McpbStagingDirectory `
+                    -Path '{{EscapePowerShellLiteral(sandbox)}}' `
+                    -Timeout ([TimeSpan]::Zero) `
+                    -RetryInterval ([TimeSpan]::Zero) `
+                    -RemoveDirectory $removeDirectory
+                """;
+
+            var result = await RunPowerShellAsync(script);
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.True(Directory.Exists(sandbox));
+            Assert.Contains(
+                "Failed to remove MCPB staging directory",
+                result.Stderr,
+                StringComparison.Ordinal);
+            Assert.Contains(sandbox, result.Stderr, StringComparison.Ordinal);
+            Assert.Contains("after 1 attempt", result.Stderr, StringComparison.Ordinal);
+            Assert.Contains("within 0 ms", result.Stderr, StringComparison.Ordinal);
+            Assert.Contains("locked by scanner", result.Stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    private static string CreateSandbox()
+    {
+        var sandbox = Path.Combine(Path.GetTempPath(), $"ExcelMcpMcpbPackaging-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(sandbox, "server"));
+        File.WriteAllText(Path.Combine(sandbox, "server", "excel-mcp-server.exe"), "test");
+        return sandbox;
+    }
+
+    private static string EscapePowerShellLiteral(string value) =>
+        value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static async Task<ScriptResult> RunPowerShellAsync(string script)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-ExecutionPolicy");
+        startInfo.ArgumentList.Add("Bypass");
+        startInfo.ArgumentList.Add("-Command");
+        startInfo.ArgumentList.Add(script);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(timeout.Token);
+
+        return new ScriptResult(process.ExitCode, await stdout, await stderr);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Sbroenne.ExcelMcp.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output directory.");
+    }
+
+    private sealed record ScriptResult(int ExitCode, string Stdout, string Stderr)
+    {
+        public string CombinedOutput => $"{Stdout}{Environment.NewLine}{Stderr}";
+    }
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -19,7 +19,7 @@ Other tools (openpyxl-based MCP servers and Agent Skills, including Anthropic's 
 
 ## Key features
 
-The Excel MCP Server (excel-mcp) provides **31 specialized tools with 325 operations** for comprehensive Excel automation:
+The Excel MCP Server (excel-mcp) provides **31 specialized tools with 328 operations** for comprehensive Excel automation:
 
 - 🔄 **Power Query & M code** - Create, edit and optimize M code. Import from files, databases and APIs. Refresh queries and manage load destinations.
 - 🧮 **Power Pivot & DAX** - Build Data Models, create DAX measures and manage table relationships. Full Power Pivot automation.
@@ -31,7 +31,7 @@ The Excel MCP Server (excel-mcp) provides **31 specialized tools with 325 operat
 - 🐍 **Python in Excel** - Write and run `=PY()` formulas that execute in Excel's cloud Python engine — process worksheet data with pandas, NumPy and more, from your AI assistant.
 - 🧪 **LLM-tested quality** - Tool behavior validated with real LLM workflows using [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering), so AI assistants reliably understand and use every operation.
 
-📚 **[See all 31 tools and 325 operations →](https://excelmcpserver.dev/features/)**
+📚 **[See all 31 tools and 328 operations →](https://excelmcpserver.dev/features/)**
 
 ### Agent Skills (Bundled)
 


### PR DESCRIPTION
## Summary
- add `range sample-values` for deterministic first/last row samples with source offsets, absolute worksheet coordinates, ordered column projection, overlap removal, and a 1,000-cell response bound
- add `range summarize-values` for per-column blank, numeric, text, logical, and error counts plus numeric sum, average, minimum, and maximum without returning a values matrix
- add `range get-formula-errors` for bounded sparse formula diagnostics using canonical Excel error mapping, including named-range and multi-area support without materializing full range values
- preserve `get-values` defaults and generated CLI/MCP parity, update shared guidance and all published operation counts, and integrate the final MCPB lifecycle packaging head

Closes #837

## API
- MCP: `range(action: "sample-values", sheet_name, range_address, first_row_count = 5, last_row_count = 5, columns?)`
- CLI: `excelcli range sample-values --session <id> --sheet-name <sheet> --range-address <range> [--first-row-count 5] [--last-row-count 5] [--columns A,D,F]`
- MCP: `range(action: "summarize-values", sheet_name, range_address, columns?)`
- CLI: `excelcli range summarize-values --session <id> --sheet-name <sheet> --range-address <range> [--columns A,D,F]`
- MCP: `range(action: "get-formula-errors", sheet_name, range_address, max_errors = 100)`
- CLI: `excelcli range get-formula-errors --session <id> --sheet-name <sheet> --range-address <range> [--max-errors 100]`

## Validation
- Release solution build with zero warnings
- 25 focused Core scoped-read tests, including 17,000-cell fragmented summary/error regressions
- focused CLI and MCP protocol/integration tests
- MCPB packaging tests
- COM leak, Core coverage/naming, MCP/Core parity, success-flag, documentation-count, and dynamic-cast audits
- strict MkDocs build (31 tools / 328 operations)
- full Excel-dependent E2E suite
- unchanged normal pre-commit hook, including all release/package deliverables