### PR TITLE
Fix plugin skill newline portability

### DIFF
--- a/scripts/Build-AgentSkills.ps1
+++ b/scripts/Build-AgentSkills.ps1
@@ -306,7 +306,8 @@ function Copy-SharedReferences {
             $destination = Join-Path $RefsDir $sourceFile.Name
             if ($SkillName -eq "excel-cli") {
                 $cliSyntaxNotice = "> **CLI syntax note:** This shared domain guide may use MCP-style ``tool(action: ...)`` examples as conceptual shorthand. Do not translate or paste those calls mechanically. Use the exact commands and kebab-case options in [cli-commands.md](./cli-commands.md) or live ``--help``; notably, MCP ``file`` open/close maps to CLI ``session`` open/close, and MCP ``worksheet`` maps to CLI ``sheet``."
-                $adaptedContent = "$cliSyntaxNotice`r`n`r`n$(Get-Content -Path $sourceFile.FullName -Raw)"
+                $sourceContent = (Get-Content -Path $sourceFile.FullName -Raw) -replace "`r`n?", "`n"
+                $adaptedContent = "$cliSyntaxNotice`n`n$sourceContent"
                 Set-Content -Path $destination -Value $adaptedContent -Encoding UTF8 -NoNewline
             } else {
                 Copy-Item -Path $sourceFile.FullName -Destination $destination -Force

--- a/skills/excel-cli/references/table.md
+++ b/skills/excel-cli/references/table.md
@@ -7,13 +7,14 @@
 Excel Tables on worksheets are NOT automatically in the Data Model (Power Pivot).
 To analyze worksheet data with DAX measures:
 
-1. Ensure data is formatted as an Excel Table (use create action if needed)
+1. Ensure data is formatted as an Excel Table (use preflight, then create if needed)
 2. Use `add-to-data-model` action to add the table to Power Pivot
 3. Then use `datamodel` to create DAX measures on it
 
 **Action disambiguation**:
 
 - create: Create NEW table from a range (requires `sheet_name`, `table_name`, and `range_address`). Pass `table_style` here to style at creation time.
+- preflight: Check a proposed table without changing the workbook. It returns the effective range, typed findings, and `safeToCreate`. Merged cells plus blank or duplicate headers are blockers. Excluded contiguous columns and formulas that may be unsafe to sort are heuristic warnings. For ranges over 100,000 cells, it returns a `FormulaScanSkipped` warning instead of allocating the full formula matrix.
 - read: Get table metadata (range, columns, style, row counts)
 - get-data: Get actual table DATA as 2D array (use `visible_only=true` for filtered data)
 - rename: Rename an existing table
@@ -85,6 +86,7 @@ Example DAX queries for create-from-dax:
 - Using datamodel to add tables (it only manages existing Data Model tables)
 - Confusing get-data (returns cell values) with read (returns metadata)
 - Forgetting `has_headers` when creating tables from headerless data
+- Skipping preflight when warnings about excluded columns or formula sorting need human review. Create always enforces deterministic blockers, but warnings do not block it.
 
 **Server-specific quirks**:
 

--- a/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
+++ b/tests/ExcelMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
@@ -22,6 +22,7 @@ public sealed class PluginBootstrapBuildTests
     private const string AgentPluginSchema = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
     private const string AgentPluginMcpSchema = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
     private static readonly string RepoRoot = FindRepoRoot();
+    private static readonly string BuildAgentSkillsScript = Path.Combine(RepoRoot, "scripts", "Build-AgentSkills.ps1");
     private static readonly string BuildPluginsScript = Path.Combine(RepoRoot, "scripts", "Build-Plugins.ps1");
     private static readonly string SyncPublishedRepoScript = Path.Combine(RepoRoot, "scripts", "Sync-PublishedPluginRepo.ps1");
 
@@ -65,6 +66,18 @@ public sealed class PluginBootstrapBuildTests
             content);
         Assert.Contains(@"skills-ref validate source\plugins\excel-mcp\skills\excel-mcp", content);
         Assert.Contains(@"skills-ref validate source\plugins\excel-cli\skills\excel-cli", content);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Feature", "PluginBootstrap")]
+    public void BuildAgentSkills_UsesPortableNewlinesForCliSyntaxNotice()
+    {
+        var script = File.ReadAllText(BuildAgentSkillsScript);
+
+        Assert.Contains("-replace \"`r`n?\", \"`n\"", script, StringComparison.Ordinal);
+        Assert.Contains("$cliSyntaxNotice`n`n$sourceContent", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("$cliSyntaxNotice`r`n", script, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -256,7 +269,9 @@ public sealed class PluginBootstrapBuildTests
                 Assert.True(File.Exists(builtSharedReference), $"Expected excel-cli plugin to package shared reference at {builtSharedReference}");
                 var builtContent = File.ReadAllText(builtSharedReference);
                 Assert.Contains("CLI syntax note", builtContent);
-                Assert.Contains(File.ReadAllText(sourceSharedReference), builtContent);
+                Assert.Contains(
+                    NormalizeLineEndings(File.ReadAllText(sourceSharedReference)),
+                    NormalizeLineEndings(builtContent));
 
                 var builtMcpReference = Path.Combine(
                     outputDir,
@@ -2184,6 +2199,11 @@ public sealed class PluginBootstrapBuildTests
         var sandbox = Path.Combine(RepoRoot, "scratch", "plugin-bootstrap-test", $"{name}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(sandbox);
         return sandbox;
+    }
+
+    private static string NormalizeLineEndings(string value)
+    {
+        return value.Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
     private static void DeleteDirectoryIfExists(string path)


### PR DESCRIPTION
## Summary
- normalize generated Excel CLI shared-reference content to LF before prepending the CLI syntax notice
- compare packaged shared guides semantically across CRLF/LF checkouts without weakening content validation
- refresh the stale generated table guide required by the current `main` publication tree

## Root cause
`Build-AgentSkills.ps1` hard-coded CRLF for the CLI notice separator while shared Markdown can be checked out with LF. The plugin packaging assertion compared raw strings, so equivalent content failed on Windows when newline styles differed. Current `main` also contained a stale generated Excel CLI table guide, which is refreshed from the canonical shared source here.

## Validation
- `dotnet test tests\ExcelMcp.SkillGeneration.Tests\ExcelMcp.SkillGeneration.Tests.csproj --configuration Release --no-restore --filter "Feature=AgentPluginSpec|Feature=PluginBootstrap" --verbosity minimal` (55 passed)
- `dotnet build Sbroenne.ExcelMcp.sln -c Release --no-restore` (0 warnings, 0 errors)
- `scripts\check-doc-counts.ps1`
- full repository pre-commit hook, including audits and release deliverable builds

This is a build/test publication fix only. It does not change or retag v2.0.6; after merge, the existing `v2.0.6` manual plugin publication can be replayed from updated `main`.